### PR TITLE
Use &Path for all load_config signatures

### DIFF
--- a/services/calibrator-flats/src/config.rs
+++ b/services/calibrator-flats/src/config.rs
@@ -118,4 +118,40 @@ mod tests {
         assert_eq!(plan.brightness, Some(80));
         assert_eq!(plan.filters.len(), 2);
     }
+
+    #[test]
+    fn load_config_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "camera_id": "main-cam",
+                "filter_wheel_id": "main-fw",
+                "calibrator_id": "flat-panel",
+                "filters": [{"name": "Luminance", "count": 20}]
+            }"#,
+        )
+        .unwrap();
+
+        let plan = load_config(&path).unwrap();
+        assert_eq!(plan.camera_id, "main-cam");
+        assert_eq!(plan.filters.len(), 1);
+    }
+
+    #[test]
+    fn load_config_missing_file() {
+        let err = load_config(Path::new("/nonexistent/calibrator-flats/plan.json")).unwrap_err();
+        assert!(err.to_string().contains("failed to read config file"));
+    }
+
+    #[test]
+    fn load_config_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.json");
+        std::fs::write(&path, "not valid json").unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        assert!(err.to_string().contains("failed to parse config file"));
+    }
 }

--- a/services/calibrator-flats/src/config.rs
+++ b/services/calibrator-flats/src/config.rs
@@ -1,4 +1,8 @@
+use std::path::Path;
+
 use serde::Deserialize;
+
+use crate::error::{CalibratorFlatsError, Result};
 
 /// Filter plan entry: which filter, how many frames.
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +50,23 @@ fn default_max_iterations() -> u32 {
 
 fn default_initial_duration_ms() -> u32 {
     1000
+}
+
+pub fn load_config(path: &Path) -> Result<FlatPlan> {
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        CalibratorFlatsError::Config(format!(
+            "failed to read config file '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+    serde_json::from_str(&contents).map_err(|e| {
+        CalibratorFlatsError::Config(format!(
+            "failed to parse config file '{}': {}",
+            path.display(),
+            e
+        ))
+    })
 }
 
 #[cfg(test)]

--- a/services/calibrator-flats/src/main.rs
+++ b/services/calibrator-flats/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
@@ -10,7 +12,7 @@ use tracing_subscriber::EnvFilter;
 struct Cli {
     /// Path to configuration file
     #[arg(long)]
-    config: String,
+    config: PathBuf,
 
     /// Port to listen on
     #[arg(long, default_value = "11170")]
@@ -35,9 +37,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    debug!(config_path = %cli.config, "loading configuration");
-    let contents = std::fs::read_to_string(&cli.config)?;
-    let plan: calibrator_flats::config::FlatPlan = serde_json::from_str(&contents)?;
+    debug!(config_path = %cli.config.display(), "loading configuration");
+    let plan = calibrator_flats::config::load_config(&cli.config)?;
 
     calibrator_flats::ServerBuilder::new()
         .with_plan(plan)

--- a/services/filemonitor/src/lib.rs
+++ b/services/filemonitor/src/lib.rs
@@ -240,7 +240,7 @@ impl SafetyMonitor for FileMonitorDevice {
     }
 }
 
-pub fn load_config(path: &PathBuf) -> Result<Config, Box<dyn std::error::Error>> {
+pub fn load_config(path: &Path) -> Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
     let config: Config = serde_json::from_str(&content)?;
     Ok(config)
@@ -359,7 +359,7 @@ pub async fn run_server_loop(
     mut reload: impl FnMut() -> Pin<Box<dyn Future<Output = ()>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     loop {
-        let config = load_config(&config_path.to_path_buf())?;
+        let config = load_config(config_path)?;
         info!("Starting filemonitor server on port {}", config.server.port);
         tokio::select! {
             result = start_server(config) => return result,

--- a/services/phd2-guider/src/config.rs
+++ b/services/phd2-guider/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration types for the PHD2 guider service
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// PHD2 service configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,7 +133,7 @@ fn default_settle_timeout_secs() -> u32 {
 }
 
 /// Load configuration from a JSON file
-pub fn load_config(path: &PathBuf) -> std::result::Result<Config, Box<dyn std::error::Error>> {
+pub fn load_config(path: &Path) -> std::result::Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
     let config: Config = serde_json::from_str(&content)?;
     Ok(config)

--- a/services/ppba-driver/src/config.rs
+++ b/services/ppba-driver/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration types for the PPBA Driver
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -142,7 +142,7 @@ pub struct DeviceConfig {
 }
 
 /// Load configuration from a JSON file
-pub fn load_config(path: &PathBuf) -> std::result::Result<Config, Box<dyn std::error::Error>> {
+pub fn load_config(path: &Path) -> std::result::Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
     let config: Config = serde_json::from_str(&content)?;
     Ok(config)

--- a/services/qhy-focuser/src/config.rs
+++ b/services/qhy-focuser/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration types for the QHY Q-Focuser driver
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -115,7 +115,7 @@ impl Default for FocuserConfig {
 }
 
 /// Load configuration from a JSON file
-pub fn load_config(path: &PathBuf) -> std::result::Result<Config, Box<dyn std::error::Error>> {
+pub fn load_config(path: &Path) -> std::result::Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
     let config: Config = serde_json::from_str(&content)?;
     Ok(config)
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn load_config_nonexistent_file() {
-        let path = PathBuf::from("/tmp/qhy_focuser_nonexistent_config_12345.json");
+        let path = std::path::PathBuf::from("/tmp/qhy_focuser_nonexistent_config_12345.json");
         let result = load_config(&path);
         assert!(result.is_err());
     }

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -117,9 +119,19 @@ fn default_bind() -> String {
     "127.0.0.1".to_string()
 }
 
-pub fn load_config(path: &str) -> Result<Config> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|e| RpError::Config(format!("failed to read config file '{}': {}", path, e)))?;
-    serde_json::from_str(&contents)
-        .map_err(|e| RpError::Config(format!("failed to parse config file '{}': {}", path, e)))
+pub fn load_config(path: &Path) -> Result<Config> {
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        RpError::Config(format!(
+            "failed to read config file '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+    serde_json::from_str(&contents).map_err(|e| {
+        RpError::Config(format!(
+            "failed to parse config file '{}': {}",
+            path.display(),
+            e
+        ))
+    })
 }

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -135,3 +135,43 @@ pub fn load_config(path: &Path) -> Result<Config> {
         ))
     })
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    const MINIMAL_CONFIG_JSON: &str = r#"{
+        "session": {"data_directory": "/tmp/rp-test"},
+        "equipment": {},
+        "server": {}
+    }"#;
+
+    #[test]
+    fn load_config_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, MINIMAL_CONFIG_JSON).unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.session.data_directory, "/tmp/rp-test");
+        assert_eq!(config.server.port, 11115);
+        assert_eq!(config.server.bind_address, "127.0.0.1");
+    }
+
+    #[test]
+    fn load_config_missing_file() {
+        let err = load_config(Path::new("/nonexistent/rp/config.json")).unwrap_err();
+        assert!(err.to_string().contains("failed to read config file"));
+    }
+
+    #[test]
+    fn load_config_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "not valid json").unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        assert!(err.to_string().contains("failed to parse config file"));
+    }
+}

--- a/services/rp/src/main.rs
+++ b/services/rp/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use clap::{Parser, Subcommand};
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
@@ -10,7 +12,7 @@ struct Cli {
 
     /// Path to configuration file (shorthand for `rp serve --config`)
     #[arg(long)]
-    config: Option<String>,
+    config: Option<PathBuf>,
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info")]
@@ -23,7 +25,7 @@ enum Commands {
     Serve {
         /// Path to configuration file
         #[arg(long)]
-        config: String,
+        config: PathBuf,
 
         /// Log level (trace, debug, info, warn, error)
         #[arg(long, default_value = "info")]
@@ -146,8 +148,8 @@ fn init_tracing(log_level: &str) {
         .init();
 }
 
-async fn run_serve(config_path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    debug!(config_path = %config_path, "loading configuration");
+async fn run_serve(config_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    debug!(config_path = %config_path.display(), "loading configuration");
     let config = rp::config::load_config(config_path)?;
 
     rp::ServerBuilder::new()


### PR DESCRIPTION
## Summary

- Fixes #83: `rp::load_config(&str)` silently coerced non-UTF8 paths to `""`, producing a confusing "could not read config" error. Now takes `&Path`.
- Migrates `filemonitor`, `ppba-driver`, `qhy-focuser`, `phd2-guider` from `&PathBuf` to `&Path` (clears the clippy `ptr_arg` lint and removes the awkward `load_config(&config_path.to_path_buf())` in filemonitor's run loop).
- Extracts `calibrator-flats`'s inline `read_to_string` + `serde_json::from_str` into `pub fn load_config(path: &Path) -> Result<FlatPlan>`, matching the convention used by every sibling service. Clap arg also moves from `String` to `PathBuf`.
- `sentinel` was already on `&Path` — untouched.

## Test plan

- [x] `cargo build --all --all-targets --all-features` clean
- [x] `cargo test --all --all-features` clean (one pre-existing flake on `phd2-guider::test_config_file_option` reproduced on main without these changes)
- [x] `cargo clippy --all --all-targets --all-features` clean
- [x] `cargo fmt --check` clean
- [x] `cargo rail run --merge-base` runs the same 6 affected packages cleanly (the 94 ppba-driver BDD failures are pre-existing — they need `--all-features` to enable the `mock` serial port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)