### PR TITLE
Implement ADR-003: HTTP Basic Auth for device access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/bdd-infra",
+  "crates/rp-auth",
   "crates/rp-tls",
   "services/filemonitor",
   "services/phd2-guider",
@@ -44,7 +45,10 @@ tokio-serial = "5.4.5"
 ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", branch = "feature/expose-into-router", default-features = false }
 axum = "0.8"
 reqwest = { version = "0.13.2", features = ["form", "json"] }
+rp-auth = { path = "crates/rp-auth" }
 rp-tls = { path = "crates/rp-tls" }
+argon2 = { version = "0.5", features = ["std"] }
+rpassword = "7"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 instant-acme = { version = "0.8", features = ["hyper-rustls", "rcgen"] }
 cloudflare = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "2.0.18"
 base64 = "0.22.1"
 mockall = "0.14.0"
 tokio-serial = "5.4.5"
-ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", branch = "feature/expose-into-router", default-features = false }
+ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", branch = "feature/client-custom-reqwest", default-features = false }
 axum = "0.8"
 reqwest = { version = "0.13.2", features = ["form", "json"] }
 rp-auth = { path = "crates/rp-auth" }

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -729,4 +729,84 @@ features = ["mock"]
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(!stderr.is_empty(), "stderr should contain error message");
     }
+
+    /// Resolve the absolute path to the rp binary in target/debug.
+    /// Builds it first if necessary.
+    fn rp_binary_path() -> String {
+        let build = std::process::Command::new("cargo")
+            .args(["build", "--package", "rp", "--quiet"])
+            .status()
+            .expect("cargo build failed");
+        assert!(build.success(), "cargo build --package rp failed");
+
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let target_dir = std::env::var("CARGO_TARGET_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| workspace_root.join("target"));
+
+        let binary_name = if cfg!(target_os = "windows") {
+            "rp.exe"
+        } else {
+            "rp"
+        };
+        let binary = target_dir.join("debug").join(binary_name);
+        assert!(
+            binary.exists(),
+            "rp binary not found at {}",
+            binary.display()
+        );
+        binary.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn test_run_once_uses_prebuilt_binary_via_env_var() {
+        let binary = rp_binary_path();
+        std::env::set_var("RP_BINARY", &binary);
+
+        let dir = tempfile::tempdir().unwrap();
+        let output = run_once(
+            &rp_manifest_dir(),
+            "rp",
+            &["init-tls", "--output-dir", dir.path().to_str().unwrap()],
+            None,
+        );
+
+        std::env::remove_var("RP_BINARY");
+
+        assert!(
+            output.status.success(),
+            "init-tls via pre-built binary should succeed"
+        );
+        assert!(dir.path().join("ca.pem").exists(), "CA cert should exist");
+    }
+
+    #[test]
+    fn test_run_once_with_stdin_via_prebuilt_binary() {
+        let binary = rp_binary_path();
+        std::env::set_var("RP_BINARY", &binary);
+
+        let output = run_once(
+            &rp_manifest_dir(),
+            "rp",
+            &["hash-password", "--stdin"],
+            Some(b"test-password\n"),
+        );
+
+        std::env::remove_var("RP_BINARY");
+
+        assert!(
+            output.status.success(),
+            "hash-password via pre-built binary should succeed"
+        );
+        let hash = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            hash.trim().starts_with("$argon2id$"),
+            "expected Argon2id hash, got: {hash}"
+        );
+    }
 }

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -178,7 +178,7 @@ impl ServiceHandle {
             .take()
             .ok_or_else(|| format!("failed to capture {} stdout", package_name))?;
 
-        match tokio::time::timeout(Duration::from_secs(10), parse_bound_port(stdout)).await {
+        match tokio::time::timeout(Duration::from_secs(30), parse_bound_port(stdout)).await {
             Ok(Some((port, stdout_drain))) => Ok(Self {
                 child: Some(child),
                 port,
@@ -255,16 +255,23 @@ impl Drop for ServiceHandle {
 ///
 /// Use this for one-shot commands like `rp init-tls` that are not
 /// long-running servers.
-pub fn run_once(manifest_dir: &str, package_name: &str, args: &[&str]) -> std::process::Output {
+/// Run a service binary once and return its output.
+///
+/// When `stdin_data` is `Some`, the data is piped to the process's stdin.
+pub fn run_once(
+    manifest_dir: &str,
+    package_name: &str,
+    args: &[&str],
+    stdin_data: Option<&[u8]>,
+) -> std::process::Output {
     let config = load_config(manifest_dir);
     let binary = find_binary(&config.env_var, package_name);
 
-    if let Some(binary) = &binary {
+    let mut cmd = if let Some(binary) = &binary {
         debug!(binary = %binary, "running {} from pre-built binary", package_name);
-        std::process::Command::new(binary)
-            .args(args)
-            .output()
-            .unwrap_or_else(|e| panic!("failed to run {} binary '{}': {}", package_name, binary, e))
+        let mut cmd = std::process::Command::new(binary);
+        cmd.args(args);
+        cmd
     } else {
         debug!("running {} via cargo run", package_name);
         let mut full_args = vec!["run", "--package", package_name];
@@ -276,10 +283,34 @@ pub fn run_once(manifest_dir: &str, package_name: &str, args: &[&str]) -> std::p
         full_args.push("--");
         full_args.extend_from_slice(args);
 
-        std::process::Command::new("cargo")
-            .args(&full_args)
-            .output()
-            .unwrap_or_else(|e| panic!("failed to run {} via cargo run: {}", package_name, e))
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.args(&full_args);
+        cmd
+    };
+
+    if let Some(data) = stdin_data {
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn {}: {}", package_name, e));
+
+        use std::io::Write;
+        if let Some(ref mut stdin) = child.stdin {
+            stdin
+                .write_all(data)
+                .unwrap_or_else(|e| panic!("failed to write stdin for {}: {}", package_name, e));
+        }
+        drop(child.stdin.take());
+
+        child
+            .wait_with_output()
+            .unwrap_or_else(|e| panic!("failed to wait on {}: {}", package_name, e))
+    } else {
+        cmd.output()
+            .unwrap_or_else(|e| panic!("failed to run {}: {}", package_name, e))
     }
 }
 
@@ -684,6 +715,7 @@ features = ["mock"]
             &rp_manifest_dir(),
             "rp",
             &["init-tls", "--output-dir", dir.path().to_str().unwrap()],
+            None,
         );
         assert!(output.status.success(), "init-tls should succeed");
         assert!(dir.path().join("ca.pem").exists(), "CA cert should exist");
@@ -691,7 +723,7 @@ features = ["mock"]
 
     #[test]
     fn test_run_once_captures_stderr_on_failure() {
-        let output = run_once(&rp_manifest_dir(), "rp", &["serve"]);
+        let output = run_once(&rp_manifest_dir(), "rp", &["serve"], None);
         // serve without --config should fail
         assert!(!output.status.success());
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/rp-auth/Cargo.toml
+++ b/crates/rp-auth/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rp-auth"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HTTP Basic Auth utilities for Rusty Photon services"
+rust-version = "1.88.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+argon2 = { workspace = true }
+axum = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+reqwest = { workspace = true }
+tower = "0.5"

--- a/crates/rp-auth/src/config.rs
+++ b/crates/rp-auth/src/config.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+
+/// Server-side authentication configuration.
+///
+/// Stored in each service's config file. The password is hashed with Argon2id;
+/// use `rp hash-password` to generate the hash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthConfig {
+    pub username: String,
+    pub password_hash: String,
+}
+
+/// Client-side authentication configuration.
+///
+/// Used by services that connect to auth-enabled services (e.g. sentinel
+/// monitoring an auth-enabled filemonitor). The password is stored in plaintext
+/// because the client needs the actual password for HTTP Basic Auth headers.
+/// File permissions (`chmod 600`) are the recommended protection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientAuthConfig {
+    pub username: String,
+    pub password: String,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_config_deserializes_from_json() {
+        let json =
+            r#"{"username": "observatory", "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$abc"}"#;
+        let config: AuthConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.username, "observatory");
+        assert_eq!(config.password_hash, "$argon2id$v=19$m=19456,t=2,p=1$abc");
+    }
+
+    #[test]
+    fn auth_config_round_trips() {
+        let config = AuthConfig {
+            username: "user".to_string(),
+            password_hash: "hash".to_string(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: AuthConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.username, "user");
+        assert_eq!(deserialized.password_hash, "hash");
+    }
+
+    #[test]
+    fn client_auth_config_deserializes_from_json() {
+        let json = r#"{"username": "observatory", "password": "secret"}"#;
+        let config: ClientAuthConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.username, "observatory");
+        assert_eq!(config.password, "secret");
+    }
+
+    #[test]
+    fn optional_auth_config_defaults_to_none() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default)]
+            auth: Option<AuthConfig>,
+        }
+        let json = r#"{}"#;
+        let wrapper: Wrapper = serde_json::from_str(json).unwrap();
+        assert!(wrapper.auth.is_none());
+    }
+}

--- a/crates/rp-auth/src/credentials.rs
+++ b/crates/rp-auth/src/credentials.rs
@@ -1,0 +1,72 @@
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+
+use crate::error::{AuthError, Result};
+
+/// Hash a plaintext password using Argon2id.
+///
+/// Returns the hash in PHC string format (e.g. `$argon2id$v=19$m=19456,t=2,p=1$...`).
+pub fn hash_password(password: &str) -> Result<String> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2
+        .hash_password(password.as_bytes(), &salt)
+        .map_err(|e| AuthError::HashingError(e.to_string()))?;
+    Ok(hash.to_string())
+}
+
+/// Verify a plaintext password against an Argon2id hash.
+///
+/// Returns `true` if the password matches the hash.
+pub fn verify_password(password: &str, hash: &str) -> bool {
+    let Ok(parsed_hash) = PasswordHash::new(hash) else {
+        return false;
+    };
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok()
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_then_verify_succeeds() {
+        let hash = hash_password("test-password").unwrap();
+        assert!(verify_password("test-password", &hash));
+    }
+
+    #[test]
+    fn verify_with_wrong_password_fails() {
+        let hash = hash_password("correct-password").unwrap();
+        assert!(!verify_password("wrong-password", &hash));
+    }
+
+    #[test]
+    fn hash_produces_argon2id_format() {
+        let hash = hash_password("test").unwrap();
+        assert!(hash.starts_with("$argon2id$"), "hash: {hash}");
+    }
+
+    #[test]
+    fn verify_with_invalid_hash_returns_false() {
+        assert!(!verify_password("test", "not-a-valid-hash"));
+    }
+
+    #[test]
+    fn verify_with_empty_hash_returns_false() {
+        assert!(!verify_password("test", ""));
+    }
+
+    #[test]
+    fn different_hashes_for_same_password() {
+        let hash1 = hash_password("same").unwrap();
+        let hash2 = hash_password("same").unwrap();
+        assert_ne!(hash1, hash2, "salts should differ");
+        assert!(verify_password("same", &hash1));
+        assert!(verify_password("same", &hash2));
+    }
+}

--- a/crates/rp-auth/src/error.rs
+++ b/crates/rp-auth/src/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("invalid Authorization header: {0}")]
+    InvalidHeader(String),
+
+    #[error("invalid credentials")]
+    InvalidCredentials,
+
+    #[error("password hashing error: {0}")]
+    HashingError(String),
+}
+
+pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/rp-auth/src/lib.rs
+++ b/crates/rp-auth/src/lib.rs
@@ -1,0 +1,22 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! HTTP Basic Auth utilities for Rusty Photon services.
+//!
+//! Provides Argon2id credential hashing/verification, axum tower middleware,
+//! and shared configuration types for opt-in authentication across all services.
+
+pub mod config;
+pub mod credentials;
+pub mod error;
+pub mod middleware;
+
+use axum::Router;
+use config::AuthConfig;
+
+/// Wrap a router with HTTP Basic Auth middleware.
+///
+/// All requests must include a valid `Authorization: Basic` header.
+/// Requests with missing or invalid credentials receive `401 Unauthorized`
+/// with a `WWW-Authenticate: Basic realm="Rusty Photon"` header.
+pub fn layer(router: Router, config: &AuthConfig) -> Router {
+    middleware::apply(router, config)
+}

--- a/crates/rp-auth/src/middleware.rs
+++ b/crates/rp-auth/src/middleware.rs
@@ -1,0 +1,214 @@
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use axum::Router;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use tracing::debug;
+
+use crate::config::AuthConfig;
+use crate::credentials;
+
+/// Apply HTTP Basic Auth middleware to a router.
+pub fn apply(router: Router, config: &AuthConfig) -> Router {
+    router.layer(middleware::from_fn_with_state(
+        config.clone(),
+        auth_middleware,
+    ))
+}
+
+async fn auth_middleware(
+    State(config): State<AuthConfig>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    let Some(header_value) = auth_header else {
+        debug!("missing Authorization header");
+        return unauthorized_response();
+    };
+
+    let Some(encoded) = header_value.strip_prefix("Basic ") else {
+        debug!("Authorization header is not Basic scheme");
+        return unauthorized_response();
+    };
+
+    let decoded = match BASE64.decode(encoded) {
+        Ok(bytes) => match String::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(_) => {
+                debug!("Authorization header contains invalid UTF-8");
+                return unauthorized_response();
+            }
+        },
+        Err(_) => {
+            debug!("Authorization header contains invalid base64");
+            return unauthorized_response();
+        }
+    };
+
+    let Some((username, password)) = decoded.split_once(':') else {
+        debug!("Authorization header missing ':' separator");
+        return unauthorized_response();
+    };
+
+    if username != config.username || !credentials::verify_password(password, &config.password_hash)
+    {
+        debug!("invalid credentials for user '{}'", username);
+        return unauthorized_response();
+    }
+
+    next.run(request).await
+}
+
+fn unauthorized_response() -> Response {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header("www-authenticate", "Basic realm=\"Rusty Photon\"")
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt as _;
+
+    fn test_config() -> AuthConfig {
+        let hash = credentials::hash_password("test-password").unwrap();
+        AuthConfig {
+            username: "testuser".to_string(),
+            password_hash: hash,
+        }
+    }
+
+    fn test_router() -> Router {
+        let config = test_config();
+        let app = Router::new().route("/test", get(|| async { "ok" }));
+        apply(app, &config)
+    }
+
+    fn basic_auth_header(username: &str, password: &str) -> String {
+        let encoded = BASE64.encode(format!("{username}:{password}"));
+        format!("Basic {encoded}")
+    }
+
+    #[tokio::test]
+    async fn valid_credentials_returns_200() {
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header(
+                "authorization",
+                basic_auth_header("testuser", "test-password"),
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn wrong_password_returns_401() {
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header("authorization", basic_auth_header("testuser", "wrong"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn wrong_username_returns_401() {
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header(
+                "authorization",
+                basic_auth_header("baduser", "test-password"),
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_auth_header_returns_401() {
+        let app = test_router();
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn malformed_auth_header_returns_401() {
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header("authorization", "Bearer some-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn response_401_includes_www_authenticate_header() {
+        let app = test_router();
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let www_auth = response
+            .headers()
+            .get("www-authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+    }
+
+    #[tokio::test]
+    async fn invalid_base64_returns_401() {
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header("authorization", "Basic !!!not-base64!!!")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_colon_separator_returns_401() {
+        let encoded = BASE64.encode("no-colon-here");
+        let app = test_router();
+        let request = Request::builder()
+            .uri("/test")
+            .header("authorization", format!("Basic {encoded}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/docs/decisions/003-authentication-for-device-access.md
+++ b/docs/decisions/003-authentication-for-device-access.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/services/filemonitor.md
+++ b/docs/services/filemonitor.md
@@ -54,7 +54,11 @@ The service uses a JSON configuration file with the following format:
   },
   "server": {
     "port": 11111,
-    "device_number": 0
+    "device_number": 0,
+    "auth": {
+      "username": "observatory",
+      "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
+    }
   }
 }
 ```
@@ -65,6 +69,7 @@ Configuration sections:
 - **file**: Path to monitor and polling interval in seconds
 - **parsing**: Multiple rule types (contains, regex) with safe/unsafe outcomes
 - **server**: ASCOM Alpaca server configuration (port, device number)
+- **server.auth**: Optional HTTP Basic Auth credentials (username, Argon2id password_hash). See [ADR-003](../decisions/003-authentication-for-device-access.md).
 
 The parsing rules are evaluated in order, with the first match determining safety status. If no rules match, the device defaults to unsafe (`false`) for safety reasons.
 

--- a/docs/services/ppba-driver.md
+++ b/docs/services/ppba-driver.md
@@ -81,7 +81,11 @@ Configuration is provided via a JSON file:
   },
   "server": {
     "port": 11112,
-    "device_number": 0
+    "device_number": 0,
+    "auth": {
+      "username": "observatory",
+      "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
+    }
   }
 }
 ```
@@ -99,6 +103,8 @@ Configuration is provided via a JSON file:
 | serial | timeout_seconds | Serial timeout | 2 |
 | server | port | HTTP server port | 11112 |
 | server | device_number | ASCOM device number | 0 |
+| server.auth | username | HTTP Basic Auth username (optional) | — |
+| server.auth | password_hash | Argon2id password hash (optional) | — |
 
 ## Usage
 

--- a/docs/services/qhy-focuser.md
+++ b/docs/services/qhy-focuser.md
@@ -76,7 +76,11 @@ Responses are JSON objects terminated by `}` (no newline). Commands are sent as 
     "timeout_seconds": 2
   },
   "server": {
-    "port": 11113
+    "port": 11113,
+    "auth": {
+      "username": "observatory",
+      "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
+    }
   },
   "focuser": {
     "name": "QHY Q-Focuser",

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1403,7 +1403,11 @@ connection details. Plugins register their webhook URLs and command endpoints.
   },
   "server": {
     "port": 11115,
-    "bind_address": "0.0.0.0"
+    "bind_address": "0.0.0.0",
+    "auth": {
+      "username": "observatory",
+      "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
+    }
   }
 }
 ```

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1264,12 +1264,16 @@ connection details. Plugins register their webhook URLs and command endpoints.
       {
         "id": "main-cam",
         "name": "Main Imaging Camera",
-        "alpaca_url": "http://localhost:11120",
+        "alpaca_url": "https://localhost:11120",
         "device_type": "camera",
         "device_number": 0,
         "cooler_target_c": -10,
         "gain": 100,
-        "offset": 50
+        "offset": 50,
+        "auth": {
+          "username": "observatory",
+          "password": "secret"
+        }
       },
       {
         "id": "guide-cam",

--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -108,7 +108,20 @@ Empty transitions config means no notifications are sent.
 
 The dashboard supports optional HTTP Basic Auth via the `dashboard.auth`
 config section. Monitor connections to auth-enabled Alpaca services use
-per-monitor `auth` credentials. See [ADR-003](../decisions/003-authentication-for-device-access.md).
+per-monitor `auth` credentials (plaintext password, `chmod 600` recommended).
+See [ADR-003](../decisions/003-authentication-for-device-access.md).
+
+```json
+{
+  "monitors": [{
+    "type": "alpaca_safety_monitor",
+    "name": "Roof Sensor",
+    "host": "localhost", "port": 11111, "device_number": 0,
+    "scheme": "https",
+    "auth": { "username": "observatory", "password": "secret" }
+  }]
+}
+```
 
 ## Dashboard
 

--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -59,7 +59,7 @@ See `examples/config.json` for a complete example.
 
 ### Monitor Types
 
-- `alpaca_safety_monitor` — Polls an ASCOM Alpaca SafetyMonitor device
+- `alpaca_safety_monitor` — Polls an ASCOM Alpaca SafetyMonitor device. Supports optional `auth` section with `username` and `password` (plaintext) for connecting to auth-enabled services. See [ADR-003](../decisions/003-authentication-for-device-access.md).
 
 ### Notifier Types
 
@@ -103,6 +103,12 @@ Transitions define when notifications should be sent. Each rule specifies:
 - Optional priority and sound overrides
 
 Empty transitions config means no notifications are sent.
+
+### Authentication
+
+The dashboard supports optional HTTP Basic Auth via the `dashboard.auth`
+config section. Monitor connections to auth-enabled Alpaca services use
+per-monitor `auth` credentials. See [ADR-003](../decisions/003-authentication-for-device-access.md).
 
 ## Dashboard
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -36,6 +36,8 @@ belong in any single service design doc.
 | Crate | Location | Purpose |
 |-------|----------|---------|
 | [bdd-infra](../crates/bdd-infra/) | `crates/bdd-infra` | Shared BDD test infrastructure: `ServiceHandle` for spawning, managing, and stopping service binaries. Config read from each service's `[package.metadata.bdd]` in Cargo.toml. See [testing.md](skills/testing.md) Section 5.1. |
+| [rp-tls](../crates/rp-tls/) | `crates/rp-tls` | Opt-in TLS for inter-service communication: certificate generation, dual-stack TCP binding, TLS/plain serving, and client CA trust. See [ADR-002](decisions/002-tls-for-inter-service-communication.md). |
+| [rp-auth](../crates/rp-auth/) | `crates/rp-auth` | Opt-in HTTP Basic Auth: Argon2id credential hashing/verification, axum tower middleware, and config types. See [ADR-003](decisions/003-authentication-for-device-access.md). |
 
 ## Shared Architecture Patterns
 

--- a/services/filemonitor/Cargo.toml
+++ b/services/filemonitor/Cargo.toml
@@ -30,6 +30,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 rp-tls = { workspace = true }
+rp-auth = { workspace = true }
 axum = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
@@ -91,6 +92,7 @@ tracing-subscriber = { workspace = true }
 cucumber = { workspace = true }
 tempfile = { workspace = true }
 cargo-husky = { workspace = true }
+reqwest = { workspace = true }
 
 [[test]]
 name = "bdd"

--- a/services/filemonitor/src/lib.rs
+++ b/services/filemonitor/src/lib.rs
@@ -64,6 +64,8 @@ pub struct ServerConfig {
     pub discovery_port: Option<u16>,
     #[serde(default)]
     pub tls: Option<rp_tls::config::TlsConfig>,
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::AuthConfig>,
 }
 
 fn default_discovery_port() -> Option<u16> {
@@ -277,6 +279,22 @@ impl ServerBuilder {
 
         let tls = self.config.server.tls.clone();
         let router = server.into_router();
+
+        // Layer authentication if configured
+        let router = match &self.config.server.auth {
+            Some(auth) => {
+                if self.config.server.tls.is_none() {
+                    tracing::warn!(
+                        "Authentication is enabled but TLS is not. \
+                         Credentials will be transmitted in cleartext. \
+                         Consider enabling TLS (see `rp init-tls`)."
+                    );
+                }
+                rp_auth::layer(router, auth)
+            }
+            None => router,
+        };
+
         let listener = rp_tls::server::bind_dual_stack_tokio(SocketAddr::from((
             [0, 0, 0, 0],
             self.config.server.port,
@@ -415,6 +433,7 @@ mod property_tests {
                 device_number: 0,
                 discovery_port: None,
                 tls: None,
+                auth: None,
             },
         }
     }
@@ -450,6 +469,7 @@ mod property_tests {
                 device_number: 0,
                 discovery_port: None,
                 tls: None,
+                auth: None,
             },
         }
     }
@@ -512,6 +532,7 @@ mod property_tests {
                     device_number: 0,
                     discovery_port: None,
                     tls: None,
+                    auth: None,
                 },
             };
 
@@ -568,6 +589,7 @@ mod property_tests {
                     device_number: 0,
                     discovery_port: None,
                     tls: None,
+                    auth: None,
                 },
             };
 
@@ -609,6 +631,7 @@ mod property_tests {
                     device_number: 0,
                     discovery_port: None,
                     tls: None,
+                    auth: None,
                 },
             };
 
@@ -650,6 +673,7 @@ mod property_tests {
                     device_number: 0,
                     discovery_port: None,
                     tls: None,
+                    auth: None,
                 },
             };
 

--- a/services/filemonitor/tests/bdd/steps/auth_steps.rs
+++ b/services/filemonitor/tests/bdd/steps/auth_steps.rs
@@ -1,0 +1,296 @@
+//! BDD step definitions for filemonitor HTTP Basic Auth
+
+use cucumber::{given, then, when};
+use tempfile::TempDir;
+
+use crate::steps::infrastructure::ServiceHandle;
+use crate::world::{FilemonitorWorld, ParsingRuleConfig};
+
+const AUTH_USERNAME: &str = "observatory";
+const AUTH_PASSWORD: &str = "test-password";
+
+#[given(expr = "a monitored file containing {string}")]
+fn monitored_file_containing(world: &mut FilemonitorWorld, content: String) {
+    world.create_temp_file(&content);
+}
+
+#[given(
+    expr = "filemonitor is configured with TLS and auth enabled and a contains rule {string} as safe"
+)]
+fn filemonitor_configured_with_tls_auth_and_rule(world: &mut FilemonitorWorld, pattern: String) {
+    world.rules.push(ParsingRuleConfig {
+        rule_type: "contains".to_string(),
+        pattern,
+        safe: true,
+    });
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+    world.auth_password = Some(AUTH_PASSWORD.to_string());
+
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let certs_dir = pki_dir.join("certs");
+
+    let mut config = world.build_config_json();
+    config["server"]["tls"] = serde_json::json!({
+        "cert": certs_dir.join("filemonitor.pem").to_string_lossy().to_string(),
+        "key": certs_dir.join("filemonitor-key.pem").to_string_lossy().to_string()
+    });
+    config["server"]["auth"] = serde_json::json!({
+        "username": AUTH_USERNAME,
+        "password_hash": hash
+    });
+
+    // Store config in temp dir for the When step to pick up
+    let dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = dir.path().join("filemonitor_auth_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+}
+
+#[given(expr = "filemonitor is configured without auth and a contains rule {string} as safe")]
+fn filemonitor_configured_without_auth_and_rule(world: &mut FilemonitorWorld, pattern: String) {
+    world.rules.push(ParsingRuleConfig {
+        rule_type: "contains".to_string(),
+        pattern,
+        safe: true,
+    });
+
+    let config = world.build_config_json();
+
+    let dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = dir.path().join("filemonitor_noauth_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+}
+
+#[when("filemonitor is started with TLS and auth")]
+async fn filemonitor_started_with_tls_and_auth(world: &mut FilemonitorWorld) {
+    let dir = world.temp_dir.as_ref().expect("temp dir not created");
+    let config_path = dir.path().join("filemonitor_auth_config.json");
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.filemonitor = Some(handle);
+}
+
+#[when("filemonitor is started without auth")]
+async fn filemonitor_started_without_auth(world: &mut FilemonitorWorld) {
+    let dir = world.temp_dir.as_ref().expect("temp dir not created");
+    let config_path = dir.path().join("filemonitor_noauth_config.json");
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.filemonitor = Some(handle);
+}
+
+#[then("the Alpaca management endpoint should respond with valid credentials")]
+async fn alpaca_management_responds_with_auth(world: &mut FilemonitorWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .filemonitor
+        .as_ref()
+        .expect("filemonitor not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond with valid credentials"
+    );
+}
+
+#[then("the Alpaca management endpoint should reject wrong credentials with 401")]
+async fn alpaca_rejects_wrong_credentials(world: &mut FilemonitorWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .filemonitor
+        .as_ref()
+        .expect("filemonitor not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for the server to be ready with correct credentials
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test with wrong credentials
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some("wrong-password"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the Alpaca management endpoint should reject missing credentials with 401")]
+async fn alpaca_rejects_missing_credentials(world: &mut FilemonitorWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .filemonitor
+        .as_ref()
+        .expect("filemonitor not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test without credentials
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the 401 response should include a WWW-Authenticate header")]
+async fn response_includes_www_authenticate(world: &mut FilemonitorWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .filemonitor
+        .as_ref()
+        .expect("filemonitor not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // Wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate header")
+        .to_str()
+        .unwrap();
+    assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+}
+
+#[then("the Alpaca management endpoint should respond without credentials")]
+async fn alpaca_responds_without_credentials(world: &mut FilemonitorWorld) {
+    let client = reqwest::Client::new();
+    let port = world
+        .filemonitor
+        .as_ref()
+        .expect("filemonitor not started")
+        .port;
+    let url = format!("http://127.0.0.1:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond without auth"
+    );
+}

--- a/services/filemonitor/tests/bdd/steps/mod.rs
+++ b/services/filemonitor/tests/bdd/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth_steps;
 pub mod concurrency_steps;
 pub mod config_steps;
 pub mod connection_steps;

--- a/services/filemonitor/tests/bdd/world.rs
+++ b/services/filemonitor/tests/bdd/world.rs
@@ -43,6 +43,9 @@ pub struct FilemonitorWorld {
 
     // TLS test state
     pub tls_pki_dir: Option<TempDir>,
+
+    // Auth test state
+    pub auth_password: Option<String>,
 }
 
 impl FilemonitorWorld {

--- a/services/filemonitor/tests/features/auth.feature
+++ b/services/filemonitor/tests/features/auth.feature
@@ -1,0 +1,37 @@
+@serial
+Feature: filemonitor HTTP Basic Auth
+  filemonitor can require authentication when auth is configured.
+
+  Scenario: auth enabled with correct credentials returns 200
+    Given generated TLS certificates for filemonitor
+    And a monitored file containing "SAFE"
+    And filemonitor is configured with TLS and auth enabled and a contains rule "SAFE" as safe
+    When filemonitor is started with TLS and auth
+    Then the Alpaca management endpoint should respond with valid credentials
+
+  Scenario: auth enabled with wrong credentials returns 401
+    Given generated TLS certificates for filemonitor
+    And a monitored file containing "SAFE"
+    And filemonitor is configured with TLS and auth enabled and a contains rule "SAFE" as safe
+    When filemonitor is started with TLS and auth
+    Then the Alpaca management endpoint should reject wrong credentials with 401
+
+  Scenario: auth enabled with missing credentials returns 401
+    Given generated TLS certificates for filemonitor
+    And a monitored file containing "SAFE"
+    And filemonitor is configured with TLS and auth enabled and a contains rule "SAFE" as safe
+    When filemonitor is started with TLS and auth
+    Then the Alpaca management endpoint should reject missing credentials with 401
+
+  Scenario: 401 response includes WWW-Authenticate header
+    Given generated TLS certificates for filemonitor
+    And a monitored file containing "SAFE"
+    And filemonitor is configured with TLS and auth enabled and a contains rule "SAFE" as safe
+    When filemonitor is started with TLS and auth
+    Then the 401 response should include a WWW-Authenticate header
+
+  Scenario: auth disabled requires no credentials
+    Given a monitored file containing "SAFE"
+    And filemonitor is configured without auth and a contains rule "SAFE" as safe
+    When filemonitor is started without auth
+    Then the Alpaca management endpoint should respond without credentials

--- a/services/filemonitor/tests/test_server.rs
+++ b/services/filemonitor/tests/test_server.rs
@@ -29,6 +29,7 @@ async fn test_start_server_creation() {
             device_number: 0,
             discovery_port: None,
             tls: None,
+            auth: None,
         },
     };
 

--- a/services/ppba-driver/Cargo.toml
+++ b/services/ppba-driver/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
+rp-auth = { workspace = true }
 axum = { workspace = true }
 
 [package.metadata.conformu]

--- a/services/ppba-driver/src/config.rs
+++ b/services/ppba-driver/src/config.rs
@@ -30,6 +30,8 @@ pub struct ServerConfig {
     pub port: u16,
     #[serde(default)]
     pub tls: Option<rp_tls::config::TlsConfig>,
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::AuthConfig>,
 }
 
 /// Switch device configuration
@@ -94,6 +96,7 @@ impl Default for ServerConfig {
         Self {
             port: 11112,
             tls: None,
+            auth: None,
         }
     }
 }

--- a/services/ppba-driver/src/lib.rs
+++ b/services/ppba-driver/src/lib.rs
@@ -99,6 +99,22 @@ impl ServerBuilder {
 
         let tls = self.config.server.tls.clone();
         let router = server.into_router();
+
+        // Layer authentication if configured
+        let router = match &self.config.server.auth {
+            Some(auth) => {
+                if self.config.server.tls.is_none() {
+                    tracing::warn!(
+                        "Authentication is enabled but TLS is not. \
+                         Credentials will be transmitted in cleartext. \
+                         Consider enabling TLS (see `rp init-tls`)."
+                    );
+                }
+                rp_auth::layer(router, auth)
+            }
+            None => router,
+        };
+
         let listener = rp_tls::server::bind_dual_stack_tokio(SocketAddr::from((
             [0, 0, 0, 0],
             self.config.server.port,

--- a/services/ppba-driver/tests/bdd/steps/auth_steps.rs
+++ b/services/ppba-driver/tests/bdd/steps/auth_steps.rs
@@ -1,0 +1,286 @@
+//! BDD step definitions for ppba-driver HTTP Basic Auth
+
+use cucumber::{given, then, when};
+
+use crate::steps::infrastructure::ServiceHandle;
+use crate::world::PpbaWorld;
+
+const AUTH_USERNAME: &str = "observatory";
+const AUTH_PASSWORD: &str = "test-password";
+
+#[given("ppba-driver is configured with TLS and auth enabled and mock serial")]
+fn ppba_configured_with_tls_and_auth(world: &mut PpbaWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let certs_dir = pki_dir.join("certs");
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+
+    world.config = serde_json::json!({
+        "serial": { "port": "/dev/mock", "baud_rate": 9600, "polling_interval_ms": 60000, "timeout_seconds": 2 },
+        "server": {
+            "port": 0,
+            "tls": {
+                "cert": certs_dir.join("ppba-driver.pem").to_string_lossy().to_string(),
+                "key": certs_dir.join("ppba-driver-key.pem").to_string_lossy().to_string()
+            },
+            "auth": {
+                "username": AUTH_USERNAME,
+                "password_hash": hash
+            }
+        },
+        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "device_number": 0, "enabled": true },
+        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "device_number": 0, "enabled": false }
+    });
+
+    world.auth_password = Some(AUTH_PASSWORD.to_string());
+}
+
+#[given("ppba-driver is configured without auth and with mock serial")]
+fn ppba_configured_without_auth(world: &mut PpbaWorld) {
+    world.config = serde_json::json!({
+        "serial": { "port": "/dev/mock", "baud_rate": 9600, "polling_interval_ms": 60000, "timeout_seconds": 2 },
+        "server": { "port": 0 },
+        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "device_number": 0, "enabled": true },
+        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "device_number": 0, "enabled": false }
+    });
+}
+
+#[when("ppba-driver is started with TLS and auth")]
+async fn ppba_started_with_tls_and_auth(world: &mut PpbaWorld) {
+    let config_path = std::env::temp_dir()
+        .join(format!(
+            "ppba-auth-test-{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .to_string_lossy()
+        .to_string();
+    tokio::fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&world.config).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        &config_path,
+    )
+    .await;
+
+    world.base_url = Some(format!("https://localhost:{}", handle.port));
+    world.ppba = Some(handle);
+}
+
+#[when("ppba-driver is started without auth")]
+async fn ppba_started_without_auth(world: &mut PpbaWorld) {
+    let config_path = std::env::temp_dir()
+        .join(format!(
+            "ppba-noauth-test-{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .to_string_lossy()
+        .to_string();
+    tokio::fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&world.config).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        &config_path,
+    )
+    .await;
+
+    world.base_url = Some(format!("http://127.0.0.1:{}", handle.port));
+    world.ppba = Some(handle);
+}
+
+#[then("the Alpaca management endpoint should respond with valid credentials")]
+async fn alpaca_management_responds_with_auth(world: &mut PpbaWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.ppba.as_ref().expect("ppba-driver not started").port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond with valid credentials"
+    );
+}
+
+#[then("the Alpaca management endpoint should reject wrong credentials with 401")]
+async fn alpaca_rejects_wrong_credentials(world: &mut PpbaWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.ppba.as_ref().expect("ppba-driver not started").port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for the server to be ready with correct credentials
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test with wrong credentials
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some("wrong-password"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the Alpaca management endpoint should reject missing credentials with 401")]
+async fn alpaca_rejects_missing_credentials(world: &mut PpbaWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.ppba.as_ref().expect("ppba-driver not started").port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test without credentials
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the 401 response should include a WWW-Authenticate header")]
+async fn response_includes_www_authenticate(world: &mut PpbaWorld) {
+    let pki_dir = world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf();
+    let ca_path = pki_dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.ppba.as_ref().expect("ppba-driver not started").port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // Wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate header")
+        .to_str()
+        .unwrap();
+    assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+}
+
+#[then("the Alpaca management endpoint should respond without credentials")]
+async fn alpaca_responds_without_credentials(world: &mut PpbaWorld) {
+    let client = reqwest::Client::new();
+    let port = world.ppba.as_ref().expect("ppba-driver not started").port;
+    let url = format!("http://127.0.0.1:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond without auth"
+    );
+}

--- a/services/ppba-driver/tests/bdd/steps/mod.rs
+++ b/services/ppba-driver/tests/bdd/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth_steps;
 pub mod connection_steps;
 pub mod infrastructure;
 pub mod oc_steps;

--- a/services/ppba-driver/tests/bdd/world.rs
+++ b/services/ppba-driver/tests/bdd/world.rs
@@ -31,6 +31,9 @@ pub struct PpbaWorld {
 
     /// TLS test state
     pub tls_pki_dir: Option<tempfile::TempDir>,
+
+    /// Auth test password (plaintext, for building requests)
+    pub auth_password: Option<String>,
 }
 
 impl PpbaWorld {

--- a/services/ppba-driver/tests/features/auth.feature
+++ b/services/ppba-driver/tests/features/auth.feature
@@ -1,0 +1,32 @@
+@serial
+Feature: ppba-driver HTTP Basic Auth
+  ppba-driver can require authentication when auth is configured.
+
+  Scenario: auth enabled with correct credentials returns 200
+    Given generated TLS certificates for ppba-driver
+    And ppba-driver is configured with TLS and auth enabled and mock serial
+    When ppba-driver is started with TLS and auth
+    Then the Alpaca management endpoint should respond with valid credentials
+
+  Scenario: auth enabled with wrong credentials returns 401
+    Given generated TLS certificates for ppba-driver
+    And ppba-driver is configured with TLS and auth enabled and mock serial
+    When ppba-driver is started with TLS and auth
+    Then the Alpaca management endpoint should reject wrong credentials with 401
+
+  Scenario: auth enabled with missing credentials returns 401
+    Given generated TLS certificates for ppba-driver
+    And ppba-driver is configured with TLS and auth enabled and mock serial
+    When ppba-driver is started with TLS and auth
+    Then the Alpaca management endpoint should reject missing credentials with 401
+
+  Scenario: 401 response includes WWW-Authenticate header
+    Given generated TLS certificates for ppba-driver
+    And ppba-driver is configured with TLS and auth enabled and mock serial
+    When ppba-driver is started with TLS and auth
+    Then the 401 response should include a WWW-Authenticate header
+
+  Scenario: auth disabled requires no credentials
+    Given ppba-driver is configured without auth and with mock serial
+    When ppba-driver is started without auth
+    Then the Alpaca management endpoint should respond without credentials

--- a/services/qhy-focuser/Cargo.toml
+++ b/services/qhy-focuser/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
+rp-auth = { workspace = true }
 axum = { workspace = true }
 
 [package.metadata.conformu]

--- a/services/qhy-focuser/src/config.rs
+++ b/services/qhy-focuser/src/config.rs
@@ -31,6 +31,8 @@ pub struct ServerConfig {
     pub discovery_port: Option<u16>,
     #[serde(default)]
     pub tls: Option<rp_tls::config::TlsConfig>,
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::AuthConfig>,
 }
 
 fn default_discovery_port() -> Option<u16> {
@@ -92,6 +94,7 @@ impl Default for ServerConfig {
             port: 11113,
             discovery_port: default_discovery_port(),
             tls: None,
+            auth: None,
         }
     }
 }

--- a/services/qhy-focuser/src/lib.rs
+++ b/services/qhy-focuser/src/lib.rs
@@ -90,6 +90,22 @@ impl ServerBuilder {
 
         let tls = self.config.server.tls.clone();
         let router = server.into_router();
+
+        // Layer authentication if configured
+        let router = match &self.config.server.auth {
+            Some(auth) => {
+                if self.config.server.tls.is_none() {
+                    tracing::warn!(
+                        "Authentication is enabled but TLS is not. \
+                         Credentials will be transmitted in cleartext. \
+                         Consider enabling TLS (see `rp init-tls`)."
+                    );
+                }
+                rp_auth::layer(router, auth)
+            }
+            None => router,
+        };
+
         let listener = rp_tls::server::bind_dual_stack_tokio(SocketAddr::from((
             [0, 0, 0, 0],
             self.config.server.port,

--- a/services/qhy-focuser/src/serial_manager.rs
+++ b/services/qhy-focuser/src/serial_manager.rs
@@ -645,6 +645,7 @@ mod mock_tests {
                 port: 0,
                 discovery_port: None,
                 tls: None,
+                auth: None,
             },
             focuser: FocuserConfig::default(),
         }

--- a/services/qhy-focuser/tests/bdd/steps/auth_steps.rs
+++ b/services/qhy-focuser/tests/bdd/steps/auth_steps.rs
@@ -1,0 +1,300 @@
+//! BDD step definitions for qhy-focuser HTTP Basic Auth
+
+use cucumber::{given, then, when};
+use tempfile::TempDir;
+
+use crate::world::QhyFocuserWorld;
+use bdd_infra::ServiceHandle;
+
+const AUTH_USERNAME: &str = "observatory";
+const AUTH_PASSWORD: &str = "test-password";
+
+fn pki_dir(world: &QhyFocuserWorld) -> std::path::PathBuf {
+    world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf()
+}
+
+#[given("qhy-focuser is configured with TLS and auth enabled and mock serial")]
+fn qhy_configured_with_tls_and_auth(world: &mut QhyFocuserWorld) {
+    let pki_dir = pki_dir(world);
+    let certs_dir = pki_dir.join("certs");
+
+    // Hash is generated in the When step when writing the config JSON
+    world.config = Some(qhy_focuser::Config {
+        serial: qhy_focuser::SerialConfig {
+            port: "/dev/mock".to_string(),
+            polling_interval_ms: 60000,
+            ..Default::default()
+        },
+        server: qhy_focuser::ServerConfig {
+            port: 0,
+            discovery_port: None,
+            tls: Some(rp_tls::config::TlsConfig {
+                cert: certs_dir
+                    .join("qhy-focuser.pem")
+                    .to_string_lossy()
+                    .into_owned(),
+                key: certs_dir
+                    .join("qhy-focuser-key.pem")
+                    .to_string_lossy()
+                    .into_owned(),
+            }),
+            auth: None,
+        },
+        focuser: qhy_focuser::FocuserConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    });
+
+    world.auth_password = Some(AUTH_PASSWORD.to_string());
+}
+
+#[given("qhy-focuser is configured without auth and with mock serial")]
+fn qhy_configured_without_auth(world: &mut QhyFocuserWorld) {
+    world.config = Some(qhy_focuser::Config {
+        serial: qhy_focuser::SerialConfig {
+            port: "/dev/mock".to_string(),
+            polling_interval_ms: 60000,
+            ..Default::default()
+        },
+        server: qhy_focuser::ServerConfig {
+            port: 0,
+            discovery_port: None,
+            tls: None,
+            auth: None,
+        },
+        focuser: qhy_focuser::FocuserConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    });
+}
+
+#[when("qhy-focuser is started with TLS and auth")]
+async fn qhy_started_with_tls_and_auth(world: &mut QhyFocuserWorld) {
+    let config = world.config.as_ref().expect("config not set");
+
+    // Serialize the typed config to JSON, then inject the auth section
+    let mut config_json: serde_json::Value =
+        serde_json::to_value(config).expect("failed to serialize config");
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+    config_json["server"]["auth"] = serde_json::json!({
+        "username": AUTH_USERNAME,
+        "password_hash": hash
+    });
+
+    let dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = dir.path().join("qhy_auth_config.json");
+    std::fs::write(&config_path, config_json.to_string()).unwrap();
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.focuser_handle = Some(handle);
+}
+
+#[when("qhy-focuser is started without auth")]
+async fn qhy_started_without_auth(world: &mut QhyFocuserWorld) {
+    let config = world.config.as_ref().expect("config not set");
+    let dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = dir.path().join("qhy_noauth_config.json");
+    std::fs::write(&config_path, serde_json::to_string_pretty(config).unwrap()).unwrap();
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.focuser_handle = Some(handle);
+}
+
+#[then("the Alpaca management endpoint should respond with valid credentials")]
+async fn alpaca_management_responds_with_auth(world: &mut QhyFocuserWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .focuser_handle
+        .as_ref()
+        .expect("qhy-focuser not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond with valid credentials"
+    );
+}
+
+#[then("the Alpaca management endpoint should reject wrong credentials with 401")]
+async fn alpaca_rejects_wrong_credentials(world: &mut QhyFocuserWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .focuser_handle
+        .as_ref()
+        .expect("qhy-focuser not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for the server to be ready with correct credentials
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test with wrong credentials
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some("wrong-password"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the Alpaca management endpoint should reject missing credentials with 401")]
+async fn alpaca_rejects_missing_credentials(world: &mut QhyFocuserWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .focuser_handle
+        .as_ref()
+        .expect("qhy-focuser not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // First wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    // Now test without credentials
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the 401 response should include a WWW-Authenticate header")]
+async fn response_includes_www_authenticate(world: &mut QhyFocuserWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world
+        .focuser_handle
+        .as_ref()
+        .expect("qhy-focuser not started")
+        .port;
+    let url = format!("https://localhost:{}/management/v1/configureddevices", port);
+
+    // Wait for server readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate header")
+        .to_str()
+        .unwrap();
+    assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+}
+
+#[then("the Alpaca management endpoint should respond without credentials")]
+async fn alpaca_responds_without_credentials(world: &mut QhyFocuserWorld) {
+    let client = reqwest::Client::new();
+    let port = world
+        .focuser_handle
+        .as_ref()
+        .expect("qhy-focuser not started")
+        .port;
+    let url = format!("http://127.0.0.1:{}/management/v1/configureddevices", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Alpaca management endpoint did not respond without auth"
+    );
+}

--- a/services/qhy-focuser/tests/bdd/steps/mod.rs
+++ b/services/qhy-focuser/tests/bdd/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth_steps;
 pub mod connection_steps;
 pub mod metadata_steps;
 pub mod movement_steps;

--- a/services/qhy-focuser/tests/bdd/steps/tls_steps.rs
+++ b/services/qhy-focuser/tests/bdd/steps/tls_steps.rs
@@ -46,6 +46,7 @@ fn qhy_configured_with_tls(world: &mut QhyFocuserWorld) {
                     .to_string_lossy()
                     .into_owned(),
             }),
+            auth: None,
         },
         focuser: qhy_focuser::FocuserConfig {
             enabled: true,

--- a/services/qhy-focuser/tests/bdd/world.rs
+++ b/services/qhy-focuser/tests/bdd/world.rs
@@ -27,6 +27,9 @@ pub struct QhyFocuserWorld {
 
     /// TLS test state
     pub tls_pki_dir: Option<TempDir>,
+
+    /// Auth test state — plaintext password for HTTP Basic Auth assertions
+    pub auth_password: Option<String>,
 }
 
 impl QhyFocuserWorld {

--- a/services/qhy-focuser/tests/features/auth.feature
+++ b/services/qhy-focuser/tests/features/auth.feature
@@ -1,0 +1,32 @@
+@serial
+Feature: qhy-focuser HTTP Basic Auth
+  qhy-focuser can require authentication when auth is configured.
+
+  Scenario: auth enabled with correct credentials returns 200
+    Given generated TLS certificates for qhy-focuser
+    And qhy-focuser is configured with TLS and auth enabled and mock serial
+    When qhy-focuser is started with TLS and auth
+    Then the Alpaca management endpoint should respond with valid credentials
+
+  Scenario: auth enabled with wrong credentials returns 401
+    Given generated TLS certificates for qhy-focuser
+    And qhy-focuser is configured with TLS and auth enabled and mock serial
+    When qhy-focuser is started with TLS and auth
+    Then the Alpaca management endpoint should reject wrong credentials with 401
+
+  Scenario: auth enabled with missing credentials returns 401
+    Given generated TLS certificates for qhy-focuser
+    And qhy-focuser is configured with TLS and auth enabled and mock serial
+    When qhy-focuser is started with TLS and auth
+    Then the Alpaca management endpoint should reject missing credentials with 401
+
+  Scenario: 401 response includes WWW-Authenticate header
+    Given generated TLS certificates for qhy-focuser
+    And qhy-focuser is configured with TLS and auth enabled and mock serial
+    When qhy-focuser is started with TLS and auth
+    Then the 401 response should include a WWW-Authenticate header
+
+  Scenario: auth disabled requires no credentials
+    Given qhy-focuser is configured without auth and with mock serial
+    When qhy-focuser is started without auth
+    Then the Alpaca management endpoint should respond without credentials

--- a/services/qhy-focuser/tests/test_lib.rs
+++ b/services/qhy-focuser/tests/test_lib.rs
@@ -46,6 +46,7 @@ fn test_config(focuser_enabled: bool) -> Config {
             port: 0,
             discovery_port: None,
             tls: None,
+            auth: None,
         },
         focuser: FocuserConfig {
             enabled: focuser_enabled,

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
+base64 = { workspace = true }
 rp-auth = { workspace = true }
 rp-tls = { workspace = true }
 rpassword = { workspace = true }

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -25,7 +25,9 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
+rp-auth = { workspace = true }
 rp-tls = { workspace = true }
+rpassword = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel"] }
 

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -79,6 +79,8 @@ pub struct ServerConfig {
     pub bind_address: String,
     #[serde(default)]
     pub tls: Option<rp_tls::config::TlsConfig>,
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::AuthConfig>,
 }
 
 fn default_port() -> u16 {

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -57,6 +57,9 @@ pub struct CameraConfig {
     pub gain: Option<i32>,
     #[serde(default)]
     pub offset: Option<i32>,
+    /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::ClientAuthConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -69,6 +72,9 @@ pub struct FilterWheelConfig {
     pub device_number: u32,
     #[serde(default)]
     pub filters: Vec<String>,
+    /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::ClientAuthConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/services/rp/src/equipment.rs
+++ b/services/rp/src/equipment.rs
@@ -3,6 +3,9 @@ use std::time::Duration;
 
 use ascom_alpaca::api::{Camera, FilterWheel, TypedDevice};
 use ascom_alpaca::Client;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use rp_auth::config::ClientAuthConfig;
 use serde::Serialize;
 use tracing::debug;
 
@@ -90,10 +93,34 @@ impl EquipmentRegistry {
     }
 }
 
+/// Build an Alpaca client with optional HTTP Basic Auth credentials.
+fn build_alpaca_client(
+    url: &str,
+    auth: Option<&ClientAuthConfig>,
+) -> Result<Client, Box<dyn std::error::Error + Send + Sync>> {
+    match auth {
+        Some(a) => {
+            let encoded = BASE64.encode(format!("{}:{}", a.username, a.password));
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                "authorization",
+                format!("Basic {encoded}")
+                    .parse()
+                    .expect("valid header value"),
+            );
+            let http = reqwest::Client::builder()
+                .default_headers(headers)
+                .build()?;
+            Ok(Client::new_with_client(url, http)?)
+        }
+        None => Ok(Client::new(url)?),
+    }
+}
+
 async fn connect_camera(config: &config::CameraConfig) -> CameraEntry {
     debug!(camera_id = %config.id, alpaca_url = %config.alpaca_url, device_number = config.device_number, "connecting to camera");
 
-    let client = match Client::new(&config.alpaca_url) {
+    let client = match build_alpaca_client(&config.alpaca_url, config.auth.as_ref()) {
         Ok(c) => c,
         Err(e) => {
             debug!(camera_id = %config.id, error = %e, "failed to create Alpaca client for camera");
@@ -179,7 +206,7 @@ async fn connect_camera(config: &config::CameraConfig) -> CameraEntry {
 async fn connect_filter_wheel(config: &config::FilterWheelConfig) -> FilterWheelEntry {
     debug!(fw_id = %config.id, alpaca_url = %config.alpaca_url, device_number = config.device_number, "connecting to filter wheel");
 
-    let client = match Client::new(&config.alpaca_url) {
+    let client = match build_alpaca_client(&config.alpaca_url, config.auth.as_ref()) {
         Ok(c) => c,
         Err(e) => {
             debug!(fw_id = %config.id, error = %e, "failed to create Alpaca client for filter wheel");

--- a/services/rp/src/equipment.rs
+++ b/services/rp/src/equipment.rs
@@ -288,3 +288,29 @@ async fn connect_filter_wheel(config: &config::FilterWheelConfig) -> FilterWheel
         }
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_alpaca_client_without_auth() {
+        build_alpaca_client("http://localhost:11111", None).unwrap();
+    }
+
+    #[test]
+    fn build_alpaca_client_with_auth() {
+        let auth = ClientAuthConfig {
+            username: "observatory".to_string(),
+            password: "secret".to_string(),
+        };
+        build_alpaca_client("http://localhost:11111", Some(&auth)).unwrap();
+    }
+
+    #[test]
+    fn build_alpaca_client_with_invalid_url_fails() {
+        let result = build_alpaca_client("not-a-url", None);
+        assert!(result.is_err());
+    }
+}

--- a/services/rp/src/hash_password_cmd.rs
+++ b/services/rp/src/hash_password_cmd.rs
@@ -1,0 +1,29 @@
+use tracing::debug;
+
+/// Run the `hash-password` command: hash a plaintext password with Argon2id.
+///
+/// In interactive mode, prompts for the password twice for confirmation.
+/// With `--stdin`, reads a single line from stdin (for scripting and BDD tests).
+pub fn run(stdin_mode: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let password = if stdin_mode {
+        debug!("reading password from stdin");
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line)?;
+        line.trim_end().to_string()
+    } else {
+        let password = rpassword::prompt_password("Enter password: ")?;
+        let confirm = rpassword::prompt_password("Confirm password: ")?;
+        if password != confirm {
+            return Err("passwords do not match".into());
+        }
+        password
+    };
+
+    if password.is_empty() {
+        return Err("password must not be empty".into());
+    }
+
+    let hash = rp_auth::credentials::hash_password(&password)?;
+    println!("{hash}");
+    Ok(())
+}

--- a/services/rp/src/lib.rs
+++ b/services/rp/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod equipment;
 pub mod error;
 pub mod events;
+pub mod hash_password_cmd;
 pub mod mcp;
 pub mod routes;
 pub mod session;
@@ -73,6 +74,22 @@ impl ServerBuilder {
         };
 
         let router = build_router(state);
+
+        // Layer authentication if configured
+        let router = match &config.server.auth {
+            Some(auth) => {
+                if config.server.tls.is_none() {
+                    tracing::warn!(
+                        "Authentication is enabled but TLS is not. \
+                         Credentials will be transmitted in cleartext. \
+                         Consider enabling TLS (see `rp init-tls`)."
+                    );
+                }
+                rp_auth::layer(router, auth)
+            }
+            None => router,
+        };
+
         let tls = config.server.tls.clone();
 
         let listener = tokio::net::TcpListener::bind(&bind_addr).await?;

--- a/services/rp/src/main.rs
+++ b/services/rp/src/main.rs
@@ -29,6 +29,16 @@ enum Commands {
         #[arg(long, default_value = "info")]
         log_level: String,
     },
+    /// Hash a password for use in service auth configuration
+    HashPassword {
+        /// Log level (trace, debug, info, warn, error)
+        #[arg(long, default_value = "info")]
+        log_level: String,
+
+        /// Read password from stdin (no prompt, no confirmation)
+        #[arg(long)]
+        stdin: bool,
+    },
     /// Generate TLS certificates for all services
     InitTls {
         /// Output directory (default: ~/.rusty-photon/pki)
@@ -81,6 +91,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(Commands::Serve { config, log_level }) => {
             init_tracing(&log_level);
             run_serve(&config).await
+        }
+        Some(Commands::HashPassword { log_level, stdin }) => {
+            init_tracing(&log_level);
+            rp::hash_password_cmd::run(stdin)
         }
         Some(Commands::InitTls {
             output_dir,

--- a/services/rp/tests/bdd/steps/acme_steps.rs
+++ b/services/rp/tests/bdd/steps/acme_steps.rs
@@ -11,7 +11,12 @@ use crate::world::RpWorld;
 
 /// Run `rp init-tls` with the given arguments and capture the output.
 fn run_init_tls_raw(args: &[&str]) -> std::process::Output {
-    bdd_infra::run_once(env!("CARGO_MANIFEST_DIR"), env!("CARGO_PKG_NAME"), args)
+    bdd_infra::run_once(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        args,
+        None,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/services/rp/tests/bdd/steps/auth_steps.rs
+++ b/services/rp/tests/bdd/steps/auth_steps.rs
@@ -1,0 +1,214 @@
+//! BDD step definitions for rp HTTP Basic Auth and hash-password CLI
+
+use std::path::PathBuf;
+
+use cucumber::{given, then, when};
+
+use crate::steps::infrastructure::ServiceHandle;
+use crate::world::RpWorld;
+
+const AUTH_USERNAME: &str = "observatory";
+const AUTH_PASSWORD: &str = "test-password";
+
+fn pki_dir(world: &RpWorld) -> PathBuf {
+    world
+        .tls_pki_dir
+        .as_ref()
+        .expect("pki_dir not set")
+        .path()
+        .to_path_buf()
+}
+
+// ---------------------------------------------------------------------------
+// Auth config steps
+// ---------------------------------------------------------------------------
+
+#[given("rp is configured with TLS and auth enabled")]
+fn rp_configured_with_tls_and_auth(_world: &mut RpWorld) {
+    // Marker — config is built in the When step
+}
+
+#[when("rp is started with auth")]
+async fn rp_started_with_auth(world: &mut RpWorld) {
+    let dir = pki_dir(world);
+    let certs_dir = dir.join("certs");
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+
+    let mut config = world.build_config();
+    config["server"]["tls"] = serde_json::json!({
+        "cert": certs_dir.join("rp.pem").to_string_lossy().to_string(),
+        "key": certs_dir.join("rp-key.pem").to_string_lossy().to_string()
+    });
+    config["server"]["auth"] = serde_json::json!({
+        "username": AUTH_USERNAME,
+        "password_hash": hash
+    });
+
+    let config_path = std::env::temp_dir()
+        .join(format!(
+            "rp-auth-test-{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .to_string_lossy()
+        .to_string();
+    tokio::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap())
+        .await
+        .unwrap();
+
+    let handle = ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        &config_path,
+    )
+    .await;
+
+    world.rp = Some(handle);
+
+    // Wait for healthy over HTTPS with auth
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.rp.as_ref().unwrap().port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let mut healthy = false;
+    for _ in 0..120 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                healthy = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(
+        healthy,
+        "rp did not become healthy with auth within timeout"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Auth validation steps
+// ---------------------------------------------------------------------------
+
+#[then("the health endpoint should respond with valid credentials")]
+async fn health_responds_with_auth(world: &mut RpWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.rp.as_ref().expect("rp not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[then("the health endpoint should reject wrong credentials with 401")]
+async fn health_rejects_wrong_credentials(world: &mut RpWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.rp.as_ref().expect("rp not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some("wrong-password"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the health endpoint should reject missing credentials with 401")]
+async fn health_rejects_missing_credentials(world: &mut RpWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.rp.as_ref().expect("rp not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the rp 401 response should include a WWW-Authenticate header")]
+async fn rp_401_includes_www_authenticate(world: &mut RpWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.rp.as_ref().expect("rp not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate header")
+        .to_str()
+        .unwrap();
+    assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+}
+
+// ---------------------------------------------------------------------------
+// hash-password CLI steps
+// ---------------------------------------------------------------------------
+
+#[when("rp hash-password is executed with a test password via stdin")]
+fn hash_password_executed(world: &mut RpWorld) {
+    let output = bdd_infra::run_once(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        &["hash-password", "--stdin"],
+        Some(b"test-password\n"),
+    );
+
+    assert!(
+        output.status.success(),
+        "hash-password failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
+    world.auth_hash_output = Some(hash);
+    world.auth_password = Some("test-password".to_string());
+}
+
+#[then("the output should be a valid Argon2id hash string")]
+fn output_is_argon2id(world: &mut RpWorld) {
+    let hash = world
+        .auth_hash_output
+        .as_ref()
+        .expect("hash output not captured");
+    assert!(
+        hash.starts_with("$argon2id$"),
+        "expected Argon2id hash, got: {hash}"
+    );
+}
+
+#[then("the hash should verify against the original password")]
+fn hash_verifies(world: &mut RpWorld) {
+    let hash = world
+        .auth_hash_output
+        .as_ref()
+        .expect("hash output not captured");
+    let password = world.auth_password.as_ref().expect("password not stored");
+    assert!(
+        rp_auth::credentials::verify_password(password, hash),
+        "hash did not verify against original password"
+    );
+}

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -1,6 +1,7 @@
 //! BDD step definitions for rp service
 
 pub mod acme_steps;
+pub mod auth_steps;
 pub mod equipment_steps;
 pub mod event_steps;
 pub mod infrastructure;

--- a/services/rp/tests/bdd/steps/tls_steps.rs
+++ b/services/rp/tests/bdd/steps/tls_steps.rs
@@ -16,7 +16,12 @@ use crate::world::RpWorld;
 fn run_init_tls(output_dir: &str, extra_args: &[&str]) {
     let mut args = vec!["init-tls", "--output-dir", output_dir];
     args.extend_from_slice(extra_args);
-    let output = bdd_infra::run_once(env!("CARGO_MANIFEST_DIR"), env!("CARGO_PKG_NAME"), &args);
+    let output = bdd_infra::run_once(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        &args,
+        None,
+    );
     assert!(
         output.status.success(),
         "rp init-tls failed: {}",

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -98,6 +98,12 @@ pub struct RpWorld {
     // --- ACME test state ---
     /// Last command output (for ACME CLI tests)
     pub last_command_output: Option<std::process::Output>,
+
+    // --- Auth test state ---
+    /// Plaintext password used for test auth
+    pub auth_password: Option<String>,
+    /// Hash output from rp hash-password CLI
+    pub auth_hash_output: Option<String>,
 }
 
 /// Camera configuration for test setup

--- a/services/rp/tests/features/auth.feature
+++ b/services/rp/tests/features/auth.feature
@@ -1,0 +1,31 @@
+@serial
+Feature: rp HTTP Basic Auth
+  rp can require authentication when auth is configured.
+
+  Scenario: auth enabled with correct credentials returns 200
+    Given generated TLS certificates
+    And rp is configured with TLS and auth enabled
+    When rp is started with auth
+    Then the health endpoint should respond with valid credentials
+
+  Scenario: auth enabled with wrong credentials returns 401
+    Given generated TLS certificates
+    And rp is configured with TLS and auth enabled
+    When rp is started with auth
+    Then the health endpoint should reject wrong credentials with 401
+
+  Scenario: auth enabled with missing credentials returns 401
+    Given generated TLS certificates
+    And rp is configured with TLS and auth enabled
+    When rp is started with auth
+    Then the health endpoint should reject missing credentials with 401
+
+  Scenario: 401 response includes WWW-Authenticate header
+    Given generated TLS certificates
+    And rp is configured with TLS and auth enabled
+    When rp is started with auth
+    Then the rp 401 response should include a WWW-Authenticate header
+
+  Scenario: auth disabled requires no credentials
+    When rp is started without TLS
+    Then the health endpoint should respond over HTTP

--- a/services/rp/tests/features/hash_password.feature
+++ b/services/rp/tests/features/hash_password.feature
@@ -1,0 +1,8 @@
+@serial
+Feature: rp hash-password CLI command
+  rp can hash a password for use in service auth configuration.
+
+  Scenario: hash-password produces valid Argon2id hash
+    When rp hash-password is executed with a test password via stdin
+    Then the output should be a valid Argon2id hash string
+    And the hash should verify against the original password

--- a/services/sentinel/Cargo.toml
+++ b/services/sentinel/Cargo.toml
@@ -28,6 +28,7 @@ tokio-util = "0.7"
 axum = { workspace = true }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
+rp-auth = { workspace = true }
 rp-tls = { workspace = true }
 
 [dev-dependencies]

--- a/services/sentinel/src/alpaca_client.rs
+++ b/services/sentinel/src/alpaca_client.rs
@@ -47,6 +47,7 @@ impl AlpacaSafetyMonitor {
             device_number,
             polling_interval_seconds,
             scheme,
+            auth: _,
         } = config;
 
         let base_url = format!("{scheme}://{host}:{port}/api/v1/safetymonitor/{device_number}");
@@ -153,6 +154,7 @@ mod tests {
             device_number: 0,
             polling_interval_seconds: 30,
             scheme: "http".to_string(),
+            auth: None,
         }
     }
 

--- a/services/sentinel/src/config.rs
+++ b/services/sentinel/src/config.rs
@@ -179,6 +179,8 @@ pub struct DashboardConfig {
     pub history_size: usize,
     #[serde(default)]
     pub tls: Option<rp_tls::config::TlsConfig>,
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::AuthConfig>,
 }
 
 impl Default for DashboardConfig {
@@ -188,6 +190,7 @@ impl Default for DashboardConfig {
             port: default_dashboard_port(),
             history_size: default_history_size(),
             tls: None,
+            auth: None,
         }
     }
 }

--- a/services/sentinel/src/config.rs
+++ b/services/sentinel/src/config.rs
@@ -98,6 +98,9 @@ pub enum MonitorConfig {
         /// URL scheme: "http" (default) or "https" for TLS-enabled services
         #[serde(default = "default_scheme")]
         scheme: String,
+        /// Optional HTTP Basic Auth credentials for connecting to auth-enabled services
+        #[serde(default)]
+        auth: Option<rp_auth::config::ClientAuthConfig>,
     },
 }
 

--- a/services/sentinel/src/io.rs
+++ b/services/sentinel/src/io.rs
@@ -27,6 +27,7 @@ pub trait HttpClient: Send + Sync {
 #[derive(Default)]
 pub struct ReqwestHttpClient {
     client: reqwest::Client,
+    auth: Option<(String, String)>,
 }
 
 impl ReqwestHttpClient {
@@ -39,7 +40,21 @@ impl ReqwestHttpClient {
         let client = rp_tls::client::build_reqwest_client(ca_cert_path).map_err(|e| {
             crate::SentinelError::Config(format!("failed to build HTTP client: {e}"))
         })?;
-        Ok(Self { client })
+        Ok(Self { client, auth: None })
+    }
+
+    /// Create a new HTTP client with CA trust and HTTP Basic Auth credentials.
+    ///
+    /// The credentials are sent with every request via the `Authorization: Basic`
+    /// header, enabling connections to auth-enabled services.
+    pub fn with_auth(
+        ca_cert_path: Option<&std::path::Path>,
+        username: String,
+        password: String,
+    ) -> crate::Result<Self> {
+        let mut client = Self::new(ca_cert_path)?;
+        client.auth = Some((username, password));
+        Ok(client)
     }
 }
 
@@ -47,9 +62,11 @@ impl ReqwestHttpClient {
 impl HttpClient for ReqwestHttpClient {
     async fn get(&self, url: &str) -> crate::Result<HttpResponse> {
         tracing::debug!("GET {}", url);
-        let response = self
-            .client
-            .get(url)
+        let mut request = self.client.get(url);
+        if let Some((ref user, ref pass)) = self.auth {
+            request = request.basic_auth(user, Some(pass));
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| crate::SentinelError::Http(format!("GET {} failed: {}", url, e)))?;
@@ -66,10 +83,11 @@ impl HttpClient for ReqwestHttpClient {
 
     async fn put_form(&self, url: &str, params: &[(&str, &str)]) -> crate::Result<HttpResponse> {
         tracing::debug!("PUT {}", url);
-        let response = self
-            .client
-            .put(url)
-            .form(params)
+        let mut request = self.client.put(url).form(params);
+        if let Some((ref user, ref pass)) = self.auth {
+            request = request.basic_auth(user, Some(pass));
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| crate::SentinelError::Http(format!("PUT {} failed: {}", url, e)))?;
@@ -86,10 +104,11 @@ impl HttpClient for ReqwestHttpClient {
 
     async fn post_form(&self, url: &str, params: &[(&str, &str)]) -> crate::Result<HttpResponse> {
         tracing::debug!("POST {}", url);
-        let response = self
-            .client
-            .post(url)
-            .form(params)
+        let mut request = self.client.post(url).form(params);
+        if let Some((ref user, ref pass)) = self.auth {
+            request = request.basic_auth(user, Some(pass));
+        }
+        let response = request
             .send()
             .await
             .map_err(|e| crate::SentinelError::Http(format!("POST {} failed: {}", url, e)))?;

--- a/services/sentinel/src/lib.rs
+++ b/services/sentinel/src/lib.rs
@@ -35,13 +35,36 @@ use crate::pushover::PushoverNotifier;
 /// concrete types (`AlpacaSafetyMonitor`, `PushoverNotifier`) that are defined
 /// in sibling modules.
 impl Config {
-    pub fn build_monitors(&self, http: &Arc<dyn io::HttpClient>) -> Vec<Arc<dyn Monitor>> {
+    pub fn build_monitors(
+        &self,
+        http: &Arc<dyn io::HttpClient>,
+        ca_path: Option<&std::path::Path>,
+    ) -> Vec<Arc<dyn Monitor>> {
         self.monitors
             .iter()
             .map(|monitor_config| -> Arc<dyn Monitor> {
                 match monitor_config {
-                    config::MonitorConfig::AlpacaSafetyMonitor { .. } => {
-                        Arc::new(AlpacaSafetyMonitor::new(monitor_config, Arc::clone(http)))
+                    config::MonitorConfig::AlpacaSafetyMonitor { auth, .. } => {
+                        let client: Arc<dyn io::HttpClient> = match auth {
+                            Some(a) => {
+                                match ReqwestHttpClient::with_auth(
+                                    ca_path,
+                                    a.username.clone(),
+                                    a.password.clone(),
+                                ) {
+                                    Ok(c) => Arc::new(c),
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to build auth HTTP client: {e}. \
+                                             Falling back to shared client."
+                                        );
+                                        Arc::clone(http)
+                                    }
+                                }
+                            }
+                            None => Arc::clone(http),
+                        };
+                        Arc::new(AlpacaSafetyMonitor::new(monitor_config, client))
                     }
                 }
             })
@@ -126,9 +149,10 @@ impl SentinelBuilder {
         let config = self.config;
 
         // Use injected monitors/notifiers or fall back to config factories
+        let ca_path = config.ca_cert.as_deref().map(rp_tls::config::expand_tilde);
         let monitors = self
             .monitors
-            .unwrap_or_else(|| config.build_monitors(&http));
+            .unwrap_or_else(|| config.build_monitors(&http, ca_path.as_deref()));
         let notifiers = self
             .notifiers
             .unwrap_or_else(|| config.build_notifiers(&http));
@@ -346,13 +370,14 @@ mod tests {
                 device_number: 0,
                 polling_interval_seconds: 30,
                 scheme: "http".to_string(),
+                auth: None,
             }],
             ..Config::default()
         };
         let mock = MockHttpClient::new();
         let http: Arc<dyn io::HttpClient> = Arc::new(mock);
 
-        let monitors = config.build_monitors(&http);
+        let monitors = config.build_monitors(&http, None);
 
         assert_eq!(monitors.len(), 1);
         assert_eq!(monitors[0].name(), "Test Monitor");
@@ -388,6 +413,7 @@ mod tests {
                 device_number: 0,
                 polling_interval_seconds: 30,
                 scheme: "http".to_string(),
+                auth: None,
             }],
             ..Config::default()
         };

--- a/services/sentinel/src/lib.rs
+++ b/services/sentinel/src/lib.rs
@@ -179,6 +179,7 @@ impl SentinelBuilder {
         };
 
         let dashboard_tls = config.dashboard.tls.clone();
+        let dashboard_auth = config.dashboard.auth.clone();
 
         Ok(Sentinel {
             engine,
@@ -186,6 +187,7 @@ impl SentinelBuilder {
             cancel,
             dashboard_listener,
             dashboard_tls,
+            dashboard_auth,
         })
     }
 }
@@ -197,6 +199,7 @@ pub struct Sentinel {
     cancel: CancellationToken,
     dashboard_listener: Option<tokio::net::TcpListener>,
     dashboard_tls: Option<rp_tls::config::TlsConfig>,
+    dashboard_auth: Option<rp_auth::config::AuthConfig>,
 }
 
 impl Sentinel {
@@ -241,6 +244,7 @@ impl Sentinel {
             let dashboard_state = Arc::clone(&self.state);
             let cancel_for_dashboard = cancel.clone();
             let dashboard_tls = self.dashboard_tls;
+            let dashboard_auth = self.dashboard_auth;
 
             let addr = listener.local_addr().unwrap();
             let scheme = if dashboard_tls.is_some() {
@@ -253,6 +257,21 @@ impl Sentinel {
 
             tokio::spawn(async move {
                 let router = dashboard::build_router(dashboard_state);
+
+                // Layer authentication if configured
+                let router = match &dashboard_auth {
+                    Some(auth) => {
+                        if dashboard_tls.is_none() {
+                            tracing::warn!(
+                                "Authentication is enabled but TLS is not. \
+                                 Credentials will be transmitted in cleartext. \
+                                 Consider enabling TLS (see `rp init-tls`)."
+                            );
+                        }
+                        rp_auth::layer(router, auth)
+                    }
+                    None => router,
+                };
 
                 match dashboard_tls {
                     Some(ref tls_config) => {

--- a/services/sentinel/tests/bdd/steps/auth_steps.rs
+++ b/services/sentinel/tests/bdd/steps/auth_steps.rs
@@ -224,3 +224,120 @@ async fn dashboard_responds_without_credentials(world: &mut SentinelWorld) {
     }
     assert!(ok, "Dashboard health endpoint did not respond without auth");
 }
+
+// --- Cross-service client-side auth scenario ---
+
+#[given(
+    expr = "filemonitor is running with TLS and auth enabled and a contains rule {string} as safe"
+)]
+async fn filemonitor_running_with_tls_and_auth(world: &mut SentinelWorld, pattern: String) {
+    let dir = pki_dir(world);
+    let certs_dir = dir.join("certs");
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+
+    world.fm_rules.push(serde_json::json!({
+        "type": "contains",
+        "pattern": pattern,
+        "safe": true
+    }));
+
+    // Create a temp file with safe content so filemonitor has something to monitor
+    world.create_temp_file(&pattern);
+
+    let mut config = world.build_filemonitor_config();
+    config["server"]["tls"] = serde_json::json!({
+        "cert": certs_dir.join("filemonitor.pem").to_string_lossy().to_string(),
+        "key": certs_dir.join("filemonitor-key.pem").to_string_lossy().to_string()
+    });
+    config["server"]["auth"] = serde_json::json!({
+        "username": AUTH_USERNAME,
+        "password_hash": hash
+    });
+
+    let temp_dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = temp_dir.path().join("filemonitor_auth_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let fm_manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("filemonitor");
+    let handle = bdd_infra::ServiceHandle::start(
+        fm_manifest.to_str().unwrap(),
+        "filemonitor",
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.filemonitor = Some(handle);
+}
+
+#[given("sentinel is configured to monitor the auth-enabled filemonitor")]
+fn sentinel_configured_with_auth_monitor(world: &mut SentinelWorld) {
+    let fm = world.filemonitor.as_ref().expect("filemonitor not started");
+
+    world.sentinel_monitors.push(serde_json::json!({
+        "type": "alpaca_safety_monitor",
+        "name": "Auth Monitor",
+        "host": "localhost",
+        "port": fm.port,
+        "device_number": 0,
+        "polling_interval_seconds": 1,
+        "scheme": "https",
+        "auth": {
+            "username": AUTH_USERNAME,
+            "password": AUTH_PASSWORD
+        }
+    }));
+
+    world.sentinel_monitor_name = "Auth Monitor".to_string();
+}
+
+#[when("sentinel is started with CA trust")]
+async fn sentinel_started_with_ca_trust(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+
+    let mut config = world.build_sentinel_config();
+    config["ca_cert"] = serde_json::json!(ca_path.to_string_lossy().to_string());
+
+    let temp_dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = temp_dir.path().join("sentinel_auth_monitor_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let handle = bdd_infra::ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.sentinel = Some(handle);
+}
+
+#[then("sentinel should successfully poll the filemonitor")]
+async fn sentinel_polls_successfully(world: &mut SentinelWorld) {
+    world.wait_for_poll().await;
+
+    let statuses = world.get_status().await;
+    assert!(!statuses.is_empty(), "no monitor statuses returned");
+
+    let monitor = statuses
+        .iter()
+        .find(|m| m.get("name").and_then(|n| n.as_str()) == Some("Auth Monitor"))
+        .expect("Auth Monitor not found in status");
+
+    let state = monitor
+        .get("state")
+        .and_then(|s| s.as_str())
+        .expect("state field missing");
+    assert_eq!(
+        state, "Safe",
+        "expected Safe state from auth-enabled filemonitor"
+    );
+}

--- a/services/sentinel/tests/bdd/steps/auth_steps.rs
+++ b/services/sentinel/tests/bdd/steps/auth_steps.rs
@@ -1,0 +1,226 @@
+//! BDD step definitions for sentinel dashboard HTTP Basic Auth
+
+use cucumber::{given, then, when};
+use tempfile::TempDir;
+
+use crate::world::SentinelWorld;
+
+const AUTH_USERNAME: &str = "observatory";
+const AUTH_PASSWORD: &str = "test-password";
+
+fn pki_dir(world: &SentinelWorld) -> std::path::PathBuf {
+    world
+        .tls_pki_dir
+        .as_ref()
+        .expect("TLS certs not generated")
+        .path()
+        .to_path_buf()
+}
+
+#[given("sentinel is configured with dashboard TLS and auth enabled")]
+fn sentinel_configured_with_dashboard_auth(_world: &mut SentinelWorld) {
+    // Marker — config is built in the When step
+}
+
+#[when("sentinel is started with dashboard auth")]
+async fn sentinel_started_with_dashboard_auth(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let certs_dir = dir.join("certs");
+
+    let hash = rp_auth::credentials::hash_password(AUTH_PASSWORD).unwrap();
+
+    let mut config = world.build_sentinel_config();
+    config["dashboard"]["tls"] = serde_json::json!({
+        "cert": certs_dir.join("sentinel.pem").to_string_lossy().to_string(),
+        "key": certs_dir.join("sentinel-key.pem").to_string_lossy().to_string()
+    });
+    config["dashboard"]["auth"] = serde_json::json!({
+        "username": AUTH_USERNAME,
+        "password_hash": hash
+    });
+
+    let temp_dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = temp_dir.path().join("sentinel_auth_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let handle = bdd_infra::ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.sentinel = Some(handle);
+}
+
+#[when("sentinel is started without dashboard auth")]
+async fn sentinel_started_without_dashboard_auth(world: &mut SentinelWorld) {
+    let config = world.build_sentinel_config();
+
+    let temp_dir = world
+        .temp_dir
+        .get_or_insert_with(|| TempDir::new().unwrap());
+    let config_path = temp_dir.path().join("sentinel_noauth_config.json");
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let handle = bdd_infra::ServiceHandle::start(
+        env!("CARGO_MANIFEST_DIR"),
+        env!("CARGO_PKG_NAME"),
+        config_path.to_str().unwrap(),
+    )
+    .await;
+
+    world.sentinel = Some(handle);
+}
+
+#[then("the dashboard health endpoint should respond with valid credentials")]
+async fn dashboard_health_responds_with_auth(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.sentinel.as_ref().expect("sentinel not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(
+        ok,
+        "Dashboard health endpoint did not respond with valid credentials"
+    );
+}
+
+#[then("the dashboard health endpoint should reject wrong credentials with 401")]
+async fn dashboard_rejects_wrong_credentials(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.sentinel.as_ref().expect("sentinel not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    // Wait for readiness with correct creds
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client
+        .get(&url)
+        .basic_auth(AUTH_USERNAME, Some("wrong-password"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the dashboard health endpoint should reject missing credentials with 401")]
+async fn dashboard_rejects_missing_credentials(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.sentinel.as_ref().expect("sentinel not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    // Wait for readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[then("the dashboard 401 response should include a WWW-Authenticate header")]
+async fn dashboard_401_includes_www_authenticate(world: &mut SentinelWorld) {
+    let dir = pki_dir(world);
+    let ca_path = dir.join("ca.pem");
+    let client = rp_tls::client::build_reqwest_client(Some(&ca_path)).unwrap();
+    let port = world.sentinel.as_ref().expect("sentinel not started").port;
+    let url = format!("https://localhost:{}/health", port);
+
+    // Wait for readiness
+    let mut ready = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client
+            .get(&url)
+            .basic_auth(AUTH_USERNAME, Some(AUTH_PASSWORD))
+            .send()
+            .await
+        {
+            if resp.status().as_u16() == 200 {
+                ready = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ready, "Server did not become ready");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate header")
+        .to_str()
+        .unwrap();
+    assert_eq!(www_auth, "Basic realm=\"Rusty Photon\"");
+}
+
+#[then("the dashboard health endpoint should respond without credentials")]
+async fn dashboard_responds_without_credentials(world: &mut SentinelWorld) {
+    let client = reqwest::Client::new();
+    let port = world.sentinel.as_ref().expect("sentinel not started").port;
+    let url = format!("http://127.0.0.1:{}/health", port);
+
+    let mut ok = false;
+    for _ in 0..60 {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().as_u16() == 200 {
+                ok = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(ok, "Dashboard health endpoint did not respond without auth");
+}

--- a/services/sentinel/tests/bdd/steps/mod.rs
+++ b/services/sentinel/tests/bdd/steps/mod.rs
@@ -1,5 +1,6 @@
 //! BDD step definitions for sentinel service
 
+pub mod auth_steps;
 pub mod dashboard_steps;
 pub mod lifecycle_steps;
 pub mod monitoring_steps;

--- a/services/sentinel/tests/features/auth.feature
+++ b/services/sentinel/tests/features/auth.feature
@@ -1,0 +1,31 @@
+@serial
+Feature: sentinel dashboard HTTP Basic Auth
+  The sentinel dashboard can require authentication when auth is configured.
+
+  Scenario: dashboard auth enabled with correct credentials returns 200
+    Given generated TLS certificates for sentinel
+    And sentinel is configured with dashboard TLS and auth enabled
+    When sentinel is started with dashboard auth
+    Then the dashboard health endpoint should respond with valid credentials
+
+  Scenario: dashboard auth enabled with wrong credentials returns 401
+    Given generated TLS certificates for sentinel
+    And sentinel is configured with dashboard TLS and auth enabled
+    When sentinel is started with dashboard auth
+    Then the dashboard health endpoint should reject wrong credentials with 401
+
+  Scenario: dashboard auth enabled with missing credentials returns 401
+    Given generated TLS certificates for sentinel
+    And sentinel is configured with dashboard TLS and auth enabled
+    When sentinel is started with dashboard auth
+    Then the dashboard health endpoint should reject missing credentials with 401
+
+  Scenario: dashboard 401 response includes WWW-Authenticate header
+    Given generated TLS certificates for sentinel
+    And sentinel is configured with dashboard TLS and auth enabled
+    When sentinel is started with dashboard auth
+    Then the dashboard 401 response should include a WWW-Authenticate header
+
+  Scenario: dashboard auth disabled requires no credentials
+    When sentinel is started without dashboard auth
+    Then the dashboard health endpoint should respond without credentials

--- a/services/sentinel/tests/features/auth.feature
+++ b/services/sentinel/tests/features/auth.feature
@@ -29,3 +29,10 @@ Feature: sentinel dashboard HTTP Basic Auth
   Scenario: dashboard auth disabled requires no credentials
     When sentinel is started without dashboard auth
     Then the dashboard health endpoint should respond without credentials
+
+  Scenario: sentinel polls auth-enabled filemonitor with correct credentials
+    Given generated TLS certificates for sentinel
+    And filemonitor is running with TLS and auth enabled and a contains rule "SAFE" as safe
+    And sentinel is configured to monitor the auth-enabled filemonitor
+    When sentinel is started with CA trust
+    Then sentinel should successfully poll the filemonitor


### PR DESCRIPTION
## Summary

- New `crates/rp-auth` shared crate: Argon2id credential hashing/verification, axum tower middleware, config types
- **Server-side auth** for all 5 HTTP services (filemonitor, ppba-driver, qhy-focuser, sentinel dashboard, rp)
- **Client-side auth** for sentinel (per-monitor credentials) and rp (per-device equipment connections)
- `rp hash-password` CLI command for generating Argon2id password hashes
- `bdd_infra::run_once` gains optional stdin support; `try_start` timeout bumped to 30s
- Upstream: `Client::new_with_client()` added to ascom-alpaca-rs for custom reqwest client injection

## Test plan

- [x] `cargo build --all --all-targets --all-features` passes
- [x] `cargo test --all --all-features` passes (18 rp-auth unit tests + BDD auth scenarios for all 5 services)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings` clean
- [x] BDD: sentinel polls auth-enabled filemonitor over TLS+auth (cross-service e2e test)
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)