### PR TITLE
Integrate qhyccd-alpaca as qhy-camera service

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,15 @@ jobs:
         toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v5
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -61,9 +61,29 @@ jobs:
       matrix:
         os: ${{ fromJson(needs.discover.outputs.os) }}
         service: ${{ fromJson(needs.discover.outputs.services) }}
+        exclude:
+          # qhy-camera requires the QHYCCD SDK which is Linux-only
+          - service:
+              name: qhy-camera
+            os: macos-latest
+          - service:
+              name: qhy-camera
+            os: windows-latest
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install libusb (Linux)
+        if: runner.os == 'Linux'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK (Linux)
+        if: runner.os == 'Linux'
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -61,14 +61,6 @@ jobs:
       matrix:
         os: ${{ fromJson(needs.discover.outputs.os) }}
         service: ${{ fromJson(needs.discover.outputs.services) }}
-        exclude:
-          # qhy-camera requires the QHYCCD SDK which is Linux-only
-          - service:
-              name: qhy-camera
-            os: macos-latest
-          - service:
-              name: qhy-camera
-            os: windows-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -79,8 +71,7 @@ jobs:
         with:
           packages: libusb-1.0-0-dev
           version: 1.0
-      - name: Install QHYCCD SDK (Linux)
-        if: runner.os == 'Linux'
+      - name: Install QHYCCD SDK
         uses: ivonnyssen/qhyccd-sdk-install@v1
         with:
           version: "25.09.29"

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [filemonitor, phd2-guider, ppba-driver, qhy-focuser, rp, sentinel, sentinel-app]
+        package: [filemonitor, phd2-guider, ppba-driver, qhy-camera, qhy-focuser, rp, sentinel, sentinel-app]
         sanitizer: [address, leak]
     # CARGO_BUILD_TARGET makes every cargo invocation (including `cargo run`
     # spawned by BDD tests) implicitly use --target. This is critical because
@@ -40,6 +40,15 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,6 +22,15 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo generate-lockfile
@@ -101,6 +110,15 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install beta
         if: hashFiles('Cargo.lock') != ''
         uses: dtolnay/rust-toolchain@beta

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,15 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -71,6 +80,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         package: ${{ fromJson(needs.discover.outputs.packages) }}
+        exclude:
+          # qhy-camera requires the QHYCCD SDK which is Linux-only
+          - package: qhy-camera
     steps:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
@@ -126,6 +138,15 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install libusb
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libusb-1.0-0-dev
+          version: 1.0
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,13 +80,14 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         package: ${{ fromJson(needs.discover.outputs.packages) }}
-        exclude:
-          # qhy-camera requires the QHYCCD SDK which is Linux-only
-          - package: qhy-camera
     steps:
       - uses: actions/checkout@v5
       - name: Install ASCOM OmniSim
         uses: ./.github/actions/install-omnisim
+      - name: Install QHYCCD SDK
+        uses: ivonnyssen/qhyccd-sdk-install@v1
+        with:
+          version: "25.09.29"
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "services/filemonitor",
   "services/phd2-guider",
   "services/ppba-driver",
+  "services/qhy-camera",
   "services/qhy-focuser",
   "services/rp",
   "services/sentinel",

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -1,0 +1,237 @@
+# QHY Camera Service
+
+## Overview
+
+The `qhy-camera` service is an ASCOM Alpaca driver for QHYCCD cameras and filter wheels. It communicates with camera hardware through the QHYCCD C SDK via `qhyccd-rs` Rust bindings, exposing ASCOM Camera and FilterWheel devices over HTTP.
+
+The service supports single-frame exposures with async abort, CCD info queries, binning, ROI, gain/offset control, cooler management, readout modes, and filter wheel positioning.
+
+## Architecture
+
+The service follows the same architecture as `qhy-focuser`:
+
+- **SDK abstraction**: Trait-based I/O (`io.rs`) for testability — `SdkProvider`, `CameraHandle`, `FilterWheelHandle`
+- **Camera device**: Implements `Device` + `Camera` traits (`camera_device.rs`)
+- **Filter wheel device**: Implements `Device` + `FilterWheel` traits (`filter_wheel_device.rs`)
+- **Mock mode**: Feature-gated mock SDK implementation for testing without hardware (`mock.rs`)
+- **Server builder**: Configures and starts the ASCOM Alpaca server (`lib.rs`)
+
+Unlike `qhy-focuser` which uses serial communication, this service uses the QHYCCD C SDK (via `qhyccd-rs`) for USB camera access. There is no serial port, no background polling, and no serial manager.
+
+## Hardware Constraints
+
+- **Connection**: USB (via libusb / QHYCCD C SDK)
+- **SDK dependency**: Requires QHYCCD SDK installed at system level (headers + shared library)
+- **Platform**: Linux only (QHYCCD SDK is Linux-only for this project)
+- **Stream mode**: Single-frame mode only (live/video mode is deferred)
+- **Binning**: Symmetric only (bin_x == bin_y), mode depends on camera model (1x1, 2x2, 3x3, 4x4, 6x6, 8x8)
+- **Filter wheel**: USB filter wheel accessed via same SDK, position changes are asynchronous
+
+## ASCOM Camera Mapping
+
+| ASCOM Property/Method | Type | Implementation |
+|---|---|---|
+| BayerOffsetX/Y | `u8` | From SDK CamColor Bayer pattern mapping |
+| BinX/Y | `u8` | Cached, set via SDK `set_bin_mode` (symmetric) |
+| CameraState | `CameraState` | From internal state machine (Idle/Exposing) |
+| CameraXSize/YSize | `u32` | From cached CCD info (`image_width/height`) |
+| CanAbortExposure | `bool` | `true` (always) |
+| CanAsymmetricBin | `bool` | `false` (symmetric only) |
+| CanFastReadout | `bool` | `true` if Speed control available with valid range |
+| CanGetCoolerPower | `bool` | `true` if Cooler control available |
+| CanPulseGuide | `bool` | `false` (deferred) |
+| CanSetCCDTemperature | `bool` | `true` if Cooler control available |
+| CanStopExposure | `bool` | `false` |
+| CCDTemperature | `f64` | From SDK `CurTemp` parameter |
+| CoolerOn | `bool` | Derived from SDK `CurPWM` > 0 |
+| CoolerPower | `f64` | From SDK `CurPWM` (scaled 0-100%) |
+| ElectronsPerADU | `f64` | NOT_IMPLEMENTED |
+| ExposureMax/Min/Resolution | `Duration` | From SDK exposure min/max/step (microseconds) |
+| FastReadout | `bool` | Speed at max = fast, min = normal |
+| FullWellCapacity | `f64` | NOT_IMPLEMENTED |
+| Gain/GainMin/GainMax | `i32` | From SDK Gain parameter with cached range |
+| HasShutter | `bool` | From SDK CamMechanicalShutter control |
+| ImageArray | `ImageArray` | From last captured image (ndarray transform) |
+| ImageReady | `bool` | `true` when Idle and image exists |
+| LastExposureDuration | `Duration` | Cached from last exposure |
+| LastExposureStartTime | `SystemTime` | Cached from last exposure |
+| MaxADU | `u32` | `2^OutputDataActualBits` |
+| MaxBinX/Y | `u8` | Max of valid binning modes |
+| NumX/Y | `u32` | From intended ROI (width/height in binned pixels) |
+| Offset/OffsetMin/OffsetMax | `i32` | From SDK Offset parameter with cached range |
+| PercentCompleted | `u8` | From SDK remaining exposure time |
+| PixelSizeX/Y | `f64` | From cached CCD info |
+| ReadoutMode | `usize` | From SDK readout mode index |
+| ReadoutModes | `Vec<String>` | From SDK readout mode names |
+| SensorName | `String` | Parsed from camera ID (model prefix) |
+| SensorType | `SensorType` | Monochrome or RGGB from SDK CamIsColor/CamColor |
+| SetCCDTemperature | `f64` | Cached target, set via SDK Cooler parameter |
+| StartX/Y | `u32` | From intended ROI |
+| StartExposure | `Duration`, `bool` | Spawns async exposure task (dark frames not supported) |
+| AbortExposure | — | Signals exposure task via oneshot channel |
+| StopExposure | — | NOT_IMPLEMENTED |
+
+## ASCOM FilterWheel Mapping
+
+| ASCOM Property/Method | Type | Implementation |
+|---|---|---|
+| FocusOffsets | `Vec<i32>` | Returns zeros (no offset data from hardware) |
+| Names | `Vec<String>` | Default names "Filter0", "Filter1", ... or from config |
+| Position | `Option<usize>` | `None` = moving (actual != target), `Some(n)` = at position |
+| SetPosition | `usize` | Validates range, sends to SDK, caches target |
+
+## Camera State Machine
+
+```
+                    start_exposure()
+        Idle ─────────────────────────> Exposing
+         ^                                  │
+         │                                  │
+         │  abort_exposure() ───────────────┤
+         │  (via oneshot channel)           │
+         │                                  │
+         │         exposure completes       │
+         └──────────────────────────────────┘
+               (image stored, state → Idle)
+```
+
+**Exposure lifecycle:**
+1. `start_exposure()` validates ROI, sets SDK parameters, transitions to Exposing state
+2. A background `tokio::spawn` task runs the blocking SDK calls:
+   - `start_single_frame_exposure()` (blocking)
+   - Check for abort signal
+   - `get_image_size()` (blocking)
+   - Check for abort signal
+   - `get_single_frame(buffer_size)` (blocking)
+   - Transform and store image
+3. On abort: sends signal via `oneshot` channel, exposure task calls `abort_exposure_and_readout()` and completes data exchange for SDK synchronization
+4. On completion: image stored in `last_image`, state returns to Idle
+
+## Image Processing Pipeline
+
+Raw bytes from `get_single_frame()` → `transform_image_static()`:
+1. Validate data length matches width × height × bytes_per_pixel
+2. For 8-bit: interpret as `Vec<u8>`, reshape to `Array3<u8>(height, width, 1)`
+3. For 16-bit: convert byte pairs to `u16` (native endian), reshape to `Array3<u16>(height, width, 1)`
+4. Swap axes 0↔1 to get `(width, height, 1)` — ASCOM expects column-major image layout
+5. Convert to `ImageArray`
+
+## Configuration
+
+```json
+{
+  "server": {
+    "port": 11116
+  },
+  "cameras": [
+    {
+      "unique_id": "QHY600M-abc123",
+      "name": "QHY600M Main Camera",
+      "description": "QHYCCD QHY600M cooled CMOS camera",
+      "device_number": 0,
+      "enabled": true
+    }
+  ],
+  "filter_wheels": [
+    {
+      "unique_id": "CFW=QHY600M-abc123",
+      "name": "QHYCCD Filter Wheel",
+      "description": "QHYCCD CFW3 filter wheel",
+      "device_number": 0,
+      "enabled": true,
+      "filter_names": ["L", "R", "G", "B", "Ha", "OIII", "SII"]
+    }
+  ]
+}
+```
+
+### CLI Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `-c, --config` | Path to configuration file |
+| `--server-port` | Server port (overrides config) |
+| `-l, --log-level` | Log level: trace, debug, info, warn, error |
+
+## Module Structure
+
+| Module | Description |
+|--------|-------------|
+| `config.rs` | Configuration types and loading |
+| `error.rs` | Error types with ASCOM error mapping |
+| `io.rs` | SDK trait abstractions (SdkProvider, CameraHandle, FilterWheelHandle) |
+| `camera_device.rs` | ASCOM Device + Camera trait implementation |
+| `filter_wheel_device.rs` | ASCOM Device + FilterWheel trait implementation |
+| `mock.rs` | Mock SDK implementation (feature-gated) |
+| `lib.rs` | Module declarations, ServerBuilder |
+| `main.rs` | CLI entry point |
+
+## Testing
+
+- **BDD tests** (cucumber-rs): Connection lifecycle, camera properties, exposure control, filter wheel control — all using mock SDK infrastructure
+- **Unit tests**: Image transformation, config defaults, error types
+- **Server tests**: Server startup with mock feature (`test_lib.rs`, feature-gated)
+- **ConformU**: ASCOM Alpaca compliance testing (using `simulation` feature, requires ConformU)
+
+```bash
+# Run all tests
+cargo test -p qhy-camera --quiet
+
+# Run BDD tests specifically
+cargo test -p qhy-camera --test bdd
+
+# Run with mock feature (for server tests)
+cargo test -p qhy-camera --features mock
+
+# Run ConformU compliance tests
+cargo test -p qhy-camera --features simulation --test conformu_integration -- --ignored
+
+# Run in mock mode
+cargo run -p qhy-camera --features mock
+```
+
+## Connection Lifecycle
+
+### Camera
+1. ASCOM client calls `set_connected(true)`
+2. SDK opens camera device
+3. Verify SingleFrameMode is available
+4. Set stream mode to SingleFrameMode
+5. Set default readout mode (0)
+6. Initialize camera (`init()`)
+7. Set transfer bit depth to 16-bit
+8. Cache CCD info (chip dimensions, pixel sizes)
+9. Cache effective area as initial ROI
+10. Detect and cache valid binning modes
+11. Cache readout speed min/max/step (if available)
+12. Cache exposure min/max/step
+13. Cache gain min/max (if available)
+14. Cache offset min/max (if available)
+
+### Filter Wheel
+1. ASCOM client calls `set_connected(true)`
+2. SDK opens filter wheel device
+3. Query and cache number of filters
+4. Query and cache current position
+
+## MVP Scope
+
+**In scope:**
+- Camera: connect, disconnect, single-frame exposure with async abort, image retrieval, gain/offset, binning, ROI, CCD info, exposure limits, cooler control, sensor type, Bayer info, readout modes, fast readout
+- FilterWheel: connect, disconnect, position get/set with moving state (`None`), filter count, filter names, focus offsets
+- JSON configuration file
+- Feature-gated mock for testing
+- BDD tests + unit tests
+- `simulation` feature for ConformU integration tests
+
+**Deferred:**
+- Live/video mode, dark frames, pulse guiding
+- Multi-camera management (SDK enumeration)
+- Camera-attached filter wheel access
+- Real `qhyccd-rs` SDK adapter (the `sdk` feature implementation is a separate PR)
+
+## References
+
+- **qhyccd-rs**: [crates.io/crates/qhyccd-rs](https://crates.io/crates/qhyccd-rs) — Rust bindings for QHYCCD SDK
+- **qhyccd-alpaca**: [github.com/ivonnyssen/qhyccd-alpaca](https://github.com/ivonnyssen/qhyccd-alpaca) — Upstream standalone driver (source for this port)
+- **QHYCCD SDK**: [qhyccd.com/html/prepub/log_en.html](https://www.qhyccd.com/html/prepub/log_en.html) — Official SDK

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -22,7 +22,7 @@ Unlike `qhy-focuser` which uses serial communication, this service uses the QHYC
 
 - **Connection**: USB (via libusb / QHYCCD C SDK)
 - **SDK dependency**: Requires QHYCCD SDK installed at system level (headers + shared library)
-- **Platform**: Linux only (QHYCCD SDK is Linux-only for this project)
+- **Platform**: Linux, macOS, and Windows (SDK available for all three via `ivonnyssen/qhyccd-sdk-install`)
 - **Stream mode**: Single-frame mode only (live/video mode is deferred)
 - **Binning**: Symmetric only (bin_x == bin_y), mode depends on camera model (1x1, 2x2, 3x3, 4x4, 6x6, 8x8)
 - **Filter wheel**: USB filter wheel accessed via same SDK, position changes are asynchronous

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -14,6 +14,7 @@ belong in any single service design doc.
 | [phd2-guider](services/phd2-guider.md) | — (client library) | — | `docs/services/phd2-guider.md` |
 | [sentinel](services/sentinel.md) | — (monitoring service) | 11114 | `docs/services/sentinel.md` |
 | [rp](services/rp.md) | — (orchestrator) | 11115 | `docs/services/rp.md` |
+| [qhy-camera](services/qhy-camera.md) | Camera + FilterWheel | 11116 | `docs/services/qhy-camera.md` |
 | sentinel-app | — (Leptos web frontend for sentinel) | — | — |
 
 ## Documentation Index
@@ -62,7 +63,7 @@ main.rs        — Entry point
 | Service | rust-version |
 |---------|-------------|
 | phd2-guider | 1.85.0 |
-| filemonitor, ppba-driver, qhy-focuser, rp, sentinel, sentinel-app | 1.88.0 |
+| filemonitor, ppba-driver, qhy-camera, qhy-focuser, rp, sentinel, sentinel-app | 1.88.0 |
 
 ## Workspace Dependencies
 

--- a/services/qhy-camera/Cargo.toml
+++ b/services/qhy-camera/Cargo.toml
@@ -28,7 +28,7 @@ educe = "0.6"
 qhyccd-rs = "0.1.9"
 
 [package.metadata.conformu]
-command = "cargo test -p qhy-camera --features simulation --test conformu_integration -- --ignored --nocapture"
+command = "cargo test -p qhy-camera --features mock --test conformu_integration -- --ignored --nocapture"
 
 [package.metadata.miri]
 command = "cargo miri test -p qhy-camera"

--- a/services/qhy-camera/Cargo.toml
+++ b/services/qhy-camera/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "qhy-camera"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version = "1.88.0"
+description = "ASCOM Alpaca driver for QHYCCD cameras and filter wheels"
+
+[features]
+default = []
+mock = []  # Enables mock SDK for testing without real hardware
+simulation = ["qhyccd-rs/simulation"]  # QHYCCD SDK simulation mode for ConformU
+
+[dependencies]
+ascom-alpaca = { workspace = true, features = ["server", "camera", "filter_wheel", "test"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }
+ndarray = "0.17"
+educe = "0.6"
+qhyccd-rs = "0.1.9"
+
+[package.metadata.conformu]
+command = "cargo test -p qhy-camera --features simulation --test conformu_integration -- --ignored --nocapture"
+
+[package.metadata.miri]
+command = "cargo miri test -p qhy-camera"
+
+[dev-dependencies]
+tokio-test = { workspace = true }
+mockall = { workspace = true }
+proptest = { workspace = true }
+reqwest = { workspace = true }
+cucumber = { workspace = true }
+tempfile = { workspace = true }
+cargo-husky = { workspace = true }
+
+[[test]]
+name = "bdd"
+harness = false

--- a/services/qhy-camera/pkg/config.json
+++ b/services/qhy-camera/pkg/config.json
@@ -1,0 +1,24 @@
+{
+  "server": {
+    "port": 11116
+  },
+  "cameras": [
+    {
+      "unique_id": "QHY600M-abc123",
+      "name": "QHY600M Main Camera",
+      "description": "QHYCCD QHY600M cooled CMOS camera",
+      "device_number": 0,
+      "enabled": true
+    }
+  ],
+  "filter_wheels": [
+    {
+      "unique_id": "CFW=QHY600M-abc123",
+      "name": "QHYCCD Filter Wheel",
+      "description": "QHYCCD CFW3 filter wheel",
+      "device_number": 0,
+      "enabled": true,
+      "filter_names": ["L", "R", "G", "B", "Ha", "OIII", "SII"]
+    }
+  ]
+}

--- a/services/qhy-camera/src/camera_device.rs
+++ b/services/qhy-camera/src/camera_device.rs
@@ -1,0 +1,1145 @@
+//! QHY Camera device implementation
+//!
+//! Implements the ASCOM Alpaca Device and Camera traits for QHYCCD cameras.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use ascom_alpaca::api::camera::{CameraState, ImageArray, SensorType};
+use ascom_alpaca::api::{Camera, Device};
+use ascom_alpaca::{ASCOMError, ASCOMResult};
+use async_trait::async_trait;
+use educe::Educe;
+use ndarray::Array3;
+use tokio::sync::{oneshot, watch, RwLock};
+use tokio::task;
+use tracing::{debug, error};
+
+use crate::config::CameraConfig;
+use crate::io::{BayerMode, CameraHandle, CcdChipArea, Control, ImageData, StreamMode};
+
+/// Signal to stop an in-progress exposure
+#[derive(Debug)]
+struct StopExposure {
+    _want_image: bool,
+}
+
+/// Camera exposure state machine
+#[derive(Educe)]
+#[educe(Debug, PartialEq)]
+enum State {
+    Idle,
+    Exposing {
+        start: SystemTime,
+        expected_duration_us: u32,
+        #[educe(PartialEq(ignore))]
+        stop_tx: Option<oneshot::Sender<StopExposure>>,
+        #[educe(PartialEq(ignore))]
+        done_rx: watch::Receiver<bool>,
+    },
+}
+
+/// Guard macro that returns NOT_CONNECTED if the device is not connected.
+macro_rules! ensure_connected {
+    ($self:ident) => {
+        if !$self.connected().await.is_ok_and(|connected| connected) {
+            debug!("Camera device not connected");
+            return Err(ASCOMError::NOT_CONNECTED);
+        }
+    };
+}
+
+/// QHY Camera device for ASCOM Alpaca
+pub struct QhyccdCamera {
+    config: CameraConfig,
+    device: Box<dyn CameraHandle>,
+    binning: RwLock<u8>,
+    valid_bins: RwLock<Option<Vec<u8>>>,
+    target_temperature: RwLock<Option<f64>>,
+    ccd_info: RwLock<Option<crate::io::CcdChipInfo>>,
+    intended_roi: RwLock<Option<CcdChipArea>>,
+    readout_speed_min_max_step: RwLock<Option<(f64, f64, f64)>>,
+    exposure_min_max_step: RwLock<Option<(f64, f64, f64)>>,
+    last_exposure_start_time: RwLock<Option<SystemTime>>,
+    last_exposure_duration_us: RwLock<Option<u32>>,
+    last_image: Arc<RwLock<Option<ImageArray>>>,
+    state: Arc<RwLock<State>>,
+    gain_min_max: RwLock<Option<(f64, f64)>>,
+    offset_min_max: RwLock<Option<(f64, f64)>>,
+}
+
+impl std::fmt::Debug for QhyccdCamera {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QhyccdCamera")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl QhyccdCamera {
+    /// Create a new QHY Camera device
+    pub fn new(config: CameraConfig, device: Box<dyn CameraHandle>) -> Self {
+        Self {
+            config,
+            device,
+            binning: RwLock::new(1_u8),
+            valid_bins: RwLock::new(None),
+            target_temperature: RwLock::new(None),
+            ccd_info: RwLock::new(None),
+            intended_roi: RwLock::new(None),
+            readout_speed_min_max_step: RwLock::new(None),
+            exposure_min_max_step: RwLock::new(None),
+            last_exposure_start_time: RwLock::new(None),
+            last_exposure_duration_us: RwLock::new(None),
+            last_image: Arc::new(RwLock::new(None)),
+            state: Arc::new(RwLock::new(State::Idle)),
+            gain_min_max: RwLock::new(None),
+            offset_min_max: RwLock::new(None),
+        }
+    }
+
+    fn get_valid_binning_modes(&self) -> Vec<u8> {
+        let mut modes = Vec::with_capacity(6);
+        let checks = [
+            (Control::CamBin1x1mode, 1_u8),
+            (Control::CamBin2x2mode, 2_u8),
+            (Control::CamBin3x3mode, 3_u8),
+            (Control::CamBin4x4mode, 4_u8),
+            (Control::CamBin6x6mode, 6_u8),
+            (Control::CamBin8x8mode, 8_u8),
+        ];
+        for (control, bin) in checks {
+            if self.device.is_control_available(control).is_some() {
+                modes.push(bin);
+            }
+        }
+        modes
+    }
+
+    /// Transform raw SDK image data into an ASCOM ImageArray
+    pub fn transform_image_static(image: ImageData) -> crate::error::Result<ImageArray> {
+        match image.channels {
+            1 => match image.bits_per_pixel {
+                8 => {
+                    let expected = image.width as usize * image.height as usize;
+                    if expected > image.data.len() {
+                        return Err(crate::error::QhyCameraError::ImageTransform(format!(
+                            "data length ({}) < width ({}) * height ({})",
+                            image.data.len(),
+                            image.width,
+                            image.height
+                        )));
+                    }
+                    let data: Vec<u8> = image.data[..expected].to_vec();
+                    let array = Array3::from_shape_vec(
+                        (image.height as usize, image.width as usize, 1),
+                        data,
+                    )
+                    .map_err(|e| crate::error::QhyCameraError::ImageTransform(e.to_string()))?;
+                    let mut swapped = array;
+                    swapped.swap_axes(0, 1);
+                    Ok(swapped.into())
+                }
+                16 => {
+                    let expected = image.width as usize * image.height as usize * 2;
+                    if expected > image.data.len() {
+                        return Err(crate::error::QhyCameraError::ImageTransform(format!(
+                            "data length ({}) < width ({}) * height ({}) * 2",
+                            image.data.len(),
+                            image.width,
+                            image.height
+                        )));
+                    }
+                    let data: Vec<u16> = image.data[..expected]
+                        .chunks_exact(2)
+                        .map(|a| u16::from_ne_bytes([a[0], a[1]]))
+                        .collect();
+                    let array = Array3::from_shape_vec(
+                        (image.height as usize, image.width as usize, 1),
+                        data,
+                    )
+                    .map_err(|e| crate::error::QhyCameraError::ImageTransform(e.to_string()))?;
+                    let mut swapped = array;
+                    swapped.swap_axes(0, 1);
+                    Ok(swapped.into())
+                }
+                other => Err(crate::error::QhyCameraError::ImageTransform(format!(
+                    "unsupported bits_per_pixel: {}",
+                    other
+                ))),
+            },
+            other => Err(crate::error::QhyCameraError::ImageTransform(format!(
+                "unsupported number of channels: {}",
+                other
+            ))),
+        }
+    }
+
+    async fn connect_camera(&self) -> ASCOMResult<()> {
+        self.device.open().map_err(|e| {
+            error!("open failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })?;
+        self.device
+            .is_control_available(Control::CamSingleFrameMode)
+            .ok_or_else(|| {
+                error!("SingleFrameMode is not available");
+                ASCOMError::NOT_CONNECTED
+            })?;
+        self.device
+            .set_stream_mode(StreamMode::SingleFrameMode)
+            .map_err(|e| {
+                error!("setting StreamMode to SingleFrameMode failed: {}", e);
+                ASCOMError::NOT_CONNECTED
+            })?;
+        self.device.set_readout_mode(0).map_err(|e| {
+            error!("setting readout mode to 0 failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })?;
+        self.device.init().map_err(|e| {
+            error!("camera init failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })?;
+        self.device
+            .set_if_available(Control::TransferBit, 16_f64)
+            .map_err(|e| {
+                error!("setting transfer bits failed: {}", e);
+                ASCOMError::NOT_CONNECTED
+            })?;
+        debug!("transfer bit set to 16");
+
+        // Cache CCD info
+        let info = self.device.get_ccd_info().map_err(|e| {
+            error!("get_ccd_info failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })?;
+        *self.ccd_info.write().await = Some(info);
+
+        // Cache effective area as initial ROI
+        let area = self.device.get_effective_area().map_err(|e| {
+            error!("get_effective_area failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })?;
+        *self.intended_roi.write().await = Some(area);
+
+        // Cache valid binning modes
+        *self.valid_bins.write().await = Some(self.get_valid_binning_modes());
+
+        // Cache readout speed range if available
+        if self.device.is_control_available(Control::Speed).is_some() {
+            match self.device.get_parameter_min_max_step(Control::Speed) {
+                Ok(mms) => *self.readout_speed_min_max_step.write().await = Some(mms),
+                Err(e) => {
+                    error!("get_readout_speed_min_max_step failed: {}", e);
+                    return Err(ASCOMError::NOT_CONNECTED);
+                }
+            }
+        } else {
+            debug!("readout_speed control not available");
+        }
+
+        // Cache exposure range
+        let exposure_mms = self
+            .device
+            .get_parameter_min_max_step(Control::Exposure)
+            .map_err(|e| {
+                error!("get_exposure_min_max_step failed: {}", e);
+                ASCOMError::NOT_CONNECTED
+            })?;
+        *self.exposure_min_max_step.write().await = Some(exposure_mms);
+
+        // Cache gain range if available
+        if self.device.is_control_available(Control::Gain).is_some() {
+            match self.device.get_parameter_min_max_step(Control::Gain) {
+                Ok((min, max, _step)) => *self.gain_min_max.write().await = Some((min, max)),
+                Err(e) => {
+                    error!("get_gain_min_max failed: {}", e);
+                    return Err(ASCOMError::NOT_CONNECTED);
+                }
+            }
+        } else {
+            debug!("gain control not available");
+        }
+
+        // Cache offset range if available
+        if self.device.is_control_available(Control::Offset).is_some() {
+            match self.device.get_parameter_min_max_step(Control::Offset) {
+                Ok((min, max, _step)) => *self.offset_min_max.write().await = Some((min, max)),
+                Err(e) => {
+                    error!("get_offset_min_max failed: {}", e);
+                    return Err(ASCOMError::NOT_CONNECTED);
+                }
+            }
+        } else {
+            debug!("offset control not available");
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Device for QhyccdCamera {
+    fn static_name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn unique_id(&self) -> &str {
+        &self.config.unique_id
+    }
+
+    async fn connected(&self) -> ASCOMResult<bool> {
+        self.device.is_open().map_err(|e| {
+            error!("is_open failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })
+    }
+
+    async fn set_connected(&self, connected: bool) -> ASCOMResult<()> {
+        if self.connected().await? == connected {
+            return Ok(());
+        }
+        match connected {
+            true => self.connect_camera().await,
+            false => self.device.close().map_err(|e| {
+                error!("close failed: {}", e);
+                ASCOMError::NOT_CONNECTED
+            }),
+        }
+    }
+
+    async fn description(&self) -> ASCOMResult<String> {
+        Ok(self.config.description.clone())
+    }
+
+    async fn driver_info(&self) -> ASCOMResult<String> {
+        Ok("QHY Camera Driver - ASCOM Alpaca interface for QHYCCD cameras".to_string())
+    }
+
+    async fn driver_version(&self) -> ASCOMResult<String> {
+        Ok(env!("CARGO_PKG_VERSION").to_string())
+    }
+}
+
+#[async_trait]
+impl Camera for QhyccdCamera {
+    async fn bayer_offset_x(&self) -> ASCOMResult<u8> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::CamIsColor)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let bayer_id = self
+            .device
+            .is_control_available(Control::CamColor)
+            .ok_or(ASCOMError::INVALID_VALUE)?;
+        match BayerMode::try_from(bayer_id) {
+            Ok(BayerMode::GBRG | BayerMode::RGGB) => Ok(0),
+            Ok(BayerMode::GRBG | BayerMode::BGGR) => Ok(1),
+            Err(_) => Err(ASCOMError::INVALID_VALUE),
+        }
+    }
+
+    async fn bayer_offset_y(&self) -> ASCOMResult<u8> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::CamIsColor)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let bayer_id = self
+            .device
+            .is_control_available(Control::CamColor)
+            .ok_or(ASCOMError::INVALID_VALUE)?;
+        match BayerMode::try_from(bayer_id) {
+            Ok(BayerMode::GBRG | BayerMode::BGGR) => Ok(1),
+            Ok(BayerMode::GRBG | BayerMode::RGGB) => Ok(0),
+            Err(_) => Err(ASCOMError::INVALID_VALUE),
+        }
+    }
+
+    async fn sensor_name(&self) -> ASCOMResult<String> {
+        ensure_connected!(self);
+        match self.unique_id().split('-').next() {
+            Some(model) => Ok(model.to_string()),
+            None => Err(ASCOMError::INVALID_OPERATION),
+        }
+    }
+
+    async fn bin_x(&self) -> ASCOMResult<u8> {
+        ensure_connected!(self);
+        Ok(*self.binning.read().await)
+    }
+
+    async fn set_bin_x(&self, bin_x: u8) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let valid_bins = self.valid_bins.read().await.clone().ok_or_else(|| {
+            error!("valid_bins not set");
+            ASCOMError::NOT_CONNECTED
+        })?;
+        valid_bins
+            .iter()
+            .find(|bin| **bin == bin_x)
+            .ok_or_else(|| ASCOMError::invalid_value("bin value must be one of the valid bins"))?;
+        let mut lock = self.binning.write().await;
+        if *lock == bin_x {
+            return Ok(());
+        }
+        self.device
+            .set_bin_mode(bin_x as u32, bin_x as u32)
+            .map_err(|e| {
+                error!("set_bin_mode failed: {}", e);
+                ASCOMError::VALUE_NOT_SET
+            })?;
+        let old = *lock;
+        *lock = bin_x;
+        let mut roi_lock = self.intended_roi.write().await;
+        *roi_lock = roi_lock.map(|roi| CcdChipArea {
+            start_x: (roi.start_x as f32 * old as f32 / bin_x as f32) as u32,
+            start_y: (roi.start_y as f32 * old as f32 / bin_x as f32) as u32,
+            width: (roi.width as f32 * old as f32 / bin_x as f32) as u32,
+            height: (roi.height as f32 * old as f32 / bin_x as f32) as u32,
+        });
+        Ok(())
+    }
+
+    async fn bin_y(&self) -> ASCOMResult<u8> {
+        self.bin_x().await
+    }
+
+    async fn set_bin_y(&self, bin_y: u8) -> ASCOMResult<()> {
+        self.set_bin_x(bin_y).await
+    }
+
+    async fn max_bin_x(&self) -> ASCOMResult<u8> {
+        ensure_connected!(self);
+        self.get_valid_binning_modes()
+            .iter()
+            .max()
+            .copied()
+            .ok_or(ASCOMError::INVALID_OPERATION)
+    }
+
+    async fn max_bin_y(&self) -> ASCOMResult<u8> {
+        self.max_bin_x().await
+    }
+
+    async fn camera_state(&self) -> ASCOMResult<CameraState> {
+        ensure_connected!(self);
+        match *self.state.read().await {
+            State::Idle => Ok(CameraState::Idle),
+            State::Exposing { .. } => Ok(CameraState::Exposing),
+        }
+    }
+
+    async fn exposure_max(&self) -> ASCOMResult<Duration> {
+        ensure_connected!(self);
+        match *self.exposure_min_max_step.read().await {
+            Some((_min, max, _step)) => Ok(Duration::from_micros(max as u64)),
+            None => Err(ASCOMError::INVALID_VALUE),
+        }
+    }
+
+    async fn exposure_min(&self) -> ASCOMResult<Duration> {
+        ensure_connected!(self);
+        match *self.exposure_min_max_step.read().await {
+            Some((min, _max, _step)) => Ok(Duration::from_micros(min as u64)),
+            None => Err(ASCOMError::INVALID_VALUE),
+        }
+    }
+
+    async fn exposure_resolution(&self) -> ASCOMResult<Duration> {
+        ensure_connected!(self);
+        match *self.exposure_min_max_step.read().await {
+            Some((_min, _max, step)) => Ok(Duration::from_micros(step as u64)),
+            None => Err(ASCOMError::INVALID_VALUE),
+        }
+    }
+
+    async fn has_shutter(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        Ok(self
+            .device
+            .is_control_available(Control::CamMechanicalShutter)
+            .is_some())
+    }
+
+    async fn image_array(&self) -> ASCOMResult<ImageArray> {
+        ensure_connected!(self);
+        self.last_image
+            .read()
+            .await
+            .clone()
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn image_ready(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        match *self.state.read().await {
+            State::Idle => Ok(self.last_image.read().await.is_some()),
+            State::Exposing { .. } => Ok(false),
+        }
+    }
+
+    async fn last_exposure_start_time(&self) -> ASCOMResult<SystemTime> {
+        ensure_connected!(self);
+        self.last_exposure_start_time
+            .read()
+            .await
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn last_exposure_duration(&self) -> ASCOMResult<Duration> {
+        ensure_connected!(self);
+        self.last_exposure_duration_us
+            .read()
+            .await
+            .map(|us| Duration::from_micros(us.into()))
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn max_adu(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.device
+            .get_parameter(Control::OutputDataActualBits)
+            .map(|bits| 2_u32.pow(bits as u32))
+            .map_err(|e| {
+                error!("could not get OutputDataActualBits: {}", e);
+                ASCOMError::VALUE_NOT_SET
+            })
+    }
+
+    async fn camera_x_size(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.ccd_info
+            .read()
+            .await
+            .map(|info| info.image_width)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn camera_y_size(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.ccd_info
+            .read()
+            .await
+            .map(|info| info.image_height)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn start_x(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.intended_roi
+            .read()
+            .await
+            .map(|roi| roi.start_x)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn set_start_x(&self, start_x: u32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let mut lock = self.intended_roi.write().await;
+        *lock = match *lock {
+            Some(roi) => Some(CcdChipArea { start_x, ..roi }),
+            None => return Err(ASCOMError::INVALID_VALUE),
+        };
+        Ok(())
+    }
+
+    async fn start_y(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.intended_roi
+            .read()
+            .await
+            .map(|roi| roi.start_y)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn set_start_y(&self, start_y: u32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let mut lock = self.intended_roi.write().await;
+        *lock = match *lock {
+            Some(roi) => Some(CcdChipArea { start_y, ..roi }),
+            None => return Err(ASCOMError::INVALID_VALUE),
+        };
+        Ok(())
+    }
+
+    async fn num_x(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.intended_roi
+            .read()
+            .await
+            .map(|roi| roi.width)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn set_num_x(&self, num_x: u32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let mut lock = self.intended_roi.write().await;
+        *lock = match *lock {
+            Some(roi) => Some(CcdChipArea {
+                width: num_x,
+                ..roi
+            }),
+            None => return Err(ASCOMError::INVALID_VALUE),
+        };
+        Ok(())
+    }
+
+    async fn num_y(&self) -> ASCOMResult<u32> {
+        ensure_connected!(self);
+        self.intended_roi
+            .read()
+            .await
+            .map(|roi| roi.height)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn set_num_y(&self, num_y: u32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let mut lock = self.intended_roi.write().await;
+        *lock = match *lock {
+            Some(roi) => Some(CcdChipArea {
+                height: num_y,
+                ..roi
+            }),
+            None => return Err(ASCOMError::INVALID_VALUE),
+        };
+        Ok(())
+    }
+
+    async fn percent_completed(&self) -> ASCOMResult<u8> {
+        ensure_connected!(self);
+        match *self.state.read().await {
+            State::Idle => Ok(100),
+            State::Exposing {
+                expected_duration_us,
+                ..
+            } => {
+                let remaining = self
+                    .device
+                    .get_remaining_exposure_us()
+                    .map_err(|_| ASCOMError::INVALID_OPERATION)?;
+                let pct = (100_f64 * remaining as f64 / expected_duration_us as f64) as u8;
+                Ok(pct.min(100))
+            }
+        }
+    }
+
+    async fn readout_mode(&self) -> ASCOMResult<usize> {
+        ensure_connected!(self);
+        self.device
+            .get_readout_mode()
+            .map(|m| m as usize)
+            .map_err(|e| {
+                error!("get_readout_mode failed: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn set_readout_mode(&self, readout_mode: usize) -> ASCOMResult<()> {
+        let readout_mode_u32 = readout_mode as u32;
+        ensure_connected!(self);
+        let number = self.device.get_number_of_readout_modes().map_err(|e| {
+            error!("get_number_of_readout_modes failed: {}", e);
+            ASCOMError::INVALID_VALUE
+        })?;
+        if !(0..number).contains(&readout_mode_u32) {
+            return Err(ASCOMError::INVALID_VALUE);
+        }
+        let (width, height) = self
+            .device
+            .get_readout_mode_resolution(readout_mode_u32)
+            .map_err(|e| {
+                error!("get_readout_mode_resolution failed: {}", e);
+                ASCOMError::INVALID_VALUE
+            })?;
+        self.device
+            .set_readout_mode(readout_mode_u32)
+            .map_err(|e| {
+                error!("set_readout_mode failed: {}", e);
+                ASCOMError::VALUE_NOT_SET
+            })?;
+        let mut lock = self.ccd_info.write().await;
+        *lock = lock.map(|ccd_info| crate::io::CcdChipInfo {
+            image_width: width,
+            image_height: height,
+            ..ccd_info
+        });
+        Ok(())
+    }
+
+    async fn readout_modes(&self) -> ASCOMResult<Vec<String>> {
+        ensure_connected!(self);
+        let number = self.device.get_number_of_readout_modes().map_err(|e| {
+            error!("get_number_of_readout_modes failed: {}", e);
+            ASCOMError::INVALID_OPERATION
+        })?;
+        let mut modes = Vec::with_capacity(number as usize);
+        for i in 0..number {
+            let name = self.device.get_readout_mode_name(i).map_err(|e| {
+                error!("get_readout_mode_name failed: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })?;
+            modes.push(name);
+        }
+        Ok(modes)
+    }
+
+    async fn sensor_type(&self) -> ASCOMResult<SensorType> {
+        ensure_connected!(self);
+        if self
+            .device
+            .is_control_available(Control::CamIsColor)
+            .is_none()
+        {
+            return Ok(SensorType::Monochrome);
+        }
+        self.device
+            .is_control_available(Control::CamColor)
+            .map(|_| SensorType::RGGB)
+            .ok_or(ASCOMError::INVALID_VALUE)
+    }
+
+    async fn start_exposure(&self, duration: Duration, light: bool) -> ASCOMResult<()> {
+        if !light {
+            return Err(ASCOMError::invalid_operation("dark frames not supported"));
+        }
+        ensure_connected!(self);
+
+        // Validate ROI
+        if self.start_x().await? > self.num_x().await? {
+            return Err(ASCOMError::invalid_value("StartX > NumX"));
+        }
+        if self.start_y().await? > self.num_y().await? {
+            return Err(ASCOMError::invalid_value("StartY > NumY"));
+        }
+        if self.num_x().await?
+            > (self.camera_x_size().await? as f32 / self.bin_x().await? as f32) as u32
+        {
+            return Err(ASCOMError::invalid_value("NumX > CameraXSize"));
+        }
+        if self.num_y().await?
+            > (self.camera_y_size().await? as f32 / self.bin_y().await? as f32) as u32
+        {
+            return Err(ASCOMError::invalid_value("NumY > CameraYSize"));
+        }
+
+        let Some(roi) = *self.intended_roi.read().await else {
+            return Err(ASCOMError::invalid_value("no ROI defined for camera"));
+        };
+        self.device.set_roi(roi).map_err(|e| {
+            debug!("failed to set ROI: {}", e);
+            ASCOMError::invalid_value("failed to set ROI")
+        })?;
+
+        let exposure_us = (duration.as_secs_f64() * 1_000_000_f64) as u32;
+        let (stop_tx, mut stop_rx) = oneshot::channel::<StopExposure>();
+        let (done_tx, done_rx) = watch::channel(false);
+
+        let mut lock = self.state.write().await;
+        *lock = match *lock {
+            State::Idle => State::Exposing {
+                start: SystemTime::now(),
+                expected_duration_us: exposure_us,
+                stop_tx: Some(stop_tx),
+                done_rx,
+            },
+            State::Exposing { .. } => {
+                return Err(ASCOMError::INVALID_OPERATION);
+            }
+        };
+        drop(lock);
+
+        *self.last_exposure_start_time.write().await = Some(SystemTime::now());
+        *self.last_exposure_duration_us.write().await = Some(exposure_us);
+
+        self.device
+            .set_parameter(Control::Exposure, exposure_us as f64)
+            .map_err(|e| {
+                error!("failed to set exposure time: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })?;
+
+        let device = self.device.clone_handle();
+        let device_for_abort = self.device.clone_handle();
+        let state = self.state.clone();
+        let last_image = self.last_image.clone();
+
+        tokio::spawn(async move {
+            debug!("exposure task started");
+
+            // Helper to handle abort and data exchange
+            let handle_abort = || async {
+                debug!("handling abort");
+                if device_for_abort.abort_exposure_and_readout().is_ok() {
+                    debug!("abort succeeded, completing data exchange");
+                    if let Ok(buffer_size) = device_for_abort.get_image_size() {
+                        if let Ok(image) = device_for_abort.get_single_frame(buffer_size) {
+                            if let Ok(transformed) = QhyccdCamera::transform_image_static(image) {
+                                *last_image.write().await = Some(transformed);
+                                debug!("aborted exposure data stored");
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Start exposure (blocking SDK call)
+            let start_result = task::spawn_blocking({
+                let device = device.clone_handle();
+                move || device.start_single_frame_exposure()
+            })
+            .await;
+
+            match start_result {
+                Ok(Ok(())) => {}
+                _ => {
+                    error!("start exposure failed");
+                    *state.write().await = State::Idle;
+                    return;
+                }
+            }
+
+            // Check for abort
+            if stop_rx.try_recv().is_ok() {
+                handle_abort().await;
+                *state.write().await = State::Idle;
+                return;
+            }
+
+            // Get image size (blocking)
+            let size_result = task::spawn_blocking({
+                let device = device.clone_handle();
+                move || device.get_image_size()
+            })
+            .await;
+
+            let buffer_size = match size_result {
+                Ok(Ok(size)) => size,
+                _ => {
+                    error!("get_image_size failed");
+                    *state.write().await = State::Idle;
+                    return;
+                }
+            };
+
+            // Check for abort
+            if stop_rx.try_recv().is_ok() {
+                handle_abort().await;
+                *state.write().await = State::Idle;
+                return;
+            }
+
+            // Get single frame (blocking)
+            let image_result = task::spawn_blocking({
+                let device = device.clone_handle();
+                move || device.get_single_frame(buffer_size)
+            })
+            .await;
+
+            let image = match image_result {
+                Ok(Ok(img)) => img,
+                _ => {
+                    error!("get_single_frame failed");
+                    *state.write().await = State::Idle;
+                    return;
+                }
+            };
+
+            // Transform and store
+            match QhyccdCamera::transform_image_static(image) {
+                Ok(transformed) => {
+                    *last_image.write().await = Some(transformed);
+                    let _ = done_tx.send(true);
+                    debug!("exposure completed successfully");
+                }
+                Err(e) => error!("failed to transform image: {}", e),
+            }
+
+            *state.write().await = State::Idle;
+        });
+
+        Ok(())
+    }
+
+    async fn can_stop_exposure(&self) -> ASCOMResult<bool> {
+        Ok(false)
+    }
+
+    async fn can_abort_exposure(&self) -> ASCOMResult<bool> {
+        Ok(true)
+    }
+
+    async fn abort_exposure(&self) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let mut state_lock = self.state.write().await;
+        match &mut *state_lock {
+            State::Exposing { stop_tx, .. } => {
+                if let Some(tx) = stop_tx.take() {
+                    let _ = tx.send(StopExposure { _want_image: false });
+                    Ok(())
+                } else {
+                    Err(ASCOMError::INVALID_OPERATION)
+                }
+            }
+            State::Idle => Ok(()),
+        }
+    }
+
+    async fn pixel_size_x(&self) -> ASCOMResult<f64> {
+        ensure_connected!(self);
+        self.ccd_info
+            .read()
+            .await
+            .map(|info| info.pixel_width)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn pixel_size_y(&self) -> ASCOMResult<f64> {
+        ensure_connected!(self);
+        self.ccd_info
+            .read()
+            .await
+            .map(|info| info.pixel_height)
+            .ok_or(ASCOMError::VALUE_NOT_SET)
+    }
+
+    async fn can_get_cooler_power(&self) -> ASCOMResult<bool> {
+        self.can_set_ccd_temperature().await
+    }
+
+    async fn can_set_ccd_temperature(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        Ok(self.device.is_control_available(Control::Cooler).is_some())
+    }
+
+    async fn ccd_temperature(&self) -> ASCOMResult<f64> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Cooler)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        self.device.get_parameter(Control::CurTemp).map_err(|e| {
+            error!("could not get current temperature: {}", e);
+            ASCOMError::INVALID_VALUE
+        })
+    }
+
+    async fn set_ccd_temperature(&self) -> ASCOMResult<f64> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Cooler)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        match *self.target_temperature.read().await {
+            Some(temp) => Ok(temp),
+            None => self.ccd_temperature().await,
+        }
+    }
+
+    async fn set_set_ccd_temperature(&self, set_ccd_temperature: f64) -> ASCOMResult<()> {
+        if !(-273.15..=80_f64).contains(&set_ccd_temperature) {
+            return Err(ASCOMError::INVALID_VALUE);
+        }
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Cooler)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        self.device
+            .set_parameter(Control::Cooler, set_ccd_temperature)
+            .map_err(|e| {
+                error!("could not set target temperature: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })?;
+        *self.target_temperature.write().await = Some(set_ccd_temperature);
+        Ok(())
+    }
+
+    async fn cooler_on(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Cooler)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let power = self.device.get_parameter(Control::CurPWM).map_err(|e| {
+            error!("could not get current power: {}", e);
+            ASCOMError::INVALID_VALUE
+        })?;
+        Ok(power > 0_f64)
+    }
+
+    async fn set_cooler_on(&self, cooler_on: bool) -> ASCOMResult<()> {
+        if self.cooler_on().await? == cooler_on {
+            return Ok(());
+        }
+        let value = if cooler_on {
+            1_f64 / 100_f64 * 255_f64
+        } else {
+            0_f64
+        };
+        self.device
+            .set_parameter(Control::ManualPWM, value)
+            .map_err(|e| {
+                error!("error setting cooler power: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn cooler_power(&self) -> ASCOMResult<f64> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Cooler)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        self.device
+            .get_parameter(Control::CurPWM)
+            .map(|pwm| pwm / 255_f64 * 100_f64)
+            .map_err(|e| {
+                error!("could not get cooler power: {}", e);
+                ASCOMError::INVALID_VALUE
+            })
+    }
+
+    async fn gain(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Gain)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        self.device
+            .get_parameter(Control::Gain)
+            .map(|g| g as i32)
+            .map_err(|e| {
+                error!("failed to get gain: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn set_gain(&self, gain: i32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Gain)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let (min, max) = self
+            .gain_min_max
+            .read()
+            .await
+            .ok_or(ASCOMError::INVALID_OPERATION)?;
+        if !(min as i32..=max as i32).contains(&gain) {
+            return Err(ASCOMError::INVALID_VALUE);
+        }
+        self.device
+            .set_parameter(Control::Gain, gain as f64)
+            .map_err(|e| {
+                error!("failed to set gain: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn gain_max(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.gain_min_max
+            .read()
+            .await
+            .map(|(_, max)| max as i32)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)
+    }
+
+    async fn gain_min(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.gain_min_max
+            .read()
+            .await
+            .map(|(min, _)| min as i32)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)
+    }
+
+    async fn offset(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Offset)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        self.device
+            .get_parameter(Control::Offset)
+            .map(|o| o as i32)
+            .map_err(|e| {
+                error!("failed to get offset: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn set_offset(&self, offset: i32) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Offset)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let (min, max) = self
+            .offset_min_max
+            .read()
+            .await
+            .ok_or(ASCOMError::INVALID_OPERATION)?;
+        if !(min as i32..=max as i32).contains(&offset) {
+            return Err(ASCOMError::INVALID_VALUE);
+        }
+        self.device
+            .set_parameter(Control::Offset, offset as f64)
+            .map_err(|e| {
+                error!("failed to set offset: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+
+    async fn offset_max(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.offset_min_max
+            .read()
+            .await
+            .map(|(_, max)| max as i32)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)
+    }
+
+    async fn offset_min(&self) -> ASCOMResult<i32> {
+        ensure_connected!(self);
+        self.offset_min_max
+            .read()
+            .await
+            .map(|(min, _)| min as i32)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)
+    }
+
+    async fn can_fast_readout(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        Ok(self.device.is_control_available(Control::Speed).is_some()
+            && self.readout_speed_min_max_step.read().await.is_some())
+    }
+
+    async fn fast_readout(&self) -> ASCOMResult<bool> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Speed)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let speed = self.device.get_parameter(Control::Speed).map_err(|e| {
+            error!("failed to get speed: {}", e);
+            ASCOMError::INVALID_OPERATION
+        })?;
+        let (_min, max, _step) = self
+            .readout_speed_min_max_step
+            .read()
+            .await
+            .ok_or(ASCOMError::INVALID_OPERATION)?;
+        Ok((speed - max).abs() < f64::EPSILON)
+    }
+
+    async fn set_fast_readout(&self, fast_readout: bool) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        self.device
+            .is_control_available(Control::Speed)
+            .ok_or(ASCOMError::NOT_IMPLEMENTED)?;
+        let (min, max, _step) = self
+            .readout_speed_min_max_step
+            .read()
+            .await
+            .ok_or(ASCOMError::INVALID_OPERATION)?;
+        let speed = if fast_readout { max } else { min };
+        self.device
+            .set_parameter(Control::Speed, speed)
+            .map_err(|e| {
+                error!("failed to set speed: {}", e);
+                ASCOMError::INVALID_OPERATION
+            })
+    }
+}

--- a/services/qhy-camera/src/config.rs
+++ b/services/qhy-camera/src/config.rs
@@ -1,0 +1,90 @@
+//! Configuration types for the QHY Camera driver
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Main configuration structure
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Config {
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub cameras: Vec<CameraConfig>,
+    #[serde(default)]
+    pub filter_wheels: Vec<FilterWheelConfig>,
+}
+
+/// Server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+/// Camera device configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CameraConfig {
+    pub unique_id: String,
+    #[serde(default = "default_camera_name")]
+    pub name: String,
+    #[serde(default = "default_camera_description")]
+    pub description: String,
+    #[serde(default)]
+    pub device_number: u32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+/// Filter wheel device configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilterWheelConfig {
+    pub unique_id: String,
+    #[serde(default = "default_filter_wheel_name")]
+    pub name: String,
+    #[serde(default = "default_filter_wheel_description")]
+    pub description: String,
+    #[serde(default)]
+    pub device_number: u32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub filter_names: Vec<String>,
+}
+
+fn default_port() -> u16 {
+    11116
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_camera_name() -> String {
+    "QHYCCD Camera".to_string()
+}
+
+fn default_camera_description() -> String {
+    "QHYCCD camera via qhyccd-rs SDK".to_string()
+}
+
+fn default_filter_wheel_name() -> String {
+    "QHYCCD Filter Wheel".to_string()
+}
+
+fn default_filter_wheel_description() -> String {
+    "QHYCCD filter wheel via qhyccd-rs SDK".to_string()
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            port: default_port(),
+        }
+    }
+}
+
+/// Load configuration from a JSON file
+pub fn load_config(path: &PathBuf) -> std::result::Result<Config, Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string(path)?;
+    let config: Config = serde_json::from_str(&content)?;
+    Ok(config)
+}

--- a/services/qhy-camera/src/error.rs
+++ b/services/qhy-camera/src/error.rs
@@ -1,0 +1,46 @@
+//! Error types for the QHY Camera driver
+
+use ascom_alpaca::{ASCOMError, ASCOMErrorCode};
+
+/// Errors that can occur when interacting with QHYCCD cameras and filter wheels
+#[derive(Debug, thiserror::Error)]
+pub enum QhyCameraError {
+    #[error("Not connected to device")]
+    NotConnected,
+
+    #[error("SDK error: {0}")]
+    SdkError(String),
+
+    #[error("Image transform error: {0}")]
+    ImageTransform(String),
+
+    #[error("Invalid value: {0}")]
+    InvalidValue(String),
+
+    #[error("Control not available: {0}")]
+    ControlNotAvailable(String),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+impl QhyCameraError {
+    /// Convert this error to an ASCOM error
+    pub fn to_ascom_error(self) -> ASCOMError {
+        match self {
+            QhyCameraError::NotConnected => {
+                ASCOMError::new(ASCOMErrorCode::NOT_CONNECTED, self.to_string())
+            }
+            QhyCameraError::InvalidValue(_) => {
+                ASCOMError::new(ASCOMErrorCode::INVALID_VALUE, self.to_string())
+            }
+            QhyCameraError::ControlNotAvailable(_) => {
+                ASCOMError::new(ASCOMErrorCode::NOT_IMPLEMENTED, self.to_string())
+            }
+            _ => ASCOMError::invalid_operation(self.to_string()),
+        }
+    }
+}
+
+/// Result type alias for QHY Camera operations
+pub type Result<T> = std::result::Result<T, QhyCameraError>;

--- a/services/qhy-camera/src/filter_wheel_device.rs
+++ b/services/qhy-camera/src/filter_wheel_device.rs
@@ -1,0 +1,184 @@
+//! QHY FilterWheel device implementation
+//!
+//! Implements the ASCOM Alpaca Device and FilterWheel traits for QHYCCD filter wheels.
+
+use ascom_alpaca::api::{Device, FilterWheel};
+use ascom_alpaca::{ASCOMError, ASCOMResult};
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+use tracing::{debug, error};
+
+use crate::config::FilterWheelConfig;
+use crate::io::FilterWheelHandle;
+
+/// Guard macro that returns NOT_CONNECTED if the device is not connected.
+macro_rules! ensure_connected {
+    ($self:ident) => {
+        if !$self.connected().await.is_ok_and(|connected| connected) {
+            debug!("FilterWheel device not connected");
+            return Err(ASCOMError::NOT_CONNECTED);
+        }
+    };
+}
+
+/// QHY FilterWheel device for ASCOM Alpaca
+pub struct QhyccdFilterWheel {
+    config: FilterWheelConfig,
+    device: Box<dyn FilterWheelHandle>,
+    number_of_filters: RwLock<Option<u32>>,
+    target_position: RwLock<Option<u32>>,
+}
+
+impl std::fmt::Debug for QhyccdFilterWheel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QhyccdFilterWheel")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl QhyccdFilterWheel {
+    /// Create a new QHY FilterWheel device
+    pub fn new(config: FilterWheelConfig, device: Box<dyn FilterWheelHandle>) -> Self {
+        Self {
+            config,
+            device,
+            number_of_filters: RwLock::new(None),
+            target_position: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl Device for QhyccdFilterWheel {
+    fn static_name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn unique_id(&self) -> &str {
+        &self.config.unique_id
+    }
+
+    async fn connected(&self) -> ASCOMResult<bool> {
+        self.device.is_open().map_err(|e| {
+            error!("is_open failed: {}", e);
+            ASCOMError::NOT_CONNECTED
+        })
+    }
+
+    async fn set_connected(&self, connected: bool) -> ASCOMResult<()> {
+        if self.connected().await? == connected {
+            return Ok(());
+        }
+        match connected {
+            true => {
+                self.device.open().map_err(|e| {
+                    error!("open failed: {}", e);
+                    ASCOMError::NOT_CONNECTED
+                })?;
+                let num = self.device.get_number_of_filters().map_err(|e| {
+                    error!("get_number_of_filters failed: {}", e);
+                    ASCOMError::NOT_CONNECTED
+                })?;
+                *self.number_of_filters.write().await = Some(num);
+                let pos = self.device.get_fw_position().map_err(|e| {
+                    error!("get_fw_position failed: {}", e);
+                    ASCOMError::NOT_CONNECTED
+                })?;
+                *self.target_position.write().await = Some(pos);
+                debug!("FilterWheel connected: {} filters, position {}", num, pos);
+                Ok(())
+            }
+            false => {
+                self.device.close().map_err(|e| {
+                    error!("close failed: {}", e);
+                    ASCOMError::NOT_CONNECTED
+                })?;
+                *self.number_of_filters.write().await = None;
+                *self.target_position.write().await = None;
+                debug!("FilterWheel disconnected");
+                Ok(())
+            }
+        }
+    }
+
+    async fn description(&self) -> ASCOMResult<String> {
+        Ok(self.config.description.clone())
+    }
+
+    async fn driver_info(&self) -> ASCOMResult<String> {
+        Ok("QHY FilterWheel Driver - ASCOM Alpaca interface for QHYCCD filter wheels".to_string())
+    }
+
+    async fn driver_version(&self) -> ASCOMResult<String> {
+        Ok(env!("CARGO_PKG_VERSION").to_string())
+    }
+}
+
+#[async_trait]
+impl FilterWheel for QhyccdFilterWheel {
+    async fn focus_offsets(&self) -> ASCOMResult<Vec<i32>> {
+        ensure_connected!(self);
+        let Some(num) = *self.number_of_filters.read().await else {
+            return Err(ASCOMError::NOT_CONNECTED);
+        };
+        Ok(vec![0; num as usize])
+    }
+
+    async fn names(&self) -> ASCOMResult<Vec<String>> {
+        ensure_connected!(self);
+        let Some(num) = *self.number_of_filters.read().await else {
+            return Err(ASCOMError::NOT_CONNECTED);
+        };
+        if !self.config.filter_names.is_empty() {
+            let mut names = self.config.filter_names.clone();
+            names.resize(num as usize, String::new());
+            // Fill any missing names with defaults
+            for (i, name) in names.iter_mut().enumerate() {
+                if name.is_empty() {
+                    *name = format!("Filter{}", i);
+                }
+            }
+            Ok(names.into_iter().take(num as usize).collect())
+        } else {
+            Ok((0..num).map(|i| format!("Filter{}", i)).collect())
+        }
+    }
+
+    async fn position(&self) -> ASCOMResult<Option<usize>> {
+        ensure_connected!(self);
+        let Some(target) = *self.target_position.read().await else {
+            return Err(ASCOMError::NOT_CONNECTED);
+        };
+        let actual = self.device.get_fw_position().map_err(|e| {
+            error!("get_fw_position failed: {}", e);
+            ASCOMError::INVALID_OPERATION
+        })?;
+        if actual == target {
+            Ok(Some(actual as usize))
+        } else {
+            debug!("filter wheel moving: target={}, actual={}", target, actual);
+            Ok(None)
+        }
+    }
+
+    async fn set_position(&self, position: usize) -> ASCOMResult<()> {
+        ensure_connected!(self);
+        let Some(num) = *self.number_of_filters.read().await else {
+            return Err(ASCOMError::NOT_CONNECTED);
+        };
+        if !(0..num).contains(&(position as u32)) {
+            return Err(ASCOMError::INVALID_VALUE);
+        }
+        let mut lock = self.target_position.write().await;
+        if lock.is_some_and(|target| target == position as u32) {
+            return Ok(());
+        }
+        self.device.set_fw_position(position as u32).map_err(|e| {
+            error!("set_fw_position failed: {}", e);
+            ASCOMError::INVALID_OPERATION
+        })?;
+        *lock = Some(position as u32);
+        Ok(())
+    }
+}

--- a/services/qhy-camera/src/io.rs
+++ b/services/qhy-camera/src/io.rs
@@ -1,0 +1,219 @@
+//! SDK trait abstractions for QHYCCD cameras and filter wheels
+//!
+//! This module provides trait abstractions for the QHYCCD SDK operations.
+//! These traits enable mockall-based testing without requiring actual hardware.
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+
+// --- Local types mirroring qhyccd-rs ---
+
+/// CCD chip information (mirrors `qhyccd_rs::CCDChipInfo`)
+#[derive(Debug, Clone, Copy)]
+pub struct CcdChipInfo {
+    pub image_width: u32,
+    pub image_height: u32,
+    pub pixel_width: f64,
+    pub pixel_height: f64,
+    pub bits_per_pixel: u32,
+}
+
+/// CCD chip area / ROI (mirrors `qhyccd_rs::CCDChipArea`)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CcdChipArea {
+    pub start_x: u32,
+    pub start_y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Raw image data from the camera (mirrors `qhyccd_rs::ImageData`)
+#[derive(Debug, Clone)]
+pub struct ImageData {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub bits_per_pixel: u32,
+    pub channels: u32,
+}
+
+/// Camera control identifiers (mirrors `qhyccd_rs::Control`)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Control {
+    Gain,
+    Offset,
+    Exposure,
+    Speed,
+    TransferBit,
+    Cooler,
+    CurTemp,
+    CurPWM,
+    ManualPWM,
+    CamBin1x1mode,
+    CamBin2x2mode,
+    CamBin3x3mode,
+    CamBin4x4mode,
+    CamBin6x6mode,
+    CamBin8x8mode,
+    CamIsColor,
+    CamColor,
+    CamMechanicalShutter,
+    CamSingleFrameMode,
+    OutputDataActualBits,
+}
+
+/// Stream mode (mirrors `qhyccd_rs::StreamMode`)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamMode {
+    SingleFrameMode,
+}
+
+/// Bayer pattern mode (mirrors `qhyccd_rs::BayerMode`)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BayerMode {
+    GBRG,
+    GRBG,
+    BGGR,
+    RGGB,
+}
+
+impl TryFrom<f64> for BayerMode {
+    type Error = String;
+
+    fn try_from(value: f64) -> std::result::Result<Self, Self::Error> {
+        match value as u32 {
+            1 => Ok(BayerMode::GBRG),
+            2 => Ok(BayerMode::GRBG),
+            3 => Ok(BayerMode::BGGR),
+            4 => Ok(BayerMode::RGGB),
+            other => Err(format!("invalid bayer mode: {}", other)),
+        }
+    }
+}
+
+// --- SDK traits ---
+
+/// Trait for enumerating QHYCCD devices
+#[async_trait]
+#[cfg_attr(test, mockall::automock)]
+pub trait SdkProvider: Send + Sync {
+    /// List available camera IDs
+    fn camera_ids(&self) -> Result<Vec<String>>;
+
+    /// List available filter wheel IDs
+    fn filter_wheel_ids(&self) -> Result<Vec<String>>;
+
+    /// Create a camera handle for the given ID
+    fn open_camera(&self, id: &str) -> Result<Box<dyn CameraHandle>>;
+
+    /// Create a filter wheel handle for the given ID
+    fn open_filter_wheel(&self, id: &str) -> Result<Box<dyn FilterWheelHandle>>;
+}
+
+/// Trait abstracting QHYCCD Camera SDK operations
+#[cfg_attr(test, mockall::automock)]
+pub trait CameraHandle: Send + Sync {
+    /// Open the camera device
+    fn open(&self) -> Result<()>;
+
+    /// Close the camera device
+    fn close(&self) -> Result<()>;
+
+    /// Check if the camera is open
+    fn is_open(&self) -> Result<bool>;
+
+    /// Initialize the camera after setting stream/readout mode
+    fn init(&self) -> Result<()>;
+
+    /// Get CCD chip information
+    fn get_ccd_info(&self) -> Result<CcdChipInfo>;
+
+    /// Set stream mode
+    fn set_stream_mode(&self, mode: StreamMode) -> Result<()>;
+
+    /// Set readout mode by index
+    fn set_readout_mode(&self, mode: u32) -> Result<()>;
+
+    /// Get current readout mode index
+    fn get_readout_mode(&self) -> Result<u32>;
+
+    /// Get number of available readout modes
+    fn get_number_of_readout_modes(&self) -> Result<u32>;
+
+    /// Get the name of a readout mode by index
+    fn get_readout_mode_name(&self, index: u32) -> Result<String>;
+
+    /// Get the resolution for a readout mode by index
+    fn get_readout_mode_resolution(&self, index: u32) -> Result<(u32, u32)>;
+
+    /// Set binning mode (width, height)
+    fn set_bin_mode(&self, bin_x: u32, bin_y: u32) -> Result<()>;
+
+    /// Set the region of interest
+    fn set_roi(&self, roi: CcdChipArea) -> Result<()>;
+
+    /// Get the effective (usable) imaging area
+    fn get_effective_area(&self) -> Result<CcdChipArea>;
+
+    /// Check if a control is available. Returns `Some(value)` if available.
+    fn is_control_available(&self, control: Control) -> Option<f64>;
+
+    /// Get a control parameter value
+    fn get_parameter(&self, control: Control) -> Result<f64>;
+
+    /// Set a control parameter value
+    fn set_parameter(&self, control: Control, value: f64) -> Result<()>;
+
+    /// Set a control parameter if it is available (no error if not)
+    fn set_if_available(&self, control: Control, value: f64) -> Result<()>;
+
+    /// Get min, max, step for a control parameter
+    fn get_parameter_min_max_step(&self, control: Control) -> Result<(f64, f64, f64)>;
+
+    /// Start a single-frame exposure (blocking)
+    fn start_single_frame_exposure(&self) -> Result<()>;
+
+    /// Get the required buffer size for the image
+    fn get_image_size(&self) -> Result<usize>;
+
+    /// Get the captured single frame (blocking)
+    fn get_single_frame(&self, buffer_size: usize) -> Result<ImageData>;
+
+    /// Abort the current exposure and readout
+    fn abort_exposure_and_readout(&self) -> Result<()>;
+
+    /// Get remaining exposure time in microseconds
+    fn get_remaining_exposure_us(&self) -> Result<u32>;
+
+    /// Get the camera ID string
+    fn id(&self) -> &str;
+
+    /// Clone the handle (for passing to spawned tasks)
+    fn clone_handle(&self) -> Box<dyn CameraHandle>;
+}
+
+/// Trait abstracting QHYCCD FilterWheel SDK operations
+#[cfg_attr(test, mockall::automock)]
+pub trait FilterWheelHandle: Send + Sync {
+    /// Open the filter wheel device
+    fn open(&self) -> Result<()>;
+
+    /// Close the filter wheel device
+    fn close(&self) -> Result<()>;
+
+    /// Check if the filter wheel is open
+    fn is_open(&self) -> Result<bool>;
+
+    /// Get the number of filter positions
+    fn get_number_of_filters(&self) -> Result<u32>;
+
+    /// Get current filter wheel position
+    fn get_fw_position(&self) -> Result<u32>;
+
+    /// Set filter wheel position
+    fn set_fw_position(&self, position: u32) -> Result<()>;
+
+    /// Get the filter wheel ID string
+    fn id(&self) -> &str;
+}

--- a/services/qhy-camera/src/lib.rs
+++ b/services/qhy-camera/src/lib.rs
@@ -1,0 +1,94 @@
+//! QHY Camera Driver
+//!
+//! ASCOM Alpaca driver for QHYCCD cameras and filter wheels.
+//!
+//! This driver exposes ASCOM Camera and FilterWheel devices for controlling
+//! QHYCCD cameras via the qhyccd-rs SDK bindings.
+
+pub mod camera_device;
+pub mod config;
+pub mod error;
+pub mod filter_wheel_device;
+pub mod io;
+#[cfg(feature = "mock")]
+pub mod mock;
+
+pub use camera_device::QhyccdCamera;
+pub use config::{load_config, CameraConfig, Config, FilterWheelConfig, ServerConfig};
+pub use error::{QhyCameraError, Result};
+pub use filter_wheel_device::QhyccdFilterWheel;
+pub use io::{CameraHandle, FilterWheelHandle, SdkProvider};
+
+#[cfg(feature = "mock")]
+pub use mock::MockSdkProvider;
+
+use std::net::SocketAddr;
+
+use ascom_alpaca::api::CargoServerInfo;
+use ascom_alpaca::Server;
+use tracing::info;
+
+/// Builder for the ASCOM Alpaca server.
+///
+/// Configures camera and filter wheel devices, then binds the server.
+pub struct ServerBuilder {
+    config: Config,
+    sdk_provider: Box<dyn SdkProvider>,
+}
+
+impl ServerBuilder {
+    pub fn new(config: Config, sdk_provider: Box<dyn SdkProvider>) -> Self {
+        Self {
+            config,
+            sdk_provider,
+        }
+    }
+
+    pub async fn build(
+        self,
+    ) -> std::result::Result<ascom_alpaca::BoundServer, Box<dyn std::error::Error>> {
+        let mut server = Server::new(CargoServerInfo!());
+        server.listen_addr = SocketAddr::from(([0, 0, 0, 0], self.config.server.port));
+
+        // Register cameras
+        for cam_config in &self.config.cameras {
+            if !cam_config.enabled {
+                continue;
+            }
+            let handle = self
+                .sdk_provider
+                .open_camera(&cam_config.unique_id)
+                .map_err(|e| format!("Failed to open camera {}: {}", cam_config.unique_id, e))?;
+            let camera = QhyccdCamera::new(cam_config.clone(), handle);
+            server.devices.register(camera);
+            info!(
+                "Registered Camera: {} (device number {})",
+                cam_config.name, cam_config.device_number
+            );
+        }
+
+        // Register filter wheels
+        for fw_config in &self.config.filter_wheels {
+            if !fw_config.enabled {
+                continue;
+            }
+            let handle = self
+                .sdk_provider
+                .open_filter_wheel(&fw_config.unique_id)
+                .map_err(|e| {
+                    format!("Failed to open filter wheel {}: {}", fw_config.unique_id, e)
+                })?;
+            let filter_wheel = QhyccdFilterWheel::new(fw_config.clone(), handle);
+            server.devices.register(filter_wheel);
+            info!(
+                "Registered FilterWheel: {} (device number {})",
+                fw_config.name, fw_config.device_number
+            );
+        }
+
+        let bound = server.bind().await?;
+        println!("Bound Alpaca server bound_addr={}", bound.listen_addr());
+        info!("Bound Alpaca server bound_addr={}", bound.listen_addr());
+        Ok(bound)
+    }
+}

--- a/services/qhy-camera/src/main.rs
+++ b/services/qhy-camera/src/main.rs
@@ -1,0 +1,113 @@
+//! QHY Camera Driver CLI
+//!
+//! Command-line interface for the QHY Camera ASCOM Alpaca driver.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use tracing::Level;
+
+use qhy_camera::{load_config, Config};
+#[cfg(feature = "mock")]
+use qhy_camera::{MockSdkProvider, ServerBuilder};
+
+#[derive(Parser)]
+#[command(name = "qhy-camera")]
+#[command(about = "ASCOM Alpaca driver for QHYCCD cameras and filter wheels")]
+#[command(version)]
+struct Args {
+    /// Path to configuration file
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+
+    /// Server port (overrides config file)
+    #[arg(long)]
+    server_port: Option<u16>,
+
+    /// Log level
+    #[arg(short, long, default_value = "info", value_parser = parse_log_level)]
+    log_level: Level,
+}
+
+fn parse_log_level(s: &str) -> Result<Level, String> {
+    s.parse().map_err(|_| {
+        format!(
+            "Invalid log level: {}. Use: trace, debug, info, warn, error",
+            s
+        )
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(args.log_level)
+        .init();
+
+    tracing::debug!(
+        "Parsed command line arguments: config={:?}, server_port={:?}, log_level={:?}",
+        args.config,
+        args.server_port,
+        args.log_level
+    );
+
+    let mut config = if let Some(config_path) = &args.config {
+        tracing::debug!("Loading configuration from {:?}", config_path);
+        load_config(config_path)?
+    } else {
+        tracing::debug!("Using default configuration");
+        Config::default()
+    };
+
+    if let Some(server_port) = args.server_port {
+        config.server.port = server_port;
+    }
+
+    tracing::info!("Starting QHY Camera driver");
+    #[cfg(feature = "mock")]
+    tracing::info!("Running in MOCK MODE - no real hardware");
+    tracing::info!("Server port: {}", config.server.port);
+
+    #[cfg(feature = "mock")]
+    {
+        let provider = Box::new(MockSdkProvider);
+        // If no cameras configured, add a default mock camera and filter wheel
+        if config.cameras.is_empty() {
+            config.cameras.push(qhy_camera::CameraConfig {
+                unique_id: "QHY600M-mock001".to_string(),
+                name: "QHY600M Mock Camera".to_string(),
+                description: "Mock QHYCCD camera for testing".to_string(),
+                device_number: 0,
+                enabled: true,
+            });
+        }
+        if config.filter_wheels.is_empty() {
+            config.filter_wheels.push(qhy_camera::FilterWheelConfig {
+                unique_id: "CFW=QHY600M-mock001".to_string(),
+                name: "Mock Filter Wheel".to_string(),
+                description: "Mock QHYCCD filter wheel for testing".to_string(),
+                device_number: 0,
+                enabled: true,
+                filter_names: vec![],
+            });
+        }
+        ServerBuilder::new(config, provider)
+            .build()
+            .await?
+            .start()
+            .await?;
+    }
+
+    #[cfg(not(feature = "mock"))]
+    {
+        // Real SDK provider would be constructed here
+        // For now, this requires the actual qhyccd-rs SDK
+        let _ = config;
+        panic!("Real SDK provider not yet implemented. Use --features mock for testing.");
+    }
+
+    #[allow(unreachable_code)]
+    Ok(())
+}

--- a/services/qhy-camera/src/mock.rs
+++ b/services/qhy-camera/src/mock.rs
@@ -1,0 +1,454 @@
+//! Mock SDK implementation for testing
+//!
+//! This module provides mock implementations of the SDK traits that simulate
+//! QHYCCD camera and filter wheel behavior, allowing the driver to be tested
+//! without real hardware.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+use crate::error::{QhyCameraError, Result};
+use crate::io::{
+    CameraHandle, CcdChipArea, CcdChipInfo, Control, FilterWheelHandle, ImageData, SdkProvider,
+    StreamMode,
+};
+
+/// Simulated camera device state
+#[derive(Debug, Clone)]
+struct MockCameraState {
+    is_open: bool,
+    initialized: bool,
+    binning: u8,
+    roi: Option<CcdChipArea>,
+    gain: f64,
+    offset: f64,
+    speed: f64,
+    exposure_us: f64,
+    cooler_on: bool,
+    cooler_pwm: f64,
+    target_temp: f64,
+    current_temp: f64,
+    readout_mode: u32,
+}
+
+impl Default for MockCameraState {
+    fn default() -> Self {
+        Self {
+            is_open: false,
+            initialized: false,
+            binning: 1,
+            roi: None,
+            gain: 10.0,
+            offset: 50.0,
+            speed: 0.0,
+            exposure_us: 1_000_000.0,
+            cooler_on: false,
+            cooler_pwm: 0.0,
+            target_temp: 0.0,
+            current_temp: 20.0,
+            readout_mode: 0,
+        }
+    }
+}
+
+/// Mock camera handle for testing
+pub struct MockCameraHandle {
+    id: String,
+    state: Arc<Mutex<MockCameraState>>,
+}
+
+impl MockCameraHandle {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            state: Arc::new(Mutex::new(MockCameraState::default())),
+        }
+    }
+}
+
+impl CameraHandle for MockCameraHandle {
+    fn open(&self) -> Result<()> {
+        let mut state = self.state.blocking_lock();
+        state.is_open = true;
+        debug!("Mock camera opened: {}", self.id);
+        Ok(())
+    }
+
+    fn close(&self) -> Result<()> {
+        let mut state = self.state.blocking_lock();
+        state.is_open = false;
+        state.initialized = false;
+        debug!("Mock camera closed: {}", self.id);
+        Ok(())
+    }
+
+    fn is_open(&self) -> Result<bool> {
+        Ok(self.state.blocking_lock().is_open)
+    }
+
+    fn init(&self) -> Result<()> {
+        let mut state = self.state.blocking_lock();
+        if !state.is_open {
+            return Err(QhyCameraError::NotConnected);
+        }
+        state.initialized = true;
+        state.roi = Some(CcdChipArea {
+            start_x: 0,
+            start_y: 0,
+            width: 4656,
+            height: 3520,
+        });
+        debug!("Mock camera initialized");
+        Ok(())
+    }
+
+    fn get_ccd_info(&self) -> Result<CcdChipInfo> {
+        Ok(CcdChipInfo {
+            image_width: 4656,
+            image_height: 3520,
+            pixel_width: 3.76,
+            pixel_height: 3.76,
+            bits_per_pixel: 16,
+        })
+    }
+
+    fn set_stream_mode(&self, _mode: StreamMode) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_readout_mode(&self, mode: u32) -> Result<()> {
+        self.state.blocking_lock().readout_mode = mode;
+        Ok(())
+    }
+
+    fn get_readout_mode(&self) -> Result<u32> {
+        Ok(self.state.blocking_lock().readout_mode)
+    }
+
+    fn get_number_of_readout_modes(&self) -> Result<u32> {
+        Ok(2)
+    }
+
+    fn get_readout_mode_name(&self, index: u32) -> Result<String> {
+        match index {
+            0 => Ok("Standard".to_string()),
+            1 => Ok("High Gain".to_string()),
+            _ => Err(QhyCameraError::InvalidValue(format!(
+                "readout mode {} out of range",
+                index
+            ))),
+        }
+    }
+
+    fn get_readout_mode_resolution(&self, _index: u32) -> Result<(u32, u32)> {
+        Ok((4656, 3520))
+    }
+
+    fn set_bin_mode(&self, bin_x: u32, _bin_y: u32) -> Result<()> {
+        self.state.blocking_lock().binning = bin_x as u8;
+        Ok(())
+    }
+
+    fn set_roi(&self, roi: CcdChipArea) -> Result<()> {
+        self.state.blocking_lock().roi = Some(roi);
+        Ok(())
+    }
+
+    fn get_effective_area(&self) -> Result<CcdChipArea> {
+        Ok(CcdChipArea {
+            start_x: 0,
+            start_y: 0,
+            width: 4656,
+            height: 3520,
+        })
+    }
+
+    fn is_control_available(&self, control: Control) -> Option<f64> {
+        match control {
+            Control::CamBin1x1mode => Some(1.0),
+            Control::CamBin2x2mode => Some(1.0),
+            Control::CamBin3x3mode => Some(1.0),
+            Control::CamBin4x4mode => Some(1.0),
+            Control::CamSingleFrameMode => Some(1.0),
+            Control::Gain => Some(1.0),
+            Control::Offset => Some(1.0),
+            Control::Speed => Some(1.0),
+            Control::Cooler => Some(1.0),
+            Control::OutputDataActualBits => Some(16.0),
+            Control::CamIsColor => None, // monochrome by default
+            Control::CamColor => None,
+            Control::CamMechanicalShutter => None,
+            _ => None,
+        }
+    }
+
+    fn get_parameter(&self, control: Control) -> Result<f64> {
+        let state = self.state.blocking_lock();
+        match control {
+            Control::Gain => Ok(state.gain),
+            Control::Offset => Ok(state.offset),
+            Control::Speed => Ok(state.speed),
+            Control::Exposure => Ok(state.exposure_us),
+            Control::CurTemp => Ok(state.current_temp),
+            Control::CurPWM => Ok(state.cooler_pwm),
+            Control::OutputDataActualBits => Ok(16.0),
+            _ => Err(QhyCameraError::ControlNotAvailable(format!(
+                "{:?}",
+                control
+            ))),
+        }
+    }
+
+    fn set_parameter(&self, control: Control, value: f64) -> Result<()> {
+        let mut state = self.state.blocking_lock();
+        match control {
+            Control::Gain => state.gain = value,
+            Control::Offset => state.offset = value,
+            Control::Speed => state.speed = value,
+            Control::Exposure => state.exposure_us = value,
+            Control::Cooler => state.target_temp = value,
+            Control::ManualPWM => {
+                state.cooler_pwm = value;
+                state.cooler_on = value > 0.0;
+            }
+            Control::TransferBit => {}
+            _ => {
+                return Err(QhyCameraError::ControlNotAvailable(format!(
+                    "{:?}",
+                    control
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn set_if_available(&self, control: Control, value: f64) -> Result<()> {
+        if self.is_control_available(control).is_some() {
+            self.set_parameter(control, value)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn get_parameter_min_max_step(&self, control: Control) -> Result<(f64, f64, f64)> {
+        match control {
+            Control::Gain => Ok((0.0, 100.0, 1.0)),
+            Control::Offset => Ok((0.0, 200.0, 1.0)),
+            Control::Speed => Ok((0.0, 2.0, 1.0)),
+            Control::Exposure => Ok((100.0, 3_600_000_000.0, 1.0)), // 100us to 3600s
+            _ => Err(QhyCameraError::ControlNotAvailable(format!(
+                "{:?}",
+                control
+            ))),
+        }
+    }
+
+    fn start_single_frame_exposure(&self) -> Result<()> {
+        debug!("Mock: starting single frame exposure");
+        Ok(())
+    }
+
+    fn get_image_size(&self) -> Result<usize> {
+        let state = self.state.blocking_lock();
+        let roi = state
+            .roi
+            .ok_or_else(|| QhyCameraError::SdkError("no ROI set".to_string()))?;
+        // 16-bit pixels
+        Ok(roi.width as usize * roi.height as usize * 2)
+    }
+
+    fn get_single_frame(&self, buffer_size: usize) -> Result<ImageData> {
+        let state = self.state.blocking_lock();
+        let roi = state
+            .roi
+            .ok_or_else(|| QhyCameraError::SdkError("no ROI set".to_string()))?;
+        debug!(
+            "Mock: returning {}x{} 16-bit image ({} bytes)",
+            roi.width, roi.height, buffer_size
+        );
+        Ok(ImageData {
+            data: vec![128_u8; buffer_size],
+            width: roi.width,
+            height: roi.height,
+            bits_per_pixel: 16,
+            channels: 1,
+        })
+    }
+
+    fn abort_exposure_and_readout(&self) -> Result<()> {
+        debug!("Mock: aborting exposure");
+        Ok(())
+    }
+
+    fn get_remaining_exposure_us(&self) -> Result<u32> {
+        Ok(0)
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn clone_handle(&self) -> Box<dyn CameraHandle> {
+        Box::new(MockCameraHandle {
+            id: self.id.clone(),
+            state: Arc::clone(&self.state),
+        })
+    }
+}
+
+/// Simulated filter wheel device state
+#[derive(Debug, Clone)]
+struct MockFilterWheelState {
+    is_open: bool,
+    position: u32,
+    number_of_filters: u32,
+}
+
+impl Default for MockFilterWheelState {
+    fn default() -> Self {
+        Self {
+            is_open: false,
+            position: 0,
+            number_of_filters: 7,
+        }
+    }
+}
+
+/// Mock filter wheel handle for testing
+pub struct MockFilterWheelHandle {
+    id: String,
+    state: Arc<Mutex<MockFilterWheelState>>,
+}
+
+impl MockFilterWheelHandle {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            state: Arc::new(Mutex::new(MockFilterWheelState::default())),
+        }
+    }
+}
+
+impl FilterWheelHandle for MockFilterWheelHandle {
+    fn open(&self) -> Result<()> {
+        self.state.blocking_lock().is_open = true;
+        debug!("Mock filter wheel opened: {}", self.id);
+        Ok(())
+    }
+
+    fn close(&self) -> Result<()> {
+        self.state.blocking_lock().is_open = false;
+        debug!("Mock filter wheel closed: {}", self.id);
+        Ok(())
+    }
+
+    fn is_open(&self) -> Result<bool> {
+        Ok(self.state.blocking_lock().is_open)
+    }
+
+    fn get_number_of_filters(&self) -> Result<u32> {
+        Ok(self.state.blocking_lock().number_of_filters)
+    }
+
+    fn get_fw_position(&self) -> Result<u32> {
+        Ok(self.state.blocking_lock().position)
+    }
+
+    fn set_fw_position(&self, position: u32) -> Result<()> {
+        self.state.blocking_lock().position = position;
+        debug!("Mock filter wheel moved to position {}", position);
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+/// Mock SDK provider for testing
+pub struct MockSdkProvider;
+
+#[async_trait]
+impl SdkProvider for MockSdkProvider {
+    fn camera_ids(&self) -> Result<Vec<String>> {
+        Ok(vec!["QHY600M-mock001".to_string()])
+    }
+
+    fn filter_wheel_ids(&self) -> Result<Vec<String>> {
+        Ok(vec!["CFW=QHY600M-mock001".to_string()])
+    }
+
+    fn open_camera(&self, id: &str) -> Result<Box<dyn CameraHandle>> {
+        Ok(Box::new(MockCameraHandle::new(id.to_string())))
+    }
+
+    fn open_filter_wheel(&self, id: &str) -> Result<Box<dyn FilterWheelHandle>> {
+        Ok(Box::new(MockFilterWheelHandle::new(id.to_string())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mock_camera_lifecycle() {
+        let handle = MockCameraHandle::new("test-cam".to_string());
+        assert!(!handle.is_open().unwrap());
+        handle.open().unwrap();
+        assert!(handle.is_open().unwrap());
+        handle.close().unwrap();
+        assert!(!handle.is_open().unwrap());
+    }
+
+    #[test]
+    fn test_mock_camera_ccd_info() {
+        let handle = MockCameraHandle::new("test-cam".to_string());
+        let info = handle.get_ccd_info().unwrap();
+        assert_eq!(info.image_width, 4656);
+        assert_eq!(info.image_height, 3520);
+    }
+
+    #[test]
+    fn test_mock_camera_controls() {
+        let handle = MockCameraHandle::new("test-cam".to_string());
+        assert!(handle.is_control_available(Control::Gain).is_some());
+        assert!(handle.is_control_available(Control::CamIsColor).is_none());
+    }
+
+    #[test]
+    fn test_mock_camera_gain() {
+        let handle = MockCameraHandle::new("test-cam".to_string());
+        let (min, max, _step) = handle.get_parameter_min_max_step(Control::Gain).unwrap();
+        assert_eq!(min, 0.0);
+        assert_eq!(max, 100.0);
+        handle.set_parameter(Control::Gain, 50.0).unwrap();
+        assert_eq!(handle.get_parameter(Control::Gain).unwrap(), 50.0);
+    }
+
+    #[test]
+    fn test_mock_filter_wheel_lifecycle() {
+        let handle = MockFilterWheelHandle::new("test-fw".to_string());
+        assert!(!handle.is_open().unwrap());
+        handle.open().unwrap();
+        assert!(handle.is_open().unwrap());
+        assert_eq!(handle.get_number_of_filters().unwrap(), 7);
+        assert_eq!(handle.get_fw_position().unwrap(), 0);
+        handle.set_fw_position(3).unwrap();
+        assert_eq!(handle.get_fw_position().unwrap(), 3);
+        handle.close().unwrap();
+        assert!(!handle.is_open().unwrap());
+    }
+
+    #[test]
+    fn test_mock_sdk_provider() {
+        let provider = MockSdkProvider;
+        let cameras = provider.camera_ids().unwrap();
+        assert_eq!(cameras.len(), 1);
+        let fws = provider.filter_wheel_ids().unwrap();
+        assert_eq!(fws.len(), 1);
+    }
+}

--- a/services/qhy-camera/tests/bdd.rs
+++ b/services/qhy-camera/tests/bdd.rs
@@ -1,0 +1,13 @@
+#[path = "bdd/world.rs"]
+mod world;
+
+#[path = "bdd/steps/mod.rs"]
+mod steps;
+
+use cucumber::World as _;
+use world::QhyCameraWorld;
+
+#[tokio::main]
+async fn main() {
+    QhyCameraWorld::run("tests/features").await;
+}

--- a/services/qhy-camera/tests/bdd/steps/camera_property_steps.rs
+++ b/services/qhy-camera/tests/bdd/steps/camera_property_steps.rs
@@ -1,0 +1,298 @@
+use ascom_alpaca::api::camera::{CameraState, SensorType};
+use ascom_alpaca::api::{Camera, Device};
+use cucumber::{then, when};
+
+use crate::world::QhyCameraWorld;
+
+// --- When ---
+
+#[when(expr = "I set bin_x to {int}")]
+async fn set_bin_x(world: &mut QhyCameraWorld, value: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_bin_x(value).await.unwrap();
+}
+
+#[when(expr = "I try to set bin_x to {int}")]
+async fn try_set_bin_x(world: &mut QhyCameraWorld, value: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.set_bin_x(value).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when(expr = "I set start_x to {int}")]
+async fn set_start_x(world: &mut QhyCameraWorld, value: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_start_x(value).await.unwrap();
+}
+
+#[when(expr = "I set num_x to {int}")]
+async fn set_num_x(world: &mut QhyCameraWorld, value: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_num_x(value).await.unwrap();
+}
+
+#[when(expr = "I set gain to {int}")]
+async fn set_gain(world: &mut QhyCameraWorld, value: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_gain(value).await.unwrap();
+}
+
+#[when(expr = "I try to set gain to {int}")]
+async fn try_set_gain(world: &mut QhyCameraWorld, value: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.set_gain(value).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I try to read camera_x_size")]
+async fn try_read_camera_x_size(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.camera_x_size().await {
+        Ok(_) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+// --- Then ---
+
+#[then(expr = "camera_x_size should be {int}")]
+async fn check_camera_x_size(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.camera_x_size().await.unwrap(), expected);
+}
+
+#[then(expr = "camera_y_size should be {int}")]
+async fn check_camera_y_size(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.camera_y_size().await.unwrap(), expected);
+}
+
+#[then(expr = "pixel_size_x should be {float}")]
+async fn check_pixel_size_x(world: &mut QhyCameraWorld, expected: f64) {
+    let camera = world.camera.as_ref().unwrap();
+    let actual = camera.pixel_size_x().await.unwrap();
+    assert!(
+        (actual - expected).abs() < 0.01,
+        "expected pixel_size_x={}, got {}",
+        expected,
+        actual
+    );
+}
+
+#[then(expr = "pixel_size_y should be {float}")]
+async fn check_pixel_size_y(world: &mut QhyCameraWorld, expected: f64) {
+    let camera = world.camera.as_ref().unwrap();
+    let actual = camera.pixel_size_y().await.unwrap();
+    assert!(
+        (actual - expected).abs() < 0.01,
+        "expected pixel_size_y={}, got {}",
+        expected,
+        actual
+    );
+}
+
+#[then(expr = "bin_x should be {int}")]
+async fn check_bin_x(world: &mut QhyCameraWorld, expected: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.bin_x().await.unwrap(), expected);
+}
+
+#[then(expr = "bin_y should be {int}")]
+async fn check_bin_y(world: &mut QhyCameraWorld, expected: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.bin_y().await.unwrap(), expected);
+}
+
+#[then(expr = "max_bin_x should be {int}")]
+async fn check_max_bin_x(world: &mut QhyCameraWorld, expected: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.max_bin_x().await.unwrap(), expected);
+}
+
+#[then(expr = "max_bin_y should be {int}")]
+async fn check_max_bin_y(world: &mut QhyCameraWorld, expected: u8) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.max_bin_y().await.unwrap(), expected);
+}
+
+#[then(expr = "start_x should be {int}")]
+async fn check_start_x(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.start_x().await.unwrap(), expected);
+}
+
+#[then(expr = "start_y should be {int}")]
+async fn check_start_y(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.start_y().await.unwrap(), expected);
+}
+
+#[then(expr = "num_x should be {int}")]
+async fn check_num_x(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.num_x().await.unwrap(), expected);
+}
+
+#[then(expr = "num_y should be {int}")]
+async fn check_num_y(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.num_y().await.unwrap(), expected);
+}
+
+#[then(expr = "gain_min should be {int}")]
+async fn check_gain_min(world: &mut QhyCameraWorld, expected: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.gain_min().await.unwrap(), expected);
+}
+
+#[then(expr = "gain_max should be {int}")]
+async fn check_gain_max(world: &mut QhyCameraWorld, expected: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.gain_max().await.unwrap(), expected);
+}
+
+#[then(expr = "gain should be {int}")]
+async fn check_gain(world: &mut QhyCameraWorld, expected: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.gain().await.unwrap(), expected);
+}
+
+#[then(expr = "offset_min should be {int}")]
+async fn check_offset_min(world: &mut QhyCameraWorld, expected: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.offset_min().await.unwrap(), expected);
+}
+
+#[then(expr = "offset_max should be {int}")]
+async fn check_offset_max(world: &mut QhyCameraWorld, expected: i32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.offset_max().await.unwrap(), expected);
+}
+
+#[then("exposure_min should be available")]
+async fn check_exposure_min(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.exposure_min().await.unwrap();
+}
+
+#[then("exposure_max should be available")]
+async fn check_exposure_max(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.exposure_max().await.unwrap();
+}
+
+#[then("exposure_resolution should be available")]
+async fn check_exposure_resolution(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.exposure_resolution().await.unwrap();
+}
+
+#[then("camera_state should be idle")]
+async fn check_camera_state_idle(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.camera_state().await.unwrap(), CameraState::Idle);
+}
+
+#[then("camera_state should be exposing")]
+async fn check_camera_state_exposing(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.camera_state().await.unwrap(), CameraState::Exposing);
+}
+
+#[then(expr = "can_abort_exposure should be {word}")]
+async fn check_can_abort(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.can_abort_exposure().await.unwrap(), expected);
+}
+
+#[then(expr = "can_stop_exposure should be {word}")]
+async fn check_can_stop(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.can_stop_exposure().await.unwrap(), expected);
+}
+
+#[then(expr = "has_shutter should be {word}")]
+async fn check_has_shutter(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.has_shutter().await.unwrap(), expected);
+}
+
+#[then("sensor_type should be monochrome")]
+async fn check_sensor_type_mono(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.sensor_type().await.unwrap(), SensorType::Monochrome);
+}
+
+#[then(expr = "sensor_name should be {string}")]
+async fn check_sensor_name(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.sensor_name().await.unwrap(), expected);
+}
+
+#[then(expr = "readout_modes should have {int} entries")]
+async fn check_readout_modes_count(world: &mut QhyCameraWorld, expected: usize) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.readout_modes().await.unwrap().len(), expected);
+}
+
+#[then(expr = "can_fast_readout should be {word}")]
+async fn check_can_fast_readout(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.can_fast_readout().await.unwrap(), expected);
+}
+
+#[then(expr = "can_set_ccd_temperature should be {word}")]
+async fn check_can_set_ccd_temp(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.can_set_ccd_temperature().await.unwrap(), expected);
+}
+
+#[then(expr = "can_get_cooler_power should be {word}")]
+async fn check_can_get_cooler_power(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.can_get_cooler_power().await.unwrap(), expected);
+}
+
+#[then(expr = "max_adu should be {int}")]
+async fn check_max_adu(world: &mut QhyCameraWorld, expected: u32) {
+    let camera = world.camera.as_ref().unwrap();
+    assert_eq!(camera.max_adu().await.unwrap(), expected);
+}
+
+#[then(expr = "driver_info should contain {string}")]
+async fn check_driver_info(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let info = camera.driver_info().await.unwrap();
+    assert!(
+        info.contains(&expected),
+        "driver_info '{}' should contain '{}'",
+        info,
+        expected
+    );
+}
+
+#[then("driver_version should not be empty")]
+async fn check_driver_version(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    let version = camera.driver_version().await.unwrap();
+    assert!(!version.is_empty(), "driver_version should not be empty");
+}

--- a/services/qhy-camera/tests/bdd/steps/connection_steps.rs
+++ b/services/qhy-camera/tests/bdd/steps/connection_steps.rs
@@ -1,0 +1,152 @@
+use ascom_alpaca::api::Device;
+use cucumber::{given, then, when};
+
+use crate::world::{QhyCameraWorld, TestCameraHandle, TestFilterWheelHandle};
+
+// --- Given ---
+
+#[given("a camera device with mock SDK")]
+fn camera_with_mock(world: &mut QhyCameraWorld) {
+    world.build_camera_with_mock();
+}
+
+#[given("a camera device with failing SDK")]
+fn camera_with_failing_sdk(world: &mut QhyCameraWorld) {
+    world.build_camera_with_handle(Box::new(TestCameraHandle::failing()));
+}
+
+#[given("a connected camera device")]
+async fn connected_camera(world: &mut QhyCameraWorld) {
+    world.build_camera_with_mock();
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_connected(true).await.unwrap();
+}
+
+#[given("a filter wheel device with mock SDK")]
+fn filter_wheel_with_mock(world: &mut QhyCameraWorld) {
+    world.build_filter_wheel_with_mock();
+}
+
+#[given("a filter wheel device with failing SDK")]
+fn filter_wheel_with_failing_sdk(world: &mut QhyCameraWorld) {
+    world.build_filter_wheel_with_handle(Box::new(TestFilterWheelHandle::failing()));
+}
+
+#[given("a connected filter wheel device")]
+async fn connected_filter_wheel(world: &mut QhyCameraWorld) {
+    world.build_filter_wheel_with_mock();
+    let fw = world.filter_wheel.as_ref().unwrap();
+    fw.set_connected(true).await.unwrap();
+}
+
+// --- When ---
+
+#[when("I connect the camera")]
+async fn connect_camera(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_connected(true).await.unwrap();
+}
+
+#[when("I disconnect the camera")]
+async fn disconnect_camera(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.set_connected(false).await.unwrap();
+}
+
+#[when("I try to connect the camera")]
+async fn try_connect_camera(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.set_connected(true).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I connect the filter wheel")]
+async fn connect_filter_wheel(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    fw.set_connected(true).await.unwrap();
+}
+
+#[when("I disconnect the filter wheel")]
+async fn disconnect_filter_wheel(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    fw.set_connected(false).await.unwrap();
+}
+
+#[when("I try to connect the filter wheel")]
+async fn try_connect_filter_wheel(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    match fw.set_connected(true).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+// --- Then ---
+
+#[then("the camera should be connected")]
+async fn camera_connected(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    assert!(
+        camera.connected().await.unwrap(),
+        "expected camera connected"
+    );
+}
+
+#[then("the camera should not be connected")]
+async fn camera_not_connected(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    assert!(
+        !camera.connected().await.unwrap(),
+        "expected camera not connected"
+    );
+}
+
+#[then("the filter wheel should be connected")]
+async fn filter_wheel_connected(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    assert!(
+        fw.connected().await.unwrap(),
+        "expected filter wheel connected"
+    );
+}
+
+#[then("the filter wheel should not be connected")]
+async fn filter_wheel_not_connected(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    assert!(
+        !fw.connected().await.unwrap(),
+        "expected filter wheel not connected"
+    );
+}
+
+#[then("the operation should fail with a not-connected error")]
+fn not_connected_error(world: &mut QhyCameraWorld) {
+    assert!(
+        world.last_error.is_some(),
+        "expected an error but none occurred"
+    );
+}
+
+#[then("the operation should fail with an invalid-value error")]
+fn invalid_value_error(world: &mut QhyCameraWorld) {
+    assert!(
+        world.last_error.is_some(),
+        "expected an error but none occurred"
+    );
+}
+
+#[then("the operation should fail with an invalid-operation error")]
+fn invalid_operation_error(world: &mut QhyCameraWorld) {
+    assert!(
+        world.last_error.is_some(),
+        "expected an error but none occurred"
+    );
+}

--- a/services/qhy-camera/tests/bdd/steps/exposure_steps.rs
+++ b/services/qhy-camera/tests/bdd/steps/exposure_steps.rs
@@ -70,10 +70,17 @@ async fn wait_for_exposure(world: &mut QhyCameraWorld) {
 
 #[when("I abort the exposure")]
 async fn abort_exposure(world: &mut QhyCameraWorld) {
+    use ascom_alpaca::api::camera::CameraState;
     let camera = world.camera.as_ref().unwrap();
     camera.abort_exposure().await.unwrap();
-    // Give the background task a moment to process
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Poll until the background task transitions state to Idle
+    for _ in 0..100 {
+        if camera.camera_state().await.unwrap() == CameraState::Idle {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("camera did not return to idle after abort within timeout");
 }
 
 // --- Then ---

--- a/services/qhy-camera/tests/bdd/steps/exposure_steps.rs
+++ b/services/qhy-camera/tests/bdd/steps/exposure_steps.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+use ascom_alpaca::api::Camera;
+use cucumber::{then, when};
+
+use crate::world::QhyCameraWorld;
+
+// --- When ---
+
+#[when(expr = "I start a {float} second exposure")]
+async fn start_exposure(world: &mut QhyCameraWorld, seconds: f64) {
+    let camera = world.camera.as_ref().unwrap();
+    camera
+        .start_exposure(Duration::from_secs_f64(seconds), true)
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I try to start a {float} second exposure")]
+async fn try_start_exposure(world: &mut QhyCameraWorld, seconds: f64) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera
+        .start_exposure(Duration::from_secs_f64(seconds), true)
+        .await
+    {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I try to start a dark frame exposure")]
+async fn try_start_dark_frame(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.start_exposure(Duration::from_secs(1), false).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I try to start another exposure")]
+async fn try_start_another_exposure(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    match camera.start_exposure(Duration::from_secs(1), true).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I wait for exposure to complete")]
+async fn wait_for_exposure(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    // Poll image_ready with a timeout
+    for _ in 0..100 {
+        if camera.image_ready().await.unwrap_or(false) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("exposure did not complete within timeout");
+}
+
+#[when("I abort the exposure")]
+async fn abort_exposure(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.abort_exposure().await.unwrap();
+    // Give the background task a moment to process
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+// --- Then ---
+
+#[then(expr = "image_ready should be {word}")]
+async fn check_image_ready(world: &mut QhyCameraWorld, expected: String) {
+    let camera = world.camera.as_ref().unwrap();
+    let expected = expected == "true";
+    assert_eq!(camera.image_ready().await.unwrap(), expected);
+}
+
+#[then("image_array should be available")]
+async fn check_image_array(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.image_array().await.unwrap();
+}
+
+#[then("last_exposure_duration should be available")]
+async fn check_last_exposure_duration(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.last_exposure_duration().await.unwrap();
+}
+
+#[then("last_exposure_start_time should be available")]
+async fn check_last_exposure_start_time(world: &mut QhyCameraWorld) {
+    let camera = world.camera.as_ref().unwrap();
+    camera.last_exposure_start_time().await.unwrap();
+}

--- a/services/qhy-camera/tests/bdd/steps/filter_wheel_steps.rs
+++ b/services/qhy-camera/tests/bdd/steps/filter_wheel_steps.rs
@@ -1,0 +1,104 @@
+use ascom_alpaca::api::{Device, FilterWheel};
+use cucumber::{given, then, when};
+
+use crate::world::{default_filter_wheel_config, QhyCameraWorld};
+use qhy_camera::FilterWheelConfig;
+
+// --- Given ---
+
+#[given(expr = "a filter wheel config with names {string}")]
+fn filter_wheel_config_with_names(world: &mut QhyCameraWorld, names: String) {
+    let filter_names: Vec<String> = names.split(',').map(|s| s.trim().to_string()).collect();
+    world.filter_wheel_config = Some(FilterWheelConfig {
+        filter_names,
+        ..default_filter_wheel_config()
+    });
+}
+
+#[given("a connected filter wheel device with config")]
+async fn connected_filter_wheel_with_config(world: &mut QhyCameraWorld) {
+    world.build_filter_wheel_with_mock();
+    let fw = world.filter_wheel.as_ref().unwrap();
+    fw.set_connected(true).await.unwrap();
+}
+
+// --- When ---
+
+#[when(expr = "I set filter wheel position to {int}")]
+async fn set_fw_position(world: &mut QhyCameraWorld, position: usize) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    fw.set_position(position).await.unwrap();
+}
+
+#[when(expr = "I try to set filter wheel position to {int}")]
+async fn try_set_fw_position(world: &mut QhyCameraWorld, position: usize) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    match fw.set_position(position).await {
+        Ok(()) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+#[when("I try to read filter wheel position")]
+async fn try_read_fw_position(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    match fw.position().await {
+        Ok(_) => world.last_error = None,
+        Err(e) => {
+            world.last_error_code = Some(format!("{:?}", e.code));
+            world.last_error = Some(e.to_string());
+        }
+    }
+}
+
+// --- Then ---
+
+#[then(expr = "filter wheel position should be {int}")]
+async fn check_fw_position(world: &mut QhyCameraWorld, expected: usize) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    let pos = fw.position().await.unwrap();
+    assert_eq!(
+        pos,
+        Some(expected),
+        "expected position Some({}), got {:?}",
+        expected,
+        pos
+    );
+}
+
+#[then(expr = "filter names should have {int} entries")]
+async fn check_filter_names_count(world: &mut QhyCameraWorld, expected: usize) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    assert_eq!(fw.names().await.unwrap().len(), expected);
+}
+
+#[then(expr = "first filter name should be {string}")]
+async fn check_first_filter_name(world: &mut QhyCameraWorld, expected: String) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    let names = fw.names().await.unwrap();
+    assert_eq!(
+        names[0], expected,
+        "first filter name should be '{}', got '{}'",
+        expected, names[0]
+    );
+}
+
+#[then(expr = "focus_offsets should have {int} entries")]
+async fn check_focus_offsets_count(world: &mut QhyCameraWorld, expected: usize) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    assert_eq!(fw.focus_offsets().await.unwrap().len(), expected);
+}
+
+#[then("all focus offsets should be 0")]
+async fn check_all_focus_offsets_zero(world: &mut QhyCameraWorld) {
+    let fw = world.filter_wheel.as_ref().unwrap();
+    let offsets = fw.focus_offsets().await.unwrap();
+    assert!(
+        offsets.iter().all(|&o| o == 0),
+        "all focus offsets should be 0, got {:?}",
+        offsets
+    );
+}

--- a/services/qhy-camera/tests/bdd/steps/mod.rs
+++ b/services/qhy-camera/tests/bdd/steps/mod.rs
@@ -1,0 +1,4 @@
+pub mod camera_property_steps;
+pub mod connection_steps;
+pub mod exposure_steps;
+pub mod filter_wheel_steps;

--- a/services/qhy-camera/tests/bdd/world.rs
+++ b/services/qhy-camera/tests/bdd/world.rs
@@ -1,0 +1,476 @@
+use std::sync::Arc;
+
+use cucumber::World;
+
+use qhy_camera::io::{
+    CameraHandle, CcdChipArea, CcdChipInfo, Control, FilterWheelHandle, ImageData, StreamMode,
+};
+use qhy_camera::{CameraConfig, FilterWheelConfig, QhyccdCamera, QhyccdFilterWheel};
+
+/// Test world for QHY Camera BDD tests
+#[derive(Debug, Default, World)]
+pub struct QhyCameraWorld {
+    pub camera: Option<Arc<QhyccdCamera>>,
+    pub filter_wheel: Option<Arc<QhyccdFilterWheel>>,
+    pub camera_config: Option<CameraConfig>,
+    pub filter_wheel_config: Option<FilterWheelConfig>,
+    pub last_error: Option<String>,
+    pub last_error_code: Option<String>,
+}
+
+impl QhyCameraWorld {
+    /// Build a camera with the default mock handle
+    pub fn build_camera_with_mock(&mut self) {
+        let config = self
+            .camera_config
+            .clone()
+            .unwrap_or_else(default_camera_config);
+        let handle = Box::new(TestCameraHandle::default());
+        let camera = QhyccdCamera::new(config, handle);
+        self.camera = Some(Arc::new(camera));
+    }
+
+    /// Build a camera with a custom handle
+    pub fn build_camera_with_handle(&mut self, handle: Box<dyn CameraHandle>) {
+        let config = self
+            .camera_config
+            .clone()
+            .unwrap_or_else(default_camera_config);
+        let camera = QhyccdCamera::new(config, handle);
+        self.camera = Some(Arc::new(camera));
+    }
+
+    /// Build a filter wheel with the default mock handle
+    pub fn build_filter_wheel_with_mock(&mut self) {
+        let config = self
+            .filter_wheel_config
+            .clone()
+            .unwrap_or_else(default_filter_wheel_config);
+        let handle = Box::new(TestFilterWheelHandle::default());
+        let fw = QhyccdFilterWheel::new(config, handle);
+        self.filter_wheel = Some(Arc::new(fw));
+    }
+
+    /// Build a filter wheel with a custom handle
+    pub fn build_filter_wheel_with_handle(&mut self, handle: Box<dyn FilterWheelHandle>) {
+        let config = self
+            .filter_wheel_config
+            .clone()
+            .unwrap_or_else(default_filter_wheel_config);
+        let fw = QhyccdFilterWheel::new(config, handle);
+        self.filter_wheel = Some(Arc::new(fw));
+    }
+}
+
+pub fn default_camera_config() -> CameraConfig {
+    CameraConfig {
+        unique_id: "QHY600M-test001".to_string(),
+        name: "Test QHY Camera".to_string(),
+        description: "Test QHYCCD camera".to_string(),
+        device_number: 0,
+        enabled: true,
+    }
+}
+
+pub fn default_filter_wheel_config() -> FilterWheelConfig {
+    FilterWheelConfig {
+        unique_id: "CFW=QHY600M-test001".to_string(),
+        name: "Test Filter Wheel".to_string(),
+        description: "Test QHYCCD filter wheel".to_string(),
+        device_number: 0,
+        enabled: true,
+        filter_names: vec![],
+    }
+}
+
+// --- Test camera handle ---
+
+use std::sync::Mutex;
+
+/// In-test camera handle with controllable behavior
+pub struct TestCameraHandle {
+    state: Mutex<TestCameraState>,
+}
+
+#[derive(Debug)]
+struct TestCameraState {
+    is_open: bool,
+    initialized: bool,
+    binning: u8,
+    roi: Option<CcdChipArea>,
+    gain: f64,
+    offset: f64,
+    speed: f64,
+    exposure_us: f64,
+    cooler_pwm: f64,
+    target_temp: f64,
+    current_temp: f64,
+    readout_mode: u32,
+    fail_open: bool,
+}
+
+impl Default for TestCameraHandle {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(TestCameraState {
+                is_open: false,
+                initialized: false,
+                binning: 1,
+                roi: None,
+                gain: 10.0,
+                offset: 50.0,
+                speed: 0.0,
+                exposure_us: 1_000_000.0,
+                cooler_pwm: 0.0,
+                target_temp: 0.0,
+                current_temp: 20.0,
+                readout_mode: 0,
+                fail_open: false,
+            }),
+        }
+    }
+}
+
+impl TestCameraHandle {
+    pub fn failing() -> Self {
+        Self {
+            state: Mutex::new(TestCameraState {
+                fail_open: true,
+                ..TestCameraState::default()
+            }),
+        }
+    }
+}
+
+impl Default for TestCameraState {
+    fn default() -> Self {
+        Self {
+            is_open: false,
+            initialized: false,
+            binning: 1,
+            roi: None,
+            gain: 10.0,
+            offset: 50.0,
+            speed: 0.0,
+            exposure_us: 1_000_000.0,
+            cooler_pwm: 0.0,
+            target_temp: 0.0,
+            current_temp: 20.0,
+            readout_mode: 0,
+            fail_open: false,
+        }
+    }
+}
+
+impl CameraHandle for TestCameraHandle {
+    fn open(&self) -> qhy_camera::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        if state.fail_open {
+            return Err(qhy_camera::QhyCameraError::SdkError(
+                "mock open failure".to_string(),
+            ));
+        }
+        state.is_open = true;
+        Ok(())
+    }
+
+    fn close(&self) -> qhy_camera::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        state.is_open = false;
+        state.initialized = false;
+        Ok(())
+    }
+
+    fn is_open(&self) -> qhy_camera::Result<bool> {
+        Ok(self.state.lock().unwrap().is_open)
+    }
+
+    fn init(&self) -> qhy_camera::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        state.initialized = true;
+        state.roi = Some(CcdChipArea {
+            start_x: 0,
+            start_y: 0,
+            width: 4656,
+            height: 3520,
+        });
+        Ok(())
+    }
+
+    fn get_ccd_info(&self) -> qhy_camera::Result<CcdChipInfo> {
+        Ok(CcdChipInfo {
+            image_width: 4656,
+            image_height: 3520,
+            pixel_width: 3.76,
+            pixel_height: 3.76,
+            bits_per_pixel: 16,
+        })
+    }
+
+    fn set_stream_mode(&self, _mode: StreamMode) -> qhy_camera::Result<()> {
+        Ok(())
+    }
+
+    fn set_readout_mode(&self, mode: u32) -> qhy_camera::Result<()> {
+        self.state.lock().unwrap().readout_mode = mode;
+        Ok(())
+    }
+
+    fn get_readout_mode(&self) -> qhy_camera::Result<u32> {
+        Ok(self.state.lock().unwrap().readout_mode)
+    }
+
+    fn get_number_of_readout_modes(&self) -> qhy_camera::Result<u32> {
+        Ok(2)
+    }
+
+    fn get_readout_mode_name(&self, index: u32) -> qhy_camera::Result<String> {
+        match index {
+            0 => Ok("Standard".to_string()),
+            1 => Ok("High Gain".to_string()),
+            _ => Err(qhy_camera::QhyCameraError::InvalidValue(format!(
+                "mode {} out of range",
+                index
+            ))),
+        }
+    }
+
+    fn get_readout_mode_resolution(&self, _index: u32) -> qhy_camera::Result<(u32, u32)> {
+        Ok((4656, 3520))
+    }
+
+    fn set_bin_mode(&self, bin_x: u32, _bin_y: u32) -> qhy_camera::Result<()> {
+        self.state.lock().unwrap().binning = bin_x as u8;
+        Ok(())
+    }
+
+    fn set_roi(&self, roi: CcdChipArea) -> qhy_camera::Result<()> {
+        self.state.lock().unwrap().roi = Some(roi);
+        Ok(())
+    }
+
+    fn get_effective_area(&self) -> qhy_camera::Result<CcdChipArea> {
+        Ok(CcdChipArea {
+            start_x: 0,
+            start_y: 0,
+            width: 4656,
+            height: 3520,
+        })
+    }
+
+    fn is_control_available(&self, control: Control) -> Option<f64> {
+        match control {
+            Control::CamBin1x1mode => Some(1.0),
+            Control::CamBin2x2mode => Some(1.0),
+            Control::CamBin3x3mode => Some(1.0),
+            Control::CamBin4x4mode => Some(1.0),
+            Control::CamSingleFrameMode => Some(1.0),
+            Control::Gain => Some(1.0),
+            Control::Offset => Some(1.0),
+            Control::Speed => Some(1.0),
+            Control::Cooler => Some(1.0),
+            Control::OutputDataActualBits => Some(16.0),
+            Control::CamIsColor => None,
+            Control::CamColor => None,
+            Control::CamMechanicalShutter => None,
+            _ => None,
+        }
+    }
+
+    fn get_parameter(&self, control: Control) -> qhy_camera::Result<f64> {
+        let state = self.state.lock().unwrap();
+        match control {
+            Control::Gain => Ok(state.gain),
+            Control::Offset => Ok(state.offset),
+            Control::Speed => Ok(state.speed),
+            Control::Exposure => Ok(state.exposure_us),
+            Control::CurTemp => Ok(state.current_temp),
+            Control::CurPWM => Ok(state.cooler_pwm),
+            Control::OutputDataActualBits => Ok(16.0),
+            _ => Err(qhy_camera::QhyCameraError::ControlNotAvailable(format!(
+                "{:?}",
+                control
+            ))),
+        }
+    }
+
+    fn set_parameter(&self, control: Control, value: f64) -> qhy_camera::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        match control {
+            Control::Gain => state.gain = value,
+            Control::Offset => state.offset = value,
+            Control::Speed => state.speed = value,
+            Control::Exposure => state.exposure_us = value,
+            Control::Cooler => state.target_temp = value,
+            Control::ManualPWM => state.cooler_pwm = value,
+            Control::TransferBit => {}
+            _ => {
+                return Err(qhy_camera::QhyCameraError::ControlNotAvailable(format!(
+                    "{:?}",
+                    control
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn set_if_available(&self, control: Control, value: f64) -> qhy_camera::Result<()> {
+        if self.is_control_available(control).is_some() {
+            self.set_parameter(control, value)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn get_parameter_min_max_step(&self, control: Control) -> qhy_camera::Result<(f64, f64, f64)> {
+        match control {
+            Control::Gain => Ok((0.0, 100.0, 1.0)),
+            Control::Offset => Ok((0.0, 200.0, 1.0)),
+            Control::Speed => Ok((0.0, 2.0, 1.0)),
+            Control::Exposure => Ok((100.0, 3_600_000_000.0, 1.0)),
+            _ => Err(qhy_camera::QhyCameraError::ControlNotAvailable(format!(
+                "{:?}",
+                control
+            ))),
+        }
+    }
+
+    fn start_single_frame_exposure(&self) -> qhy_camera::Result<()> {
+        Ok(())
+    }
+
+    fn get_image_size(&self) -> qhy_camera::Result<usize> {
+        let state = self.state.lock().unwrap();
+        let roi = state
+            .roi
+            .ok_or_else(|| qhy_camera::QhyCameraError::SdkError("no ROI set".to_string()))?;
+        Ok(roi.width as usize * roi.height as usize * 2)
+    }
+
+    fn get_single_frame(&self, buffer_size: usize) -> qhy_camera::Result<ImageData> {
+        let state = self.state.lock().unwrap();
+        let roi = state
+            .roi
+            .ok_or_else(|| qhy_camera::QhyCameraError::SdkError("no ROI set".to_string()))?;
+        Ok(ImageData {
+            data: vec![128_u8; buffer_size],
+            width: roi.width,
+            height: roi.height,
+            bits_per_pixel: 16,
+            channels: 1,
+        })
+    }
+
+    fn abort_exposure_and_readout(&self) -> qhy_camera::Result<()> {
+        Ok(())
+    }
+
+    fn get_remaining_exposure_us(&self) -> qhy_camera::Result<u32> {
+        Ok(0)
+    }
+
+    fn id(&self) -> &str {
+        "QHY600M-test001"
+    }
+
+    fn clone_handle(&self) -> Box<dyn CameraHandle> {
+        let state = self.state.lock().unwrap();
+        let new_state = TestCameraState {
+            is_open: state.is_open,
+            initialized: state.initialized,
+            binning: state.binning,
+            roi: state.roi,
+            gain: state.gain,
+            offset: state.offset,
+            speed: state.speed,
+            exposure_us: state.exposure_us,
+            cooler_pwm: state.cooler_pwm,
+            target_temp: state.target_temp,
+            current_temp: state.current_temp,
+            readout_mode: state.readout_mode,
+            fail_open: false,
+        };
+        Box::new(TestCameraHandle {
+            state: Mutex::new(new_state),
+        })
+    }
+}
+
+// --- Test filter wheel handle ---
+
+pub struct TestFilterWheelHandle {
+    state: Mutex<TestFilterWheelState>,
+}
+
+#[derive(Debug)]
+struct TestFilterWheelState {
+    is_open: bool,
+    position: u32,
+    number_of_filters: u32,
+    fail_open: bool,
+}
+
+impl Default for TestFilterWheelHandle {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(TestFilterWheelState {
+                is_open: false,
+                position: 0,
+                number_of_filters: 7,
+                fail_open: false,
+            }),
+        }
+    }
+}
+
+impl TestFilterWheelHandle {
+    pub fn failing() -> Self {
+        Self {
+            state: Mutex::new(TestFilterWheelState {
+                is_open: false,
+                position: 0,
+                number_of_filters: 7,
+                fail_open: true,
+            }),
+        }
+    }
+}
+
+impl FilterWheelHandle for TestFilterWheelHandle {
+    fn open(&self) -> qhy_camera::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        if state.fail_open {
+            return Err(qhy_camera::QhyCameraError::SdkError(
+                "mock open failure".to_string(),
+            ));
+        }
+        state.is_open = true;
+        Ok(())
+    }
+
+    fn close(&self) -> qhy_camera::Result<()> {
+        self.state.lock().unwrap().is_open = false;
+        Ok(())
+    }
+
+    fn is_open(&self) -> qhy_camera::Result<bool> {
+        Ok(self.state.lock().unwrap().is_open)
+    }
+
+    fn get_number_of_filters(&self) -> qhy_camera::Result<u32> {
+        Ok(self.state.lock().unwrap().number_of_filters)
+    }
+
+    fn get_fw_position(&self) -> qhy_camera::Result<u32> {
+        Ok(self.state.lock().unwrap().position)
+    }
+
+    fn set_fw_position(&self, position: u32) -> qhy_camera::Result<()> {
+        self.state.lock().unwrap().position = position;
+        Ok(())
+    }
+
+    fn id(&self) -> &str {
+        "CFW=QHY600M-test001"
+    }
+}

--- a/services/qhy-camera/tests/conformu_integration.rs
+++ b/services/qhy-camera/tests/conformu_integration.rs
@@ -1,0 +1,238 @@
+//! ConformU compliance tests for QHY Camera driver
+//!
+//! These tests verify ASCOM Alpaca compliance by running the ConformU test suite
+//! against the driver running in mock mode. Two test functions cover the Camera
+//! and FilterWheel device types.
+#![allow(clippy::await_holding_lock)]
+
+use ascom_alpaca::api::{Camera, FilterWheel};
+use ascom_alpaca::test::conformu_tests;
+use std::process::Stdio;
+use std::sync::Mutex;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tracing_subscriber::{fmt, EnvFilter};
+
+static CONFORMU_LOCK: Mutex<()> = Mutex::new(());
+
+/// Parse the bound port from service stdout.
+async fn parse_bound_port(
+    stdout: tokio::process::ChildStdout,
+) -> Option<(u16, tokio::task::JoinHandle<()>)> {
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+
+    while reader.read_line(&mut line).await.ok()? > 0 {
+        if let Some(addr_str) = line.trim().strip_prefix("Bound Alpaca server bound_addr=") {
+            if let Some(port_str) = addr_str.split(':').next_back() {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    let drain_handle = tokio::spawn(async move {
+                        let mut buf = String::new();
+                        while reader.read_line(&mut buf).await.unwrap_or(0) > 0 {
+                            buf.clear();
+                        }
+                    });
+                    return Some((port, drain_handle));
+                }
+            }
+        }
+        line.clear();
+    }
+    None
+}
+
+/// Start the qhy-camera service in mock mode and return the bound port.
+async fn start_mock_server(
+    config_path: &std::path::Path,
+) -> Result<(tokio::process::Child, u16, tokio::task::JoinHandle<()>), Box<dyn std::error::Error>> {
+    let mut child = Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "qhy-camera",
+            "--features",
+            "mock",
+            "--",
+            "-c",
+            config_path.to_str().unwrap(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
+    let (port, stdout_drain) = parse_bound_port(stdout)
+        .await
+        .ok_or("Failed to parse bound port from service output")?;
+
+    Ok((child, port, stdout_drain))
+}
+
+fn write_test_config(
+    test_dir: &std::path::Path,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), Box<dyn std::error::Error>> {
+    let config_path = test_dir.join("config.json");
+    let conformu_settings_path = test_dir.join("conformu-settings.json");
+
+    let conformu_settings = serde_json::json!({
+        "SettingsCompatibilityVersion": 1,
+        "GoHomeOnDeviceSelected": true,
+        "ConnectionTimeout": 2,
+        "RunAs32Bit": false,
+        "RiskAcknowledged": false,
+        "DisplayMethodCalls": false,
+        "UpdateCheck": false,
+        "ApplicationPort": 0,
+        "ConnectDisconnectTimeout": 5,
+        "Debug": false,
+        "TraceDiscovery": false,
+        "TraceAlpacaCalls": false,
+        "TestProperties": true,
+        "TestMethods": true,
+        "TestPerformance": false,
+        "AlpacaDevice": {},
+        "AlpacaConfiguration": {},
+        "ComDevice": {},
+        "ComConfiguration": {},
+        "DeviceName": "No device selected",
+        "DeviceTechnology": "NotSelected",
+        "ReportGoodTimings": true,
+        "ReportBadTimings": true,
+        "TelescopeTests": {},
+        "TelescopeExtendedRateOffsetTests": true,
+        "TelescopeFirstUseTests": true,
+        "TestSideOfPierRead": false,
+        "TestSideOfPierWrite": false,
+        "CameraFirstUseTests": true,
+        "CameraTestImageArrayVariant": true,
+        "FocuserTimeout": 30
+    });
+    std::fs::write(
+        &conformu_settings_path,
+        serde_json::to_string_pretty(&conformu_settings)?,
+    )?;
+
+    let config = serde_json::json!({
+        "server": {
+            "port": 0
+        },
+        "cameras": [{
+            "unique_id": "QHY600M-conformu001",
+            "name": "ConformU Test QHY Camera",
+            "description": "Test QHYCCD camera for ConformU compliance",
+            "device_number": 0,
+            "enabled": true
+        }],
+        "filter_wheels": [{
+            "unique_id": "CFW=QHY600M-conformu001",
+            "name": "ConformU Test Filter Wheel",
+            "description": "Test QHYCCD filter wheel for ConformU compliance",
+            "device_number": 0,
+            "enabled": true,
+            "filter_names": ["L", "R", "G", "B", "Ha", "OIII", "SII"]
+        }]
+    });
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+
+    Ok((config_path, conformu_settings_path))
+}
+
+#[tokio::test]
+#[ignore] // Run with --ignored flag since it requires ConformU installation
+async fn conformu_camera_compliance_tests() -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = CONFORMU_LOCK.lock().unwrap();
+
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("ascom_alpaca::conformu=trace,info")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let test_dir = std::env::temp_dir().join("conformu_qhy_camera_test");
+    std::fs::create_dir_all(&test_dir)?;
+
+    let (config_path, conformu_settings_path) = write_test_config(&test_dir)?;
+    let (mut child, port, stdout_drain) = start_mock_server(&config_path).await?;
+
+    println!("::group::ConformU Camera Compliance Test Results");
+    println!(
+        "Running ASCOM Alpaca Camera compliance tests on port {}...",
+        port
+    );
+
+    let result = conformu_tests::<dyn Camera>(&format!("http://localhost:{}", port), 0)?
+        .settings_file(&conformu_settings_path)
+        .run()
+        .await;
+
+    match &result {
+        Ok(_) => {
+            println!("ConformU Camera compliance tests PASSED");
+        }
+        Err(e) => {
+            println!("ConformU Camera compliance tests FAILED: {}", e);
+        }
+    }
+
+    println!("::endgroup::");
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+    stdout_drain.abort();
+    std::fs::remove_dir_all(&test_dir).ok();
+
+    result?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore] // Run with --ignored flag since it requires ConformU installation
+async fn conformu_filter_wheel_compliance_tests() -> Result<(), Box<dyn std::error::Error>> {
+    let _lock = CONFORMU_LOCK.lock().unwrap();
+
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("ascom_alpaca::conformu=trace,info")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let test_dir = std::env::temp_dir().join("conformu_qhy_filterwheel_test");
+    std::fs::create_dir_all(&test_dir)?;
+
+    let (config_path, conformu_settings_path) = write_test_config(&test_dir)?;
+    let (mut child, port, stdout_drain) = start_mock_server(&config_path).await?;
+
+    println!("::group::ConformU FilterWheel Compliance Test Results");
+    println!(
+        "Running ASCOM Alpaca FilterWheel compliance tests on port {}...",
+        port
+    );
+
+    let result = conformu_tests::<dyn FilterWheel>(&format!("http://localhost:{}", port), 0)?
+        .settings_file(&conformu_settings_path)
+        .run()
+        .await;
+
+    match &result {
+        Ok(_) => {
+            println!("ConformU FilterWheel compliance tests PASSED");
+        }
+        Err(e) => {
+            println!("ConformU FilterWheel compliance tests FAILED: {}", e);
+        }
+    }
+
+    println!("::endgroup::");
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+    stdout_drain.abort();
+    std::fs::remove_dir_all(&test_dir).ok();
+
+    result?;
+    Ok(())
+}

--- a/services/qhy-camera/tests/features/camera_properties.feature
+++ b/services/qhy-camera/tests/features/camera_properties.feature
@@ -1,0 +1,122 @@
+Feature: Camera properties
+  A connected camera exposes CCD information, binning modes, gain/offset
+  ranges, exposure limits, cooler status, readout modes, and sensor info.
+  All properties require a connected device.
+
+  Scenario: CCD dimensions available after connect
+    Given a connected camera device
+    Then camera_x_size should be 4656
+    And camera_y_size should be 3520
+
+  Scenario: Pixel sizes available after connect
+    Given a connected camera device
+    Then pixel_size_x should be 3.76
+    And pixel_size_y should be 3.76
+
+  Scenario: Default binning is 1x1
+    Given a connected camera device
+    Then bin_x should be 1
+    And bin_y should be 1
+
+  Scenario: Max binning reflects available modes
+    Given a connected camera device
+    Then max_bin_x should be 4
+    And max_bin_y should be 4
+
+  Scenario: Binning can be changed
+    Given a connected camera device
+    When I set bin_x to 2
+    Then bin_x should be 2
+
+  Scenario: Invalid binning is rejected
+    Given a connected camera device
+    When I try to set bin_x to 5
+    Then the operation should fail with an invalid-value error
+
+  Scenario: ROI defaults to full effective area
+    Given a connected camera device
+    Then start_x should be 0
+    And start_y should be 0
+    And num_x should be 4656
+    And num_y should be 3520
+
+  Scenario: ROI can be modified
+    Given a connected camera device
+    When I set start_x to 100
+    And I set num_x to 1000
+    Then start_x should be 100
+    And num_x should be 1000
+
+  Scenario: Gain range available after connect
+    Given a connected camera device
+    Then gain_min should be 0
+    And gain_max should be 100
+
+  Scenario: Gain can be set within range
+    Given a connected camera device
+    When I set gain to 50
+    Then gain should be 50
+
+  Scenario: Gain out of range is rejected
+    Given a connected camera device
+    When I try to set gain to 150
+    Then the operation should fail with an invalid-value error
+
+  Scenario: Offset range available after connect
+    Given a connected camera device
+    Then offset_min should be 0
+    And offset_max should be 200
+
+  Scenario: Exposure limits available after connect
+    Given a connected camera device
+    Then exposure_min should be available
+    And exposure_max should be available
+    And exposure_resolution should be available
+
+  Scenario: Camera state is idle when not exposing
+    Given a connected camera device
+    Then camera_state should be idle
+
+  Scenario: Camera can abort exposure
+    Given a connected camera device
+    Then can_abort_exposure should be true
+    And can_stop_exposure should be false
+
+  Scenario: Camera has no shutter by default
+    Given a connected camera device
+    Then has_shutter should be false
+
+  Scenario: Sensor is monochrome by default
+    Given a connected camera device
+    Then sensor_type should be monochrome
+
+  Scenario: Sensor name parsed from unique ID
+    Given a connected camera device
+    Then sensor_name should be "QHY600M"
+
+  Scenario: Readout modes available after connect
+    Given a connected camera device
+    Then readout_modes should have 2 entries
+
+  Scenario: Fast readout supported
+    Given a connected camera device
+    Then can_fast_readout should be true
+
+  Scenario: Cooler capabilities available
+    Given a connected camera device
+    Then can_set_ccd_temperature should be true
+    And can_get_cooler_power should be true
+
+  Scenario: Max ADU based on bit depth
+    Given a connected camera device
+    Then max_adu should be 65536
+
+  Scenario: Properties fail when not connected
+    Given a camera device with mock SDK
+    When I try to read camera_x_size
+    Then the operation should fail with a not-connected error
+
+  Scenario: Driver info and version available
+    Given a connected camera device
+    Then driver_info should contain "QHY Camera"
+    And driver_version should not be empty

--- a/services/qhy-camera/tests/features/connection_lifecycle.feature
+++ b/services/qhy-camera/tests/features/connection_lifecycle.feature
@@ -1,0 +1,55 @@
+Feature: Connection lifecycle
+  Camera and filter wheel devices manage connections to QHYCCD hardware
+  through the SDK. Connection initializes the device and caches hardware
+  capabilities. Disconnection releases the device.
+
+  Scenario: Camera starts disconnected
+    Given a camera device with mock SDK
+    Then the camera should not be connected
+
+  Scenario: Camera connects successfully
+    Given a camera device with mock SDK
+    When I connect the camera
+    Then the camera should be connected
+
+  Scenario: Camera disconnects successfully
+    Given a camera device with mock SDK
+    When I connect the camera
+    And I disconnect the camera
+    Then the camera should not be connected
+
+  Scenario: Camera connect is idempotent
+    Given a camera device with mock SDK
+    When I connect the camera
+    And I connect the camera
+    Then the camera should be connected
+
+  Scenario: Camera disconnect is idempotent
+    Given a camera device with mock SDK
+    When I disconnect the camera
+    Then the camera should not be connected
+
+  Scenario: Camera connect fails with SDK error
+    Given a camera device with failing SDK
+    When I try to connect the camera
+    Then the operation should fail with a not-connected error
+
+  Scenario: Filter wheel starts disconnected
+    Given a filter wheel device with mock SDK
+    Then the filter wheel should not be connected
+
+  Scenario: Filter wheel connects successfully
+    Given a filter wheel device with mock SDK
+    When I connect the filter wheel
+    Then the filter wheel should be connected
+
+  Scenario: Filter wheel disconnects successfully
+    Given a filter wheel device with mock SDK
+    When I connect the filter wheel
+    And I disconnect the filter wheel
+    Then the filter wheel should not be connected
+
+  Scenario: Filter wheel connect fails with SDK error
+    Given a filter wheel device with failing SDK
+    When I try to connect the filter wheel
+    Then the operation should fail with a not-connected error

--- a/services/qhy-camera/tests/features/exposure_control.feature
+++ b/services/qhy-camera/tests/features/exposure_control.feature
@@ -1,0 +1,66 @@
+Feature: Exposure control
+  The camera supports single-frame exposures with async completion and abort.
+  Exposure runs in a background task. The image is available after exposure
+  completes. Dark frames are not supported.
+
+  Scenario: Start exposure transitions to exposing state
+    Given a connected camera device
+    When I start a 1 second exposure
+    Then camera_state should be exposing
+
+  Scenario: Image not ready during exposure
+    Given a connected camera device
+    When I start a 1 second exposure
+    Then image_ready should be false
+
+  Scenario: Exposure completes and image becomes ready
+    Given a connected camera device
+    When I start a 0.01 second exposure
+    And I wait for exposure to complete
+    Then image_ready should be true
+    And camera_state should be idle
+
+  Scenario: Image array available after exposure
+    Given a connected camera device
+    When I start a 0.01 second exposure
+    And I wait for exposure to complete
+    Then image_array should be available
+
+  Scenario: Abort exposure returns to idle
+    Given a connected camera device
+    When I start a 10 second exposure
+    And I abort the exposure
+    Then camera_state should be idle
+
+  Scenario: Abort when idle is no-op
+    Given a connected camera device
+    When I abort the exposure
+    Then camera_state should be idle
+
+  Scenario: Dark frames are not supported
+    Given a connected camera device
+    When I try to start a dark frame exposure
+    Then the operation should fail with an invalid-operation error
+
+  Scenario: Cannot start exposure when already exposing
+    Given a connected camera device
+    When I start a 10 second exposure
+    And I try to start another exposure
+    Then the operation should fail with an invalid-operation error
+
+  Scenario: Exposure fails when not connected
+    Given a camera device with mock SDK
+    When I try to start a 1 second exposure
+    Then the operation should fail with a not-connected error
+
+  Scenario: Last exposure duration recorded
+    Given a connected camera device
+    When I start a 0.01 second exposure
+    And I wait for exposure to complete
+    Then last_exposure_duration should be available
+
+  Scenario: Last exposure start time recorded
+    Given a connected camera device
+    When I start a 0.01 second exposure
+    And I wait for exposure to complete
+    Then last_exposure_start_time should be available

--- a/services/qhy-camera/tests/features/filter_wheel_control.feature
+++ b/services/qhy-camera/tests/features/filter_wheel_control.feature
@@ -1,0 +1,43 @@
+Feature: Filter wheel control
+  The filter wheel reports its position and supports position changes.
+  While moving, position returns None. Filter names can come from
+  configuration or default to "Filter0", "Filter1", etc.
+
+  Scenario: Filter wheel position after connect
+    Given a connected filter wheel device
+    Then filter wheel position should be 0
+
+  Scenario: Filter wheel position can be changed
+    Given a connected filter wheel device
+    When I set filter wheel position to 3
+    Then filter wheel position should be 3
+
+  Scenario: Setting same position is idempotent
+    Given a connected filter wheel device
+    When I set filter wheel position to 0
+    Then filter wheel position should be 0
+
+  Scenario: Invalid position is rejected
+    Given a connected filter wheel device
+    When I try to set filter wheel position to 99
+    Then the operation should fail with an invalid-value error
+
+  Scenario: Default filter names
+    Given a connected filter wheel device
+    Then filter names should have 7 entries
+    And first filter name should be "Filter0"
+
+  Scenario: Custom filter names from config
+    Given a filter wheel config with names "L,R,G,B,Ha,OIII,SII"
+    And a connected filter wheel device with config
+    Then first filter name should be "L"
+
+  Scenario: Focus offsets are all zeros
+    Given a connected filter wheel device
+    Then focus_offsets should have 7 entries
+    And all focus offsets should be 0
+
+  Scenario: Filter wheel properties fail when not connected
+    Given a filter wheel device with mock SDK
+    When I try to read filter wheel position
+    Then the operation should fail with a not-connected error


### PR DESCRIPTION
## Summary

- Port the QHYCCD camera/filter wheel ASCOM Alpaca driver from the standalone [qhyccd-alpaca](https://github.com/ivonnyssen/qhyccd-alpaca) repository (post-[PR #35](https://github.com/ivonnyssen/qhyccd-alpaca/pull/35)) into the rusty-photon workspace as `services/qhy-camera`
- Trait-based SDK abstraction (`SdkProvider`, `CameraHandle`, `FilterWheelHandle`) enabling mockall-based testing without hardware
- 53 BDD scenarios (164 steps) covering connection lifecycle, camera properties, exposure control, and filter wheel operations
- CI workflows updated with QHYCCD SDK + libusb installation; `qhy-camera` excluded from macOS/Windows os-check (SDK is Linux-only)

## What's included

| Area | Details |
|------|---------|
| Design doc | `docs/services/qhy-camera.md` — ASCOM mapping tables, state machine, image pipeline, config |
| Camera | Single-frame exposure with async abort (tokio::spawn + oneshot), CCD info, binning, ROI, gain/offset, cooler, readout modes, Bayer/sensor info |
| FilterWheel | Position get/set with moving state (`None`), filter names from config, focus offsets |
| Mock | Feature-gated mock SDK with persistent state for ConformU/server testing |
| CI | SDK + libusb install in test/safety/check/scheduled workflows |

## Test plan

- [x] `cargo build --all` passes
- [x] `cargo test -p qhy-camera` — 53 BDD scenarios, 164 steps, all green
- [x] `cargo test -p qhy-camera --features mock` — 6 unit tests + 53 BDD scenarios pass
- [x] `cargo fmt --check` clean
- [x] Pre-commit hook (clippy + fmt) passes
- [ ] CI workflows run with QHYCCD SDK installed (verify in this PR)
- [ ] `cargo run -p qhy-camera --features mock` starts server on port 11116

🤖 Generated with [Claude Code](https://claude.com/claude-code)