### PR TITLE
Handle SIGTERM in filemonitor for coverage data flush

### DIFF
--- a/services/filemonitor/src/main.rs
+++ b/services/filemonitor/src/main.rs
@@ -53,7 +53,27 @@ async fn run_with_reload(config_path: &std::path::Path) -> Result<(), Box<dyn st
         config_path,
         || {
             Box::pin(async {
-                let _ = tokio::signal::ctrl_c().await;
+                let ctrl_c = async {
+                    tokio::signal::ctrl_c()
+                        .await
+                        .expect("failed to install Ctrl+C handler");
+                };
+
+                #[cfg(unix)]
+                let terminate = async {
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                        .expect("failed to install SIGTERM handler")
+                        .recv()
+                        .await;
+                };
+
+                #[cfg(not(unix))]
+                let terminate = std::future::pending::<()>();
+
+                tokio::select! {
+                    () = ctrl_c => debug!("received Ctrl+C"),
+                    () = terminate => debug!("received SIGTERM"),
+                }
             })
         },
         || {


### PR DESCRIPTION
## Summary
- Add SIGTERM handler to filemonitor's stop signal closure, matching the pattern already used by the rp service
- Without this, BDD tests send SIGTERM to stop the binary but the process is killed by the OS default handler before `llvm-cov` profraw data can be flushed
- This caused Device and SafetyMonitor impl coverage to report as 0% despite being thoroughly exercised by 31 BDD scenarios

## Test plan
- [x] `cargo build --all --all-targets` passes
- [x] `cargo test --package filemonitor` — all 31 BDD scenarios pass (183 steps)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)