### PR TITLE
Add FITS file support via fitsio crate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,8 @@ jobs:
         toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -62,6 +64,8 @@ jobs:
     name: ubuntu / stable / features
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
@@ -81,6 +85,8 @@ jobs:
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - run: |
@@ -54,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - run: |
           echo "NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> "$GITHUB_ENV"
       - name: Install ${{ env.NIGHTLY }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,6 +20,8 @@ jobs:
     name: scheduled / ubuntu / nightly
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo generate-lockfile
@@ -41,6 +43,8 @@ jobs:
     # steps, so we repeat it.
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install beta
         if: hashFiles('Cargo.lock') != ''
         uses: dtolnay/rust-toolchain@beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -57,6 +59,9 @@ jobs:
       # - run: vcpkg install openssl:x64-windows-static-md
       #   if: runner.os == 'Windows'
       - uses: actions/checkout@v5
+      - name: Install cfitsio (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cfitsio
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo generate-lockfile
@@ -90,6 +95,8 @@ jobs:
     name: ubuntu / stable / coverage
     steps:
       - uses: actions/checkout@v5
+      - name: Install cfitsio
+        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tokio-test = "0.4"
 proptest = "1.5"
+fitsio = "0.21"

--- a/docs/decisions/001-fits-file-support.md
+++ b/docs/decisions/001-fits-file-support.md
@@ -1,0 +1,100 @@
+# ADR-001: FITS File Support via fitsio Crate
+
+## Status
+
+Accepted
+
+## Context
+
+Rusty Photon is an astrophotography application that needs to read and write FITS (Flexible Image Transport System) files. FITS is the standard file format used in astronomy for storing images, tables, and metadata.
+
+We needed to decide how to implement FITS file support in the workspace.
+
+## Options Considered
+
+### Option 1: Custom FFI Bindings
+
+Build custom Rust bindings directly to NASA's CFITSIO C library.
+
+**Pros:**
+- Full control over the API surface
+- Could optimize for specific use cases
+
+**Cons:**
+- Significant development effort
+- Need to maintain FFI safety
+- No clear benefit over existing solutions
+
+### Option 2: Wrapper Crate
+
+Create a thin wrapper crate around an existing FITS library to provide async compatibility.
+
+**Pros:**
+- Could provide a cleaner async API
+- Centralized error handling
+
+**Cons:**
+- Unnecessary abstraction layer
+- Async compatibility can be achieved via `spawn_blocking` at call sites
+- Additional maintenance burden
+
+### Option 3: Direct Dependency on fitsio Crate (Chosen)
+
+Use the existing `fitsio` crate (v0.21) as a direct workspace dependency.
+
+**Pros:**
+- Well-maintained crate (latest release Sept 2025)
+- Wraps NASA's CFITSIO library with safe Rust API
+- Good Linux/macOS support (Tier 1)
+- Minimal integration effort
+- Active community and documentation
+
+**Cons:**
+- Limited Windows support (Tier 3/MSYS2)
+- Synchronous API (requires `spawn_blocking` for async contexts)
+- Dependency on system CFITSIO library
+
+## Decision
+
+We chose **Option 3: Direct dependency on fitsio crate**.
+
+The `fitsio` crate provides a mature, well-tested wrapper around CFITSIO with good platform support for our primary targets (Linux and macOS). The synchronous API is acceptable since blocking I/O can be offloaded to a thread pool using `tokio::task::spawn_blocking` where needed.
+
+## Consequences
+
+### CI/CD Changes
+
+All CI workflows must install the CFITSIO system library:
+- Ubuntu: `sudo apt-get install -y libcfitsio-dev`
+- macOS: `brew install cfitsio`
+- Windows: Limited support, skipped in CI or requires MSYS2
+
+### Usage Pattern
+
+Services using fitsio in async contexts should wrap blocking calls:
+
+```rust
+use fitsio::FitsFile;
+
+async fn read_fits_header(path: &str) -> Result<HeaderValue, Error> {
+    let path = path.to_string();
+    tokio::task::spawn_blocking(move || {
+        let mut fptr = FitsFile::open(&path)?;
+        let hdu = fptr.primary_hdu()?;
+        // ... read data
+        Ok(result)
+    }).await?
+}
+```
+
+### Platform Support
+
+- **Linux**: Full support (Tier 1)
+- **macOS**: Full support (Tier 1)
+- **Windows**: Limited support (Tier 3) - requires MSYS2 or vendored builds
+
+## References
+
+- [fitsio crate](https://crates.io/crates/fitsio)
+- [NASA CFITSIO](https://heasarc.gsfc.nasa.gov/fitsio/)
+- [FITS Standard](https://fits.gsfc.nasa.gov/fits_standard.html)


### PR DESCRIPTION
## Summary

- Add `fitsio` v0.21 as a workspace dependency for reading/writing FITS files
- Update all CI workflows to install the cfitsio system library
- Create ADR documentation explaining the decision rationale

## Context

FITS (Flexible Image Transport System) is the standard file format used in astronomy for storing images, tables, and metadata. This change integrates the well-maintained `fitsio` crate which wraps NASA's CFITSIO library.

## Test plan

- [x] `cargo build --all` passes locally
- [x] `cargo test --all` passes locally
- [ ] CI passes on Ubuntu (stable, beta)
- [ ] CI passes on macOS
- [ ] Windows build may fail (expected - fitsio has limited Windows support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)