### PR TITLE
Update toml dependency to 1.x

### DIFF
--- a/crates/bdd-infra/Cargo.toml
+++ b/crates/bdd-infra/Cargo.toml
@@ -14,7 +14,7 @@ env_var = "TEST_SERVICE_BINARY"
 [dependencies]
 libc = { workspace = true }
 serde = { workspace = true }
-toml = "0.8"
+toml = "1.1.0+spec-1.1.0"
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -52,7 +52,7 @@ fn load_config(manifest_dir: &str) -> BddConfig {
     let path = format!("{}/Cargo.toml", manifest_dir);
     let content =
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path, e));
-    let toml: toml::Value = content
+    let toml: toml::Table = content
         .parse()
         .unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e));
     let bdd = toml


### PR DESCRIPTION
## Summary
- Upgrade `toml` crate from 0.8 to 1.1.0 in bdd-infra
- Fix `load_config` to parse with `toml::Table` instead of `toml::Value`, as toml 1.x changed `Value::from_str` to parse a single value rather than a full document

## Test plan
- [x] `cargo build --all --all-targets` passes
- [x] `cargo test --all` passes (all 14 bdd-infra tests green)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)