### PR TITLE
Replace fitsio with fitrs (pure Rust FITS)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,15 +45,6 @@ jobs:
         toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -75,15 +66,6 @@ jobs:
     name: ubuntu / stable / features
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
@@ -131,15 +113,6 @@ jobs:
     name: ubuntu / msrv / ${{ matrix.service }}
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install cargo-msrv
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -65,17 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install cfitsio (cached)
-        if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -19,15 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,15 +20,6 @@ jobs:
     name: scheduled / ubuntu / nightly
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo generate-lockfile
@@ -76,15 +67,6 @@ jobs:
         service: ${{ fromJson(needs.discover-miri.outputs.services) }}
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - run: |
           echo "NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> "$GITHUB_ENV"
       - name: Install ${{ env.NIGHTLY }}
@@ -112,15 +94,6 @@ jobs:
     # steps, so we repeat it.
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install beta
         if: hashFiles('Cargo.lock') != ''
         uses: dtolnay/rust-toolchain@beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,6 @@ jobs:
         toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -66,23 +57,13 @@ jobs:
       # - run: vcpkg install openssl:x64-windows-static-md
       #   if: runner.os == 'Windows'
       - uses: actions/checkout@v5
-      - name: Install cfitsio (macOS)
-        if: runner.os == 'macOS'
-        run: brew install cfitsio
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo test
-        # Exclude phd2-guider on Windows (cfitsio not available)
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            cargo test --locked --all-features --all-targets --workspace --exclude phd2-guider
-          else
-            cargo test --locked --all-features --all-targets
-          fi
-        shell: bash
+        run: cargo test --locked --all-features --all-targets
   coverage:
     # use llvm-cov to build and collect coverage and outputs in a format that
     # is compatible with codecov.io
@@ -109,15 +90,6 @@ jobs:
     name: ubuntu / stable / coverage
     steps:
       - uses: actions/checkout@v5
-      - name: Install cfitsio (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        continue-on-error: true
-        with:
-          packages: libcfitsio-dev
-          version: 1.0
-      - name: Install cfitsio (act fallback)
-        if: env.ACT == 'true'
-        run: sudo apt-get update && sudo apt-get install -y libcfitsio-dev
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tokio-test = "0.4.5"
 proptest = "1.9.0"
-fitsio = "0.21.9"
+fitrs = "0.5.0"
 thiserror = "2.0.18"
 base64 = "0.22.1"
 mockall = "0.14.0"

--- a/docs/decisions/001-fits-file-support.md
+++ b/docs/decisions/001-fits-file-support.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Accepted
+Superseded — replaced `fitsio` (CFITSIO wrapper) with `fitrs` (pure Rust).
+The CFITSIO C dependency caused Windows/MSVC build failures due to missing
+`pthread.h`. Since our usage is limited to writing small guide star
+thumbnails, the pure Rust `fitrs` crate covers our needs without any
+system library dependencies. Pixel data is stored as BITPIX=32 (i32)
+instead of BITPIX=16 (u16) because `fitrs` does not support u16, but
+this is acceptable for guide star images.
 
 ## Context
 

--- a/docs/pre-push-checklist.md
+++ b/docs/pre-push-checklist.md
@@ -75,10 +75,10 @@ cargo test --locked --all-features --doc
 | CI Job | CI Command | Local Equivalent | Prerequisites | Required? |
 |--------|-----------|------------------|---------------|-----------|
 | **fmt** | `cargo fmt --check` | `cargo fmt --check` | stable rustfmt | Yes |
-| **clippy (stable)** | clippy-action (stable) | `cargo clippy --all-targets --all-features -- -D warnings` | stable clippy, cfitsio | Yes |
-| **clippy (beta)** | clippy-action (beta) | `cargo +beta clippy --all-targets --all-features -- -D warnings` | beta toolchain, cfitsio | Optional |
-| **hack** | `cargo hack --feature-powerset check` | `cargo hack --feature-powerset check` | cargo-hack, cfitsio | Yes |
-| **msrv** | `cargo msrv verify` per service | `cargo msrv verify --manifest-path services/<name>/Cargo.toml` | cargo-msrv, cfitsio | Optional |
+| **clippy (stable)** | clippy-action (stable) | `cargo clippy --all-targets --all-features -- -D warnings` | stable clippy | Yes |
+| **clippy (beta)** | clippy-action (beta) | `cargo +beta clippy --all-targets --all-features -- -D warnings` | beta toolchain | Optional |
+| **hack** | `cargo hack --feature-powerset check` | `cargo hack --feature-powerset check` | cargo-hack | Yes |
+| **msrv** | `cargo msrv verify` per service | `cargo msrv verify --manifest-path services/<name>/Cargo.toml` | cargo-msrv | Optional |
 
 MSRV services are discovered dynamically. Current services with MSRV:
 - filemonitor (1.88.0)
@@ -100,8 +100,8 @@ done
 
 | CI Job | CI Command | Local Equivalent | Prerequisites | Required? |
 |--------|-----------|------------------|---------------|-----------|
-| **required (stable)** | `cargo test --locked --all-features --all-targets` | Same | stable, cfitsio | Yes |
-| **required (stable, doc)** | `cargo test --locked --all-features --doc` | Same | stable, cfitsio | Yes |
+| **required (stable)** | `cargo test --locked --all-features --all-targets` | Same | stable | Yes |
+| **required (stable, doc)** | `cargo test --locked --all-features --doc` | Same | stable | Yes |
 | **required (beta)** | Same commands with beta | `cargo +beta test --locked --all-features --all-targets` | beta toolchain | Optional |
 | **os-check** | Tests on macOS/Windows | N/A (cross-platform) | — | CI-only |
 | **coverage** | `cargo llvm-cov --locked --all-features --lcov` | Same | cargo-llvm-cov, llvm-tools-preview | Optional |
@@ -110,8 +110,8 @@ done
 
 | CI Job | CI Command | Local Equivalent | Prerequisites | Required? |
 |--------|-----------|------------------|---------------|-----------|
-| **address sanitizer** | `cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu` with `RUSTFLAGS="-Z sanitizer=address"` | Same (see below) | nightly, llvm, cfitsio | Optional |
-| **leak sanitizer** | `cargo test --all-features --target x86_64-unknown-linux-gnu` with `RUSTFLAGS="-Z sanitizer=leak"` | Same (see below) | nightly, cfitsio | Optional |
+| **address sanitizer** | `cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu` with `RUSTFLAGS="-Z sanitizer=address"` | Same (see below) | nightly, llvm | Optional |
+| **leak sanitizer** | `cargo test --all-features --target x86_64-unknown-linux-gnu` with `RUSTFLAGS="-Z sanitizer=leak"` | Same (see below) | nightly | Optional |
 
 Address sanitizer:
 
@@ -138,7 +138,7 @@ RUSTFLAGS="-Z sanitizer=leak" \
 | CI Job | CI Command | Local Equivalent | Prerequisites | Required? |
 |--------|-----------|------------------|---------------|-----------|
 | **discover** | `cargo metadata` + jq | Same | jq | — |
-| **conformu** | Per-service command from metadata | Same (see below) | ConformU, cfitsio | Optional |
+| **conformu** | Per-service command from metadata | Same (see below) | ConformU | Optional |
 
 ConformU services are discovered dynamically via `[package.metadata.conformu]`
 in each service's `Cargo.toml`. To list them:
@@ -157,7 +157,7 @@ Current services and their commands:
 
 | CI Job | CI Command | Local Equivalent | Prerequisites | Required? |
 |--------|-----------|------------------|---------------|-----------|
-| **nightly** | `cargo test --locked --all-features --all-targets` (nightly) | `cargo +nightly test --locked --all-features --all-targets` | nightly, cfitsio | Optional |
+| **nightly** | `cargo test --locked --all-features --all-targets` (nightly) | `cargo +nightly test --locked --all-features --all-targets` | nightly | Optional |
 | **discover-miri** | `cargo metadata` + jq | Same | jq | — |
 | **miri** | Per-service command from metadata | Same (see below) | nightly + miri component | Optional |
 | **update** | `cargo update && cargo test` (beta) | `cargo +beta update && cargo +beta test --locked --all-features --all-targets` | beta | Optional |
@@ -189,7 +189,6 @@ Current services and their commands:
 | Tool | Install | Used by |
 |------|---------|---------|
 | Rust stable | `rustup default stable` | All checks |
-| cfitsio | `sudo apt install libcfitsio-dev` (Ubuntu) / `brew install cfitsio` (macOS) | All workspace builds |
 | cargo-hack | `cargo install cargo-hack` | Feature powerset checks |
 | Docker | [docs.docker.com](https://docs.docker.com/get-docker/) | act-based workflow execution |
 | act | `curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh \| sudo bash` | Local CI runner |
@@ -211,9 +210,6 @@ Current services and their commands:
 
 ## Conditional Compilation Notes
 
-- The `filemonitor` crate requires `cfitsio` to compile. If cfitsio is not
-  installed, use `-p <package>` to build/test specific packages that don't
-  need it.
 - The `mock` feature is used by ppba-driver and qhy-focuser for integration
   testing (including ConformU). It is not required for normal builds.
 - Feature powerset checks (`cargo hack --feature-powerset`) test all

--- a/docs/services/phd2-guider.md
+++ b/docs/services/phd2-guider.md
@@ -678,7 +678,7 @@ serde_json = "1"
 tracing = "0.1"
 thiserror = "2"
 base64 = "0.22"
-fitsio = "0.21"
+fitrs = "0.5"
 ```
 
 ## Testing Strategy

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -54,8 +54,5 @@ reference them with `dep.workspace = true`.
 
 ## Build Notes
 
-- The `filemonitor` crate depends on `fitsio-sys` which requires the `cfitsio`
-  system library (`libcfitsio-dev` on Ubuntu, `cfitsio` via Homebrew on macOS).
-  Use `-p <package>` to build other services when cfitsio is not installed.
 - The `ascom-alpaca` crate is a git dependency from
   `ivonnyssen/ascom-alpaca-rs.git` (branch `feature/conformu-settings-file`).

--- a/services/phd2-guider/Cargo.toml
+++ b/services/phd2-guider/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
-fitsio = { workspace = true }
+fitrs = { workspace = true }
 async-trait = { workspace = true }
 
 [package.metadata.miri]

--- a/services/phd2-guider/src/fits.rs
+++ b/services/phd2-guider/src/fits.rs
@@ -6,8 +6,7 @@
 use std::path::Path;
 
 use base64::Engine;
-use fitsio::images::{ImageDescription, ImageType};
-use fitsio::FitsFile;
+use fitrs::{Fits, Hdu};
 use tracing::debug;
 
 use crate::error::{Phd2Error, Result};
@@ -51,6 +50,10 @@ pub fn decode_base64_u16(base64_data: &str) -> Result<Vec<u16>> {
 ///
 /// Creates a new FITS file with the given pixel data. The file will be
 /// overwritten if it already exists.
+///
+/// Pixel values are stored as 32-bit integers (BITPIX=32) because the
+/// `fitrs` crate does not support unsigned 16-bit. This is acceptable
+/// for guide star thumbnails where file size is not a concern.
 ///
 /// # Arguments
 /// * `path` - Path where the FITS file will be written
@@ -121,45 +124,27 @@ fn write_fits_sync(
     height: u32,
     headers: Option<&[(String, String)]>,
 ) -> Result<()> {
-    // FITS uses FORTRAN-style column-major ordering, so dimensions are [NAXIS1, NAXIS2]
-    // where NAXIS1 is the fastest-varying dimension (columns/width)
-    let description = ImageDescription {
-        data_type: ImageType::UnsignedShort,
-        dimensions: &[width as usize, height as usize],
-    };
-
-    // Remove existing file if present (fitsio requires this)
+    // Remove existing file if present (fitrs does not overwrite)
     if path.exists() {
         std::fs::remove_file(path).map_err(|e| {
             Phd2Error::InvalidState(format!("Failed to remove existing file: {}", e))
         })?;
     }
 
-    let mut fptr = FitsFile::create(path)
-        .with_custom_primary(&description)
-        .open()
-        .map_err(|e| Phd2Error::InvalidState(format!("Failed to create FITS file: {}", e)))?;
-
-    let hdu = fptr
-        .primary_hdu()
-        .map_err(|e| Phd2Error::InvalidState(format!("Failed to get primary HDU: {}", e)))?;
-
-    // Convert u16 to i64 for fitsio (it expects signed values for write_image)
-    // Actually, fitsio's write_image can handle u16 directly for UnsignedShort type
-    // But we need to convert to the appropriate type
+    // Convert u16 to i32 — fitrs does not support u16 directly.
+    // FITS dimensions are [NAXIS1, NAXIS2] where NAXIS1 = width.
     let pixels_i32: Vec<i32> = pixels.iter().map(|&p| p as i32).collect();
 
-    hdu.write_image(&mut fptr, &pixels_i32)
-        .map_err(|e| Phd2Error::InvalidState(format!("Failed to write image data: {}", e)))?;
+    let mut hdu = Hdu::new(&[width as usize, height as usize], pixels_i32);
 
-    // Write optional headers
     if let Some(headers) = headers {
         for (key, value) in headers {
-            hdu.write_key(&mut fptr, key, value.as_str()).map_err(|e| {
-                Phd2Error::InvalidState(format!("Failed to write header {}: {}", key, e))
-            })?;
+            hdu.insert(key.as_str(), value.as_str());
         }
     }
+
+    Fits::create(path, hdu)
+        .map_err(|e| Phd2Error::InvalidState(format!("Failed to create FITS file: {}", e)))?;
 
     debug!("FITS file written successfully to {}", path.display());
     Ok(())

--- a/services/phd2-guider/tests/test_fits.rs
+++ b/services/phd2-guider/tests/test_fits.rs
@@ -64,7 +64,6 @@ async fn test_write_grayscale_u16_fits_dimension_mismatch() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri can't call fitsio FFI functions
 async fn test_write_grayscale_u16_fits_success() {
     let pixels = vec![1u16, 2, 3, 4];
     let temp_file = std::env::temp_dir().join("test_fits_write.fits");
@@ -83,7 +82,6 @@ async fn test_write_grayscale_u16_fits_success() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri can't call fitsio FFI functions
 async fn test_write_grayscale_u16_fits_with_headers() {
     let pixels = vec![100u16, 200, 300, 400, 500, 600, 700, 800, 900];
     let temp_file = std::env::temp_dir().join("test_fits_headers.fits");
@@ -103,7 +101,6 @@ async fn test_write_grayscale_u16_fits_with_headers() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri can't call fitsio FFI functions
 async fn test_write_grayscale_u16_fits_single_pixel() {
     let pixels = vec![42u16];
     let temp_file = std::env::temp_dir().join("test_fits_single.fits");
@@ -118,7 +115,6 @@ async fn test_write_grayscale_u16_fits_single_pixel() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri can't call fitsio FFI functions
 async fn test_write_grayscale_u16_fits_larger_image() {
     // 32x32 image
     let pixels: Vec<u16> = (0..1024).map(|i| i as u16).collect();

--- a/services/phd2-guider/tests/test_main_integration.rs
+++ b/services/phd2-guider/tests/test_main_integration.rs
@@ -730,8 +730,9 @@ fn test_monitor_receives_version_event() {
         .spawn()
         .expect("Failed to spawn monitor");
 
-    // Give it time to connect and receive the version event
-    std::thread::sleep(Duration::from_secs(1));
+    // Give it time to connect and receive the version event.
+    // Windows process startup + TCP connect is slower than Linux.
+    std::thread::sleep(Duration::from_secs(3));
 
     // Kill the monitor
     child.kill().expect("Failed to kill monitor");
@@ -752,10 +753,12 @@ fn test_monitor_receives_version_event() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_connection_refused() {
-    // Use a port that's definitely not listening
+    // Use a port that's definitely not listening.
+    // The CLI has a 10s connection timeout, so allow enough time for it to
+    // fail and exit (Windows TCP refusal can be slower than Linux).
     let port = get_available_port();
 
-    let output = run_cli_with_timeout(&["status"], port, Duration::from_secs(3));
+    let output = run_cli_with_timeout(&["status"], port, Duration::from_secs(15));
 
     assert!(
         !output.status.success(),
@@ -766,9 +769,11 @@ fn test_connection_refused() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_connection_timeout_message() {
+    // The CLI has a 10s connection timeout; allow enough for it to fail
+    // and exit on Windows where TCP refusal is slower.
     let port = get_available_port();
 
-    let output = run_cli_with_timeout(&["status"], port, Duration::from_secs(3));
+    let output = run_cli_with_timeout(&["status"], port, Duration::from_secs(15));
 
     assert!(
         !output.status.success(),


### PR DESCRIPTION
## Summary
- Replace `fitsio` (CFITSIO C wrapper) with `fitrs` (pure Rust) for FITS file writing
- Eliminates the CFITSIO system library dependency that caused Windows/MSVC build failures (`pthread.h` not found)
- Remove all `cfitsio` installation steps from 6 CI workflow files
- Remove `fitsio-src` feature and Windows `--exclude phd2-guider` workaround

## Context
The `fitsio` crate wraps NASA's CFITSIO C library, which unconditionally enables pthreads in its build script. Windows/MSVC doesn't have `pthread.h`, causing CI failures. Our FITS usage is limited to writing small guide star thumbnails in phd2-guider, so the pure Rust `fitrs` crate eliminates the C dependency entirely, fixing Windows builds and removing cfitsio installation steps from all CI workflows.

## Trade-offs
- FITS images stored as BITPIX=32 (i32) instead of BITPIX=16 (u16) since `fitrs` doesn't support u16. Acceptable for small guide star thumbnails.

## Test plan
- [x] `act -W .github/workflows/test.yml -j required` passes locally (stable + beta)
- [x] CI passes on all platforms (Linux, macOS, Windows)
- [x] Windows build succeeds without cfitsio

🤖 Generated with [Claude Code](https://claude.com/claude-code)