### PR TITLE
Fix Miri failure in filemonitor BDD test

### DIFF
--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -29,6 +29,42 @@
 //! // ...
 //! handle.stop().await;
 //! ```
+//!
+//! # Miri compatibility
+//!
+//! BDD tests that spawn child processes cannot run under Miri (`pidfd_spawnp`
+//! is unsupported). Use the [`bdd_main!`] macro in your `bdd.rs` entry point
+//! to automatically skip the test under Miri:
+//!
+//! ```rust,ignore
+//! bdd_infra::bdd_main! {
+//!     use cucumber::World as _;
+//!     use world::MyWorld;
+//!
+//!     MyWorld::cucumber()
+//!         .run_and_exit("tests/features")
+//!         .await;
+//! }
+//! ```
+
+/// Entry-point macro for BDD tests that spawn child processes.
+///
+/// Under Miri the macro expands to an empty `fn main() {}`, because Miri does
+/// not support `pidfd_spawnp` and other process-spawning FFI. Under normal
+/// compilation it expands to `#[tokio::main] async fn main() { ... }`.
+#[macro_export]
+macro_rules! bdd_main {
+    ($($body:tt)*) => {
+        #[cfg(miri)]
+        fn main() {}
+
+        #[cfg(not(miri))]
+        #[tokio::main]
+        async fn main() {
+            $($body)*
+        }
+    };
+}
 
 use std::process::Stdio;
 use std::time::Duration;

--- a/docs/skills/development-workflow.md
+++ b/docs/skills/development-workflow.md
@@ -104,6 +104,10 @@ name = "bdd"
 harness = false
 ```
 
+If the BDD tests spawn child processes (via `ServiceHandle`), use the
+`bdd_infra::bdd_main!` macro for Miri compatibility — see
+docs/skills/testing.md Section 5.2.
+
 #### Step 2b: Build test doubles
 
 For services that depend on external systems, build test infrastructure early:

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -367,7 +367,14 @@ tests/
     ...
 ```
 
-The `bdd.rs` entry point uses `#[path = "..."]` imports because test crate roots see siblings, not children:
+The `bdd.rs` entry point uses `#[path = "..."]` imports because test crate roots see siblings, not children.
+
+**BDD tests that spawn child processes** (i.e. use `ServiceHandle`) **must** use the
+`bdd_infra::bdd_main!` macro instead of a hand-written `#[tokio::main] async fn main()`.
+The macro expands to an empty `fn main() {}` under Miri, because Miri does not
+support the `pidfd_spawnp` FFI that tokio uses for process spawning on Linux.
+BDD tests that are purely in-process (e.g. qhy-focuser with mock serial ports)
+do not need the macro.
 
 ```rust
 #[path = "bdd/world.rs"]
@@ -376,11 +383,10 @@ mod world;
 #[path = "bdd/steps/mod.rs"]
 mod steps;
 
-use cucumber::World as _;
-use world::MyWorld;
+bdd_infra::bdd_main! {
+    use cucumber::World as _;
+    use world::MyWorld;
 
-#[tokio::main]
-async fn main() {
     MyWorld::cucumber()
         .after(|_feature, _rule, _scenario, _finished, maybe_world| {
             Box::pin(async move {

--- a/services/filemonitor/tests/bdd.rs
+++ b/services/filemonitor/tests/bdd.rs
@@ -6,11 +6,10 @@ mod world;
 #[path = "bdd/steps/mod.rs"]
 mod steps;
 
-use cucumber::World as _;
-use world::FilemonitorWorld;
+bdd_infra::bdd_main! {
+    use cucumber::World as _;
+    use world::FilemonitorWorld;
 
-#[tokio::main]
-async fn main() {
     FilemonitorWorld::cucumber()
         .after(|_feature, _rule, _scenario, _finished, maybe_world| {
             Box::pin(async move {

--- a/services/ppba-driver/tests/bdd.rs
+++ b/services/ppba-driver/tests/bdd.rs
@@ -4,11 +4,10 @@ mod world;
 #[path = "bdd/steps/mod.rs"]
 mod steps;
 
-use cucumber::World as _;
-use world::PpbaWorld;
+bdd_infra::bdd_main! {
+    use cucumber::World as _;
+    use world::PpbaWorld;
 
-#[tokio::main]
-async fn main() {
     PpbaWorld::cucumber()
         // Run one scenario at a time: each spawns a ppba-driver subprocess
         // that binds the Alpaca discovery UDP port (32227). On macOS,

--- a/services/rp/tests/bdd.rs
+++ b/services/rp/tests/bdd.rs
@@ -6,11 +6,10 @@ mod world;
 #[path = "bdd/steps/mod.rs"]
 mod steps;
 
-use cucumber::World as _;
-use world::RpWorld;
+bdd_infra::bdd_main! {
+    use cucumber::World as _;
+    use world::RpWorld;
 
-#[tokio::main]
-async fn main() {
     RpWorld::cucumber()
         .after(|_feature, _rule, _scenario, _finished, maybe_world| {
             Box::pin(async move {


### PR DESCRIPTION
## Summary
- Adds `bdd_infra::bdd_main!` macro that expands to an empty `fn main()` under Miri and `#[tokio::main] async fn main()` otherwise
- Updates all three process-spawning BDD entry points (filemonitor, rp, ppba-driver) to use the macro
- Documents the macro requirement in testing.md and development-workflow.md

**Root cause:** Miri does not support the `pidfd_spawnp` FFI that tokio uses for process spawning on Linux, causing the filemonitor BDD test to crash in the scheduled CI workflow ([failing run](https://github.com/ivonnyssen/rusty-photon/actions/runs/23472875601/job/68299253835)).

## Test plan
- [x] `cargo build --all --all-targets` passes
- [x] `cargo test --all` passes (all BDD scenarios green)
- [x] `cargo fmt` clean
- [ ] Miri scheduled workflow passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)