### PR TITLE
Gate ConformU on merge queue instead of every PR push

### DIFF
--- a/.claude/commands/pre-push.md
+++ b/.claude/commands/pre-push.md
@@ -69,7 +69,7 @@ Replace `{PREFIX}` with the worktree name from the Context section above:
 | sanitizers          | `act --container-name-prefix={PREFIX}- -W .github/workflows/safety.yml -j sanitizers`    |
 | nightly             | `act --container-name-prefix={PREFIX}- -W .github/workflows/scheduled.yml -j nightly`    |
 | update              | `act --container-name-prefix={PREFIX}- -W .github/workflows/scheduled.yml -j update`     |
-| conformu            | `act --container-name-prefix={PREFIX}- -W .github/workflows/conformu.yml -j discover -j conformu` |
+| conformu            | `act workflow_dispatch --container-name-prefix={PREFIX}- -W .github/workflows/conformu.yml -j plan -j conformu` |
 
 **Optional** — only when `$ARGUMENTS` contains `miri`:
 

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -25,7 +25,10 @@ jobs:
       - uses: loadingalias/cargo-rail-action@v4
         id: rail
         with:
-          since: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          # github.sha is the final fallback for workflow_dispatch, where the
+          # other three are unset. It resolves to HEAD, so rail computes an
+          # empty diff and the shell below falls through to "run all services".
+          since: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || github.sha }}
       - name: Discover affected ConformU services
         id: discover
         run: |

--- a/.github/workflows/conformu.yml
+++ b/.github/workflows/conformu.yml
@@ -3,10 +3,13 @@ name: ConformU
 permissions:
   contents: read
 
+# ConformU runs only at merge time via the GitHub merge queue, not on every PR
+# push. PR iteration is gated on fmt/clippy/unit/BDD/coverage (see check.yml and
+# test.yml); ConformU is the final pre-merge validation against the merged tree.
+# workflow_dispatch allows manual reruns when debugging conformance failures.
 on:
-  push:
-    branches: [main]
-  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   plan:
@@ -22,7 +25,7 @@ jobs:
       - uses: loadingalias/cargo-rail-action@v4
         id: rail
         with:
-          since: ${{ github.event.pull_request.base.sha || github.event.before }}
+          since: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
       - name: Discover affected ConformU services
         id: discover
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
-# This is the main CI workflow that runs the test suite on all pushes to main and all pull requests.
+# This is the main CI workflow that runs the test suite on all pull requests.
+# Pre-merge validation against the merged tree is handled by conformu.yml via
+# the GitHub merge queue; this workflow does not run on push: main.
 # It runs the following jobs:
 # - required: runs the test suite on ubuntu with the stable rust toolchain
 # - os-check: runs the test suite on mac and windows (workspace-level)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@
 # See check.yml for information about how the concurrency cancellation and workflow triggering works
 permissions:
   contents: read
+# Runs on PRs so unit/BDD/coverage signal is visible during iteration.
+# No push:main trigger — merge queue + conformu.yml handles pre-merge validation,
+# and re-running the full matrix on main after merge is duplicate spend.
 on:
-  push:
-    branches: [main]
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/docs/skills/pre-push.md
+++ b/docs/skills/pre-push.md
@@ -52,8 +52,10 @@ act -W .github/workflows/test.yml -j plan -j coverage &
 act -W .github/workflows/safety.yml -j plan -j sanitizers &
 wait
 
-# Then run jobs with dependencies
-act -W .github/workflows/conformu.yml -j plan -j conformu
+# Then run jobs with dependencies.
+# conformu.yml triggers on merge_group/workflow_dispatch only (not push),
+# so pass `workflow_dispatch` to simulate it locally.
+act workflow_dispatch -W .github/workflows/conformu.yml -j plan -j conformu
 
 # Optional: rolling jobs (these only run on main/scheduled, not PRs)
 act -W .github/workflows/scheduled.yml -j nightly &
@@ -176,10 +178,15 @@ RUSTFLAGS="-Z sanitizer=leak" \
 
 ### conformu.yml
 
+ConformU runs via the GitHub **merge queue** (`on: merge_group`), not on PR
+pushes. Unit/BDD/coverage gate PR iteration; ConformU is the final pre-merge
+validation against the merged tree when a PR is queued for merge. Use
+`workflow_dispatch` to rerun manually when debugging a queue failure.
+
 | CI Job | Local Command | Prerequisites | Required? |
 |--------|---------------|---------------|-----------|
 | **plan** | `cargo rail plan --merge-base` | cargo-rail | Yes (gates other jobs) |
-| **conformu** | Per-service command (see below) | ConformU | Optional |
+| **conformu** | Per-service command (see below) | ConformU | Yes (blocks merge) |
 
 ConformU services are discovered dynamically via `[package.metadata.conformu]`
 in each service's `Cargo.toml`. To list them:


### PR DESCRIPTION
## Summary

Moves ConformU off `pull_request` + `push: main` and onto `merge_group` so it runs once against the merged tree when a PR is queued for merge, blocking the merge if conformance regresses. PR iteration still gets the fast feedback it had before (fmt, clippy, unit, BDD, coverage). Also drops `push: main` from `test.yml` since merge queue already validates the merged commit.

- `conformu.yml`: `on: merge_group` + `workflow_dispatch`; adds `merge_group.base_sha` to the cargo-rail `since:` fallback chain so change detection works on queue events.
- `test.yml`: removes `push: main`, keeps `pull_request`.
- Docs: `docs/skills/pre-push.md` and `.claude/commands/pre-push.md` updated — `act` needs `workflow_dispatch` to drive conformu locally now that `push` isn't a trigger.

## Required follow-up in repo settings (not in this PR)

Merging this PR alone does nothing to merge behavior — the ruleset has to be updated too. After merge:

1. **Enable merge queue on `main`** in the `main_protection` ruleset (currently `enforcement: disabled`).
2. **Update required status checks** on that ruleset:
   - Keep PR-side: `stable / fmt`, `stable / clippy`, `ubuntu / stable`, `ubuntu / stable / coverage`, `ubuntu / stable / features`.
   - Add merge-queue-side ConformU contexts. Names to verify after the first queued PR (GitHub registers them as jobs run): `ubuntu-latest`, `macos-latest`, and the per-service `windows / <service>` matrix (`windows / filemonitor`, `windows / ppba-driver`, `windows / qhy-focuser`).
3. **Set `enforcement: active`** on `main_protection`.

The matrix job names depend on the contents of `[package.metadata.conformu]` across the workspace, so re-verify the windows contexts whenever a service is added or removed from conformu coverage.

## Tradeoffs acknowledged

- No conformance signal until you click "Merge when ready". The small cost of the cache miss + queue wall-clock is the price of not running conformu on every push.
- If a queued PR fails conformu, it's kicked out of the queue and you iterate from the PR branch. `workflow_dispatch` is there for manual reruns while debugging.

## Test plan

- [ ] After merge, enable merge queue + required checks + active enforcement in the ruleset.
- [ ] Open a throwaway PR that touches a conformu-covered service, queue it for merge, confirm `ConformU` jobs run against the merge commit and gate the merge.
- [ ] Confirm a normal PR push no longer triggers the `ConformU` workflow in the Actions tab.
- [ ] Run `act workflow_dispatch -W .github/workflows/conformu.yml -j plan -j conformu` locally and confirm it still executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)