### PR TITLE
Add calibrator-flats coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cross-platform [ASCOM Alpaca](https://ascom-standards.org/Developer/Alpaca.htm) 
 | [qhy-focuser](services/qhy-focuser) | ASCOM Focuser | 11113 | [![coverage][cov-qhy-focuser]][cov-qhy-focuser-link] | Driver for QHY Q-Focuser (EAF) |
 | [phd2-guider](services/phd2-guider) | Client library | — | [![coverage][cov-phd2-guider]][cov-phd2-guider-link] | Rust client for PHD2 autoguiding via JSON RPC |
 | [sentinel](services/sentinel) | Monitoring service | 11114 | [![coverage][cov-sentinel]][cov-sentinel-link] | Polls devices, sends notifications, serves web dashboard |
-| [calibrator-flats](services/calibrator-flats) | Orchestrator plugin | 11170 | | Flat field calibration with CoverCalibrator device |
+| [calibrator-flats](services/calibrator-flats) | Orchestrator plugin | 11170 | [![coverage][cov-calibrator-flats]][cov-calibrator-flats-link] | Flat field calibration with CoverCalibrator device |
 
 ### RP (Main Application)
 
@@ -176,3 +176,5 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT L
 [cov-phd2-guider-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=phd2-guider
 [cov-sentinel]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=sentinel
 [cov-sentinel-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=sentinel
+[cov-calibrator-flats]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=calibrator-flats
+[cov-calibrator-flats-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=calibrator-flats


### PR DESCRIPTION
## Summary
- Fill in the empty Coverage cell for the `calibrator-flats` row in the Services table with a Codecov badge, matching the pattern used by the other services.
- Add the corresponding `cov-calibrator-flats` / `cov-calibrator-flats-link` reference-link definitions at the bottom of `README.md`.

The coverage CI job (`.github/workflows/test.yml`) already iterates over every workspace package and uploads an lcov report to Codecov with a flag matching the package name, so `calibrator-flats` coverage data is already flowing — this PR just surfaces it in the README.

## Test plan
- [ ] After merge, confirm the badge renders on the repository's main page and resolves to the `calibrator-flats` flag on Codecov.