### PR TITLE
Fix Miri failures by gating ascom-alpaca test feature

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
   schedule:
     - cron: "7 7 * * *"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/services/filemonitor/Cargo.toml
+++ b/services/filemonitor/Cargo.toml
@@ -8,8 +8,12 @@ repository.workspace = true
 rust-version = "1.88.0"
 description = "File monitoring service for Rusty Photon"
 
+[features]
+default = []
+conformu = ["ascom-alpaca/test"]
+
 [dependencies]
-ascom-alpaca = { workspace = true, features = ["server", "safety_monitor", "test", "client"] }
+ascom-alpaca = { workspace = true, features = ["server", "safety_monitor", "client"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -23,7 +27,7 @@ tracing-subscriber = { workspace = true }
 windows-service = "0.8"
 
 [package.metadata.conformu]
-command = "cargo test -p filemonitor --test conformu_integration -- --ignored --nocapture"
+command = "cargo test -p filemonitor --features conformu --test conformu_integration -- --ignored --nocapture"
 
 [package.metadata.miri]
 command = "cargo miri test -p filemonitor"

--- a/services/filemonitor/tests/conformu_integration.rs
+++ b/services/filemonitor/tests/conformu_integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "conformu")]
+
 use ascom_alpaca::api::SafetyMonitor;
 use ascom_alpaca::test::run_conformu_tests;
 use std::process::Stdio;

--- a/services/qhy-focuser/Cargo.toml
+++ b/services/qhy-focuser/Cargo.toml
@@ -11,9 +11,10 @@ description = "ASCOM Alpaca driver for QHY Q-Focuser (EAF)"
 [features]
 default = []
 mock = []  # Enables mock hardware for testing without real serial port
+conformu = ["ascom-alpaca/test"]
 
 [dependencies]
-ascom-alpaca = { workspace = true, features = ["server", "focuser", "test"] }
+ascom-alpaca = { workspace = true, features = ["server", "focuser"] }
 tokio = { workspace = true }
 tokio-serial = { workspace = true }
 serde = { workspace = true }
@@ -25,7 +26,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 [package.metadata.conformu]
-command = "cargo test -p qhy-focuser --features mock --test conformu_integration -- --ignored --nocapture"
+command = "cargo test -p qhy-focuser --features mock,conformu --test conformu_integration -- --ignored --nocapture"
 
 [package.metadata.miri]
 command = "cargo miri test -p qhy-focuser"

--- a/services/qhy-focuser/tests/conformu_integration.rs
+++ b/services/qhy-focuser/tests/conformu_integration.rs
@@ -2,6 +2,7 @@
 //!
 //! These tests verify ASCOM Alpaca compliance by running the ConformU test suite
 //! against the driver running in mock mode.
+#![cfg(feature = "conformu")]
 #![allow(clippy::await_holding_lock)]
 
 use ascom_alpaca::api::Focuser;


### PR DESCRIPTION
## Summary
- Gate `ascom-alpaca/test` behind a new `conformu` Cargo feature in filemonitor and qhy-focuser
- The `test` feature uses `#[dtor::dtor]` which calls `atexit` — unsupported by Miri — crashing all test binaries at startup
- ConformU integration tests are gated with `#![cfg(feature = "conformu")]` and their metadata commands updated to pass `--features conformu`

## Test plan
- [x] `cargo build --all --all-targets` passes
- [x] `cargo build --all --all-targets --all-features` passes (simulates nightly/update CI)
- [x] `cargo test --all` passes
- [x] `cargo fmt` clean
- [ ] Miri CI job passes for filemonitor and qhy-focuser

🤖 Generated with [Claude Code](https://claude.com/claude-code)