### PR TITLE
Add homebrew-rusty-photon as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/phd2"]
 	path = external/phd2
 	url = https://github.com/OpenPHDGuiding/phd2.git
+[submodule "external/homebrew-rusty-photon"]
+	path = external/homebrew-rusty-photon
+	url = https://github.com/ivonnyssen/homebrew-rusty-photon.git


### PR DESCRIPTION
## Summary
- Created `ivonnyssen/homebrew-rusty-photon` public repo as a Homebrew tap
- Added it as a git submodule under `external/homebrew-rusty-photon`

## What's left
- Add `HOMEBREW_TAP_TOKEN` secret to repo settings for the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)