### PR TITLE
Trim redundant Cargo.toml entries from MODULE.bazel manifests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,20 +38,7 @@ crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
 crate.from_cargo(
     name = "cr",
     cargo_lockfile = "//:Cargo.lock",
-    manifests = [
-        "//:Cargo.toml",
-        "//crates/bdd-infra:Cargo.toml",
-        "//crates/rp-auth:Cargo.toml",
-        "//crates/rp-tls:Cargo.toml",
-        "//services/calibrator-flats:Cargo.toml",
-        "//services/filemonitor:Cargo.toml",
-        "//services/phd2-guider:Cargo.toml",
-        "//services/ppba-driver:Cargo.toml",
-        "//services/qhy-focuser:Cargo.toml",
-        "//services/rp:Cargo.toml",
-        "//services/sentinel:Cargo.toml",
-        "//services/sentinel-app:Cargo.toml",
-    ],
+    manifests = ["//:Cargo.toml"],
 )
 
 # aws-lc-sys vendors a large C library (aws-lc/) and compiles it via the

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2828,7 +2828,7 @@
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
         "bzlTransitiveDigest": "rfE0u75zINNeKkkOlA4SVDGiXInBayQhrBpkJDrccp4=",
-        "usagesDigest": "a2oup/LPdcoz64doK5PugiHyLJ7rDETXu/God8v6aaE=",
+        "usagesDigest": "6qni3jvstpF/aGbXbYi3ZaJKVny4hFi1ss0PrSsuerU=",
         "recordedFileInputs": {
           "@@//Cargo.lock": "458fdbe2c3cafe7984cc2b037ab0500cb83ef0c32b1e93572653c509e43ab96d",
           "@@//Cargo.toml": "9a03dbbf874885a5478205bf34d7926d47ef511975ef4c9e458f1b618ea4c18e",

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -50,7 +50,7 @@ repo root/
     └── BUILD.bazel
 ```
 
-**Dependency resolution.** `MODULE.bazel` uses `crate.from_cargo(manifests = ["//:Cargo.toml", ...])`. Cargo.toml and Cargo.lock stay as single source of truth. Adding a dep is still `cargo add`, followed by `CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh the Bazel crate index.
+**Dependency resolution.** `MODULE.bazel` uses `crate.from_cargo(manifests = ["//:Cargo.toml"])` — only the workspace root manifest is listed; `crate_universe` follows `[workspace.members]` to discover the rest. Cargo.toml and Cargo.lock stay as single source of truth. Adding a dep is still `cargo add`, followed by `CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh the Bazel crate index. Adding a new workspace member does **not** require editing `MODULE.bazel`.
 
 **Known limitation.** rules_rust issue #1574: `workspace.dependencies` inheritance has edge cases in `crate_universe`. Mitigation: if repin fails on a specific crate, declare that crate directly in MODULE.bazel with `crate.spec(...)`. Track cases in this file as they arise.
 

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -50,7 +50,7 @@ repo root/
     └── BUILD.bazel
 ```
 
-**Dependency resolution.** `MODULE.bazel` uses `crate.from_cargo(manifests = ["//:Cargo.toml"])` — only the workspace root manifest is listed; `crate_universe` follows `[workspace.members]` to discover the rest. Cargo.toml and Cargo.lock stay as single source of truth. Adding a dep is still `cargo add`, followed by `CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh the Bazel crate index. Adding a new workspace member does **not** require editing `MODULE.bazel`.
+**Dependency resolution.** `MODULE.bazel` uses `crate.from_cargo(manifests = ["//:Cargo.toml"])` — only the workspace root manifest is listed; `crate_universe` follows the `members` field in `[workspace]` to discover the rest. Cargo.toml and Cargo.lock stay as single source of truth. Adding a dep is still `cargo add`, followed by `CARGO_BAZEL_REPIN=1 bazel mod tidy` to refresh the Bazel crate index. Adding a new workspace member does **not** require editing `MODULE.bazel`.
 
 **Known limitation.** rules_rust issue #1574: `workspace.dependencies` inheritance has edge cases in `crate_universe`. Mitigation: if repin fails on a specific crate, declare that crate directly in MODULE.bazel with `crate.spec(...)`. Track cases in this file as they arise.
 


### PR DESCRIPTION
## Summary
- Reduce `crate.from_cargo(manifests = [...])` in `MODULE.bazel` to just `["//:Cargo.toml"]`. `crate_universe` already discovers workspace members via the root manifest's `[workspace.members]`, so per-member entries were redundant — `bazel mod tidy` had been emitting an advisory to that effect. Adding a new workspace member no longer requires touching `MODULE.bazel`.
- Repin `MODULE.bazel.lock`. The diff also catches up from #90 (which refreshed `Cargo.lock` to drop `rust-openssl` but did not repin Bazel): `toml_writer` drops from the resolved graph and a few feature flags shift on `toml`/`toml_datetime`/`toml_parser`/`serde_spanned`. `bzlTransitiveDigest` is unchanged; only `usagesDigest` plus the catch-up-related changes.
- Update `docs/plans/bazel-migration.md` to reflect the trimmed manifest list and call out that new workspace members no longer require `MODULE.bazel` edits.

Closes #92.

## Test plan
- [x] `bazel build //...` — 1796 actions, completed successfully
- [x] `bazel test //...` — 14 / 14 tests pass
- [x] `cargo rail run --merge-base` — no test targets (only Bazel files changed)
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hook: `cargo clippy --all --all-targets --all-features -- -D warnings` + `cargo fmt --all -- --check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)