### PR TITLE
Upgrade ascom-alpaca to 1.0.0-beta.10

### DIFF
--- a/filemonitor/Cargo.toml
+++ b/filemonitor/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "File monitoring service for Rusty Photon"
 
 [dependencies]
-ascom-alpaca = { version = "1.0.0-beta.7", features = ["server", "safety_monitor", "test"] }
+ascom-alpaca = { version = "1.0.0-beta.10", features = ["server", "safety_monitor", "test"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Upgrades ascom-alpaca dependency from 1.0.0-beta.7 to 1.0.0-beta.10 in filemonitor.