### PR TITLE
Add core ACME/Let's Encrypt infrastructure (ADR-002 Phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", bran
 axum = "0.8"
 reqwest = { version = "0.13.2", features = ["form", "json"] }
 rp-tls = { path = "crates/rp-tls" }
-rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
+rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
+instant-acme = { version = "0.8", features = ["hyper-rustls", "rcgen"] }
+cloudflare = "0.14"
 rustls = "0.23"
 rustls-pemfile = "2"
 tokio-rustls = "0.26"

--- a/crates/rp-tls/Cargo.toml
+++ b/crates/rp-tls/Cargo.toml
@@ -24,7 +24,10 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
+async-trait = { workspace = true }
+cloudflare = { workspace = true }
 hostname = "0.4"
+instant-acme = { workspace = true }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
 time = "0.3"
 

--- a/crates/rp-tls/Cargo.toml
+++ b/crates/rp-tls/Cargo.toml
@@ -32,6 +32,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
 time = "0.3"
 
 [dev-dependencies]
+mockall = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 reqwest = { workspace = true }

--- a/crates/rp-tls/src/acme.rs
+++ b/crates/rp-tls/src/acme.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::sync::Mutex;
 use tracing::{debug, info};
 
 use crate::acme_config::{self, AcmeConfig};
@@ -31,21 +33,26 @@ pub trait AcmeClient: Send + Sync {
 
     /// Run the full ACME order flow for a wildcard domain:
     /// create order, solve DNS-01 challenges, finalize, return (cert_pem, key_pem).
+    ///
+    /// Must be called after `create_or_load_account`.
     async fn order_certificate(&self, domain: String) -> Result<(String, String)>;
 }
 
 /// Real ACME client using `instant-acme`.
 ///
-/// Holds the DNS provider reference needed for challenge solving.
-/// Constructed per-issuance by `issue_certificate_real`.
+/// Stores the account handle after `create_or_load_account` so that
+/// `order_certificate` can use it. Holds a DNS provider reference
+/// for solving DNS-01 challenges.
 pub struct RealAcmeClient<'a> {
-    _dns_provider: &'a dyn DnsProvider,
+    dns_provider: &'a dyn DnsProvider,
+    account: Arc<Mutex<Option<instant_acme::Account>>>,
 }
 
 impl<'a> RealAcmeClient<'a> {
     pub fn new(dns_provider: &'a dyn DnsProvider) -> Self {
         Self {
-            _dns_provider: dns_provider,
+            dns_provider,
+            account: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -64,11 +71,12 @@ impl AcmeClient for RealAcmeClient<'_> {
             debug!("Loading ACME account from credentials");
             let credentials: AccountCredentials = serde_json::from_str(&json)
                 .map_err(|e| TlsError::Acme(format!("failed to parse account credentials: {e}")))?;
-            Account::builder()
+            let account = Account::builder()
                 .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
                 .from_credentials(credentials)
                 .await
                 .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?;
+            *self.account.lock().await = Some(account);
             debug!("Loaded existing ACME account");
             Ok(None)
         } else {
@@ -80,11 +88,13 @@ impl AcmeClient for RealAcmeClient<'_> {
                 only_return_existing: false,
             };
 
-            let (_account, credentials) = Account::builder()
+            let (account, credentials) = Account::builder()
                 .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
                 .create(&new_account, directory_url, None)
                 .await
                 .map_err(|e| TlsError::Acme(format!("failed to create ACME account: {e}")))?;
+
+            *self.account.lock().await = Some(account);
 
             let json = serde_json::to_string_pretty(&credentials)
                 .map_err(|e| TlsError::Acme(format!("failed to serialize credentials: {e}")))?;
@@ -93,23 +103,95 @@ impl AcmeClient for RealAcmeClient<'_> {
         }
     }
 
-    async fn order_certificate(&self, _domain: String) -> Result<(String, String)> {
-        // This trait method exists for the mock boundary; the real implementation
-        // uses issue_certificate_real which manages the full lifecycle directly.
-        Err(TlsError::Acme(
-            "RealAcmeClient::order_certificate should not be called directly; \
-             use issue_certificate_real for the full lifecycle"
-                .to_string(),
-        ))
+    async fn order_certificate(&self, domain: String) -> Result<(String, String)> {
+        use instant_acme::{ChallengeType, Identifier, NewOrder, RetryPolicy};
+
+        let mut account_guard = self.account.lock().await;
+        let account = account_guard.as_mut().ok_or_else(|| {
+            TlsError::Acme(
+                "account not initialized — call create_or_load_account first".to_string(),
+            )
+        })?;
+
+        // Create order for wildcard domain
+        let wildcard = format!("*.{domain}");
+        let identifiers = [Identifier::Dns(wildcard.clone())];
+        let new_order = NewOrder::new(&identifiers);
+
+        debug!("Creating ACME order for {}", wildcard);
+        let mut order = account
+            .new_order(&new_order)
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to create order: {e}")))?;
+
+        // Solve DNS-01 challenges
+        let challenge_fqdn = format!("_acme-challenge.{domain}");
+        let mut auths = order.authorizations();
+        while let Some(auth_result) = auths.next().await {
+            let mut auth = auth_result
+                .map_err(|e| TlsError::Acme(format!("failed to get authorization: {e}")))?;
+
+            let mut challenge = auth.challenge(ChallengeType::Dns01).ok_or_else(|| {
+                TlsError::Acme("no DNS-01 challenge offered by server".to_string())
+            })?;
+
+            let key_auth = challenge.key_authorization();
+            let dns_value = key_auth.dns_value();
+
+            debug!(
+                "Setting up DNS-01 challenge for {} with value {}",
+                challenge_fqdn, dns_value
+            );
+
+            self.dns_provider
+                .create_txt_record(&challenge_fqdn, &dns_value)
+                .await?;
+
+            debug!("Waiting 15 seconds for DNS propagation");
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+
+            challenge
+                .set_ready()
+                .await
+                .map_err(|e| TlsError::Acme(format!("failed to set challenge ready: {e}")))?;
+
+            debug!("Challenge marked as ready");
+        }
+
+        debug!("Polling order until ready");
+        order
+            .poll_ready(&RetryPolicy::default())
+            .await
+            .map_err(|e| TlsError::Acme(format!("order did not become ready: {e}")))?;
+
+        debug!("Cleaning up DNS challenge record");
+        if let Err(e) = self.dns_provider.delete_txt_record(&challenge_fqdn).await {
+            debug!("Warning: failed to clean up DNS record: {e}");
+        }
+
+        // Finalize
+        debug!("Finalizing order (generating CSR)");
+        let private_key_pem = order
+            .finalize()
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to finalize order: {e}")))?;
+
+        debug!("Polling for certificate");
+        let cert_chain_pem = order
+            .poll_certificate(&RetryPolicy::default())
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to retrieve certificate: {e}")))?;
+
+        Ok((cert_chain_pem, private_key_pem))
     }
 }
 
-/// Issue a wildcard certificate via ACME (mockable version).
+/// Issue a wildcard certificate via ACME.
 ///
-/// This is the testable entry point that uses the `AcmeClient` trait:
-/// 1. Creates or loads an ACME account
+/// This is the main entry point for certificate issuance:
+/// 1. Creates or loads an ACME account (via `AcmeClient`)
 /// 2. Persists new account credentials if created
-/// 3. Orders the certificate
+/// 3. Orders the certificate (via `AcmeClient`)
 /// 4. Writes the certificate and private key to disk
 pub async fn issue_certificate(
     config: &AcmeConfig,
@@ -146,147 +228,6 @@ pub async fn issue_certificate(
     // Order certificate
     let (cert_chain_pem, private_key_pem) =
         acme_client.order_certificate(config.domain.clone()).await?;
-
-    // Write certificate and key
-    let certs_dir = pki_dir.join("certs");
-    std::fs::create_dir_all(&certs_dir)?;
-
-    let cert_path = acme_config::acme_cert_path(pki_dir);
-    let key_path = acme_config::acme_key_path(pki_dir);
-
-    std::fs::write(&cert_path, &cert_chain_pem)?;
-    std::fs::write(&key_path, &private_key_pem)?;
-    set_restricted_permissions(&key_path)?;
-
-    info!("Certificate written to {}", cert_path.display());
-    info!("Private key written to {}", key_path.display());
-
-    Ok(())
-}
-
-/// Issue a certificate using the real ACME client (instant-acme).
-///
-/// This is the production entry point that handles the full lifecycle
-/// including account management and the ACME protocol flow directly.
-pub async fn issue_certificate_real(
-    config: &AcmeConfig,
-    pki_dir: &Path,
-    dns_provider: &dyn DnsProvider,
-) -> Result<()> {
-    use instant_acme::{
-        Account, AccountCredentials, ChallengeType, Identifier, NewAccount, NewOrder, RetryPolicy,
-    };
-
-    let account_path = acme_config::acme_account_path(pki_dir);
-    let directory_url = acme_config::directory_url(config.staging).to_string();
-
-    // Create or load account
-    let account = if account_path.exists() {
-        debug!("Loading ACME account from {}", account_path.display());
-        let json = std::fs::read_to_string(&account_path)?;
-        let credentials: AccountCredentials = serde_json::from_str(&json)
-            .map_err(|e| TlsError::Acme(format!("failed to parse account credentials: {e}")))?;
-        Account::builder()
-            .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
-            .from_credentials(credentials)
-            .await
-            .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?
-    } else {
-        debug!("Creating new ACME account at {}", directory_url);
-        let contact = format!("mailto:{}", config.email);
-        let new_account = NewAccount {
-            contact: &[&contact],
-            terms_of_service_agreed: true,
-            only_return_existing: false,
-        };
-
-        let (account, credentials) = Account::builder()
-            .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
-            .create(&new_account, directory_url, None)
-            .await
-            .map_err(|e| TlsError::Acme(format!("failed to create ACME account: {e}")))?;
-
-        std::fs::create_dir_all(pki_dir)?;
-        let json = serde_json::to_string_pretty(&credentials)
-            .map_err(|e| TlsError::Acme(format!("failed to serialize credentials: {e}")))?;
-        std::fs::write(&account_path, json)?;
-        set_restricted_permissions(&account_path)?;
-        info!(
-            "Created new ACME account, saved to {}",
-            account_path.display()
-        );
-
-        account
-    };
-
-    // Create order for wildcard domain
-    let wildcard = format!("*.{}", config.domain);
-    let identifiers = [Identifier::Dns(wildcard.clone())];
-    let new_order = NewOrder::new(&identifiers);
-
-    debug!("Creating ACME order for {}", wildcard);
-    let mut order = account
-        .new_order(&new_order)
-        .await
-        .map_err(|e| TlsError::Acme(format!("failed to create order: {e}")))?;
-
-    // Solve DNS-01 challenges
-    let challenge_fqdn = format!("_acme-challenge.{}", config.domain);
-    let mut auths = order.authorizations();
-    while let Some(auth_result) = auths.next().await {
-        let mut auth =
-            auth_result.map_err(|e| TlsError::Acme(format!("failed to get authorization: {e}")))?;
-
-        let mut challenge = auth
-            .challenge(ChallengeType::Dns01)
-            .ok_or_else(|| TlsError::Acme("no DNS-01 challenge offered by server".to_string()))?;
-
-        let key_auth = challenge.key_authorization();
-        let dns_value = key_auth.dns_value();
-
-        debug!(
-            "Setting up DNS-01 challenge for {} with value {}",
-            challenge_fqdn, dns_value
-        );
-
-        dns_provider
-            .create_txt_record(&challenge_fqdn, &dns_value)
-            .await?;
-
-        debug!("Waiting 15 seconds for DNS propagation");
-        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
-
-        challenge
-            .set_ready()
-            .await
-            .map_err(|e| TlsError::Acme(format!("failed to set challenge ready: {e}")))?;
-
-        debug!("Challenge marked as ready");
-    }
-
-    debug!("Polling order until ready");
-    order
-        .poll_ready(&RetryPolicy::default())
-        .await
-        .map_err(|e| TlsError::Acme(format!("order did not become ready: {e}")))?;
-
-    debug!("Cleaning up DNS challenge record");
-    if let Err(e) = dns_provider.delete_txt_record(&challenge_fqdn).await {
-        debug!("Warning: failed to clean up DNS record: {e}");
-    }
-
-    // Finalize
-    debug!("Finalizing order (generating CSR)");
-    let private_key_pem = order
-        .finalize()
-        .await
-        .map_err(|e| TlsError::Acme(format!("failed to finalize order: {e}")))?;
-
-    debug!("Polling for certificate");
-    let cert_chain_pem = order
-        .poll_certificate(&RetryPolicy::default())
-        .await
-        .map_err(|e| TlsError::Acme(format!("failed to retrieve certificate: {e}")))?;
 
     // Write certificate and key
     let certs_dir = pki_dir.join("certs");

--- a/crates/rp-tls/src/acme.rs
+++ b/crates/rp-tls/src/acme.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 
-use instant_acme::{
-    Account, AccountCredentials, ChallengeType, Identifier, NewAccount, NewOrder, RetryPolicy,
-};
+use async_trait::async_trait;
 use tracing::{debug, info};
 
 use crate::acme_config::{self, AcmeConfig};
@@ -10,27 +8,189 @@ use crate::dns::DnsProvider;
 use crate::error::{Result, TlsError};
 use crate::permissions::set_restricted_permissions;
 
-/// Create or load an ACME account.
+/// Trait abstracting the ACME protocol operations.
 ///
-/// If `acme-account.json` exists in the PKI directory, the account is
-/// restored from the saved credentials. Otherwise, a new account is
-/// created and the credentials are persisted.
-pub async fn create_or_load_account(config: &AcmeConfig, pki_dir: &Path) -> Result<Account> {
+/// This allows mocking the ACME client in tests without making real
+/// HTTP calls to Let's Encrypt. Uses owned types to be mockall-compatible.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait AcmeClient: Send + Sync {
+    /// Create or load an ACME account.
+    ///
+    /// If `existing_credentials_json` is `Some`, the account is restored
+    /// from those credentials. Otherwise a new account is created.
+    ///
+    /// Returns `Some(credentials_json)` if a new account was created
+    /// (caller should persist it), or `None` if an existing account was loaded.
+    async fn create_or_load_account(
+        &self,
+        email: String,
+        directory_url: String,
+        existing_credentials_json: Option<String>,
+    ) -> Result<Option<String>>;
+
+    /// Run the full ACME order flow for a wildcard domain:
+    /// create order, solve DNS-01 challenges, finalize, return (cert_pem, key_pem).
+    async fn order_certificate(&self, domain: String) -> Result<(String, String)>;
+}
+
+/// Real ACME client using `instant-acme`.
+///
+/// Holds the DNS provider reference needed for challenge solving.
+/// Constructed per-issuance by `issue_certificate_real`.
+pub struct RealAcmeClient<'a> {
+    _dns_provider: &'a dyn DnsProvider,
+}
+
+impl<'a> RealAcmeClient<'a> {
+    pub fn new(dns_provider: &'a dyn DnsProvider) -> Self {
+        Self {
+            _dns_provider: dns_provider,
+        }
+    }
+}
+
+#[async_trait]
+impl AcmeClient for RealAcmeClient<'_> {
+    async fn create_or_load_account(
+        &self,
+        email: String,
+        directory_url: String,
+        existing_credentials_json: Option<String>,
+    ) -> Result<Option<String>> {
+        use instant_acme::{Account, AccountCredentials, NewAccount};
+
+        if let Some(json) = existing_credentials_json {
+            debug!("Loading ACME account from credentials");
+            let credentials: AccountCredentials = serde_json::from_str(&json)
+                .map_err(|e| TlsError::Acme(format!("failed to parse account credentials: {e}")))?;
+            Account::builder()
+                .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
+                .from_credentials(credentials)
+                .await
+                .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?;
+            debug!("Loaded existing ACME account");
+            Ok(None)
+        } else {
+            debug!("Creating new ACME account at {}", directory_url);
+            let contact = format!("mailto:{email}");
+            let new_account = NewAccount {
+                contact: &[&contact],
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            };
+
+            let (_account, credentials) = Account::builder()
+                .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
+                .create(&new_account, directory_url, None)
+                .await
+                .map_err(|e| TlsError::Acme(format!("failed to create ACME account: {e}")))?;
+
+            let json = serde_json::to_string_pretty(&credentials)
+                .map_err(|e| TlsError::Acme(format!("failed to serialize credentials: {e}")))?;
+            info!("Created new ACME account");
+            Ok(Some(json))
+        }
+    }
+
+    async fn order_certificate(&self, _domain: String) -> Result<(String, String)> {
+        // This trait method exists for the mock boundary; the real implementation
+        // uses issue_certificate_real which manages the full lifecycle directly.
+        Err(TlsError::Acme(
+            "RealAcmeClient::order_certificate should not be called directly; \
+             use issue_certificate_real for the full lifecycle"
+                .to_string(),
+        ))
+    }
+}
+
+/// Issue a wildcard certificate via ACME (mockable version).
+///
+/// This is the testable entry point that uses the `AcmeClient` trait:
+/// 1. Creates or loads an ACME account
+/// 2. Persists new account credentials if created
+/// 3. Orders the certificate
+/// 4. Writes the certificate and private key to disk
+pub async fn issue_certificate(
+    config: &AcmeConfig,
+    pki_dir: &Path,
+    acme_client: &dyn AcmeClient,
+) -> Result<()> {
     let account_path = acme_config::acme_account_path(pki_dir);
     let directory_url = acme_config::directory_url(config.staging).to_string();
 
-    if account_path.exists() {
+    // Load existing credentials if available
+    let existing_creds = if account_path.exists() {
+        debug!("Loading ACME account from {}", account_path.display());
+        Some(std::fs::read_to_string(&account_path)?)
+    } else {
+        None
+    };
+
+    // Create or load account
+    let new_creds = acme_client
+        .create_or_load_account(config.email.clone(), directory_url, existing_creds)
+        .await?;
+
+    // Persist new credentials if account was just created
+    if let Some(creds_json) = new_creds {
+        std::fs::create_dir_all(pki_dir)?;
+        std::fs::write(&account_path, &creds_json)?;
+        set_restricted_permissions(&account_path)?;
+        info!(
+            "Saved ACME account credentials to {}",
+            account_path.display()
+        );
+    }
+
+    // Order certificate
+    let (cert_chain_pem, private_key_pem) =
+        acme_client.order_certificate(config.domain.clone()).await?;
+
+    // Write certificate and key
+    let certs_dir = pki_dir.join("certs");
+    std::fs::create_dir_all(&certs_dir)?;
+
+    let cert_path = acme_config::acme_cert_path(pki_dir);
+    let key_path = acme_config::acme_key_path(pki_dir);
+
+    std::fs::write(&cert_path, &cert_chain_pem)?;
+    std::fs::write(&key_path, &private_key_pem)?;
+    set_restricted_permissions(&key_path)?;
+
+    info!("Certificate written to {}", cert_path.display());
+    info!("Private key written to {}", key_path.display());
+
+    Ok(())
+}
+
+/// Issue a certificate using the real ACME client (instant-acme).
+///
+/// This is the production entry point that handles the full lifecycle
+/// including account management and the ACME protocol flow directly.
+pub async fn issue_certificate_real(
+    config: &AcmeConfig,
+    pki_dir: &Path,
+    dns_provider: &dyn DnsProvider,
+) -> Result<()> {
+    use instant_acme::{
+        Account, AccountCredentials, ChallengeType, Identifier, NewAccount, NewOrder, RetryPolicy,
+    };
+
+    let account_path = acme_config::acme_account_path(pki_dir);
+    let directory_url = acme_config::directory_url(config.staging).to_string();
+
+    // Create or load account
+    let account = if account_path.exists() {
         debug!("Loading ACME account from {}", account_path.display());
         let json = std::fs::read_to_string(&account_path)?;
         let credentials: AccountCredentials = serde_json::from_str(&json)
             .map_err(|e| TlsError::Acme(format!("failed to parse account credentials: {e}")))?;
-        let account = Account::builder()
+        Account::builder()
             .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
             .from_credentials(credentials)
             .await
-            .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?;
-        debug!("Loaded existing ACME account");
-        Ok(account)
+            .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?
     } else {
         debug!("Creating new ACME account at {}", directory_url);
         let contact = format!("mailto:{}", config.email);
@@ -46,7 +206,6 @@ pub async fn create_or_load_account(config: &AcmeConfig, pki_dir: &Path) -> Resu
             .await
             .map_err(|e| TlsError::Acme(format!("failed to create ACME account: {e}")))?;
 
-        // Persist account credentials
         std::fs::create_dir_all(pki_dir)?;
         let json = serde_json::to_string_pretty(&credentials)
             .map_err(|e| TlsError::Acme(format!("failed to serialize credentials: {e}")))?;
@@ -57,26 +216,22 @@ pub async fn create_or_load_account(config: &AcmeConfig, pki_dir: &Path) -> Resu
             account_path.display()
         );
 
-        Ok(account)
-    }
-}
+        account
+    };
 
-/// Solve DNS-01 challenges for all authorizations in an order.
-///
-/// For each authorization:
-/// 1. Creates a TXT record via the DNS provider
-/// 2. Waits for DNS propagation
-/// 3. Notifies the ACME server the challenge is ready
-///
-/// After all challenges are solved, polls the order until it is ready
-/// and cleans up the DNS record.
-pub async fn solve_dns01_challenges(
-    order: &mut instant_acme::Order,
-    dns_provider: &dyn DnsProvider,
-    domain: &str,
-) -> Result<()> {
-    let challenge_fqdn = format!("_acme-challenge.{domain}");
+    // Create order for wildcard domain
+    let wildcard = format!("*.{}", config.domain);
+    let identifiers = [Identifier::Dns(wildcard.clone())];
+    let new_order = NewOrder::new(&identifiers);
 
+    debug!("Creating ACME order for {}", wildcard);
+    let mut order = account
+        .new_order(&new_order)
+        .await
+        .map_err(|e| TlsError::Acme(format!("failed to create order: {e}")))?;
+
+    // Solve DNS-01 challenges
+    let challenge_fqdn = format!("_acme-challenge.{}", config.domain);
     let mut auths = order.authorizations();
     while let Some(auth_result) = auths.next().await {
         let mut auth =
@@ -94,16 +249,13 @@ pub async fn solve_dns01_challenges(
             challenge_fqdn, dns_value
         );
 
-        // Create TXT record
         dns_provider
             .create_txt_record(&challenge_fqdn, &dns_value)
             .await?;
 
-        // Wait for DNS propagation
         debug!("Waiting 15 seconds for DNS propagation");
         tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-        // Notify the ACME server
         challenge
             .set_ready()
             .await
@@ -112,59 +264,24 @@ pub async fn solve_dns01_challenges(
         debug!("Challenge marked as ready");
     }
 
-    // Poll until order is ready for finalization
     debug!("Polling order until ready");
     order
         .poll_ready(&RetryPolicy::default())
         .await
         .map_err(|e| TlsError::Acme(format!("order did not become ready: {e}")))?;
 
-    // Clean up DNS record
     debug!("Cleaning up DNS challenge record");
     if let Err(e) = dns_provider.delete_txt_record(&challenge_fqdn).await {
         debug!("Warning: failed to clean up DNS record: {e}");
     }
 
-    Ok(())
-}
-
-/// Issue a wildcard certificate via ACME.
-///
-/// This is the main entry point for certificate issuance:
-/// 1. Creates or loads an ACME account
-/// 2. Creates a new order for `*.<domain>`
-/// 3. Solves DNS-01 challenges
-/// 4. Finalizes the order (generates CSR internally)
-/// 5. Retrieves and writes the certificate and private key
-pub async fn issue_certificate(
-    config: &AcmeConfig,
-    pki_dir: &Path,
-    dns_provider: &dyn DnsProvider,
-) -> Result<()> {
-    let account = create_or_load_account(config, pki_dir).await?;
-
-    // Create order for wildcard domain
-    let wildcard = format!("*.{}", config.domain);
-    let identifiers = [Identifier::Dns(wildcard.clone())];
-    let new_order = NewOrder::new(&identifiers);
-
-    debug!("Creating ACME order for {}", wildcard);
-    let mut order = account
-        .new_order(&new_order)
-        .await
-        .map_err(|e| TlsError::Acme(format!("failed to create order: {e}")))?;
-
-    // Solve challenges
-    solve_dns01_challenges(&mut order, dns_provider, &config.domain).await?;
-
-    // Finalize — generates CSR and returns private key PEM
+    // Finalize
     debug!("Finalizing order (generating CSR)");
     let private_key_pem = order
         .finalize()
         .await
         .map_err(|e| TlsError::Acme(format!("failed to finalize order: {e}")))?;
 
-    // Poll for certificate
     debug!("Polling for certificate");
     let cert_chain_pem = order
         .poll_certificate(&RetryPolicy::default())
@@ -193,31 +310,158 @@ pub async fn issue_certificate(
 mod tests {
     use super::*;
 
-    #[test]
-    fn invalid_account_json_returns_error() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let dir = tempfile::tempdir().unwrap();
-            let account_path = dir.path().join("acme-account.json");
-            std::fs::write(&account_path, "not valid json").unwrap();
+    fn test_config() -> AcmeConfig {
+        AcmeConfig {
+            email: "test@example.com".to_string(),
+            domain: "example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: std::collections::HashMap::new(),
+            staging: true,
+            renewal_days_before_expiry: 30,
+            post_renewal_hooks: vec![],
+        }
+    }
 
-            let config = AcmeConfig {
-                email: "test@example.com".to_string(),
-                domain: "example.com".to_string(),
-                dns_provider: "cloudflare".to_string(),
-                dns_credentials: std::collections::HashMap::new(),
-                staging: true,
-                renewal_days_before_expiry: 30,
-                post_renewal_hooks: vec![],
-            };
+    #[tokio::test]
+    async fn issue_certificate_happy_path_new_account() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config();
 
-            let result = create_or_load_account(&config, dir.path()).await;
-            assert!(result.is_err(), "should fail with invalid JSON");
-            let msg = result.err().unwrap().to_string();
-            assert!(
-                msg.contains("parse"),
-                "error should mention parse failure: {msg}"
-            );
-        });
+        let mut mock_acme = MockAcmeClient::new();
+        mock_acme
+            .expect_create_or_load_account()
+            .returning(|_, _, _| Ok(Some(r#"{"fake":"credentials"}"#.to_string())));
+        mock_acme
+            .expect_order_certificate()
+            .returning(|_| Ok(("CERT-PEM-DATA".to_string(), "KEY-PEM-DATA".to_string())));
+
+        issue_certificate(&config, dir.path(), &mock_acme)
+            .await
+            .unwrap();
+
+        // Verify account credentials were saved
+        let account_path = acme_config::acme_account_path(dir.path());
+        assert!(account_path.exists(), "account credentials should be saved");
+        let saved = std::fs::read_to_string(&account_path).unwrap();
+        assert_eq!(saved, r#"{"fake":"credentials"}"#);
+
+        // Verify cert and key were written
+        let cert_path = acme_config::acme_cert_path(dir.path());
+        let key_path = acme_config::acme_key_path(dir.path());
+        assert_eq!(std::fs::read_to_string(cert_path).unwrap(), "CERT-PEM-DATA");
+        assert_eq!(std::fs::read_to_string(key_path).unwrap(), "KEY-PEM-DATA");
+    }
+
+    #[tokio::test]
+    async fn issue_certificate_loads_existing_account() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config();
+
+        // Pre-create account credentials file
+        let account_path = acme_config::acme_account_path(dir.path());
+        std::fs::create_dir_all(account_path.parent().unwrap()).unwrap();
+        std::fs::write(&account_path, r#"{"existing":"creds"}"#).unwrap();
+
+        let mut mock_acme = MockAcmeClient::new();
+        mock_acme
+            .expect_create_or_load_account()
+            .withf(|_, _, existing| existing.as_deref() == Some(r#"{"existing":"creds"}"#))
+            .returning(|_, _, _| Ok(None));
+        mock_acme
+            .expect_order_certificate()
+            .returning(|_| Ok(("CERT".to_string(), "KEY".to_string())));
+
+        issue_certificate(&config, dir.path(), &mock_acme)
+            .await
+            .unwrap();
+
+        // Verify cert was still written
+        let cert_path = acme_config::acme_cert_path(dir.path());
+        assert!(cert_path.exists());
+    }
+
+    #[tokio::test]
+    async fn issue_certificate_acme_account_error_propagates() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config();
+
+        let mut mock_acme = MockAcmeClient::new();
+        mock_acme
+            .expect_create_or_load_account()
+            .returning(|_, _, _| Err(TlsError::Acme("account creation failed".to_string())));
+
+        let err = issue_certificate(&config, dir.path(), &mock_acme)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("account creation failed"),
+            "error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_certificate_order_error_propagates() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config();
+
+        let mut mock_acme = MockAcmeClient::new();
+        mock_acme
+            .expect_create_or_load_account()
+            .returning(|_, _, _| Ok(None));
+        mock_acme
+            .expect_order_certificate()
+            .returning(|_| Err(TlsError::Acme("order failed".to_string())));
+
+        let err = issue_certificate(&config, dir.path(), &mock_acme)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("order failed"), "error: {err}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn issue_certificate_sets_key_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config();
+
+        let mut mock_acme = MockAcmeClient::new();
+        mock_acme
+            .expect_create_or_load_account()
+            .returning(|_, _, _| Ok(None));
+        mock_acme
+            .expect_order_certificate()
+            .returning(|_| Ok(("CERT".to_string(), "KEY".to_string())));
+
+        issue_certificate(&config, dir.path(), &mock_acme)
+            .await
+            .unwrap();
+
+        let key_path = acme_config::acme_key_path(dir.path());
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "key should have 0600 permissions, got {mode:o}"
+        );
+    }
+
+    #[tokio::test]
+    async fn real_acme_client_invalid_credentials_returns_parse_error() {
+        let dns = crate::dns::MockDnsProvider::new();
+        let client = RealAcmeClient::new(&dns);
+        let result = client
+            .create_or_load_account(
+                "test@example.com".to_string(),
+                "https://acme-staging-v02.api.letsencrypt.org/directory".to_string(),
+                Some("not valid json".to_string()),
+            )
+            .await;
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parse"),
+            "error should mention parse failure: {msg}"
+        );
     }
 }

--- a/crates/rp-tls/src/acme.rs
+++ b/crates/rp-tls/src/acme.rs
@@ -126,6 +126,16 @@ impl AcmeClient for RealAcmeClient<'_> {
 
         // Solve DNS-01 challenges
         let challenge_fqdn = format!("_acme-challenge.{domain}");
+
+        // Clean up any leftover challenge records from previous runs
+        debug!(
+            "Cleaning up any existing challenge records for {}",
+            challenge_fqdn
+        );
+        if let Err(e) = self.dns_provider.delete_txt_record(&challenge_fqdn).await {
+            debug!("Pre-cleanup warning (non-fatal): {e}");
+        }
+
         let mut auths = order.authorizations();
         while let Some(auth_result) = auths.next().await {
             let mut auth = auth_result

--- a/crates/rp-tls/src/acme.rs
+++ b/crates/rp-tls/src/acme.rs
@@ -1,0 +1,223 @@
+use std::path::Path;
+
+use instant_acme::{
+    Account, AccountCredentials, ChallengeType, Identifier, NewAccount, NewOrder, RetryPolicy,
+};
+use tracing::{debug, info};
+
+use crate::acme_config::{self, AcmeConfig};
+use crate::dns::DnsProvider;
+use crate::error::{Result, TlsError};
+use crate::permissions::set_restricted_permissions;
+
+/// Create or load an ACME account.
+///
+/// If `acme-account.json` exists in the PKI directory, the account is
+/// restored from the saved credentials. Otherwise, a new account is
+/// created and the credentials are persisted.
+pub async fn create_or_load_account(config: &AcmeConfig, pki_dir: &Path) -> Result<Account> {
+    let account_path = acme_config::acme_account_path(pki_dir);
+    let directory_url = acme_config::directory_url(config.staging).to_string();
+
+    if account_path.exists() {
+        debug!("Loading ACME account from {}", account_path.display());
+        let json = std::fs::read_to_string(&account_path)?;
+        let credentials: AccountCredentials = serde_json::from_str(&json)
+            .map_err(|e| TlsError::Acme(format!("failed to parse account credentials: {e}")))?;
+        let account = Account::builder()
+            .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
+            .from_credentials(credentials)
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to load account: {e}")))?;
+        debug!("Loaded existing ACME account");
+        Ok(account)
+    } else {
+        debug!("Creating new ACME account at {}", directory_url);
+        let contact = format!("mailto:{}", config.email);
+        let new_account = NewAccount {
+            contact: &[&contact],
+            terms_of_service_agreed: true,
+            only_return_existing: false,
+        };
+
+        let (account, credentials) = Account::builder()
+            .map_err(|e| TlsError::Acme(format!("failed to create account builder: {e}")))?
+            .create(&new_account, directory_url, None)
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to create ACME account: {e}")))?;
+
+        // Persist account credentials
+        std::fs::create_dir_all(pki_dir)?;
+        let json = serde_json::to_string_pretty(&credentials)
+            .map_err(|e| TlsError::Acme(format!("failed to serialize credentials: {e}")))?;
+        std::fs::write(&account_path, json)?;
+        set_restricted_permissions(&account_path)?;
+        info!(
+            "Created new ACME account, saved to {}",
+            account_path.display()
+        );
+
+        Ok(account)
+    }
+}
+
+/// Solve DNS-01 challenges for all authorizations in an order.
+///
+/// For each authorization:
+/// 1. Creates a TXT record via the DNS provider
+/// 2. Waits for DNS propagation
+/// 3. Notifies the ACME server the challenge is ready
+///
+/// After all challenges are solved, polls the order until it is ready
+/// and cleans up the DNS record.
+pub async fn solve_dns01_challenges(
+    order: &mut instant_acme::Order,
+    dns_provider: &dyn DnsProvider,
+    domain: &str,
+) -> Result<()> {
+    let challenge_fqdn = format!("_acme-challenge.{domain}");
+
+    let mut auths = order.authorizations();
+    while let Some(auth_result) = auths.next().await {
+        let mut auth =
+            auth_result.map_err(|e| TlsError::Acme(format!("failed to get authorization: {e}")))?;
+
+        let mut challenge = auth
+            .challenge(ChallengeType::Dns01)
+            .ok_or_else(|| TlsError::Acme("no DNS-01 challenge offered by server".to_string()))?;
+
+        let key_auth = challenge.key_authorization();
+        let dns_value = key_auth.dns_value();
+
+        debug!(
+            "Setting up DNS-01 challenge for {} with value {}",
+            challenge_fqdn, dns_value
+        );
+
+        // Create TXT record
+        dns_provider
+            .create_txt_record(&challenge_fqdn, &dns_value)
+            .await?;
+
+        // Wait for DNS propagation
+        debug!("Waiting 15 seconds for DNS propagation");
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+
+        // Notify the ACME server
+        challenge
+            .set_ready()
+            .await
+            .map_err(|e| TlsError::Acme(format!("failed to set challenge ready: {e}")))?;
+
+        debug!("Challenge marked as ready");
+    }
+
+    // Poll until order is ready for finalization
+    debug!("Polling order until ready");
+    order
+        .poll_ready(&RetryPolicy::default())
+        .await
+        .map_err(|e| TlsError::Acme(format!("order did not become ready: {e}")))?;
+
+    // Clean up DNS record
+    debug!("Cleaning up DNS challenge record");
+    if let Err(e) = dns_provider.delete_txt_record(&challenge_fqdn).await {
+        debug!("Warning: failed to clean up DNS record: {e}");
+    }
+
+    Ok(())
+}
+
+/// Issue a wildcard certificate via ACME.
+///
+/// This is the main entry point for certificate issuance:
+/// 1. Creates or loads an ACME account
+/// 2. Creates a new order for `*.<domain>`
+/// 3. Solves DNS-01 challenges
+/// 4. Finalizes the order (generates CSR internally)
+/// 5. Retrieves and writes the certificate and private key
+pub async fn issue_certificate(
+    config: &AcmeConfig,
+    pki_dir: &Path,
+    dns_provider: &dyn DnsProvider,
+) -> Result<()> {
+    let account = create_or_load_account(config, pki_dir).await?;
+
+    // Create order for wildcard domain
+    let wildcard = format!("*.{}", config.domain);
+    let identifiers = [Identifier::Dns(wildcard.clone())];
+    let new_order = NewOrder::new(&identifiers);
+
+    debug!("Creating ACME order for {}", wildcard);
+    let mut order = account
+        .new_order(&new_order)
+        .await
+        .map_err(|e| TlsError::Acme(format!("failed to create order: {e}")))?;
+
+    // Solve challenges
+    solve_dns01_challenges(&mut order, dns_provider, &config.domain).await?;
+
+    // Finalize — generates CSR and returns private key PEM
+    debug!("Finalizing order (generating CSR)");
+    let private_key_pem = order
+        .finalize()
+        .await
+        .map_err(|e| TlsError::Acme(format!("failed to finalize order: {e}")))?;
+
+    // Poll for certificate
+    debug!("Polling for certificate");
+    let cert_chain_pem = order
+        .poll_certificate(&RetryPolicy::default())
+        .await
+        .map_err(|e| TlsError::Acme(format!("failed to retrieve certificate: {e}")))?;
+
+    // Write certificate and key
+    let certs_dir = pki_dir.join("certs");
+    std::fs::create_dir_all(&certs_dir)?;
+
+    let cert_path = acme_config::acme_cert_path(pki_dir);
+    let key_path = acme_config::acme_key_path(pki_dir);
+
+    std::fs::write(&cert_path, &cert_chain_pem)?;
+    std::fs::write(&key_path, &private_key_pem)?;
+    set_restricted_permissions(&key_path)?;
+
+    info!("Certificate written to {}", cert_path.display());
+    info!("Private key written to {}", key_path.display());
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_account_json_returns_error() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let account_path = dir.path().join("acme-account.json");
+            std::fs::write(&account_path, "not valid json").unwrap();
+
+            let config = AcmeConfig {
+                email: "test@example.com".to_string(),
+                domain: "example.com".to_string(),
+                dns_provider: "cloudflare".to_string(),
+                dns_credentials: std::collections::HashMap::new(),
+                staging: true,
+                renewal_days_before_expiry: 30,
+                post_renewal_hooks: vec![],
+            };
+
+            let result = create_or_load_account(&config, dir.path()).await;
+            assert!(result.is_err(), "should fail with invalid JSON");
+            let msg = result.err().unwrap().to_string();
+            assert!(
+                msg.contains("parse"),
+                "error should mention parse failure: {msg}"
+            );
+        });
+    }
+}

--- a/crates/rp-tls/src/acme_config.rs
+++ b/crates/rp-tls/src/acme_config.rs
@@ -1,0 +1,281 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::config::expand_tilde;
+use crate::error::{Result, TlsError};
+use crate::permissions::set_restricted_permissions;
+
+/// ACME configuration stored at `~/.rusty-photon/acme.json`.
+///
+/// This is standalone and decoupled from any service config, supporting
+/// multi-machine deployments where the ACME client runs on one host.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcmeConfig {
+    /// ACME account email for expiry notifications.
+    pub email: String,
+    /// Base domain (wildcard cert issued for `*.<domain>`).
+    pub domain: String,
+    /// DNS provider identifier (e.g., `"cloudflare"`).
+    pub dns_provider: String,
+    /// Provider-specific credentials; values starting with `$` are read from
+    /// environment variables.
+    pub dns_credentials: HashMap<String, String>,
+    /// Use Let's Encrypt staging endpoint (default: `false`).
+    #[serde(default)]
+    pub staging: bool,
+    /// Days before expiry to trigger renewal (default: `30`).
+    #[serde(default = "default_renewal_days")]
+    pub renewal_days_before_expiry: u32,
+    /// Shell commands to run after successful renewal.
+    #[serde(default)]
+    pub post_renewal_hooks: Vec<String>,
+}
+
+fn default_renewal_days() -> u32 {
+    30
+}
+
+/// Default path for the ACME configuration file: `~/.rusty-photon/acme.json`.
+pub fn default_acme_config_path() -> PathBuf {
+    expand_tilde("~/.rusty-photon/acme.json")
+}
+
+/// Path to the ACME account credentials file within the PKI directory.
+pub fn acme_account_path(pki_dir: &Path) -> PathBuf {
+    pki_dir.join("acme-account.json")
+}
+
+/// Path to the ACME wildcard certificate file within the PKI directory.
+pub fn acme_cert_path(pki_dir: &Path) -> PathBuf {
+    pki_dir.join("certs").join("acme-cert.pem")
+}
+
+/// Path to the ACME wildcard private key file within the PKI directory.
+pub fn acme_key_path(pki_dir: &Path) -> PathBuf {
+    pki_dir.join("certs").join("acme-key.pem")
+}
+
+/// Load ACME configuration from a JSON file.
+pub fn load_acme_config(path: &Path) -> Result<AcmeConfig> {
+    debug!("Loading ACME config from {}", path.display());
+    let content = std::fs::read_to_string(path)?;
+    let config: AcmeConfig =
+        serde_json::from_str(&content).map_err(|e| TlsError::Config(format!("{e}")))?;
+    Ok(config)
+}
+
+/// Save ACME configuration to a JSON file with restricted permissions.
+pub fn save_acme_config(config: &AcmeConfig, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(config)
+        .map_err(|e| TlsError::Config(format!("failed to serialize ACME config: {e}")))?;
+    std::fs::write(path, json)?;
+    set_restricted_permissions(path)?;
+    debug!("Saved ACME config to {}", path.display());
+    Ok(())
+}
+
+/// Expand credential values that start with `$` by reading from environment variables.
+///
+/// Literal values (not starting with `$`) are passed through unchanged.
+pub fn resolve_credentials(creds: &HashMap<String, String>) -> Result<HashMap<String, String>> {
+    let mut resolved = HashMap::new();
+    for (key, value) in creds {
+        let resolved_value = if let Some(var_name) = value.strip_prefix('$') {
+            std::env::var(var_name).map_err(|_| {
+                TlsError::Config(format!(
+                    "environment variable '{var_name}' not set (referenced by dns_credentials.{key})"
+                ))
+            })?
+        } else {
+            value.clone()
+        };
+        resolved.insert(key.clone(), resolved_value);
+    }
+    Ok(resolved)
+}
+
+/// Return the ACME directory URL for Let's Encrypt staging or production.
+pub fn directory_url(staging: bool) -> &'static str {
+    if staging {
+        "https://acme-staging-v02.api.letsencrypt.org/directory"
+    } else {
+        "https://acme-v02.api.letsencrypt.org/directory"
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acme_config_round_trip_serde() {
+        let config = AcmeConfig {
+            email: "user@example.com".to_string(),
+            domain: "observatory.example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: HashMap::from([("api_token".to_string(), "tok123".to_string())]),
+            staging: true,
+            renewal_days_before_expiry: 30,
+            post_renewal_hooks: vec!["scp cert pi:~/".to_string()],
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: AcmeConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.email, "user@example.com");
+        assert_eq!(deserialized.domain, "observatory.example.com");
+        assert_eq!(deserialized.dns_provider, "cloudflare");
+        assert_eq!(
+            deserialized.dns_credentials.get("api_token").unwrap(),
+            "tok123"
+        );
+        assert!(deserialized.staging);
+        assert_eq!(deserialized.renewal_days_before_expiry, 30);
+        assert_eq!(deserialized.post_renewal_hooks.len(), 1);
+    }
+
+    #[test]
+    fn acme_config_defaults() {
+        let json = r#"{
+            "email": "user@example.com",
+            "domain": "example.com",
+            "dns_provider": "cloudflare",
+            "dns_credentials": {"api_token": "tok"}
+        }"#;
+        let config: AcmeConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.staging);
+        assert_eq!(config.renewal_days_before_expiry, 30);
+        assert!(config.post_renewal_hooks.is_empty());
+    }
+
+    #[test]
+    fn resolve_credentials_expands_env_var() {
+        std::env::set_var("TEST_ACME_TOKEN_XYZ", "secret123");
+        let creds = HashMap::from([("api_token".to_string(), "$TEST_ACME_TOKEN_XYZ".to_string())]);
+        let resolved = resolve_credentials(&creds).unwrap();
+        assert_eq!(resolved.get("api_token").unwrap(), "secret123");
+        std::env::remove_var("TEST_ACME_TOKEN_XYZ");
+    }
+
+    #[test]
+    fn resolve_credentials_passes_through_literal() {
+        let creds = HashMap::from([("api_token".to_string(), "literal-value".to_string())]);
+        let resolved = resolve_credentials(&creds).unwrap();
+        assert_eq!(resolved.get("api_token").unwrap(), "literal-value");
+    }
+
+    #[test]
+    fn resolve_credentials_missing_env_var_returns_error() {
+        let creds = HashMap::from([(
+            "api_token".to_string(),
+            "$NONEXISTENT_VAR_FOR_ACME_TEST".to_string(),
+        )]);
+        let err = resolve_credentials(&creds).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NONEXISTENT_VAR_FOR_ACME_TEST"),
+            "error should mention the missing var: {msg}"
+        );
+    }
+
+    #[test]
+    fn directory_url_staging() {
+        let url = directory_url(true);
+        assert!(url.contains("staging"), "staging URL: {url}");
+    }
+
+    #[test]
+    fn directory_url_production() {
+        let url = directory_url(false);
+        assert!(!url.contains("staging"), "production URL: {url}");
+        assert!(url.contains("acme-v02"), "production URL: {url}");
+    }
+
+    #[test]
+    fn path_helpers_return_expected_paths() {
+        let pki_dir = Path::new("/home/user/.rusty-photon/pki");
+        assert_eq!(
+            acme_account_path(pki_dir),
+            PathBuf::from("/home/user/.rusty-photon/pki/acme-account.json")
+        );
+        assert_eq!(
+            acme_cert_path(pki_dir),
+            PathBuf::from("/home/user/.rusty-photon/pki/certs/acme-cert.pem")
+        );
+        assert_eq!(
+            acme_key_path(pki_dir),
+            PathBuf::from("/home/user/.rusty-photon/pki/certs/acme-key.pem")
+        );
+    }
+
+    #[test]
+    fn default_acme_config_path_under_home() {
+        if std::env::var_os("HOME").is_some() || std::env::var_os("USERPROFILE").is_some() {
+            let path = default_acme_config_path();
+            assert!(
+                !path.starts_with("~"),
+                "tilde should be expanded: {}",
+                path.display()
+            );
+            assert!(
+                path.to_string_lossy().contains("acme.json"),
+                "should end with acme.json: {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn load_acme_config_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acme.json");
+        let json = r#"{
+            "email": "user@example.com",
+            "domain": "example.com",
+            "dns_provider": "cloudflare",
+            "dns_credentials": {"api_token": "tok"}
+        }"#;
+        std::fs::write(&path, json).unwrap();
+        let config = load_acme_config(&path).unwrap();
+        assert_eq!(config.email, "user@example.com");
+    }
+
+    #[test]
+    fn load_acme_config_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acme.json");
+        std::fs::write(&path, "not json").unwrap();
+        let result = load_acme_config(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn save_and_load_acme_config_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acme.json");
+
+        let config = AcmeConfig {
+            email: "test@example.com".to_string(),
+            domain: "test.example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: HashMap::from([("api_token".to_string(), "tok".to_string())]),
+            staging: true,
+            renewal_days_before_expiry: 15,
+            post_renewal_hooks: vec![],
+        };
+
+        save_acme_config(&config, &path).unwrap();
+        let loaded = load_acme_config(&path).unwrap();
+        assert_eq!(loaded.email, "test@example.com");
+        assert_eq!(loaded.domain, "test.example.com");
+        assert!(loaded.staging);
+        assert_eq!(loaded.renewal_days_before_expiry, 15);
+    }
+}

--- a/crates/rp-tls/src/cert.rs
+++ b/crates/rp-tls/src/cert.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use rcgen::{
-    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
     KeyUsagePurpose, SanType,
 };
 use tracing::debug;
@@ -65,10 +65,10 @@ pub fn generate_service_cert(
 ) -> Result<()> {
     fs::create_dir_all(output_dir)?;
 
-    // Load CA
+    // Load CA as an Issuer for signing
     let ca_key = KeyPair::from_pem(ca_key_pem)?;
-    let ca_params = CertificateParams::from_ca_cert_pem(ca_cert_pem)?;
-    let ca_cert = ca_params.self_signed(&ca_key)?;
+    let issuer = Issuer::from_ca_cert_pem(ca_cert_pem, &ca_key)
+        .map_err(|e| TlsError::Other(format!("failed to load CA issuer: {e}")))?;
 
     // Build service cert params
     let mut params = CertificateParams::new(build_dns_sans(extra_sans))
@@ -100,7 +100,7 @@ pub fn generate_service_cert(
         )));
 
     let service_key = KeyPair::generate()?;
-    let service_cert = params.signed_by(&service_key, &ca_cert, &ca_key)?;
+    let service_cert = params.signed_by(&service_key, &issuer)?;
 
     let cert_path = output_dir.join(format!("{service_name}.pem"));
     let key_path = output_dir.join(format!("{service_name}-key.pem"));

--- a/crates/rp-tls/src/dns.rs
+++ b/crates/rp-tls/src/dns.rs
@@ -133,15 +133,15 @@ impl CloudflareApi for RealCloudflareApi {
     async fn list_txt_records(&self, zone_id: String, name: String) -> Result<Vec<RecordInfo>> {
         use cloudflare::endpoints::dns::dns::{DnsContent, ListDnsRecords, ListDnsRecordsParams};
 
+        // Filter by name only; the record_type filter with DnsContent::TXT { content: "" }
+        // may not serialize correctly to the API's `type=TXT` parameter.
+        // Filter for TXT records client-side instead.
         let response = self
             .client
             .request(&ListDnsRecords {
                 zone_identifier: &zone_id,
                 params: ListDnsRecordsParams {
                     name: Some(name),
-                    record_type: Some(DnsContent::TXT {
-                        content: String::new(),
-                    }),
                     ..Default::default()
                 },
             })
@@ -151,6 +151,7 @@ impl CloudflareApi for RealCloudflareApi {
         Ok(response
             .result
             .into_iter()
+            .filter(|r| matches!(r.content, DnsContent::TXT { .. }))
             .map(|r| RecordInfo { id: r.id })
             .collect())
     }

--- a/crates/rp-tls/src/dns.rs
+++ b/crates/rp-tls/src/dns.rs
@@ -8,8 +8,9 @@ use crate::error::{Result, TlsError};
 
 /// Trait for DNS providers that can create and delete TXT records
 /// for ACME DNS-01 challenge validation.
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
-pub trait DnsProvider: Send + Sync + Debug {
+pub trait DnsProvider: Send + Sync {
     /// Create a TXT record for the ACME challenge.
     async fn create_txt_record(&self, fqdn: &str, value: &str) -> Result<()>;
 
@@ -195,10 +196,9 @@ mod tests {
     #[tokio::test]
     async fn build_dns_provider_unknown_provider_returns_error() {
         let creds = HashMap::from([("api_token".to_string(), "tok".to_string())]);
-        let err = build_dns_provider("unknown", &creds, "example.com")
-            .await
-            .unwrap_err();
-        let msg = err.to_string();
+        let result = build_dns_provider("unknown", &creds, "example.com").await;
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
         assert!(
             msg.contains("unsupported DNS provider"),
             "error should mention unsupported provider: {msg}"
@@ -208,10 +208,9 @@ mod tests {
     #[tokio::test]
     async fn build_dns_provider_cloudflare_missing_token_returns_error() {
         let creds = HashMap::new();
-        let err = build_dns_provider("cloudflare", &creds, "example.com")
-            .await
-            .unwrap_err();
-        let msg = err.to_string();
+        let result = build_dns_provider("cloudflare", &creds, "example.com").await;
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
         assert!(
             msg.contains("api_token"),
             "error should mention missing api_token: {msg}"

--- a/crates/rp-tls/src/dns.rs
+++ b/crates/rp-tls/src/dns.rs
@@ -18,12 +18,170 @@ pub trait DnsProvider: Send + Sync {
     async fn delete_txt_record(&self, fqdn: &str) -> Result<()>;
 }
 
-/// Cloudflare DNS provider using the official `cloudflare` crate.
+// ---------------------------------------------------------------------------
+// Cloudflare API abstraction (mockable boundary)
+// ---------------------------------------------------------------------------
+
+/// Minimal zone info returned by zone lookup.
+#[derive(Debug, Clone)]
+pub struct ZoneInfo {
+    pub id: String,
+}
+
+/// Minimal DNS record info returned by record listing.
+#[derive(Debug, Clone)]
+pub struct RecordInfo {
+    pub id: String,
+}
+
+/// Trait abstracting Cloudflare API calls so `CloudflareDnsProvider` can be
+/// tested without real HTTP calls.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CloudflareApi: Send + Sync {
+    /// List zones matching the given domain name.
+    async fn list_zones(&self, domain: String) -> Result<Vec<ZoneInfo>>;
+
+    /// Create a TXT DNS record in the given zone.
+    async fn create_txt_record_api(
+        &self,
+        zone_id: String,
+        name: String,
+        content: String,
+    ) -> Result<()>;
+
+    /// List TXT DNS records matching the given name in the zone.
+    async fn list_txt_records(&self, zone_id: String, name: String) -> Result<Vec<RecordInfo>>;
+
+    /// Delete a DNS record by ID.
+    async fn delete_record(&self, zone_id: String, record_id: String) -> Result<()>;
+}
+
+/// Real Cloudflare API implementation using the `cloudflare` crate.
+pub struct RealCloudflareApi {
+    client: cloudflare::framework::client::async_api::Client,
+}
+
+impl RealCloudflareApi {
+    pub fn new(api_token: &str) -> Result<Self> {
+        use cloudflare::framework::auth::Credentials;
+        use cloudflare::framework::client::ClientConfig;
+        use cloudflare::framework::Environment;
+
+        let credentials = Credentials::UserAuthToken {
+            token: api_token.to_string(),
+        };
+        let client = cloudflare::framework::client::async_api::Client::new(
+            credentials,
+            ClientConfig::default(),
+            Environment::Production,
+        )
+        .map_err(|e| TlsError::DnsProvider(format!("failed to create Cloudflare client: {e}")))?;
+
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl CloudflareApi for RealCloudflareApi {
+    async fn list_zones(&self, domain: String) -> Result<Vec<ZoneInfo>> {
+        use cloudflare::endpoints::zones::zone::{ListZones, ListZonesParams};
+
+        let response = self
+            .client
+            .request(&ListZones {
+                params: ListZonesParams {
+                    name: Some(domain),
+                    ..Default::default()
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to list zones: {e}")))?;
+
+        Ok(response
+            .result
+            .into_iter()
+            .map(|z| ZoneInfo { id: z.id })
+            .collect())
+    }
+
+    async fn create_txt_record_api(
+        &self,
+        zone_id: String,
+        name: String,
+        content: String,
+    ) -> Result<()> {
+        use cloudflare::endpoints::dns::dns::{CreateDnsRecord, CreateDnsRecordParams, DnsContent};
+
+        self.client
+            .request(&CreateDnsRecord {
+                zone_identifier: &zone_id,
+                params: CreateDnsRecordParams {
+                    name: &name,
+                    content: DnsContent::TXT { content },
+                    ttl: Some(60),
+                    priority: None,
+                    proxied: Some(false),
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to create TXT record: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn list_txt_records(&self, zone_id: String, name: String) -> Result<Vec<RecordInfo>> {
+        use cloudflare::endpoints::dns::dns::{DnsContent, ListDnsRecords, ListDnsRecordsParams};
+
+        let response = self
+            .client
+            .request(&ListDnsRecords {
+                zone_identifier: &zone_id,
+                params: ListDnsRecordsParams {
+                    name: Some(name),
+                    record_type: Some(DnsContent::TXT {
+                        content: String::new(),
+                    }),
+                    ..Default::default()
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to list TXT records: {e}")))?;
+
+        Ok(response
+            .result
+            .into_iter()
+            .map(|r| RecordInfo { id: r.id })
+            .collect())
+    }
+
+    async fn delete_record(&self, zone_id: String, record_id: String) -> Result<()> {
+        use cloudflare::endpoints::dns::dns::DeleteDnsRecord;
+
+        self.client
+            .request(&DeleteDnsRecord {
+                zone_identifier: &zone_id,
+                identifier: &record_id,
+            })
+            .await
+            .map_err(|e| {
+                TlsError::DnsProvider(format!("failed to delete TXT record {record_id}: {e}"))
+            })?;
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CloudflareDnsProvider (testable via CloudflareApi trait)
+// ---------------------------------------------------------------------------
+
+/// Cloudflare DNS provider using the `CloudflareApi` abstraction.
 ///
 /// The zone ID is resolved once at construction time by looking up
 /// the zone matching the provided domain.
 pub struct CloudflareDnsProvider {
-    client: cloudflare::framework::client::async_api::Client,
+    api: Box<dyn CloudflareApi>,
     zone_id: String,
 }
 
@@ -41,33 +199,16 @@ impl CloudflareDnsProvider {
     /// Connects to the Cloudflare API with the given token and resolves
     /// the zone ID for the specified domain.
     pub async fn new(api_token: &str, domain: &str) -> Result<Self> {
-        use cloudflare::endpoints::zones::zone::{ListZones, ListZonesParams};
-        use cloudflare::framework::auth::Credentials;
-        use cloudflare::framework::client::ClientConfig;
-        use cloudflare::framework::Environment;
+        let api = RealCloudflareApi::new(api_token)?;
+        Self::with_api(Box::new(api), domain).await
+    }
 
-        let credentials = Credentials::UserAuthToken {
-            token: api_token.to_string(),
-        };
-        let client = cloudflare::framework::client::async_api::Client::new(
-            credentials,
-            ClientConfig::default(),
-            Environment::Production,
-        )
-        .map_err(|e| TlsError::DnsProvider(format!("failed to create Cloudflare client: {e}")))?;
+    /// Create a provider with a custom `CloudflareApi` implementation.
+    /// Used internally and for testing.
+    async fn with_api(api: Box<dyn CloudflareApi>, domain: &str) -> Result<Self> {
+        let zones = api.list_zones(domain.to_string()).await?;
 
-        // Look up zone ID by domain name
-        let zones_response = client
-            .request(&ListZones {
-                params: ListZonesParams {
-                    name: Some(domain.to_string()),
-                    ..Default::default()
-                },
-            })
-            .await
-            .map_err(|e| TlsError::DnsProvider(format!("failed to list zones: {e}")))?;
-
-        let zone = zones_response.result.first().ok_or_else(|| {
+        let zone = zones.first().ok_or_else(|| {
             TlsError::DnsProvider(format!("no Cloudflare zone found for domain '{domain}'"))
         })?;
 
@@ -77,7 +218,7 @@ impl CloudflareDnsProvider {
         );
 
         Ok(Self {
-            client,
+            api,
             zone_id: zone.id.clone(),
         })
     }
@@ -86,70 +227,31 @@ impl CloudflareDnsProvider {
 #[async_trait]
 impl DnsProvider for CloudflareDnsProvider {
     async fn create_txt_record(&self, fqdn: &str, value: &str) -> Result<()> {
-        use cloudflare::endpoints::dns::dns::{CreateDnsRecord, CreateDnsRecordParams, DnsContent};
-
         debug!("Creating TXT record: {} = {}", fqdn, value);
-
-        self.client
-            .request(&CreateDnsRecord {
-                zone_identifier: &self.zone_id,
-                params: CreateDnsRecordParams {
-                    name: fqdn,
-                    content: DnsContent::TXT {
-                        content: value.to_string(),
-                    },
-                    ttl: Some(60),
-                    priority: None,
-                    proxied: Some(false),
-                },
-            })
-            .await
-            .map_err(|e| TlsError::DnsProvider(format!("failed to create TXT record: {e}")))?;
-
+        self.api
+            .create_txt_record_api(self.zone_id.clone(), fqdn.to_string(), value.to_string())
+            .await?;
         debug!("Created TXT record for {}", fqdn);
         Ok(())
     }
 
     async fn delete_txt_record(&self, fqdn: &str) -> Result<()> {
-        use cloudflare::endpoints::dns::dns::{
-            DeleteDnsRecord, DnsContent, ListDnsRecords, ListDnsRecordsParams,
-        };
-
         debug!("Deleting TXT records for {}", fqdn);
 
-        // List TXT records matching the FQDN
-        let records_response = self
-            .client
-            .request(&ListDnsRecords {
-                zone_identifier: &self.zone_id,
-                params: ListDnsRecordsParams {
-                    name: Some(fqdn.to_string()),
-                    record_type: Some(DnsContent::TXT {
-                        content: String::new(),
-                    }),
-                    ..Default::default()
-                },
-            })
-            .await
-            .map_err(|e| TlsError::DnsProvider(format!("failed to list TXT records: {e}")))?;
+        let records = self
+            .api
+            .list_txt_records(self.zone_id.clone(), fqdn.to_string())
+            .await?;
 
-        let records = &records_response.result;
         if records.is_empty() {
             debug!("No TXT records found for {} (already cleaned up)", fqdn);
             return Ok(());
         }
 
-        // Delete each matching record
-        for record in records {
-            self.client
-                .request(&DeleteDnsRecord {
-                    zone_identifier: &self.zone_id,
-                    identifier: &record.id,
-                })
-                .await
-                .map_err(|e| {
-                    TlsError::DnsProvider(format!("failed to delete TXT record {}: {e}", record.id))
-                })?;
+        for record in &records {
+            self.api
+                .delete_record(self.zone_id.clone(), record.id.clone())
+                .await?;
             debug!("Deleted TXT record {} for {}", record.id, fqdn);
         }
 
@@ -189,9 +291,12 @@ mod tests {
 
     #[test]
     fn trait_object_safety() {
-        // Verify DnsProvider is object-safe (compiles if so)
         fn _assert_object_safe(_: &dyn DnsProvider) {}
     }
+
+    // -----------------------------------------------------------------------
+    // build_dns_provider tests
+    // -----------------------------------------------------------------------
 
     #[tokio::test]
     async fn build_dns_provider_unknown_provider_returns_error() {
@@ -215,5 +320,187 @@ mod tests {
             msg.contains("api_token"),
             "error should mention missing api_token: {msg}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // CloudflareDnsProvider tests (via MockCloudflareApi)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn cloudflare_provider_resolves_zone_id() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-123".to_string(),
+            }])
+        });
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        assert_eq!(provider.zone_id, "zone-123");
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_no_zone_found_returns_error() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| Ok(vec![]));
+
+        let err = CloudflareDnsProvider::with_api(Box::new(mock_api), "missing.com")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no Cloudflare zone found"), "error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_creates_txt_record() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-abc".to_string(),
+            }])
+        });
+        mock_api
+            .expect_create_txt_record_api()
+            .withf(|zone_id, name, content| {
+                zone_id == "zone-abc"
+                    && name == "_acme-challenge.example.com"
+                    && content == "dns-value-xyz"
+            })
+            .returning(|_, _, _| Ok(()));
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        provider
+            .create_txt_record("_acme-challenge.example.com", "dns-value-xyz")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_create_record_error_propagates() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-1".to_string(),
+            }])
+        });
+        mock_api
+            .expect_create_txt_record_api()
+            .returning(|_, _, _| Err(TlsError::DnsProvider("API error".to_string())));
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        let err = provider
+            .create_txt_record("_acme-challenge.example.com", "val")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("API error"), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_deletes_matching_records() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-del".to_string(),
+            }])
+        });
+        mock_api.expect_list_txt_records().returning(|_, _| {
+            Ok(vec![
+                RecordInfo {
+                    id: "rec-1".to_string(),
+                },
+                RecordInfo {
+                    id: "rec-2".to_string(),
+                },
+            ])
+        });
+        mock_api
+            .expect_delete_record()
+            .times(2)
+            .returning(|_, _| Ok(()));
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        provider
+            .delete_txt_record("_acme-challenge.example.com")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_delete_no_records_is_ok() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-empty".to_string(),
+            }])
+        });
+        mock_api
+            .expect_list_txt_records()
+            .returning(|_, _| Ok(vec![]));
+        mock_api.expect_delete_record().never();
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        provider
+            .delete_txt_record("_acme-challenge.example.com")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_delete_record_error_propagates() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-err".to_string(),
+            }])
+        });
+        mock_api.expect_list_txt_records().returning(|_, _| {
+            Ok(vec![RecordInfo {
+                id: "rec-x".to_string(),
+            }])
+        });
+        mock_api
+            .expect_delete_record()
+            .returning(|_, _| Err(TlsError::DnsProvider("delete failed".to_string())));
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        let err = provider
+            .delete_txt_record("_acme-challenge.example.com")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("delete failed"), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn cloudflare_provider_list_records_error_propagates() {
+        let mut mock_api = MockCloudflareApi::new();
+        mock_api.expect_list_zones().returning(|_| {
+            Ok(vec![ZoneInfo {
+                id: "zone-le".to_string(),
+            }])
+        });
+        mock_api
+            .expect_list_txt_records()
+            .returning(|_, _| Err(TlsError::DnsProvider("list failed".to_string())));
+
+        let provider = CloudflareDnsProvider::with_api(Box::new(mock_api), "example.com")
+            .await
+            .unwrap();
+        let err = provider
+            .delete_txt_record("_acme-challenge.example.com")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("list failed"), "error: {err}");
     }
 }

--- a/crates/rp-tls/src/dns.rs
+++ b/crates/rp-tls/src/dns.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use tracing::debug;
+
+use crate::error::{Result, TlsError};
+
+/// Trait for DNS providers that can create and delete TXT records
+/// for ACME DNS-01 challenge validation.
+#[async_trait]
+pub trait DnsProvider: Send + Sync + Debug {
+    /// Create a TXT record for the ACME challenge.
+    async fn create_txt_record(&self, fqdn: &str, value: &str) -> Result<()>;
+
+    /// Remove the TXT record after validation completes.
+    async fn delete_txt_record(&self, fqdn: &str) -> Result<()>;
+}
+
+/// Cloudflare DNS provider using the official `cloudflare` crate.
+///
+/// The zone ID is resolved once at construction time by looking up
+/// the zone matching the provided domain.
+pub struct CloudflareDnsProvider {
+    client: cloudflare::framework::client::async_api::Client,
+    zone_id: String,
+}
+
+impl Debug for CloudflareDnsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudflareDnsProvider")
+            .field("zone_id", &self.zone_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CloudflareDnsProvider {
+    /// Create a new Cloudflare DNS provider.
+    ///
+    /// Connects to the Cloudflare API with the given token and resolves
+    /// the zone ID for the specified domain.
+    pub async fn new(api_token: &str, domain: &str) -> Result<Self> {
+        use cloudflare::endpoints::zones::zone::{ListZones, ListZonesParams};
+        use cloudflare::framework::auth::Credentials;
+        use cloudflare::framework::client::ClientConfig;
+        use cloudflare::framework::Environment;
+
+        let credentials = Credentials::UserAuthToken {
+            token: api_token.to_string(),
+        };
+        let client = cloudflare::framework::client::async_api::Client::new(
+            credentials,
+            ClientConfig::default(),
+            Environment::Production,
+        )
+        .map_err(|e| TlsError::DnsProvider(format!("failed to create Cloudflare client: {e}")))?;
+
+        // Look up zone ID by domain name
+        let zones_response = client
+            .request(&ListZones {
+                params: ListZonesParams {
+                    name: Some(domain.to_string()),
+                    ..Default::default()
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to list zones: {e}")))?;
+
+        let zone = zones_response.result.first().ok_or_else(|| {
+            TlsError::DnsProvider(format!("no Cloudflare zone found for domain '{domain}'"))
+        })?;
+
+        debug!(
+            "Resolved Cloudflare zone ID '{}' for domain '{}'",
+            zone.id, domain
+        );
+
+        Ok(Self {
+            client,
+            zone_id: zone.id.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl DnsProvider for CloudflareDnsProvider {
+    async fn create_txt_record(&self, fqdn: &str, value: &str) -> Result<()> {
+        use cloudflare::endpoints::dns::dns::{CreateDnsRecord, CreateDnsRecordParams, DnsContent};
+
+        debug!("Creating TXT record: {} = {}", fqdn, value);
+
+        self.client
+            .request(&CreateDnsRecord {
+                zone_identifier: &self.zone_id,
+                params: CreateDnsRecordParams {
+                    name: fqdn,
+                    content: DnsContent::TXT {
+                        content: value.to_string(),
+                    },
+                    ttl: Some(60),
+                    priority: None,
+                    proxied: Some(false),
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to create TXT record: {e}")))?;
+
+        debug!("Created TXT record for {}", fqdn);
+        Ok(())
+    }
+
+    async fn delete_txt_record(&self, fqdn: &str) -> Result<()> {
+        use cloudflare::endpoints::dns::dns::{
+            DeleteDnsRecord, DnsContent, ListDnsRecords, ListDnsRecordsParams,
+        };
+
+        debug!("Deleting TXT records for {}", fqdn);
+
+        // List TXT records matching the FQDN
+        let records_response = self
+            .client
+            .request(&ListDnsRecords {
+                zone_identifier: &self.zone_id,
+                params: ListDnsRecordsParams {
+                    name: Some(fqdn.to_string()),
+                    record_type: Some(DnsContent::TXT {
+                        content: String::new(),
+                    }),
+                    ..Default::default()
+                },
+            })
+            .await
+            .map_err(|e| TlsError::DnsProvider(format!("failed to list TXT records: {e}")))?;
+
+        let records = &records_response.result;
+        if records.is_empty() {
+            debug!("No TXT records found for {} (already cleaned up)", fqdn);
+            return Ok(());
+        }
+
+        // Delete each matching record
+        for record in records {
+            self.client
+                .request(&DeleteDnsRecord {
+                    zone_identifier: &self.zone_id,
+                    identifier: &record.id,
+                })
+                .await
+                .map_err(|e| {
+                    TlsError::DnsProvider(format!("failed to delete TXT record {}: {e}", record.id))
+                })?;
+            debug!("Deleted TXT record {} for {}", record.id, fqdn);
+        }
+
+        Ok(())
+    }
+}
+
+/// Build a DNS provider from a provider name and credentials.
+///
+/// Currently supports:
+/// - `"cloudflare"` — requires `api_token` in credentials
+pub async fn build_dns_provider(
+    provider_name: &str,
+    credentials: &HashMap<String, String>,
+    domain: &str,
+) -> Result<Box<dyn DnsProvider>> {
+    match provider_name {
+        "cloudflare" => {
+            let api_token = credentials.get("api_token").ok_or_else(|| {
+                TlsError::Config(
+                    "Cloudflare DNS provider requires 'api_token' in dns_credentials".to_string(),
+                )
+            })?;
+            let provider = CloudflareDnsProvider::new(api_token, domain).await?;
+            Ok(Box::new(provider))
+        }
+        other => Err(TlsError::Config(format!(
+            "unsupported DNS provider: '{other}'. Supported providers: cloudflare"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_object_safety() {
+        // Verify DnsProvider is object-safe (compiles if so)
+        fn _assert_object_safe(_: &dyn DnsProvider) {}
+    }
+
+    #[tokio::test]
+    async fn build_dns_provider_unknown_provider_returns_error() {
+        let creds = HashMap::from([("api_token".to_string(), "tok".to_string())]);
+        let err = build_dns_provider("unknown", &creds, "example.com")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported DNS provider"),
+            "error should mention unsupported provider: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_dns_provider_cloudflare_missing_token_returns_error() {
+        let creds = HashMap::new();
+        let err = build_dns_provider("cloudflare", &creds, "example.com")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("api_token"),
+            "error should mention missing api_token: {msg}"
+        );
+    }
+}

--- a/crates/rp-tls/src/error.rs
+++ b/crates/rp-tls/src/error.rs
@@ -14,6 +14,15 @@ pub enum TlsError {
     #[error("PEM parsing error: {0}")]
     Pem(String),
 
+    #[error("ACME protocol error: {0}")]
+    Acme(String),
+
+    #[error("DNS provider error: {0}")]
+    DnsProvider(String),
+
+    #[error("configuration error: {0}")]
+    Config(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/rp-tls/src/lib.rs
+++ b/crates/rp-tls/src/lib.rs
@@ -4,8 +4,12 @@
 //! Provides certificate generation, TLS server helpers, client CA trust,
 //! and shared configuration types for opt-in HTTPS across all services.
 
+pub mod acme;
+pub mod acme_config;
 pub mod cert;
 pub mod client;
 pub mod config;
+pub mod dns;
 pub mod error;
+pub mod permissions;
 pub mod server;

--- a/crates/rp-tls/src/permissions.rs
+++ b/crates/rp-tls/src/permissions.rs
@@ -47,6 +47,7 @@ mod tests {
         assert_eq!(mode, 0o600, "expected 0600 but got {mode:o}");
     }
 
+    #[cfg(unix)]
     #[test]
     fn set_restricted_permissions_on_nonexistent_file_returns_error() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/rp-tls/src/permissions.rs
+++ b/crates/rp-tls/src/permissions.rs
@@ -1,0 +1,57 @@
+use std::path::Path;
+
+use tracing::debug;
+
+use crate::error::Result;
+
+/// Set file permissions to owner-only read/write (0600).
+///
+/// On Unix systems, this restricts access to the file owner.
+/// On non-Unix systems, this is a no-op with a debug log.
+pub fn set_restricted_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+        debug!("Set permissions 0600 on {}", path.display());
+    }
+    #[cfg(not(unix))]
+    {
+        debug!(
+            "Skipping permission restriction on non-Unix platform: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn set_restricted_permissions_sets_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("secret.key");
+        std::fs::write(&file_path, "secret").unwrap();
+
+        set_restricted_permissions(&file_path).unwrap();
+
+        let meta = std::fs::metadata(&file_path).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600 but got {mode:o}");
+    }
+
+    #[test]
+    fn set_restricted_permissions_on_nonexistent_file_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("does-not-exist");
+        let result = set_restricted_permissions(&file_path);
+        assert!(result.is_err());
+    }
+}

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -494,6 +494,52 @@ async fn test_server_starts() {
 }
 ```
 
+#### 6.7 Mock Strategy: Hand-Written vs mockall
+
+The project uses two mock strategies depending on the use case:
+
+**Hand-written mocks** — Use for stateful device simulators that maintain internal
+state across multiple calls. These mocks simulate hardware behavior: they process
+commands, maintain device state (temperature, position, voltage), and return
+responses from a queue. mockall cannot express this kind of stateful simulation.
+
+Examples: `MockSerialPortFactory` in ppba-driver and qhy-focuser, which simulate
+serial port communication with response queues and device state machines.
+
+**mockall (`#[automock]`)** — Use for service-boundary traits where you need simple
+"expect this call, return this value" behavior. These are thin abstractions over
+external APIs (HTTP clients, DNS providers, ACME protocol) where the mock just
+needs to return canned responses or verify call arguments.
+
+Examples: `DnsProvider` trait in rp-tls (mocks Cloudflare API), `AcmeClient` trait
+in rp-tls (mocks Let's Encrypt ACME protocol).
+
+**How to use mockall with async traits:**
+
+Place `#[automock]` before `#[async_trait]` on the trait definition, gated to
+test builds only:
+
+```rust
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait MyService: Send + Sync {
+    async fn do_something(&self, input: String) -> Result<String>;
+}
+```
+
+In tests, configure expectations on the generated `MockMyService`:
+
+```rust
+let mut mock = MockMyService::new();
+mock.expect_do_something()
+    .withf(|input| input == "expected")
+    .returning(|_| Ok("result".to_string()));
+```
+
+**Rule of thumb:** If the mock needs internal state or command processing logic,
+hand-write it. If it wraps an external API and just needs call/return behavior,
+use mockall.
+
 ---
 
 ### 7. Migration Strategy: From Integration Tests to BDD

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -33,6 +33,7 @@ ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel
 bdd-infra = { workspace = true }
 cucumber = { workspace = true }
 libc = { workspace = true }
+mockall = { workspace = true }
 tempfile = { workspace = true }
 tokio-test = { workspace = true }
 cargo-husky = { workspace = true }

--- a/services/rp/src/main.rs
+++ b/services/rp/src/main.rs
@@ -43,6 +43,30 @@ enum Commands {
         #[arg(long)]
         extra_san: Option<Vec<String>>,
 
+        /// Use ACME/Let's Encrypt instead of self-signed CA
+        #[arg(long)]
+        acme: bool,
+
+        /// Domain for ACME wildcard certificate (requires --acme)
+        #[arg(long, requires = "acme")]
+        domain: Option<String>,
+
+        /// DNS provider for ACME challenge (e.g., "cloudflare") (requires --acme)
+        #[arg(long, requires = "acme")]
+        dns_provider: Option<String>,
+
+        /// DNS provider API token (requires --acme)
+        #[arg(long, requires = "acme")]
+        dns_token: Option<String>,
+
+        /// Email for ACME account registration (requires --acme)
+        #[arg(long, requires = "acme")]
+        email: Option<String>,
+
+        /// Use Let's Encrypt staging environment (requires --acme)
+        #[arg(long, requires = "acme")]
+        staging: bool,
+
         /// Log level (trace, debug, info, warn, error)
         #[arg(long, default_value = "info")]
         log_level: String,
@@ -62,14 +86,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
             services,
             extra_san,
+            acme,
+            domain,
+            dns_provider,
+            dns_token,
+            email,
+            staging,
             log_level,
         }) => {
             init_tracing(&log_level);
-            rp::tls_cmd::run(
-                output_dir.as_deref(),
-                services.as_deref(),
-                &extra_san.unwrap_or_default(),
-            )
+            if acme {
+                rp::tls_cmd::run_acme(
+                    output_dir.as_deref(),
+                    domain.as_deref(),
+                    dns_provider.as_deref(),
+                    dns_token.as_deref(),
+                    email.as_deref(),
+                    staging,
+                )
+                .await
+            } else {
+                rp::tls_cmd::run(
+                    output_dir.as_deref(),
+                    services.as_deref(),
+                    &extra_san.unwrap_or_default(),
+                )
+            }
         }
         None => {
             // Backward compat: `rp --config <path>` works without a subcommand

--- a/services/rp/src/tls_cmd.rs
+++ b/services/rp/src/tls_cmd.rs
@@ -76,6 +76,95 @@ pub fn run(
     Ok(())
 }
 
+/// Run the ACME certificate issuance flow.
+///
+/// Creates an ACME account, requests a wildcard certificate via DNS-01
+/// challenge, and writes the certificate and key to the PKI directory.
+pub async fn run_acme(
+    output_dir: Option<&str>,
+    domain: Option<&str>,
+    dns_provider_name: Option<&str>,
+    dns_token: Option<&str>,
+    email: Option<&str>,
+    staging: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let domain = domain.ok_or("--domain is required with --acme")?;
+    let dns_provider_name = dns_provider_name.ok_or("--dns-provider is required with --acme")?;
+    let dns_token = dns_token.ok_or("--dns-token is required with --acme")?;
+    let email = email.ok_or("--email is required with --acme")?;
+
+    let pki_dir = match output_dir {
+        Some(dir) => config::expand_tilde(dir),
+        None => config::default_pki_dir(),
+    };
+
+    // Build and save ACME config
+    let mut dns_credentials = std::collections::HashMap::new();
+    dns_credentials.insert("api_token".to_string(), dns_token.to_string());
+
+    let acme_config = rp_tls::acme_config::AcmeConfig {
+        email: email.to_string(),
+        domain: domain.to_string(),
+        dns_provider: dns_provider_name.to_string(),
+        dns_credentials,
+        staging,
+        renewal_days_before_expiry: 30,
+        post_renewal_hooks: vec![],
+    };
+
+    let config_path = match output_dir {
+        Some(dir) => config::expand_tilde(dir).join("acme.json"),
+        None => rp_tls::acme_config::default_acme_config_path(),
+    };
+    rp_tls::acme_config::save_acme_config(&acme_config, &config_path)?;
+    info!("Saved ACME configuration to {}", config_path.display());
+
+    // Build DNS provider
+    let resolved_creds = rp_tls::acme_config::resolve_credentials(&acme_config.dns_credentials)?;
+    let dns_provider =
+        rp_tls::dns::build_dns_provider(&acme_config.dns_provider, &resolved_creds, domain).await?;
+
+    // Issue certificate
+    info!("Requesting wildcard certificate for *.{}", domain);
+    if staging {
+        info!("Using Let's Encrypt STAGING environment");
+    }
+    rp_tls::acme::issue_certificate(&acme_config, &pki_dir, dns_provider.as_ref()).await?;
+
+    // Print summary
+    let cert_path = rp_tls::acme_config::acme_cert_path(&pki_dir);
+    let key_path = rp_tls::acme_config::acme_key_path(&pki_dir);
+    println!("\nACME certificate issued successfully:");
+    println!("  Certificate: {}", cert_path.display());
+    println!("  Private key: {}", key_path.display());
+    println!("  Domain:      *.{}", domain);
+    if staging {
+        println!("  Environment: STAGING (not trusted by browsers)");
+    }
+
+    print_acme_config_hint(&pki_dir);
+
+    Ok(())
+}
+
+/// Print a hint showing how to configure services to use ACME certs.
+fn print_acme_config_hint(pki_dir: &Path) {
+    let cert = rp_tls::acme_config::acme_cert_path(pki_dir);
+    let key = rp_tls::acme_config::acme_key_path(pki_dir);
+    println!("\nAdd to each service's config.json:");
+    println!(
+        r#"  "server": {{
+    "tls": {{
+      "cert": "{}",
+      "key": "{}"
+    }}
+  }}"#,
+        cert.display(),
+        key.display()
+    );
+    println!("\nNo CA configuration needed for clients -- Let's Encrypt is publicly trusted.");
+}
+
 /// Print a hint showing how to configure services to use the generated certs.
 fn print_config_hint(certs_dir: &Path, ca_cert_path: &Path, services: &[&str]) {
     if let Some(first) = services.first() {

--- a/services/rp/src/tls_cmd.rs
+++ b/services/rp/src/tls_cmd.rs
@@ -129,7 +129,8 @@ pub async fn run_acme(
     if staging {
         info!("Using Let's Encrypt STAGING environment");
     }
-    rp_tls::acme::issue_certificate_real(&acme_config, &pki_dir, dns_provider.as_ref()).await?;
+    let acme_client = rp_tls::acme::RealAcmeClient::new(dns_provider.as_ref());
+    rp_tls::acme::issue_certificate(&acme_config, &pki_dir, &acme_client).await?;
 
     // Print summary
     let cert_path = rp_tls::acme_config::acme_cert_path(&pki_dir);

--- a/services/rp/src/tls_cmd.rs
+++ b/services/rp/src/tls_cmd.rs
@@ -119,31 +119,45 @@ pub async fn run_acme(
     rp_tls::acme_config::save_acme_config(&acme_config, &config_path)?;
     info!("Saved ACME configuration to {}", config_path.display());
 
-    // Build DNS provider
+    // Build DNS provider and issue certificate
     let resolved_creds = rp_tls::acme_config::resolve_credentials(&acme_config.dns_credentials)?;
     let dns_provider =
         rp_tls::dns::build_dns_provider(&acme_config.dns_provider, &resolved_creds, domain).await?;
+    let acme_client = rp_tls::acme::RealAcmeClient::new(dns_provider.as_ref());
 
-    // Issue certificate
-    info!("Requesting wildcard certificate for *.{}", domain);
-    if staging {
+    run_acme_issue(&acme_config, &pki_dir, &acme_client).await
+}
+
+/// Inner function that issues the certificate and prints the summary.
+///
+/// Separated from `run_acme` so it can be tested with mock dependencies.
+async fn run_acme_issue(
+    acme_config: &rp_tls::acme_config::AcmeConfig,
+    pki_dir: &Path,
+    acme_client: &dyn rp_tls::acme::AcmeClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!(
+        "Requesting wildcard certificate for *.{}",
+        acme_config.domain
+    );
+    if acme_config.staging {
         info!("Using Let's Encrypt STAGING environment");
     }
-    let acme_client = rp_tls::acme::RealAcmeClient::new(dns_provider.as_ref());
-    rp_tls::acme::issue_certificate(&acme_config, &pki_dir, &acme_client).await?;
+
+    rp_tls::acme::issue_certificate(acme_config, pki_dir, acme_client).await?;
 
     // Print summary
-    let cert_path = rp_tls::acme_config::acme_cert_path(&pki_dir);
-    let key_path = rp_tls::acme_config::acme_key_path(&pki_dir);
+    let cert_path = rp_tls::acme_config::acme_cert_path(pki_dir);
+    let key_path = rp_tls::acme_config::acme_key_path(pki_dir);
     println!("\nACME certificate issued successfully:");
     println!("  Certificate: {}", cert_path.display());
     println!("  Private key: {}", key_path.display());
-    println!("  Domain:      *.{}", domain);
-    if staging {
+    println!("  Domain:      *.{}", acme_config.domain);
+    if acme_config.staging {
         println!("  Environment: STAGING (not trusted by browsers)");
     }
 
-    print_acme_config_hint(&pki_dir);
+    print_acme_config_hint(pki_dir);
 
     Ok(())
 }
@@ -193,6 +207,107 @@ fn print_config_hint(certs_dir: &Path, ca_cert_path: &Path, services: &[&str]) {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use rp_tls::acme::AcmeClient;
+    use rp_tls::error::TlsError;
+
+    // Local mock of AcmeClient for testing run_acme_issue.
+    // The rp-tls crate's MockAcmeClient is only available in its own test builds,
+    // so we define one here via mockall::mock!.
+    mockall::mock! {
+        Acme {}
+        #[async_trait::async_trait]
+        impl AcmeClient for Acme {
+            async fn create_or_load_account(
+                &self,
+                email: String,
+                directory_url: String,
+                existing_credentials_json: Option<String>,
+            ) -> rp_tls::error::Result<Option<String>>;
+            async fn order_certificate(
+                &self,
+                domain: String,
+            ) -> rp_tls::error::Result<(String, String)>;
+        }
+    }
+
+    #[tokio::test]
+    async fn run_acme_issue_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let acme_config = rp_tls::acme_config::AcmeConfig {
+            email: "test@example.com".to_string(),
+            domain: "observatory.example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: std::collections::HashMap::new(),
+            staging: false,
+            renewal_days_before_expiry: 30,
+            post_renewal_hooks: vec![],
+        };
+
+        let mut mock = MockAcme::new();
+        mock.expect_create_or_load_account()
+            .returning(|_, _, _| Ok(Some(r#"{"account":"creds"}"#.to_string())));
+        mock.expect_order_certificate()
+            .returning(|_| Ok(("CERT-CHAIN".to_string(), "PRIV-KEY".to_string())));
+
+        run_acme_issue(&acme_config, dir.path(), &mock)
+            .await
+            .unwrap();
+
+        // Verify cert and key files written
+        let cert_path = rp_tls::acme_config::acme_cert_path(dir.path());
+        let key_path = rp_tls::acme_config::acme_key_path(dir.path());
+        assert_eq!(std::fs::read_to_string(cert_path).unwrap(), "CERT-CHAIN");
+        assert_eq!(std::fs::read_to_string(key_path).unwrap(), "PRIV-KEY");
+    }
+
+    #[tokio::test]
+    async fn run_acme_issue_staging_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let acme_config = rp_tls::acme_config::AcmeConfig {
+            email: "test@example.com".to_string(),
+            domain: "observatory.example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: std::collections::HashMap::new(),
+            staging: true,
+            renewal_days_before_expiry: 30,
+            post_renewal_hooks: vec![],
+        };
+
+        let mut mock = MockAcme::new();
+        mock.expect_create_or_load_account()
+            .returning(|_, _, _| Ok(None));
+        mock.expect_order_certificate()
+            .returning(|_| Ok(("CERT".to_string(), "KEY".to_string())));
+
+        run_acme_issue(&acme_config, dir.path(), &mock)
+            .await
+            .unwrap();
+
+        assert!(rp_tls::acme_config::acme_cert_path(dir.path()).exists());
+    }
+
+    #[tokio::test]
+    async fn run_acme_issue_error_propagates() {
+        let dir = tempfile::tempdir().unwrap();
+        let acme_config = rp_tls::acme_config::AcmeConfig {
+            email: "test@example.com".to_string(),
+            domain: "example.com".to_string(),
+            dns_provider: "cloudflare".to_string(),
+            dns_credentials: std::collections::HashMap::new(),
+            staging: true,
+            renewal_days_before_expiry: 30,
+            post_renewal_hooks: vec![],
+        };
+
+        let mut mock = MockAcme::new();
+        mock.expect_create_or_load_account()
+            .returning(|_, _, _| Err(TlsError::Acme("test error".to_string())));
+
+        let err = run_acme_issue(&acme_config, dir.path(), &mock)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("test error"), "error: {err}");
+    }
 
     #[test]
     fn run_generates_all_default_certs() {

--- a/services/rp/src/tls_cmd.rs
+++ b/services/rp/src/tls_cmd.rs
@@ -129,7 +129,7 @@ pub async fn run_acme(
     if staging {
         info!("Using Let's Encrypt STAGING environment");
     }
-    rp_tls::acme::issue_certificate(&acme_config, &pki_dir, dns_provider.as_ref()).await?;
+    rp_tls::acme::issue_certificate_real(&acme_config, &pki_dir, dns_provider.as_ref()).await?;
 
     // Print summary
     let cert_path = rp_tls::acme_config::acme_cert_path(&pki_dir);

--- a/services/rp/tests/bdd/steps/acme_steps.rs
+++ b/services/rp/tests/bdd/steps/acme_steps.rs
@@ -1,0 +1,204 @@
+//! BDD step definitions for ACME certificate setup
+
+use cucumber::{then, when};
+use tempfile::TempDir;
+
+use crate::world::RpWorld;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Run `rp init-tls` with the given arguments and capture the output.
+fn run_init_tls_raw(args: &[&str]) -> std::process::Output {
+    bdd_infra::run_once(env!("CARGO_MANIFEST_DIR"), env!("CARGO_PKG_NAME"), args)
+}
+
+// ---------------------------------------------------------------------------
+// When steps — ACME flag validation
+// ---------------------------------------------------------------------------
+
+#[when("rp init-tls is run with --acme but no --domain")]
+fn acme_without_domain(world: &mut RpWorld) {
+    let output = run_init_tls_raw(&["init-tls", "--acme"]);
+    world.last_command_output = Some(output);
+}
+
+#[when("rp init-tls is run with --acme --domain but no --dns-provider")]
+fn acme_without_dns_provider(world: &mut RpWorld) {
+    let output = run_init_tls_raw(&["init-tls", "--acme", "--domain", "test.example.com"]);
+    world.last_command_output = Some(output);
+}
+
+#[when("rp init-tls is run with --acme --domain --dns-provider but no --email")]
+fn acme_without_email(world: &mut RpWorld) {
+    let output = run_init_tls_raw(&[
+        "init-tls",
+        "--acme",
+        "--domain",
+        "test.example.com",
+        "--dns-provider",
+        "cloudflare",
+        "--dns-token",
+        "fake-token",
+    ]);
+    world.last_command_output = Some(output);
+}
+
+#[when("rp init-tls is run with --acme and all required flags pointing to staging")]
+fn acme_with_all_flags_staging(world: &mut RpWorld) {
+    let dir = TempDir::new().unwrap();
+    let output_dir = dir.path().to_str().unwrap().to_string();
+
+    // This will fail at the DNS provider step (no real Cloudflare token),
+    // but it should successfully save the acme.json config first.
+    let output = run_init_tls_raw(&[
+        "init-tls",
+        "--acme",
+        "--staging",
+        "--domain",
+        "observatory.example.com",
+        "--dns-provider",
+        "cloudflare",
+        "--dns-token",
+        "test-token-for-bdd",
+        "--email",
+        "test@example.com",
+        "--output-dir",
+        &output_dir,
+    ]);
+
+    world.last_command_output = Some(output);
+    world.tls_pki_dir = Some(dir);
+}
+
+#[when("rp init-tls is run without --acme")]
+fn init_tls_without_acme(world: &mut RpWorld) {
+    let dir = TempDir::new().unwrap();
+    let output_dir = dir.path().to_str().unwrap().to_string();
+    let output = run_init_tls_raw(&["init-tls", "--output-dir", &output_dir]);
+    world.last_command_output = Some(output);
+    world.tls_pki_dir = Some(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Then steps — exit status and stderr
+// ---------------------------------------------------------------------------
+
+#[then("the command exits with a non-zero status")]
+fn command_failed(world: &mut RpWorld) {
+    let output = world
+        .last_command_output
+        .as_ref()
+        .expect("no command output captured");
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit status but got success"
+    );
+}
+
+#[then(expr = "stderr contains {string}")]
+fn stderr_contains(world: &mut RpWorld, expected: String) {
+    let output = world
+        .last_command_output
+        .as_ref()
+        .expect("no command output captured");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.to_lowercase().contains(&expected.to_lowercase()),
+        "stderr should contain '{expected}' but was: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Then steps — ACME config file validation
+// ---------------------------------------------------------------------------
+
+#[then("acme.json exists in the output directory")]
+fn acme_json_exists(world: &mut RpWorld) {
+    let dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("output directory not set");
+    let acme_path = dir.path().join("acme.json");
+    assert!(
+        acme_path.exists(),
+        "acme.json should exist at {}",
+        acme_path.display()
+    );
+}
+
+#[then("acme.json contains the provided domain")]
+fn acme_json_has_domain(world: &mut RpWorld) {
+    let config = load_acme_json(world);
+    assert_eq!(
+        config["domain"].as_str().unwrap(),
+        "observatory.example.com"
+    );
+}
+
+#[then("acme.json contains the provided email")]
+fn acme_json_has_email(world: &mut RpWorld) {
+    let config = load_acme_json(world);
+    assert_eq!(config["email"].as_str().unwrap(), "test@example.com");
+}
+
+#[then("acme.json contains the DNS provider name")]
+fn acme_json_has_dns_provider(world: &mut RpWorld) {
+    let config = load_acme_json(world);
+    assert_eq!(config["dns_provider"].as_str().unwrap(), "cloudflare");
+}
+
+#[then("acme.json has staging set to true")]
+fn acme_json_staging_true(world: &mut RpWorld) {
+    let config = load_acme_json(world);
+    assert!(config["staging"].as_bool().unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Then steps — self-signed CA fallback
+// ---------------------------------------------------------------------------
+
+#[then("ca.pem exists in the output directory")]
+fn ca_pem_exists(world: &mut RpWorld) {
+    let dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("output directory not set");
+    assert!(dir.path().join("ca.pem").exists());
+}
+
+#[then("service certificates exist for default services")]
+fn default_service_certs_exist(world: &mut RpWorld) {
+    let dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("output directory not set");
+    for svc in &[
+        "filemonitor",
+        "ppba-driver",
+        "qhy-focuser",
+        "rp",
+        "sentinel",
+    ] {
+        assert!(
+            dir.path().join("certs").join(format!("{svc}.pem")).exists(),
+            "missing cert for {svc}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn load_acme_json(world: &RpWorld) -> serde_json::Value {
+    let dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("output directory not set");
+    let path = dir.path().join("acme.json");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    serde_json::from_str(&content).expect("acme.json should be valid JSON")
+}

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -1,5 +1,6 @@
 //! BDD step definitions for rp service
 
+pub mod acme_steps;
 pub mod equipment_steps;
 pub mod event_steps;
 pub mod infrastructure;

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -94,6 +94,10 @@ pub struct RpWorld {
     pub tls_ca_cert_pem: Option<String>,
     /// Last HTTPS response status for TLS validation tests
     pub tls_https_status: Option<u16>,
+
+    // --- ACME test state ---
+    /// Last command output (for ACME CLI tests)
+    pub last_command_output: Option<std::process::Output>,
 }
 
 /// Camera configuration for test setup

--- a/services/rp/tests/features/acme_setup.feature
+++ b/services/rp/tests/features/acme_setup.feature
@@ -1,0 +1,32 @@
+Feature: ACME certificate setup
+  The rp init-tls command supports --acme mode to request certificates
+  from Let's Encrypt via DNS-01 challenge validation. ACME mode requires
+  --domain, --dns-provider, --dns-token, and --email flags.
+
+  Scenario: init-tls --acme fails without --domain
+    When rp init-tls is run with --acme but no --domain
+    Then the command exits with a non-zero status
+    And stderr contains "domain"
+
+  Scenario: init-tls --acme fails without --dns-provider
+    When rp init-tls is run with --acme --domain but no --dns-provider
+    Then the command exits with a non-zero status
+    And stderr contains "dns-provider"
+
+  Scenario: init-tls --acme fails without --email
+    When rp init-tls is run with --acme --domain --dns-provider but no --email
+    Then the command exits with a non-zero status
+    And stderr contains "email"
+
+  Scenario: init-tls --acme saves ACME configuration file
+    When rp init-tls is run with --acme and all required flags pointing to staging
+    Then acme.json exists in the output directory
+    And acme.json contains the provided domain
+    And acme.json contains the provided email
+    And acme.json contains the DNS provider name
+    And acme.json has staging set to true
+
+  Scenario: init-tls without --acme still generates self-signed CA
+    When rp init-tls is run without --acme
+    Then ca.pem exists in the output directory
+    And service certificates exist for default services


### PR DESCRIPTION
## Summary
- Implements ADR-002 Phase 1: core ACME certificate issuance via DNS-01 challenge validation
- Adds `rp init-tls --acme` to request publicly-trusted wildcard certificates from Let's Encrypt
- New rp-tls modules: `acme.rs`, `acme_config.rs`, `dns.rs` (DnsProvider trait + Cloudflare), `permissions.rs`
- Upgrades rcgen 0.13 → 0.14 to share version with instant-acme
- BDD tests cover CLI argument validation and config file generation (5 scenarios, 18 steps)

## Test plan
- [x] All 38 rp-tls unit/integration tests pass
- [x] All 57 rp BDD scenarios pass (313 steps), including 5 new ACME scenarios
- [x] Clippy clean, no warnings
- [x] Manual staging test with real Cloudflare token (requires domain)
- [ ] End-to-end Pebble tests (deferred to Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)