### PR TITLE
Add Windows graceful shutdown for BDD test services

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -63,6 +63,7 @@ infrastructure = [
   "Cargo.lock",
   "rust-toolchain.toml",
   ".config/**",
+  "crates/bdd-infra/**",
   "scripts/**",
 ]
 conservative_unclassified_owner_fallback = true

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -106,8 +106,9 @@ fn load_config(manifest_dir: &str) -> BddConfig {
 /// Manages the full lifecycle: binary discovery, spawning with stdout capture,
 /// port parsing, graceful SIGTERM shutdown, and stdout draining.
 ///
-/// On [`Drop`], sends a best-effort SIGTERM so the process is cleaned up even
-/// if [`stop`](ServiceHandle::stop) is not called explicitly.
+/// On [`Drop`], sends a best-effort graceful-shutdown signal (SIGTERM on Unix,
+/// `CTRL_BREAK_EVENT` on Windows) so the process is cleaned up even if
+/// [`stop`](ServiceHandle::stop) is not called explicitly.
 #[derive(Debug)]
 pub struct ServiceHandle {
     child: Option<tokio::process::Child>,
@@ -353,6 +354,10 @@ fn find_binary(env_var: &str, package_name: &str) -> Option<String> {
 }
 
 /// Spawn the service process, either from a pre-built binary or via `cargo run`.
+///
+/// On Windows the child is spawned with `CREATE_NEW_PROCESS_GROUP` so that
+/// [`send_sigterm`] can deliver `CTRL_BREAK_EVENT` only to the child's group
+/// without affecting the test runner.
 fn spawn_process(
     binary: &Option<String>,
     package_name: &str,
@@ -361,17 +366,22 @@ fn spawn_process(
 ) -> tokio::process::Child {
     if let Some(binary) = binary {
         debug!(binary = %binary, "starting {} from pre-built binary", package_name);
-        tokio::process::Command::new(binary)
-            .args(["--config", config_path])
+        let mut cmd = tokio::process::Command::new(binary);
+        cmd.args(["--config", config_path])
             .stdout(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .unwrap_or_else(|e| {
-                panic!(
-                    "failed to start {} binary '{}': {}",
-                    package_name, binary, e
-                )
-            })
+            .kill_on_drop(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        }
+        cmd.spawn().unwrap_or_else(|e| {
+            panic!(
+                "failed to start {} binary '{}': {}",
+                package_name, binary, e
+            )
+        })
     } else {
         debug!("starting {} via cargo run", package_name);
         let mut args = vec![
@@ -390,11 +400,15 @@ fn spawn_process(
             config_path.to_string(),
         ]);
 
-        tokio::process::Command::new("cargo")
-            .args(&args)
-            .stdout(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
+        let mut cmd = tokio::process::Command::new("cargo");
+        cmd.args(&args).stdout(Stdio::piped()).kill_on_drop(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        }
+        cmd.spawn()
             .unwrap_or_else(|e| panic!("failed to start {} via cargo run: {}", package_name, e))
     }
 }
@@ -434,14 +448,31 @@ pub async fn parse_bound_port(
     None
 }
 
-/// Send SIGTERM to a process (Unix only). No-op on other platforms.
+/// Send a graceful-shutdown signal to a process.
+///
+/// * **Unix** — sends `SIGTERM`.
+/// * **Windows** — sends `CTRL_BREAK_EVENT` via `GenerateConsoleCtrlEvent`.
+///   The child must have been spawned with `CREATE_NEW_PROCESS_GROUP` so the
+///   event targets only its process group (see [`spawn_process`]).
 fn send_sigterm(pid: u32) {
     #[cfg(unix)]
+    // SAFETY: libc::kill with a valid pid and SIGTERM is safe.
     unsafe {
         libc::kill(pid as i32, libc::SIGTERM);
     }
-    #[cfg(not(unix))]
-    let _ = pid;
+    #[cfg(windows)]
+    {
+        // SAFETY: GenerateConsoleCtrlEvent with CTRL_BREAK_EVENT and a valid
+        // process-group id is the documented way to request graceful shutdown
+        // of a console process on Windows.
+        extern "system" {
+            fn GenerateConsoleCtrlEvent(dw_ctrl_event: u32, dw_process_group_id: u32) -> i32;
+        }
+        const CTRL_BREAK_EVENT: u32 = 1;
+        unsafe {
+            GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -355,9 +355,14 @@ fn find_binary(env_var: &str, package_name: &str) -> Option<String> {
     None
 }
 
+/// Windows process creation flag: place the child in its own process group so
+/// that `CTRL_BREAK_EVENT` can target it without affecting the test runner.
+#[cfg(windows)]
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
 /// Spawn the service process, either from a pre-built binary or via `cargo run`.
 ///
-/// On Windows the child is spawned with `CREATE_NEW_PROCESS_GROUP` so that
+/// On Windows the child is spawned with [`CREATE_NEW_PROCESS_GROUP`] so that
 /// [`send_sigterm`] can deliver `CTRL_BREAK_EVENT` only to the child's group
 /// without affecting the test runner.
 fn spawn_process(
@@ -374,7 +379,6 @@ fn spawn_process(
             .kill_on_drop(true);
         #[cfg(windows)]
         {
-            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }
         cmd.spawn().unwrap_or_else(|e| {
@@ -405,7 +409,6 @@ fn spawn_process(
         cmd.args(&args).stdout(Stdio::piped()).kill_on_drop(true);
         #[cfg(windows)]
         {
-            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }
         cmd.spawn()
@@ -472,6 +475,7 @@ fn send_sigterm(pid: u32) {
         // SAFETY: GenerateConsoleCtrlEvent with CTRL_BREAK_EVENT and a valid
         // process-group id is the documented way to request graceful shutdown
         // of a console process on Windows.
+        #[allow(non_snake_case)]
         extern "system" {
             fn GenerateConsoleCtrlEvent(dw_ctrl_event: u32, dw_process_group_id: u32) -> i32;
         }

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -104,11 +104,13 @@ fn load_config(manifest_dir: &str) -> BddConfig {
 /// Handle to a running service process.
 ///
 /// Manages the full lifecycle: binary discovery, spawning with stdout capture,
-/// port parsing, graceful SIGTERM shutdown, and stdout draining.
+/// port parsing, graceful shutdown signaling, and stdout draining.
 ///
 /// On [`Drop`], sends a best-effort graceful-shutdown signal (SIGTERM on Unix,
-/// `CTRL_BREAK_EVENT` on Windows) so the process is cleaned up even if
-/// [`stop`](ServiceHandle::stop) is not called explicitly.
+/// `CTRL_BREAK_EVENT` on Windows) before the child handle is dropped. Callers
+/// should use [`stop`](ServiceHandle::stop) when they need an explicit
+/// graceful shutdown path, because dropping the handle may still force the
+/// process to terminate if it has not already exited.
 #[derive(Debug)]
 pub struct ServiceHandle {
     child: Option<tokio::process::Child>,
@@ -456,9 +458,16 @@ pub async fn parse_bound_port(
 ///   event targets only its process group (see [`spawn_process`]).
 fn send_sigterm(pid: u32) {
     #[cfg(unix)]
-    // SAFETY: libc::kill with a valid pid and SIGTERM is safe.
-    unsafe {
-        libc::kill(pid as i32, libc::SIGTERM);
+    {
+        // SAFETY: libc::kill with a valid pid and SIGTERM is safe.
+        let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+        if ret != 0 {
+            debug!(
+                "failed to send SIGTERM to pid {}: {}",
+                pid,
+                std::io::Error::last_os_error()
+            );
+        }
     }
     #[cfg(windows)]
     {
@@ -469,8 +478,13 @@ fn send_sigterm(pid: u32) {
             fn GenerateConsoleCtrlEvent(dw_ctrl_event: u32, dw_process_group_id: u32) -> i32;
         }
         const CTRL_BREAK_EVENT: u32 = 1;
-        unsafe {
-            GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid);
+        let ret = unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) };
+        if ret == 0 {
+            debug!(
+                "failed to send CTRL_BREAK_EVENT to process group {}: {}",
+                pid,
+                std::io::Error::last_os_error()
+            );
         }
     }
 }

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -374,7 +374,6 @@ fn spawn_process(
             .kill_on_drop(true);
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }
@@ -406,7 +405,6 @@ fn spawn_process(
         cmd.args(&args).stdout(Stdio::piped()).kill_on_drop(true);
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }

--- a/crates/bdd-infra/tests/service_handle.rs
+++ b/crates/bdd-infra/tests/service_handle.rs
@@ -204,6 +204,34 @@ async fn test_port_is_actually_listening() {
     handle.stop().await;
 }
 
+/// Graceful shutdown must complete well under the 5-second SIGKILL fallback
+/// timeout. If the shutdown signal is not delivered (e.g. a no-op
+/// `send_sigterm`), `stop()` would wait the full 5 seconds before hard-killing.
+/// A 2-second budget catches such regressions on any platform while leaving
+/// generous margin for slow CI runners.
+#[tokio::test]
+async fn test_stop_completes_via_graceful_signal() {
+    let manifest = setup_manifest("BDD_TEST_STOP_GRACEFUL", env!("CARGO_BIN_EXE_test_service"));
+    let config = empty_config();
+
+    let mut handle = ServiceHandle::start(
+        manifest.path().to_str().unwrap(),
+        "test-service",
+        config.path().to_str().unwrap(),
+    )
+    .await;
+
+    let start = std::time::Instant::now();
+    handle.stop().await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < std::time::Duration::from_millis(2000),
+        "stop() took {:?}, expected < 2s — graceful shutdown signal may not be working",
+        elapsed
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Cargo run fallback tests (no env var set, exercises `cargo run --package`)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the no-op `send_sigterm()` on Windows with `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)`, enabling graceful shutdown of service processes during BDD tests
- Spawn child processes with `CREATE_NEW_PROCESS_GROUP` so the break event targets only the child's process group, not the test runner
- Eliminates the 5-second timeout penalty per scenario on Windows (previously `send_sigterm` was a no-op, so every `stop()` call waited 5s before falling back to hard kill)

## How it works
Services already listen for `tokio::signal::ctrl_c()` which handles both `CTRL_C_EVENT` and `CTRL_BREAK_EVENT` on Windows. By sending `CTRL_BREAK_EVENT` to the child's process group, the existing graceful shutdown path triggers without any changes to the services themselves.

## Test plan
- [x] `cargo rail run --merge-base` passes (no errors or warnings)
- [x] `cargo fmt` clean
- [ ] Verify on Windows CI that BDD tests complete without the 5-second-per-scenario delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)