### PR TITLE
Schedule nightly Bazel build to keep BuildBuddy cache warm

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,6 +11,14 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Nightly run from main keeps the BuildBuddy remote cache warm.
+  # BuildBuddy uses LRU eviction on a shared free-tier cache with no
+  # documented retention guarantee, so quiet stretches on main let
+  # action results age out and PRs pay the full uncached cost. A daily
+  # main-equivalent build refreshes last-used timestamps and re-uploads
+  # anything that did get evicted.
+  schedule:
+    - cron: "7 7 * * *"
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -32,11 +40,13 @@ jobs:
       run:
         shell: bash
     env:
-      # Read+write key on push to main populates the cache from trusted code.
-      # Read-only key on pull requests prevents cache poisoning from forks.
-      # Empty for fork PRs (secrets not exposed); steps below detect this and
-      # skip --config=remote-cache so the job still provides build signal.
-      BUILDBUDDY_API_KEY: ${{ github.event_name == 'push' && secrets.BUILDBUDDY_API_KEY || secrets.BUILDBUDDY_API_KEY_READONLY }}
+      # Read+write key on push to main and on the nightly schedule populates
+      # the cache from trusted code (scheduled runs always execute against the
+      # default branch). Read-only key on pull requests prevents cache
+      # poisoning from forks. Empty for fork PRs (secrets not exposed); steps
+      # below detect this and skip --config=remote-cache so the job still
+      # provides build signal.
+      BUILDBUDDY_API_KEY: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && secrets.BUILDBUDDY_API_KEY || secrets.BUILDBUDDY_API_KEY_READONLY }}
     steps:
       - uses: actions/checkout@v5
 

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -100,8 +100,8 @@ repo root/
 **Exit criteria:** `bazel build //services/sentinel-app:sentinel_app_wasm` produces the same `.wasm` + JS bindings that `cargo leptos build` does today.
 
 ### Phase 5 — Remote cache + CI (DONE)
-- [x] `.github/workflows/bazel.yml` — triggers on PR + push to main, runs `bazel test //...` with remote cache.
-- [x] BuildBuddy free tier credentials in GHA secrets (`BUILDBUDDY_API_KEY` read+write for push to main, `BUILDBUDDY_API_KEY_READONLY` for PRs to prevent cache poisoning).
+- [x] `.github/workflows/bazel.yml` — triggers on PR, push to main, and a nightly schedule (07:07 UTC), runs `bazel test //...` with remote cache. The nightly run keeps the BuildBuddy LRU warm during quiet stretches on main: free-tier eviction is capacity-driven with no documented retention, and PR builds use a read-only key so they cannot repopulate the cache themselves.
+- [x] BuildBuddy free tier credentials in GHA secrets (`BUILDBUDDY_API_KEY` read+write for push to main and the nightly schedule, `BUILDBUDDY_API_KEY_READONLY` for PRs to prevent cache poisoning).
 - [x] Shadow mode: job is **not required** for merges; runs alongside Cargo jobs for 2+ weeks of parity validation.
 - [ ] Compare wall-clock and correctness against Cargo jobs weekly.
 


### PR DESCRIPTION
## Summary

- Adds a daily `schedule:` trigger (07:07 UTC, matching `scheduled.yml`) to `.github/workflows/bazel.yml` so main re-runs `bazel build/test //...` even on quiet days.
- Updates the `BUILDBUDDY_API_KEY` env conditional so scheduled runs use the read+write key (scheduled GHA workflows always run from the default branch, so this is safe).
- Updates `docs/plans/bazel-migration.md` Phase 5 description to reflect the three triggers.

## Why

BuildBuddy's free tier evicts via LRU on shared capacity with no published retention guarantee. PR #91 (docs-mostly) hit a cold cache 4.5 days after the previous main push and rebuilt from scratch — `0 remote cache hits, 1255 sandbox actions, ~7.5 min on ubuntu-latest` vs `1232 hits, 23 sandbox actions, ~2 min` when warm. PRs use `BUILDBUDDY_API_KEY_READONLY` (cache-poisoning mitigation for forks), so they cannot refill the cache themselves; only main pushes can. A nightly main build keeps last-used timestamps fresh and re-uploads anything that did get evicted.

## Test plan

- [ ] Merge to main → first scheduled run fires at 07:07 UTC and writes to BuildBuddy (verify in BuildBuddy invocation page).
- [ ] Subsequent PR builds against main show the usual `~1232 remote cache hit, ~547 internal, ~23 processwrapper-sandbox` stats line on ubuntu (similar shape on macos/windows).
- [ ] PR builds against this branch still use the read-only key (no `BUILDBUDDY_API_KEY` written in PR-event jobs) — verify by checking the workflow's invocation log shows the `--remote_upload_local_results … not authorized` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)