### PR TITLE
fix: skip slow tests under miri to prevent hanging

### DIFF
--- a/filemonitor/src/property_tests.rs
+++ b/filemonitor/src/property_tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg(not(miri))] // Skip property tests under miri as they're too slow
 mod tests {
     use crate::*;
     use proptest::prelude::*;

--- a/filemonitor/tests/integration_test.rs
+++ b/filemonitor/tests/integration_test.rs
@@ -166,6 +166,7 @@ fn test_evaluate_safety_case_sensitive() {
 }
 
 #[test]
+#[cfg(not(miri))] // Skip under miri - regex compilation is too slow
 fn test_evaluate_safety_regex_rules() {
     let config = Config {
         device: DeviceConfig {


### PR DESCRIPTION
- Skip property tests module under miri using #[cfg(not(miri))]
- Skip regex compilation test under miri due to performance
- Miri tests now complete successfully in ~6 seconds
- Regular tests continue to run all tests including property and regex tests