### PR TITLE
Targeted CI testing for workspace dependency changes

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -69,6 +69,13 @@ conservative_unclassified_owner_fallback = true
 confidence_profile = "balanced"
 bot_pr_confidence_profile = "strict"  # optional bot PR override
 
+# Intercept workspace Cargo.toml before cargo-rail's hardcoded
+# FILE_KIND_TOML_WORKSPACE classifier (custom patterns take priority).
+# This prevents blanket infra=true on dependency changes. The CI
+# workflow handles this surface with targeted dep-to-crate resolution.
+[change-detection.custom]
+workspace-manifest = ["Cargo.toml"]
+
 
 [run]
 default_profile = "local"

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -23,6 +23,20 @@ jobs:
         id: rail
         with:
           since: ${{ github.event.pull_request.base.sha || github.event.before }}
+      - name: Resolve workspace manifest changes
+        id: manifest
+        if: steps.rail.outputs.infra != 'true'
+        run: |
+          SCOPE_JSON='${{ steps.rail.outputs.scope-json }}'
+          HAS_MANIFEST=$(echo "$SCOPE_JSON" | jq -r '.surfaces["custom:workspace-manifest"] // false')
+
+          if [ "$HAS_MANIFEST" != "true" ]; then
+            echo "mode=passthrough" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BASE_REF=$(echo "$SCOPE_JSON" | jq -r '.resolved_base')
+          bash scripts/resolve-workspace-deps.sh "$BASE_REF"
       - name: Discover affected ConformU services
         id: discover
         run: |
@@ -30,11 +44,18 @@ jobs:
           ALL_SERVICES=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | \
             jq -c '[.packages[] | select(.metadata.conformu.command) | {name: .name, command: .metadata.conformu.command}]')
 
-          # If infra changed or no rail filtering, test all; otherwise intersect with affected
-          if [ "${{ steps.rail.outputs.infra }}" = "true" ] || [ "${{ steps.rail.outputs.test }}" != "true" ]; then
+          # If infra changed or workspace-wide manifest change, test all;
+          # otherwise intersect with affected crates from rail + manifest resolver
+          if [ "${{ steps.rail.outputs.infra }}" = "true" ] || \
+             [ "${{ steps.manifest.outputs.mode }}" = "workspace" ]; then
             SERVICES="$ALL_SERVICES"
+          elif [ "${{ steps.rail.outputs.test }}" != "true" ] && \
+               [ "${{ steps.manifest.outputs.test }}" != "true" ]; then
+            SERVICES="[]"
           else
-            AFFECTED='${{ steps.rail.outputs.crates }}'
+            RAIL_CRATES='${{ steps.rail.outputs.crates }}'
+            MANIFEST_CRATES='${{ steps.manifest.outputs.crates }}'
+            AFFECTED=$(echo "$RAIL_CRATES $MANIFEST_CRATES" | xargs -n1 2>/dev/null | sort -u | xargs echo 2>/dev/null)
             SERVICES=$(echo "$ALL_SERVICES" | jq -c --arg affected "$AFFECTED" \
               '[.[] | select(.name as $n | ($affected | split(" ") | index($n)))]')
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     name: plan
     outputs:
-      test: ${{ steps.rail.outputs.test }}
+      test: ${{ steps.manifest.outputs.test || steps.rail.outputs.test }}
       infra: ${{ steps.rail.outputs.infra }}
-      cargo-args: ${{ steps.rail.outputs.cargo-args }}
+      manifest-mode: ${{ steps.manifest.outputs.mode }}
+      cargo-args: ${{ steps.manifest.outputs.cargo-args || steps.rail.outputs.cargo-args }}
+      crates: ${{ steps.manifest.outputs.crates || steps.rail.outputs.crates }}
       bdd-packages: ${{ steps.bdd.outputs.packages }}
       has-bdd: ${{ steps.bdd.outputs.has_bdd }}
     steps:
@@ -34,6 +36,20 @@ jobs:
         id: rail
         with:
           since: ${{ github.event.pull_request.base.sha || github.event.before }}
+      - name: Resolve workspace manifest changes
+        id: manifest
+        if: steps.rail.outputs.infra != 'true'
+        run: |
+          SCOPE_JSON='${{ steps.rail.outputs.scope-json }}'
+          HAS_MANIFEST=$(echo "$SCOPE_JSON" | jq -r '.surfaces["custom:workspace-manifest"] // false')
+
+          if [ "$HAS_MANIFEST" != "true" ]; then
+            echo "mode=passthrough" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BASE_REF=$(echo "$SCOPE_JSON" | jq -r '.resolved_base')
+          bash scripts/resolve-workspace-deps.sh "$BASE_REF"
       - name: Discover BDD packages
         id: bdd
         run: |
@@ -41,11 +57,15 @@ jobs:
           ALL_BDD=$(cargo metadata --format-version 1 --no-deps | \
             jq -c '[.packages[] | select(.targets[] | .kind[] == "test" and .name == "bdd") | .name]')
 
-          # If infra changed, test all BDD packages; otherwise intersect with affected
-          if [ "${{ steps.rail.outputs.infra }}" = "true" ]; then
+          # If infra changed or workspace-wide manifest change, test all BDD packages;
+          # otherwise intersect with affected crates from rail + manifest resolver
+          if [ "${{ steps.rail.outputs.infra }}" = "true" ] || \
+             [ "${{ steps.manifest.outputs.mode }}" = "workspace" ]; then
             BDD_PACKAGES="$ALL_BDD"
           else
-            AFFECTED='${{ steps.rail.outputs.crates }}'
+            RAIL_CRATES='${{ steps.rail.outputs.crates }}'
+            MANIFEST_CRATES='${{ steps.manifest.outputs.crates }}'
+            AFFECTED=$(echo "$RAIL_CRATES $MANIFEST_CRATES" | xargs -n1 2>/dev/null | sort -u | xargs echo 2>/dev/null)
             BDD_PACKAGES=$(echo "$ALL_BDD" | jq -c --arg affected "$AFFECTED" \
               '[.[] | select(. as $pkg | ($affected | split(" ") | .[] | select(. == $pkg)) // empty)]')
           fi
@@ -76,16 +96,16 @@ jobs:
       # Pre-build all targets (bins + test/bench/example targets) so nextest
       # and BDD tests find cached binaries without recompilation
       - name: cargo build
-        run: cargo build --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+        run: cargo build --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo nextest run
-        run: cargo nextest run --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+        run: cargo nextest run --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       # BDD tests use custom harness (bdd_main!) incompatible with nextest
       - name: cargo test --test bdd
-        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
+        run: cargo test --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
-        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --doc
+        run: cargo test --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --doc
   macos:
     needs: plan
     if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true'
@@ -106,11 +126,11 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo build
-        run: cargo build --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+        run: cargo build --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       - name: cargo nextest run
-        run: cargo nextest run --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+        run: cargo nextest run --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       - name: cargo test --test bdd
-        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
+        run: cargo test --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
   windows:
     # Windows nextest (unit + integration tests, no BDD).
     # BDD tests are split into per-service parallel jobs below to avoid
@@ -140,7 +160,7 @@ jobs:
       - name: cargo build
         run: cargo build --locked --workspace --all-features --all-targets
       - name: cargo nextest run
-        run: cargo nextest run --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+        run: cargo nextest run --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
   windows-bdd:
     # Per-service BDD tests on Windows, run in parallel via matrix.
     # Each service spawns its own process per scenario; on Windows this takes
@@ -204,11 +224,11 @@ jobs:
       - name: Build with coverage instrumentation
         run: |
           source <(cargo llvm-cov show-env --sh)
-          cargo build --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+          cargo build --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       - name: Run tests with coverage
         run: |
           source <(cargo llvm-cov show-env --sh)
-          cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
+          cargo test --locked ${{ (needs.plan.outputs.infra == 'true' || needs.plan.outputs.manifest-mode == 'workspace') && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --all-targets
       - name: Generate per-package coverage reports
         run: |
           source <(cargo llvm-cov show-env --sh)

--- a/docs/decisions/004-build-system-evaluation.md
+++ b/docs/decisions/004-build-system-evaluation.md
@@ -1,0 +1,87 @@
+# ADR-004: Build System Evaluation — cargo-rail, Bazel, Buck2
+
+## Status
+
+Accepted — optimize cargo-rail; revisit when the UI technology is decided.
+
+## Context
+
+The workspace uses cargo-rail for change detection in CI, reducing the
+build matrix from ~75 to ~21 jobs per PR. However, any change to the
+workspace `Cargo.toml` triggers a full rebuild across all CI jobs because
+cargo-rail's file classifier hardcodes workspace `Cargo.toml` as
+infrastructure (`FILE_KIND_TOML_WORKSPACE`), setting `infra=true`
+regardless of what section changed. In practice, adding or updating a
+workspace dependency — the most common PR type — forces all 315 BDD
+scenarios to run across 5 services on 3 OSes, even though BDD tests
+account for 69-72% of each job's runtime.
+
+With less than a third of the planned services written and a web UI on
+the roadmap (technology undecided), we evaluated Bazel and Buck2 as
+alternatives.
+
+## Options Considered
+
+### 1. Optimize cargo-rail with targeted workspace dep resolution (selected)
+
+cargo-rail's `[change-detection.custom]` patterns take priority over the
+hardcoded file classifier. Adding `workspace-manifest = ["Cargo.toml"]`
+to the custom patterns intercepts the classification, producing a
+`custom:workspace-manifest` surface instead of blanket `infra=true`.
+
+A shell script (`scripts/resolve-workspace-deps.sh`) then uses
+`cargo metadata` and TOML section comparison to determine which crates
+are actually affected:
+
+- If only `[workspace.dependencies]` changed: greps member `Cargo.toml`
+  files for workspace references to the changed deps, walks the reverse
+  dependency graph, and outputs targeted `-p` flags.
+- If `[workspace.package]`, `[workspace.lints]`, `[profile]`, `members`,
+  or other sections changed: falls back to `--workspace`.
+
+Cargo's own fingerprinting handles incremental compilation correctly
+regardless — the optimization targets test execution (BDD, ConformU),
+which is the dominant CI cost.
+
+### 2. Bazel with rules_rust + rules_ts
+
+rules_rust provides mature Rust support. crate_universe reads
+`Cargo.toml` for external deps. Bazel's content-addressable action
+cache and sandboxed execution provide fine-grained, correct dependency
+tracking. rules_ts offers production-ready TypeScript support.
+
+**Not selected because:**
+- The rp architecture (Tenet 7: "UI is a client, not a component")
+  intentionally decouples the web UI from Rust services via REST +
+  WebSocket. The build graphs are architecturally independent —
+  Bazel's multi-language advantage does not apply.
+- No Bazel integration exists for Leptos SSR + WASM builds.
+- Migration effort is disproportionate at 12 crates.
+- The immediate problem (unnecessary test execution) is solvable with
+  cargo-rail configuration.
+
+Bazel remains the preferred alternative if the workspace grows beyond
+~50 crates, if the UI technology decision introduces shared build
+artifacts between Rust and TypeScript, or if build hermeticity becomes
+critical.
+
+### 3. Buck2
+
+**Disqualified:** No TypeScript support, immature ecosystem outside
+Meta, sparse documentation, limited Windows support.
+
+## Decision
+
+Optimize cargo-rail with the custom pattern and workspace dep resolver.
+
+## Consequences
+
+- `.config/rail.toml` gains a `[change-detection.custom]` entry for
+  `Cargo.toml`.
+- `scripts/resolve-workspace-deps.sh` added for CI workspace dep
+  resolution.
+- `test.yml` and `conformu.yml` plan jobs updated with a manifest
+  resolver step.
+- Planned upstream cargo-rail PR to add native workspace Cargo.toml
+  semantic analysis, which would eliminate the workaround.
+- Revisit this ADR when the UI technology decision is made.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -31,6 +31,7 @@ belong in any single service design doc.
 | [docs/references/ascom-alpaca.md](references/ascom-alpaca.md) | ASCOM Alpaca protocol reference |
 | **Decisions** | |
 | [docs/decisions/](decisions/) | Architecture Decision Records |
+| [docs/decisions/004-build-system-evaluation.md](decisions/004-build-system-evaluation.md) | ADR-004: Build system evaluation — cargo-rail vs Bazel vs Buck2 |
 
 ## Shared Crates
 

--- a/scripts/resolve-workspace-deps.sh
+++ b/scripts/resolve-workspace-deps.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Resolve which workspace members are affected by changes to [workspace.dependencies].
+#
+# Used by CI workflows when cargo-rail's custom:workspace-manifest surface fires.
+# Instead of rebuilding/testing everything, this script uses cargo metadata to
+# determine which crates actually depend on the changed workspace dependencies.
+#
+# Usage: resolve-workspace-deps.sh <base-ref>
+#
+# Outputs (via $GITHUB_OUTPUT or stdout):
+#   mode=targeted|workspace|none
+#   cargo-args=-p crate1 -p crate2    (only when mode=targeted)
+#   crates=crate1 crate2              (only when mode=targeted)
+#   test=true|false
+
+set -euo pipefail
+
+BASE_REF="${1:?Usage: resolve-workspace-deps.sh <base-ref>}"
+
+# --- Section comparison ---
+# Check if non-dependency sections of Cargo.toml changed.
+# If [workspace.package], [workspace.lints], [profile], members, or resolver
+# changed, the entire workspace must be rebuilt and tested.
+
+OLD_TOML=$(git show "${BASE_REF}:Cargo.toml" 2>/dev/null) || {
+  echo "mode=workspace" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  echo "test=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  exit 0
+}
+NEW_TOML=$(cat Cargo.toml)
+
+# --- Section comparison ---
+# Strip the [workspace.dependencies] section from both files and compare the
+# remainder. If anything outside that section changed, trigger full rebuild.
+# This correctly handles [workspace.lints], [workspace.package], [profile], etc.
+#
+# The sed command deletes lines from [workspace.dependencies] up to (but not
+# including) the next section header or EOF.
+strip_ws_deps() {
+  sed '/^\[workspace\.dependencies\]/,/^\[/{/^\[workspace\.dependencies\]/d;/^\[/!d;}' | \
+    sed '/^$/d'
+}
+
+OLD_STRIPPED=$(echo "$OLD_TOML" | strip_ws_deps)
+NEW_STRIPPED=$(echo "$NEW_TOML" | strip_ws_deps)
+
+if [ "$OLD_STRIPPED" != "$NEW_STRIPPED" ]; then
+  echo "Non-dependency sections changed -- full rebuild required"
+  diff <(echo "$OLD_STRIPPED") <(echo "$NEW_STRIPPED") | head -10 || true
+  echo "mode=workspace" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  echo "test=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  exit 0
+fi
+
+# --- Dep extraction ---
+# Only [workspace.dependencies] entries changed. Extract the dep names from
+# the old and new sections, then find which ones differ.
+extract_ws_deps() {
+  sed -n '/^\[workspace\.dependencies\]/,/^\[/{/^\[/d;/^$/d;/^#/d;p;}' | \
+    awk '{print $1}' | sort
+}
+
+OLD_DEPS=$(echo "$OLD_TOML" | extract_ws_deps)
+NEW_DEPS=$(echo "$NEW_TOML" | extract_ws_deps)
+
+# Find dep names that were added, removed, or whose value changed
+CHANGED_DEPS=""
+for dep in $(echo "$OLD_DEPS"$'\n'"$NEW_DEPS" | sort -u); do
+  OLD_LINE=$(echo "$OLD_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep} /p;}")
+  NEW_LINE=$(echo "$NEW_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep} /p;}")
+  if [ "$OLD_LINE" != "$NEW_LINE" ]; then
+    CHANGED_DEPS="$CHANGED_DEPS $dep"
+  fi
+done
+CHANGED_DEPS=$(echo "$CHANGED_DEPS" | xargs echo 2>/dev/null)
+
+if [ -z "$CHANGED_DEPS" ]; then
+  echo "No dependency changes detected"
+  echo "mode=none" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  echo "test=false" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  exit 0
+fi
+
+echo "Changed workspace deps: $CHANGED_DEPS"
+
+# --- Member resolution ---
+# Find which workspace members reference the changed deps with workspace = true.
+
+METADATA=$(cargo metadata --format-version 1 --no-deps 2>/dev/null)
+
+AFFECTED=""
+while IFS= read -r pkg_line; do
+  pkg_name=$(echo "$pkg_line" | jq -r '.name')
+  manifest_path=$(echo "$pkg_line" | jq -r '.manifest_path')
+
+  for dep in $CHANGED_DEPS; do
+    # Check if the member's Cargo.toml has this dep with workspace = true.
+    # Handles both `dep = { workspace = true }` and `dep.workspace = true` forms.
+    if grep -qE "^${dep}[[:space:]]*(=.*workspace|\.workspace)" "$manifest_path" 2>/dev/null; then
+      AFFECTED="$AFFECTED $pkg_name"
+      break
+    fi
+  done
+done < <(echo "$METADATA" | jq -c '.packages[]') || true
+
+AFFECTED=$(echo "$AFFECTED" | xargs -n1 2>/dev/null | sort -u | xargs echo 2>/dev/null)
+
+if [ -z "$AFFECTED" ] || [ "$AFFECTED" = "" ]; then
+  echo "Changed deps not used by any workspace member"
+  echo "mode=none" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  echo "test=false" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  exit 0
+fi
+
+echo "Directly affected crates: $AFFECTED"
+
+# --- Reverse dependency walk ---
+# Include workspace members that transitively depend on affected crates.
+# Uses --no-deps metadata + member Cargo.toml grep to avoid full resolution
+# (which would fail if a new dep version hasn't been published yet).
+
+ALL_AFFECTED="$AFFECTED"
+for crate in $AFFECTED; do
+  # Find workspace members whose Cargo.toml references this crate as a
+  # workspace dependency (internal path deps like rp-auth, rp-tls, bdd-infra)
+  while IFS= read -r pkg_line; do
+    other_name=$(echo "$pkg_line" | jq -r '.name')
+    other_manifest=$(echo "$pkg_line" | jq -r '.manifest_path')
+
+    # Skip self
+    [ "$other_name" = "$crate" ] && continue
+
+    if grep -qE "^${crate}[[:space:]]*(=.*workspace|\.workspace)" "$other_manifest" 2>/dev/null; then
+      ALL_AFFECTED="$ALL_AFFECTED $other_name"
+    fi
+  done < <(echo "$METADATA" | jq -c '.packages[]') || true
+done
+
+ALL_AFFECTED=$(echo "$ALL_AFFECTED" | xargs -n1 2>/dev/null | sort -u | xargs echo 2>/dev/null)
+CARGO_ARGS=$(echo "$ALL_AFFECTED" | xargs -n1 2>/dev/null | sed 's/^/-p /' | xargs echo 2>/dev/null)
+
+echo "All affected crates (with reverse deps): $ALL_AFFECTED"
+echo "Cargo args: $CARGO_ARGS"
+
+echo "mode=targeted" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "cargo-args=$CARGO_ARGS" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "crates=$ALL_AFFECTED" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "test=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/scripts/resolve-workspace-deps.sh
+++ b/scripts/resolve-workspace-deps.sh
@@ -55,9 +55,12 @@ fi
 # --- Dep extraction ---
 # Only [workspace.dependencies] entries changed. Extract the dep names from
 # the old and new sections, then find which ones differ.
+# Filter to key lines only (start with dep-name followed by whitespace and =)
+# to skip multi-line continuation lines (e.g., features = [ ... ]).
 extract_ws_deps() {
   sed -n '/^\[workspace\.dependencies\]/,/^\[/{/^\[/d;/^$/d;/^#/d;p;}' | \
-    awk '{print $1}' | sort
+    grep -E '^[a-zA-Z0-9_][a-zA-Z0-9_.-]*[[:space:]]*=' | \
+    sed 's/[[:space:]]*=.*//' | sort
 }
 
 OLD_DEPS=$(echo "$OLD_TOML" | extract_ws_deps)
@@ -66,8 +69,8 @@ NEW_DEPS=$(echo "$NEW_TOML" | extract_ws_deps)
 # Find dep names that were added, removed, or whose value changed
 CHANGED_DEPS=""
 for dep in $(echo "$OLD_DEPS"$'\n'"$NEW_DEPS" | sort -u); do
-  OLD_LINE=$(echo "$OLD_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep} /p;}")
-  NEW_LINE=$(echo "$NEW_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep} /p;}")
+  OLD_LINE=$(echo "$OLD_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep}[[:space:]]*=/p;}")
+  NEW_LINE=$(echo "$NEW_TOML" | sed -n "/^\[workspace\.dependencies\]/,/^\[/{/^${dep}[[:space:]]*=/p;}")
   if [ "$OLD_LINE" != "$NEW_LINE" ]; then
     CHANGED_DEPS="$CHANGED_DEPS $dep"
   fi
@@ -114,26 +117,32 @@ fi
 
 echo "Directly affected crates: $AFFECTED"
 
-# --- Reverse dependency walk ---
+# --- Reverse dependency walk (transitive BFS) ---
 # Include workspace members that transitively depend on affected crates.
 # Uses --no-deps metadata + member Cargo.toml grep to avoid full resolution
 # (which would fail if a new dep version hasn't been published yet).
+# Iterates until fixpoint to catch multi-hop chains (A -> B -> C).
 
 ALL_AFFECTED="$AFFECTED"
-for crate in $AFFECTED; do
-  # Find workspace members whose Cargo.toml references this crate as a
-  # workspace dependency (internal path deps like rp-auth, rp-tls, bdd-infra)
-  while IFS= read -r pkg_line; do
-    other_name=$(echo "$pkg_line" | jq -r '.name')
-    other_manifest=$(echo "$pkg_line" | jq -r '.manifest_path')
+QUEUE="$AFFECTED"
 
-    # Skip self
-    [ "$other_name" = "$crate" ] && continue
+while [ -n "$QUEUE" ]; do
+  NEXT_QUEUE=""
+  for crate in $QUEUE; do
+    while IFS= read -r pkg_line; do
+      other_name=$(echo "$pkg_line" | jq -r '.name')
+      other_manifest=$(echo "$pkg_line" | jq -r '.manifest_path')
 
-    if grep -qE "^${crate}[[:space:]]*(=.*workspace|\.workspace)" "$other_manifest" 2>/dev/null; then
-      ALL_AFFECTED="$ALL_AFFECTED $other_name"
-    fi
-  done < <(echo "$METADATA" | jq -c '.packages[]') || true
+      # Skip self and already-known crates
+      echo " $ALL_AFFECTED " | grep -q " $other_name " && continue
+
+      if grep -qE "^${crate}[[:space:]]*(=.*workspace|\.workspace)" "$other_manifest" 2>/dev/null; then
+        ALL_AFFECTED="$ALL_AFFECTED $other_name"
+        NEXT_QUEUE="$NEXT_QUEUE $other_name"
+      fi
+    done < <(echo "$METADATA" | jq -c '.packages[]') || true
+  done
+  QUEUE=$(echo "$NEXT_QUEUE" | xargs echo 2>/dev/null)
 done
 
 ALL_AFFECTED=$(echo "$ALL_AFFECTED" | xargs -n1 2>/dev/null | sort -u | xargs echo 2>/dev/null)


### PR DESCRIPTION
## Summary

- **Intercept cargo-rail's hardcoded workspace Cargo.toml classification** using
  `[change-detection.custom]` patterns, which take priority over the built-in
  `FILE_KIND_TOML_WORKSPACE` classifier
- **Add `scripts/resolve-workspace-deps.sh`** that uses `cargo metadata` + TOML
  section comparison to determine which crates are affected by workspace
  dependency changes, including reverse-dependency walk
- **Update `test.yml` and `conformu.yml` plan jobs** with a manifest resolver
  step that produces targeted `-p` flags when only `[workspace.dependencies]`
  changed, falling back to `--workspace` for workspace-wide changes (lints,
  package metadata, profiles, members)
- **Add ADR-004** documenting the build system evaluation (cargo-rail vs Bazel
  vs Buck2) and the rationale for the chosen approach

### Problem

cargo-rail hardcodes `FILE_KIND_TOML_WORKSPACE` for any workspace `Cargo.toml`
change, setting `infra=true` and triggering full test runs: 315 BDD scenarios
across 5 services on 3 OSes. BDD tests are 69-72% of each CI job's runtime.
Adding or updating a workspace dependency — the most common PR type — triggers
this unnecessarily.

### Solution

1. A custom cargo-rail pattern intercepts the classification before the
   hardcoded classifier fires
2. A shell script resolves affected crates using `cargo metadata`
3. CI workflows use the targeted output for test scoping

### Verified locally

- `argon2` version bump → correctly resolves `rp-auth` + 5 reverse deps
- `rmcp` version bump → correctly resolves `rp` + `calibrator-flats`
- `uuid` addition (unused) → correctly outputs `mode=none` (skip tests)
- `[workspace.lints]` change → correctly falls back to `mode=workspace`

## Test plan

- [ ] CI passes on this PR (the `.config/rail.toml` change triggers
  `custom:workspace-manifest` surface — verify plan job handles it)
- [ ] Open a follow-up test PR that adds a workspace dependency used by
  one service — verify targeted BDD/ConformU execution
- [ ] Verify `[workspace.lints]` change still triggers full workspace rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)