### PR TITLE
Use cargo rail commit profile with --all-features for rule 4

### DIFF
--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -79,11 +79,18 @@ default_profile = "local"
 # commit = "ci"
 # nightly = "nightly"
 
-# Optional user-defined run profiles:
-# [run.profile.ci]
-# surfaces = ["build", "test"]
-# merge_base = true
+# Pre-commit gate (referenced from docs/AGENTS.md rule 4). Mirrors CI's invocation:
+# cargo check --workspace + cargo nextest run, both with --locked --all-features --all-targets.
+# --all-features is required so feature-gated test code (e.g. #[cfg(feature = "mock")])
+# compiles. Requires cargo-nextest -- without it, rail's test surface falls back to
+# `cargo test ... -- <run_args>`, where the run_args land as test-binary args (a noop)
+# instead of cargo args, silently skipping mock-gated code.
+[run.profile.commit]
+surfaces = ["build", "test"]
+merge_base = true
+run_args = ["--locked", "--all-features", "--all-targets", "--color", "never"]
 
+# Optional user-defined run profiles:
 # [run.profile.docs_custom]
 # surfaces = ["docs"]
 # run_args = ["--workspace", "{cargo_args}"]

--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -79,8 +79,9 @@ default_profile = "local"
 # commit = "ci"
 # nightly = "nightly"
 
-# Pre-commit gate (referenced from docs/AGENTS.md rule 4). Mirrors CI's invocation:
-# cargo check --workspace + cargo nextest run, both with --locked --all-features --all-targets.
+# Pre-commit gate (referenced from docs/AGENTS.md rule 4). Runs `cargo check --workspace`
+# (a fast proxy -- CI itself uses `cargo build` for the same flags) and `cargo nextest run`
+# against only the affected crates, both with --locked --all-features --all-targets --color never.
 # --all-features is required so feature-gated test code (e.g. #[cfg(feature = "mock")])
 # compiles. Requires cargo-nextest -- without it, rail's test surface falls back to
 # `cargo test ... -- <run_args>`, where the run_args land as test-binary args (a noop)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,11 +11,11 @@
 
 3. You MUST use `cargo run` when you start any service for testing.
 
-4. You MUST ALWAYS run `cargo rail run --profile commit -q` and `cargo fmt` before committing your work and fix all errors and warnings from the change you've made. The `commit` profile (defined in `.config/rail.toml`) runs `cargo check` and `cargo nextest run` against only the packages affected by your changes vs. the merge base, with `--locked --all-features --all-targets` baked in so feature-gated test code (e.g. `#[cfg(feature = "mock")]`) is exercised and feature-unification errors on test/bench/example targets are caught. Use `cargo rail plan --merge-base` to preview which packages would be affected.
+4. You MUST ALWAYS run `cargo rail run --profile commit -q` and `cargo fmt` before committing your work and fix all errors and warnings from the change you've made. The `commit` profile (defined in `.config/rail.toml`) runs `cargo check` and `cargo nextest run` against only the packages affected by your changes vs. the merge base, with `--locked --all-features --all-targets` baked in so feature-gated test code (e.g. `#[cfg(feature = "mock")]`) is exercised and feature-unification errors on test/bench/example targets are caught. Use `cargo rail plan --merge-base` to preview which packages would be affected. Note: rail's `build` surface is hardcoded to `cargo check` (a faster proxy for codegen-free type-checking); CI itself runs `cargo build` for the same flags, so a final `cargo build` is still worth running before you push if your change touches linker-visible code.
 
    **Requires `cargo-nextest`** (`cargo install cargo-nextest --locked`). Without nextest, rail's test surface falls back to plain `cargo test` and the profile's `--all-features` flag silently lands in the test-binary args slot instead of cargo's — mock-gated code will not be compiled and you will pass locally but fail CI.
 
-   If `cargo-rail` is not available, fall back to `cargo build --all --all-targets --all-features --locked --quiet --color never` and `cargo nextest run --locked --all-features --all-targets`. See docs/skills/pre-push.md for the full CI quality-gate suite.
+   If `cargo-rail` is not available, fall back to `cargo build --all --all-targets --all-features --locked --quiet --color never` and `cargo nextest run --locked --all-features --all-targets --color never`. See docs/skills/pre-push.md for the full CI quality-gate suite.
 
    A Bazel build system is being introduced alongside Cargo (see `docs/plans/bazel-migration.md`). Cargo remains the canonical build during the migration; Bazel runs in shadow mode and is not a required pre-push step yet. If you want to exercise it, `bazel test //...` runs all non-`requires-cargo`, non-BDD targets.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,7 +11,11 @@
 
 3. You MUST use `cargo run` when you start any service for testing.
 
-4. You MUST ALWAYS run `cargo rail run --merge-base -q -- --color never` and `cargo fmt` before committing your work and fix all errors and warnings from the change you've made. This builds and tests only the packages affected by your changes. Use `cargo rail plan --merge-base` to preview which packages would be affected. If `cargo-rail` is not available, fall back to `cargo build --all --all-targets --all-features --quiet --color never` and `cargo test --all --all-features --quiet --color never`. The `--all-targets` flag compiles test, bench, and example targets, catching feature-unification errors that a plain `cargo build --all` misses. The `--all-features` flag is critical: it enables feature-gated test code (e.g. `#[cfg(feature = "mock")]`) that CI always compiles. See docs/skills/pre-push.md for the full CI quality-gate suite.
+4. You MUST ALWAYS run `cargo rail run --profile commit -q` and `cargo fmt` before committing your work and fix all errors and warnings from the change you've made. The `commit` profile (defined in `.config/rail.toml`) runs `cargo check` and `cargo nextest run` against only the packages affected by your changes vs. the merge base, with `--locked --all-features --all-targets` baked in so feature-gated test code (e.g. `#[cfg(feature = "mock")]`) is exercised and feature-unification errors on test/bench/example targets are caught. Use `cargo rail plan --merge-base` to preview which packages would be affected.
+
+   **Requires `cargo-nextest`** (`cargo install cargo-nextest --locked`). Without nextest, rail's test surface falls back to plain `cargo test` and the profile's `--all-features` flag silently lands in the test-binary args slot instead of cargo's — mock-gated code will not be compiled and you will pass locally but fail CI.
+
+   If `cargo-rail` is not available, fall back to `cargo build --all --all-targets --all-features --locked --quiet --color never` and `cargo nextest run --locked --all-features --all-targets`. See docs/skills/pre-push.md for the full CI quality-gate suite.
 
    A Bazel build system is being introduced alongside Cargo (see `docs/plans/bazel-migration.md`). Cargo remains the canonical build during the migration; Bazel runs in shadow mode and is not a required pre-push step yet. If you want to exercise it, `bazel test //...` runs all non-`requires-cargo`, non-BDD targets.
 


### PR DESCRIPTION
## Summary
- Add `[run.profile.commit]` to `.config/rail.toml` that pins `--locked --all-features --all-targets --color never` across the build and test surfaces, mirroring what CI runs.
- Switch `docs/AGENTS.md` rule 4 to invoke `cargo rail run --profile commit -q` and document `cargo-nextest` as a hard requirement.

## Why
Rule 4 previously invoked `cargo rail run --merge-base -q -- --color never`. cargo-rail 0.11.0 has no per-surface `cargo_args` knob — its `run_args` slot lands as test-binary args (after `--`) when the test surface falls back to plain `cargo test`, so `--all-features` was silently dropped for tests and `#[cfg(feature = "mock")]` code never compiled at the pre-commit gate. Devs would pass locally and fail CI.

The fix relies on `cargo nextest run -p ... <run_args>` (which slots `<run_args>` as cargo args, not test-binary args). Nextest is already required by `docs/skills/pre-push.md` and used in CI, so this is a documentation/config change, not a new dependency. Without nextest the failure mode is now explicitly called out in rule 4.

The underlying rail per-surface-args limitation is also worth an upstream PR — tracking it locally for now.

## Test plan
- [x] `cargo rail config validate` passes.
- [x] `cargo rail run --profile commit --dry-run --print-cmd` shows correct cargo invocations on both surfaces.
- [x] End-to-end `cargo rail run --profile commit -q` ran the full workspace (`.config/rail.toml` is in the `infrastructure` change-detection list) — 838 tests passed, exit 0.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)