### PR TITLE
Refresh workspace.md and add duration-naming plans

### DIFF
--- a/docs/plans/duration-naming-convention.md
+++ b/docs/plans/duration-naming-convention.md
@@ -1,0 +1,107 @@
+# Plan: Align duration field names with the workspace convention
+
+## Background
+
+`docs/workspace.md` § "Coding Conventions / Duration Units" requires:
+
+- `_ms` suffix for sub-second precision.
+- `_secs` suffix for human-facing config values (note: `_secs`, not
+  `_seconds`).
+- Never use a bare `duration` or `timeout` field without a unit suffix.
+
+A grep across `services/*/src/**.rs` and `crates/*/src/**.rs` finds **8
+fields across 5 files** that violate the convention. All eight live in
+`#[derive(Serialize, Deserialize)]` types, so the renames touch on-disk
+sample configs and one PHD2 wire-protocol call site. There are no external
+users yet, so straight renames with no compatibility shims are fine.
+
+A separate follow-up — see
+[duration-type-migration.md](duration-type-migration.md) — considers
+switching these fields to `std::time::Duration` via `serde_with`. That is
+intentionally out of scope here; this plan only normalises the existing
+`u64`-based names.
+
+## Inventory
+
+### `_seconds` → `_secs`
+
+| File | Line | Field |
+|---|---|---|
+| `services/phd2-guider/src/config.rs` | 24 | `Phd2Config::connection_timeout_seconds` |
+| `services/phd2-guider/src/config.rs` | 26 | `Phd2Config::command_timeout_seconds` |
+| `services/phd2-guider/src/config.rs` | 46 | `ReconnectConfig::interval_seconds` |
+| `services/filemonitor/src/lib.rs` | 35 | `FileConfig::polling_interval_seconds` |
+| `services/qhy-focuser/src/config.rs` | 23 | `SerialConfig::timeout_seconds` |
+| `services/ppba-driver/src/config.rs` | 24 | `SerialConfig::timeout_seconds` |
+| `services/sentinel/src/config.rs` | 97 | `MonitorConfig::AlpacaSafetyMonitor::polling_interval_seconds` |
+
+### Bare → `_secs`
+
+| File | Line | Field |
+|---|---|---|
+| `services/phd2-guider/src/config.rs` | 108 | `SettleParams::time` |
+| `services/phd2-guider/src/config.rs` | 110 | `SettleParams::timeout` |
+
+## One constraint to be aware of
+
+`SettleParams::time` and `SettleParams::timeout` are also used to build the
+PHD2 JSON-RPC `settle` payload at `services/phd2-guider/src/client.rs:
+373-374, 466-467, 917-918`. PHD2's wire protocol requires the literal keys
+`"time"` and `"timeout"`. The `serde_json::json!` macro takes literal keys,
+so renaming the Rust struct fields does not change the wire format —
+the `json!` calls just need to read from `settle.time_secs` /
+`settle.timeout_secs` instead.
+
+## Stepwise plan
+
+Per service, the loop is:
+
+1. Rename the field in the struct definition.
+2. Rename the matching `default_*` fn (e.g. `default_command_timeout` →
+   `default_command_timeout_secs`) so reader and constructor stay
+   parallel.
+3. Update every call site: constructors, `Default` impls, tests,
+   doctests, example code in lib.rs module comments.
+4. Update sample `config.json` files in lockstep.
+5. Update the service's design doc / README if either spells the old
+   field name.
+6. Run `cargo rail run --merge-base -q -- --color never` and `cargo fmt
+   --all` (CLAUDE.md rule 4); fix anything red.
+
+### Per-service notes
+
+- **filemonitor** — one field. Sample configs:
+  `services/filemonitor/pkg/config.json`,
+  `services/filemonitor/tests/config.json`. Tests in `lib.rs` reference
+  the field by name in proptest fixtures (~line 432+); update those too.
+- **ppba-driver** — `SerialConfig::timeout_seconds` plus `default_timeout`
+  and tests at `config.rs:171, 211, 222`. Sample config:
+  `services/ppba-driver/config.json`.
+- **qhy-focuser** — same shape as ppba-driver. Sample config:
+  `services/qhy-focuser/config.json`. Tests at `config.rs:142, 168`.
+- **sentinel** — field lives inside an enum variant; check the
+  serialisation tests at `config.rs:280, 313, 341, 354, 377`. Sample
+  config: `services/sentinel/examples/config.json`.
+- **phd2-guider** — three `_seconds` renames plus `SettleParams`. Touch
+  points:
+  - `client.rs` `json!` calls — keep wire keys literal, read new field
+    names from the struct.
+  - Doctest in `lib.rs:22` and any other rustdoc samples.
+  - Sample config: `services/phd2-guider/tests/config.json`.
+
+## Out of scope
+
+- Switching to `std::time::Duration` — see
+  [duration-type-migration.md](duration-type-migration.md).
+- Re-auditing fields that already comply (e.g. `polling_interval_ms`,
+  `poll_interval_secs`).
+
+## Acceptance
+
+- `grep -RIn '_seconds\b' services/*/src crates/*/src` returns no struct
+  fields.
+- `grep -RIn 'pub time:\|pub timeout:\|pub duration:\|pub interval:'
+  services/*/src crates/*/src` returns no production-config types.
+- `cargo rail run --merge-base -q -- --color never` is green.
+- Sample config files round-trip via `serde_json::from_str::<Config>` in
+  the existing config tests.

--- a/docs/plans/duration-naming-convention.md
+++ b/docs/plans/duration-naming-convention.md
@@ -9,8 +9,9 @@
   `_seconds`).
 - Never use a bare `duration` or `timeout` field without a unit suffix.
 
-A grep across `services/*/src/**.rs` and `crates/*/src/**.rs` finds **8
-fields across 5 files** that violate the convention. All eight live in
+A grep across `services/*/src/**.rs` and `crates/*/src/**.rs` finds **9
+fields across 5 files** that violate the convention (7 use `_seconds`
+instead of `_secs`; 2 are bare). All nine live in
 `#[derive(Serialize, Deserialize)]` types, so the renames touch on-disk
 sample configs and one PHD2 wire-protocol call site. There are no external
 users yet, so straight renames with no compatibility shims are fine.

--- a/docs/plans/duration-type-migration.md
+++ b/docs/plans/duration-type-migration.md
@@ -1,0 +1,177 @@
+# Plan: Migrate config duration fields to `std::time::Duration`
+
+## Background
+
+This is a **follow-up** to
+[duration-naming-convention.md](duration-naming-convention.md). That plan
+normalises the names of `u64`/`u32` duration fields (`_seconds` → `_secs`,
+no bare `time` / `timeout`). This plan picks up after that lands and
+considers replacing the underlying type with `std::time::Duration`.
+
+The codebase already uses `Duration` everywhere at runtime — any time we
+call `tokio::time::sleep`, set a `reqwest` timeout, or build a polling
+loop, we wrap the config integer in `Duration::from_secs(...)` /
+`Duration::from_millis(...)`. The only place `Duration` is *not* used is
+in serde-deserialised config structs, where the type is currently `u64` /
+`u32` plus a unit-suffixed name.
+
+The motivation for switching is type safety: a `Duration` field cannot be
+silently mixed with a different-unit integer at a call site, and the
+`Duration::from_secs()` wrap at every consumer goes away.
+
+## Why a separate PR
+
+- It's a wider refactor (every call site that wraps these fields in
+  `Duration::from_*` gets simplified, plus tests need new assertion
+  shapes).
+- It introduces a new workspace dependency (`serde_with`).
+- It changes the documented coding convention in `docs/workspace.md`
+  ("always include the unit suffix in the field name") — that rule
+  becomes either softened or scoped to "fields that aren't `Duration`".
+- The naming-only PR is small, mechanical, and reviewable; bundling
+  would obscure what's a rename and what's a real semantic change.
+
+## Approach
+
+Use `serde_with`'s `DurationSeconds<u64>` / `DurationMilliSeconds<u64>`
+adapters so the JSON wire format stays a bare integer (no breakage of
+existing sample configs, no new format for users to learn). Example:
+
+```rust
+use serde_with::{serde_as, DurationSeconds};
+use std::time::Duration;
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Phd2Config {
+    #[serde_as(as = "DurationSeconds<u64>")]
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout: Duration,
+    // …
+}
+
+fn default_connection_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+```
+
+The wire format remains `"connection_timeout": 10`. Internal call sites
+that previously wrote `Duration::from_secs(cfg.connection_timeout_secs)`
+become just `cfg.connection_timeout`.
+
+### Alternative considered: `humantime-serde`
+
+`humantime-serde` lets users write `"5m30s"` strings in JSON. Rejected
+because it changes the wire format (string instead of integer), which
+would break the PHD2 `SettleParams` use — PHD2's JSON-RPC protocol
+requires integer `"time"` / `"timeout"` keys. Sticking with
+`DurationSeconds<u64>` keeps PHD2 happy.
+
+### Alternative considered: hand-rolled `#[serde(with = "...")]`
+
+Workable, ~10 lines of helper module per unit. Rejected as a small,
+consistent dep is preferable to maintaining serde glue ourselves.
+
+## Naming convention update
+
+Once fields are `Duration`, the unit suffix in the field name is no
+longer load-bearing — the type carries the unit. Two options:
+
+1. **Drop the suffix** (`connection_timeout: Duration`,
+   `polling_interval: Duration`). Cleaner, but the JSON key changes
+   shape (e.g. `connection_timeout_secs` → `connection_timeout`). With
+   no external users today, that's safe.
+2. **Keep the suffix** to document the JSON representation
+   (`connection_timeout_secs: Duration` with `DurationSeconds<u64>`).
+   Slightly redundant but minimises churn — the JSON keys land at the
+   same names as the rename PR.
+
+Option 1 is preferable long-term. Pick one and update
+`docs/workspace.md` § "Duration Units" accordingly:
+
+- The rule "always include the unit suffix in the field name" becomes
+  "include the unit suffix in the field name **when the field type is
+  not `Duration`**".
+- Add a paragraph: "For new code, prefer `std::time::Duration` with a
+  `serde_with::DurationSeconds<u64>` / `DurationMilliSeconds<u64>`
+  adapter. The unit suffix is then unnecessary — the type carries the
+  unit."
+
+## Inventory
+
+The same eight fields covered by the rename PR, post-rename:
+
+| File | Field (post-rename) | Adapter |
+|---|---|---|
+| `services/phd2-guider/src/config.rs` | `Phd2Config::connection_timeout_secs` | `DurationSeconds<u64>` |
+| `services/phd2-guider/src/config.rs` | `Phd2Config::command_timeout_secs` | `DurationSeconds<u64>` |
+| `services/phd2-guider/src/config.rs` | `ReconnectConfig::interval_secs` | `DurationSeconds<u64>` |
+| `services/phd2-guider/src/config.rs` | `SettleParams::time_secs` | `DurationSeconds<u64>` |
+| `services/phd2-guider/src/config.rs` | `SettleParams::timeout_secs` | `DurationSeconds<u64>` |
+| `services/filemonitor/src/lib.rs` | `FileConfig::polling_interval_secs` | `DurationSeconds<u64>` |
+| `services/qhy-focuser/src/config.rs` | `SerialConfig::timeout_secs` | `DurationSeconds<u64>` |
+| `services/ppba-driver/src/config.rs` | `SerialConfig::timeout_secs` | `DurationSeconds<u64>` |
+| `services/sentinel/src/config.rs` | `MonitorConfig::AlpacaSafetyMonitor::polling_interval_secs` | `DurationSeconds<u64>` |
+
+(One additional candidate exists today as `polling_interval_ms` in
+`qhy-focuser/src/config.rs:21`. It already uses `_ms` and complies, but
+when migrating to `Duration` it would use `DurationMilliSeconds<u64>`.)
+
+## PHD2 wire-protocol check
+
+`SettleParams::time_secs` and `SettleParams::timeout_secs` feed the
+`json!` macro at `services/phd2-guider/src/client.rs:373-374, 466-467,
+917-918` to construct the PHD2 settle payload. After migration, those
+calls need to convert back to integer seconds:
+
+```rust
+"time": settle.time_secs.as_secs(),
+"timeout": settle.timeout_secs.as_secs(),
+```
+
+That's a single-token edit at each site, but easy to miss — add it to
+the PR checklist.
+
+## Stepwise plan
+
+1. Add `serde_with` (latest stable 3.x) to `[workspace.dependencies]` in
+   the root `Cargo.toml` per CLAUDE.md rule 10. Re-run
+   `CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh `MODULE.bazel.lock`.
+2. Decide naming policy (Option 1 — drop suffix — recommended) and
+   update `docs/workspace.md` § "Duration Units" in the same PR.
+3. For each service's config.rs:
+   - Pull in `use serde_with::{serde_as, DurationSeconds};` and
+     `use std::time::Duration;`.
+   - Annotate the struct with `#[serde_as]`, change the field type to
+     `Duration`, and add `#[serde_as(as = "DurationSeconds<u64>")]`.
+   - Update `default_*` fns to return `Duration::from_secs(N)`.
+4. Update all call sites that previously wrapped the field in
+   `Duration::from_secs(...)` — drop the wrap. A grep for
+   `Duration::from_secs.*\.connection_timeout` etc. will find them.
+5. Update the PHD2 `client.rs` `json!` calls per the section above.
+6. Update tests:
+   - Equality assertions need `Duration::from_secs(N)`, not bare
+     integers.
+   - Sample config tests round-trip via `serde_json::from_str::<Config>`
+     and back.
+7. Sample `config.json` files: no change needed if option 1 keeps wire
+   integers (which it does with `DurationSeconds<u64>`).
+8. Run `cargo rail run --merge-base -q -- --color never` and
+   `cargo fmt --all`. Fix anything red.
+
+## Acceptance
+
+- New workspace dep `serde_with` is in `[workspace.dependencies]`.
+- All eight target fields are typed `Duration`.
+- No `Duration::from_secs(cfg.<field>)` patterns remain — direct field
+  access only.
+- `docs/workspace.md` § "Duration Units" reflects the new policy.
+- `cargo rail run --merge-base -q -- --color never` is green.
+- All sample `config.json` files still deserialise without modification.
+
+## Out of scope
+
+- Migrating runtime-only `Duration` usages (already `Duration` today).
+- Adding a `humantime` representation as an opt-in alternative — punt
+  to a separate decision if user-facing string durations become
+  desirable.

--- a/docs/plans/duration-type-migration.md
+++ b/docs/plans/duration-type-migration.md
@@ -99,7 +99,7 @@ Option 1 is preferable long-term. Pick one and update
 
 ## Inventory
 
-The same eight fields covered by the rename PR, post-rename:
+The same nine fields covered by the rename PR, post-rename:
 
 | File | Field (post-rename) | Adapter |
 |---|---|---|
@@ -154,20 +154,29 @@ the PR checklist.
      integers.
    - Sample config tests round-trip via `serde_json::from_str::<Config>`
      and back.
-7. Sample `config.json` files: no change needed if option 1 keeps wire
-   integers (which it does with `DurationSeconds<u64>`).
+7. Sample `config.json` files:
+   - `DurationSeconds<u64>` keeps the **integer values** unchanged in
+     JSON — no value rewrites.
+   - The **JSON key names** are decided by the naming choice above:
+     - Option 1 (drop suffix) → keys change in lockstep
+       (`connection_timeout_secs` → `connection_timeout`); update every
+       sample `config.json`.
+     - Option 2 (keep suffix) → keys stay identical to the rename PR;
+       sample configs untouched.
 8. Run `cargo rail run --merge-base -q -- --color never` and
    `cargo fmt --all`. Fix anything red.
 
 ## Acceptance
 
 - New workspace dep `serde_with` is in `[workspace.dependencies]`.
-- All eight target fields are typed `Duration`.
+- All nine target fields are typed `Duration`.
 - No `Duration::from_secs(cfg.<field>)` patterns remain — direct field
   access only.
 - `docs/workspace.md` § "Duration Units" reflects the new policy.
 - `cargo rail run --merge-base -q -- --color never` is green.
-- All sample `config.json` files still deserialise without modification.
+- All sample `config.json` files still deserialise — value formats are
+  unchanged; key names only change if Option 1 (drop suffix) is chosen,
+  in which case every sample is updated in the same PR.
 
 ## Out of scope
 

--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -28,7 +28,7 @@ AlpacaSafetyMonitor   PushoverNotifier
 SharedState (Arc<RwLock>) <-- Engine updates
      |
      v
-Dashboard (axum + Leptos SSR) --- reactive web UI
+Dashboard (axum + hand-rolled HTML) --- web UI w/ JS polling
 ```
 
 ### Key Traits

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -15,7 +15,7 @@ belong in any single service design doc.
 | [sentinel](services/sentinel.md) | — (monitoring service) | 11114 | `docs/services/sentinel.md` |
 | [rp](services/rp.md) | — (orchestrator) | 11115 | `docs/services/rp.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
-| sentinel-app | — (Leptos frontend; `cargo leptos` build target `sentinel-dashboard`) | served by sentinel on 11114 | — |
+| sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |
 
 ## Documentation Index
 
@@ -136,13 +136,20 @@ main.rs      — Entry point
 
 ### Monitoring service + Leptos frontend (sentinel, sentinel-app)
 
-`sentinel` is the standalone Axum + reqwest backend. `sentinel-app` is a
-separate Leptos crate (`cdylib + rlib`) wired to `sentinel` via the
-`[[workspace.metadata.leptos]]` block at the workspace root, intended to be
-built and served through `cargo leptos` (build target name
-`sentinel-dashboard`). At present the `sentinel` binary does not directly
-depend on the `sentinel-app` crate — the integration is declared but not
-yet wired into the `sentinel` Axum router.
+`sentinel` is a standalone Axum + reqwest backend. The dashboard at
+`http://127.0.0.1:11114/` works today, but it is **not** Leptos: it's
+hand-rolled HTML built with `format!()` in
+`services/sentinel/src/dashboard.rs`, refreshed client-side by a vanilla
+`fetch()` loop hitting `/api/status` and `/api/history` every five seconds.
+
+`sentinel-app` is a separate Leptos crate (`cdylib + rlib`) intended to
+replace that hand-rolled UI in the future, via `cargo leptos` (build
+target `sentinel-dashboard`, declared in the workspace-root
+`[[workspace.metadata.leptos]]` block). At present the `sentinel` binary
+does **not** depend on `sentinel-app`, on `leptos`, on `leptos_axum`, or
+on any static-file middleware (`tower-http` is pulled with `["cors"]`
+only) — the integration is scaffolded in workspace metadata but not yet
+in code.
 
 ```
 sentinel/src/

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -15,7 +15,7 @@ belong in any single service design doc.
 | [sentinel](services/sentinel.md) | — (monitoring service) | 11114 | `docs/services/sentinel.md` |
 | [rp](services/rp.md) | — (orchestrator) | 11115 | `docs/services/rp.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
-| sentinel-app | — (Leptos web frontend for sentinel) | — | — |
+| sentinel-app | — (Leptos frontend; `cargo leptos` build target `sentinel-dashboard`) | served by sentinel on 11114 | — |
 
 ## Documentation Index
 
@@ -29,8 +29,17 @@ belong in any single service design doc.
 | [docs/skills/pre-push.md](skills/pre-push.md) | Skill: running CI quality gates before pushing |
 | **References** | |
 | [docs/references/ascom-alpaca.md](references/ascom-alpaca.md) | ASCOM Alpaca protocol reference |
-| **Decisions** | |
-| [docs/decisions/](decisions/) | Architecture Decision Records |
+| **Decisions** (Architecture Decision Records — see [docs/decisions/](decisions/)) | |
+| [ADR-001](decisions/001-fits-file-support.md) | FITS file support |
+| [ADR-002](decisions/002-tls-for-inter-service-communication.md) | TLS for inter-service communication |
+| [ADR-003](decisions/003-authentication-for-device-access.md) | Authentication for device access |
+| **Plans** (in-flight initiatives — see [docs/plans/](plans/)) | |
+| [bazel-migration.md](plans/bazel-migration.md) | Bazel build alongside Cargo (shadow mode) |
+| [build-optimization-test-reorganization.md](plans/build-optimization-test-reorganization.md) | Build/test reorganization |
+| [duration-naming-convention.md](plans/duration-naming-convention.md) | Rename `_seconds` → `_secs` and bare duration fields |
+| [duration-type-migration.md](plans/duration-type-migration.md) | Follow-up: switch config duration fields to `std::time::Duration` |
+| [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
+| [migrate-test-harnesses-to-bdd-infra.md](plans/migrate-test-harnesses-to-bdd-infra.md) | Migrate per-service BDD harnesses to `bdd-infra` |
 
 ## Shared Crates
 
@@ -78,33 +87,92 @@ generates JSON Schema from parameter structs via `schemars::JsonSchema`.
 ### Serial-based services (ppba-driver, qhy-focuser)
 
 ```
+config.rs      — Configuration types and JSON loading
+error.rs       — Service-specific error enum (thiserror)
 io.rs          — Traits (SerialReader, SerialWriter, SerialPortFactory)
 serial.rs      — tokio-serial implementation of the traits
+mock.rs        — In-memory mock factory (cfg(feature = "mock"))
+protocol.rs    — Wire-format encode/decode for the device's serial protocol
 serial_manager.rs — Ref-counted connection + background polling
 *_device.rs    — ASCOM trait implementation
 lib.rs         — ServerBuilder (CLI args → server)
 main.rs        — Entry point
 ```
 
+ppba-driver additionally has `switches.rs` (Switch device wiring) and
+`mean.rs` (running-mean smoothing for ObservingConditions readings).
+
 ### HTTP gateway services (rp)
 
 ```
-config.rs      — Configuration types and loading
-equipment.rs   — EquipmentRegistry, ASCOM Alpaca client
-events.rs      — EventBus, webhook delivery
-mcp.rs         — rmcp tool_router: #[tool] methods, ServerHandler impl
-session.rs     — SessionManager, orchestrator invocation
-routes.rs      — Axum router (REST + MCP endpoints)
-lib.rs         — ServerBuilder (two-phase: build → start)
-main.rs        — Entry point
+config.rs            — Configuration types and loading
+error.rs             — RpError enum + Result alias (thiserror)
+equipment.rs         — EquipmentRegistry, ASCOM Alpaca client
+events.rs            — EventBus, webhook delivery
+imaging.rs           — FITS read/write and pixel statistics
+mcp.rs               — rmcp tool_router: #[tool] methods, ServerHandler impl
+session.rs           — SessionManager, orchestrator invocation
+routes.rs            — Axum router (REST + MCP endpoints)
+hash_password_cmd.rs — `rp hash-password` subcommand (Argon2id hashing)
+tls_cmd.rs           — `rp init-tls` subcommand (CA + per-service certs)
+lib.rs               — ServerBuilder (two-phase: build → start)
+main.rs              — Entry point
+```
+
+### Orchestrator plugins (calibrator-flats)
+
+Plugins act as MCP clients of `rp` and expose an HTTP `/invoke` endpoint that
+`rp` calls when a session is started.
+
+```
+config.rs    — Plugin config + FlatPlan request schema
+error.rs     — CalibratorFlatsError enum
+mcp_client.rs — rmcp StreamableHttpClient wrapper for calling rp's tools
+workflow.rs  — Iterative exposure optimization + batch capture state machine
+routes.rs    — Axum router: GET /health, POST /invoke
+lib.rs       — Plugin server bootstrap
+main.rs      — Entry point
+```
+
+### Monitoring service + Leptos frontend (sentinel, sentinel-app)
+
+`sentinel` is the standalone Axum + reqwest backend. `sentinel-app` is a
+separate Leptos crate (`cdylib + rlib`) wired to `sentinel` via the
+`[[workspace.metadata.leptos]]` block at the workspace root, intended to be
+built and served through `cargo leptos` (build target name
+`sentinel-dashboard`). At present the `sentinel` binary does not directly
+depend on the `sentinel-app` crate — the integration is declared but not
+yet wired into the `sentinel` Axum router.
+
+```
+sentinel/src/
+  config.rs        — Config types: monitors, notifiers, dashboard
+  error.rs         — SentinelError enum
+  io.rs            — HTTP client trait abstraction (testability)
+  alpaca_client.rs — ASCOM Alpaca SafetyMonitor client
+  monitor.rs       — Monitor trait + state types
+  pushover.rs      — Pushover notifier
+  notifier.rs      — Notifier trait
+  state.rs         — Shared monitor status + notification history
+  engine.rs        — Orchestrates monitors, transitions, notifiers
+  dashboard.rs     — Axum routes for JSON API + dashboard HTML
+  lib.rs / main.rs — Server bootstrap and entry point
+
+sentinel-app/src/
+  lib.rs           — Crate root (re-exports App)
+  app.rs           — Root Leptos component
+  api.rs           — Client-side API helpers
+  components/      — monitor_table, history_table, status_badge
 ```
 
 ## MSRV
 
-| Service | rust-version |
-|---------|-------------|
-| phd2-guider | 1.85.0 |
-| filemonitor, ppba-driver, qhy-focuser, rp, sentinel, sentinel-app | 1.88.0 |
+The minimum supported Rust version is pinned in `[workspace.package]` of the
+root `Cargo.toml` (`rust-version = "1.94.1"`). All workspace members —
+services (`filemonitor`, `phd2-guider`, `ppba-driver`, `qhy-focuser`,
+`calibrator-flats`, `rp`, `sentinel`, `sentinel-app`) and shared crates
+(`bdd-infra`, `rp-auth`, `rp-tls`) — inherit it via
+`rust-version.workspace = true`.
 
 ## Workspace Dependencies
 
@@ -114,10 +182,19 @@ reference them with `dep.workspace = true`.
 
 ### Pre-commit hooks
 
-The workspace uses `cargo-husky` as a dev-dependency with `precommit-hook`,
-`run-cargo-fmt`, `run-cargo-clippy`, and `run-for-all` features. This
-automatically installs a git pre-commit hook that runs `cargo fmt` and
-`cargo clippy` on every commit.
+The workspace uses `cargo-husky` as a dev-dependency configured with
+`default-features = false` and the `precommit-hook` + `user-hooks` features
+(see root `Cargo.toml`). The `user-hooks` feature tells `cargo-husky` to
+install a custom hook script kept in the repo at
+`.cargo-husky/hooks/pre-commit`, which currently runs:
+
+```sh
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+The hook is installed automatically the first time any test build pulls
+`cargo-husky` in as a dev-dependency.
 
 ## Coding Conventions
 
@@ -139,11 +216,31 @@ Never use a bare `duration` or `timeout` field without a unit suffix.
 - **`mock`** — Enables `MockSerialPortFactory` with persistent state for
   integration testing (ConformU, server tests). Used by ppba-driver and
   qhy-focuser. Not used for unit tests — those define inline mocks.
-- **`hydrate`** / **`ssr`** — Leptos rendering modes for sentinel-app.
-  `ssr` is used by the sentinel binary for server-side rendering; `hydrate`
-  is for future WASM-hydrated frontend builds.
+- **`hydrate`** / **`ssr`** — Leptos rendering modes for `sentinel-app`.
+  `ssr` is intended for native compilation linked into a server binary;
+  `hydrate` is intended for `wasm32-unknown-unknown` + wasm-bindgen
+  client-side hydration. The `sentinel` binary does not yet link
+  `sentinel-app` in either mode — `cargo build -p sentinel-app` exercises
+  the crate in isolation pending the integration work.
 
 ## Build Notes
 
 - The `ascom-alpaca` crate is a git dependency from
-  `ivonnyssen/ascom-alpaca-rs.git` (branch `fix/macos-trait-recursion-overflow`).
+  `ivonnyssen/ascom-alpaca-rs.git` (branch `integration`,
+  `default-features = false`).
+
+### Bazel (shadow mode)
+
+A Bazel build is being introduced alongside Cargo — see
+[docs/plans/bazel-migration.md](plans/bazel-migration.md). Cargo remains the
+canonical build system during the migration: `Cargo.toml` and `Cargo.lock`
+are the single source of truth for dependency versions, and Bazel's
+`crate_universe` reads them. The repo root holds `MODULE.bazel` and
+`BUILD.bazel`; `bazel test //...` runs all non-`requires-cargo`, non-BDD
+targets. Bazel is **not** a required pre-push gate yet — the canonical
+pre-push command is still `cargo rail run --merge-base` (see
+[docs/skills/pre-push.md](skills/pre-push.md)).
+
+After adding a crates.io dependency to the workspace, run
+`CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh `MODULE.bazel.lock` before
+committing.

--- a/services/sentinel/src/dashboard.rs
+++ b/services/sentinel/src/dashboard.rs
@@ -1,4 +1,4 @@
-//! Web dashboard with JSON API endpoints and Leptos SSR
+//! Web dashboard with JSON API endpoints (hand-rolled HTML + JS polling)
 
 use axum::extract::State;
 use axum::response::{Html, IntoResponse};


### PR DESCRIPTION
Audit-driven update to docs/workspace.md to match current code:
- MSRV: collapsed table; all members inherit workspace pin 1.94.1.
- Build Notes: ascom-alpaca branch is now `integration`, not `fix/macos-trait-recursion-overflow`.
- Pre-commit hooks: cargo-husky now uses `precommit-hook` + `user-hooks` (custom script in `.cargo-husky/hooks/pre-commit`).
- HTTP gateway pattern (rp): added error.rs, imaging.rs, hash_password_cmd.rs, tls_cmd.rs.
- Serial-driver pattern: added config.rs, error.rs, mock.rs, protocol.rs; noted ppba-driver-specific switches.rs / mean.rs.
- Added architecture sections for orchestrator plugins (calibrator-flats) and the sentinel + sentinel-app split, including the current not-yet-wired Leptos integration gap.
- Added Bazel shadow-mode subsection linking the migration plan.
- Documentation Index now enumerates ADRs and the in-flight plans under docs/plans/.
- Services table: clarified that sentinel-app is served by sentinel on 11114 via cargo leptos.
- Feature Flags: corrected ssr/hydrate description to reflect that sentinel does not yet link sentinel-app.

Two new plan documents in docs/plans/ for the next refactor:
- duration-naming-convention.md: rename `_seconds` -> `_secs` and remove bare `time`/`timeout` fields across 8 fields in 5 files.
- duration-type-migration.md: follow-up to switch those fields to std::time::Duration via serde_with's DurationSeconds<u64>.