### PR TITLE
Skip proptest under Miri for filemonitor

### DIFF
--- a/services/filemonitor/tests/test_property.rs
+++ b/services/filemonitor/tests/test_property.rs
@@ -1,3 +1,7 @@
+// Proptest is prohibitively slow under Miri's interpreter and uses getcwd
+// which is unsupported without -Zmiri-disable-isolation.
+#![cfg(not(miri))]
+
 use filemonitor::{
     Config, DeviceConfig, FileConfig, FileMonitorDevice, ParsingConfig, ParsingRule, RuleType,
     ServerConfig,


### PR DESCRIPTION
## Summary
- Gates `test_property.rs` with `#![cfg(not(miri))]` to skip proptest tests under Miri

**Root cause:** After merging #58 (bdd_main! macro), the filemonitor Miri job still timed out at 6 hours. Local reproduction confirmed proptest tests are the culprit — proptest uses `getcwd` (unsupported without `-Zmiri-disable-isolation`) and running hundreds of randomized iterations under Miri's interpreter is prohibitively slow.

With this change, `cargo miri test -p filemonitor` completes instantly locally.

## Test plan
- [x] `cargo +nightly miri test -p filemonitor` passes locally (with `-Zmiri-disable-isolation`)
- [x] `cargo build --all --all-targets` passes
- [x] `cargo fmt` clean
- [ ] Scheduled Miri workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)