### PR TITLE
Remove inert device_number from ASCOM service configs

### DIFF
--- a/docs/services/filemonitor.md
+++ b/docs/services/filemonitor.md
@@ -54,7 +54,6 @@ The service uses a JSON configuration file with the following format:
   },
   "server": {
     "port": 11111,
-    "device_number": 0,
     "auth": {
       "username": "observatory",
       "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
@@ -68,7 +67,7 @@ Configuration sections:
 - **device**: ASCOM device metadata (name, unique ID, description)
 - **file**: Path to monitor and polling interval (humantime string, e.g. `"60s"`)
 - **parsing**: Multiple rule types (contains, regex) with safe/unsafe outcomes
-- **server**: ASCOM Alpaca server configuration (port, device number)
+- **server**: ASCOM Alpaca server configuration (port, optional TLS/auth)
 - **server.auth**: Optional HTTP Basic Auth credentials (username, Argon2id password_hash). See [ADR-003](../decisions/003-authentication-for-device-access.md).
 
 The parsing rules are evaluated in order, with the first match determining safety status. If no rules match, the device defaults to unsafe (`false`) for safety reasons.

--- a/docs/services/ppba-driver.md
+++ b/docs/services/ppba-driver.md
@@ -68,11 +68,6 @@ Configuration is provided via a JSON file:
 
 ```json
 {
-  "device": {
-    "name": "Pegasus PPBA",
-    "unique_id": "ppba-switch-001",
-    "description": "Pegasus Astro Pocket Powerbox Advance Gen2"
-  },
   "serial": {
     "port": "/dev/ttyUSB0",
     "baud_rate": 9600,
@@ -85,6 +80,19 @@ Configuration is provided via a JSON file:
       "username": "observatory",
       "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
     }
+  },
+  "switch": {
+    "name": "Pegasus PPBA Switch",
+    "unique_id": "ppba-switch-001",
+    "description": "Pegasus Astro PPBA Gen2 Power Control",
+    "enabled": true
+  },
+  "observingconditions": {
+    "name": "Pegasus PPBA Weather",
+    "unique_id": "ppba-observingconditions-001",
+    "description": "Pegasus Astro PPBA Environmental Sensors",
+    "enabled": true,
+    "averaging_period": "5m"
   }
 }
 ```
@@ -93,9 +101,6 @@ Configuration is provided via a JSON file:
 
 | Section | Field | Description | Default |
 |---------|-------|-------------|---------|
-| device | name | Device name for ASCOM | "Pegasus PPBA" |
-| device | unique_id | Unique identifier | "ppba-switch-001" |
-| device | description | Device description | (see above) |
 | serial | port | Serial port path | "/dev/ttyUSB0" |
 | serial | baud_rate | Baud rate | 9600 |
 | serial | polling_interval | Status poll interval (humantime, e.g. `"5s"`, `"500ms"`) | `"5s"` |
@@ -103,6 +108,15 @@ Configuration is provided via a JSON file:
 | server | port | HTTP server port | 11112 |
 | server.auth | username | HTTP Basic Auth username (optional) | — |
 | server.auth | password_hash | Argon2id password hash (optional) | — |
+| switch | name | ASCOM device name for the Switch | "Pegasus PPBA Switch" |
+| switch | unique_id | Unique identifier for the Switch | "ppba-switch-001" |
+| switch | description | Switch description | "Pegasus Astro PPBA Gen2 Power Control" |
+| switch | enabled | Whether to register the Switch device | `true` |
+| observingconditions | name | ASCOM device name for ObservingConditions | "Pegasus PPBA Weather" |
+| observingconditions | unique_id | Unique identifier for ObservingConditions | "ppba-observingconditions-001" |
+| observingconditions | description | ObservingConditions description | "Pegasus Astro PPBA Environmental Sensors" |
+| observingconditions | enabled | Whether to register the ObservingConditions device | `true` |
+| observingconditions | averaging_period | Sliding-window length for sensor means (humantime) | `"5m"` |
 
 ## Usage
 

--- a/docs/services/ppba-driver.md
+++ b/docs/services/ppba-driver.md
@@ -81,7 +81,6 @@ Configuration is provided via a JSON file:
   },
   "server": {
     "port": 11112,
-    "device_number": 0,
     "auth": {
       "username": "observatory",
       "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
@@ -102,7 +101,6 @@ Configuration is provided via a JSON file:
 | serial | polling_interval | Status poll interval (humantime, e.g. `"5s"`, `"500ms"`) | `"5s"` |
 | serial | timeout | Serial timeout (humantime) | `"2s"` |
 | server | port | HTTP server port | 11112 |
-| server | device_number | ASCOM device number | 0 |
 | server.auth | username | HTTP Basic Auth username (optional) | — |
 | server.auth | password_hash | Argon2id password hash (optional) | — |
 

--- a/docs/services/qhy-focuser.md
+++ b/docs/services/qhy-focuser.md
@@ -86,7 +86,6 @@ Responses are JSON objects terminated by `}` (no newline). Commands are sent as 
     "name": "QHY Q-Focuser",
     "unique_id": "qhy-focuser-001",
     "description": "QHY Q-Focuser (EAF) Stepper Motor Controller",
-    "device_number": 0,
     "enabled": true,
     "max_step": 64000,
     "speed": 0,

--- a/docs/services/sky-survey-camera.md
+++ b/docs/services/sky-survey-camera.md
@@ -97,8 +97,7 @@ second backend (e.g. CDS `hips2fits`) is added; see *Future Work*.
     "cache_dir": "/var/cache/sky-survey-camera"
   },
   "server": {
-    "port": 11116,
-    "device_number": 0
+    "port": 11116
   }
 }
 ```
@@ -113,9 +112,8 @@ Configuration sections:
   overrides them. Stored as plain `f64` degrees in J2000.
 - **survey** — Backend selector + request timeout (humantime per the
   `Duration` convention) + on-disk cache directory.
-- **server** — Listening port and ASCOM device number. TLS and Basic
-  Auth are added later via `rp-tls` / `rp-auth` if needed; out of scope
-  for v0.
+- **server** — Listening port. TLS and Basic Auth are added later via
+  `rp-tls` / `rp-auth` if needed; out of scope for v0.
 
 ### Derived Quantities
 

--- a/services/filemonitor/examples/README.md
+++ b/services/filemonitor/examples/README.md
@@ -39,5 +39,5 @@ cargo run --release -- -c config-windows.json
 
 - All configurations use the same JSON structure
 - Only file paths need to be adjusted for each platform
-- Network settings (port, device_number) are identical across platforms
+- Network settings (port) are identical across platforms
 - Parsing rules work the same way on all platforms

--- a/services/filemonitor/examples/config-linux.json
+++ b/services/filemonitor/examples/config-linux.json
@@ -30,7 +30,6 @@
     "case_sensitive": false
   },
   "server": {
-    "port": 11111,
-    "device_number": 0
+    "port": 11111
   }
 }

--- a/services/filemonitor/examples/config-macos.json
+++ b/services/filemonitor/examples/config-macos.json
@@ -30,7 +30,6 @@
     "case_sensitive": false
   },
   "server": {
-    "port": 11111,
-    "device_number": 0
+    "port": 11111
   }
 }

--- a/services/filemonitor/examples/config-windows.json
+++ b/services/filemonitor/examples/config-windows.json
@@ -30,7 +30,6 @@
     "case_sensitive": false
   },
   "server": {
-    "port": 11111,
-    "device_number": 0
+    "port": 11111
   }
 }

--- a/services/filemonitor/pkg/config.json
+++ b/services/filemonitor/pkg/config.json
@@ -30,7 +30,6 @@
     "case_sensitive": false
   },
   "server": {
-    "port": 11111,
-    "device_number": 0
+    "port": 11111
   }
 }

--- a/services/filemonitor/src/lib.rs
+++ b/services/filemonitor/src/lib.rs
@@ -60,7 +60,6 @@ pub enum RuleType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub port: u16,
-    pub device_number: u32,
     #[serde(default = "default_discovery_port")]
     pub discovery_port: Option<u16>,
     #[serde(default)]
@@ -431,7 +430,6 @@ mod property_tests {
             },
             server: ServerConfig {
                 port: 8080,
-                device_number: 0,
                 discovery_port: None,
                 tls: None,
                 auth: None,
@@ -467,7 +465,6 @@ mod property_tests {
             },
             server: ServerConfig {
                 port: 8080,
-                device_number: 0,
                 discovery_port: None,
                 tls: None,
                 auth: None,
@@ -530,7 +527,6 @@ mod property_tests {
                 },
                 server: ServerConfig {
                     port: 8080,
-                    device_number: 0,
                     discovery_port: None,
                     tls: None,
                     auth: None,
@@ -587,7 +583,6 @@ mod property_tests {
                 },
                 server: ServerConfig {
                     port: 8080,
-                    device_number: 0,
                     discovery_port: None,
                     tls: None,
                     auth: None,
@@ -629,7 +624,6 @@ mod property_tests {
                 },
                 server: ServerConfig {
                     port,
-                    device_number: 0,
                     discovery_port: None,
                     tls: None,
                     auth: None,
@@ -671,7 +665,6 @@ mod property_tests {
                 },
                 server: ServerConfig {
                     port: 8080,
-                    device_number: 0,
                     discovery_port: None,
                     tls: None,
                     auth: None,

--- a/services/filemonitor/tests/bdd/world.rs
+++ b/services/filemonitor/tests/bdd/world.rs
@@ -106,7 +106,6 @@ impl FilemonitorWorld {
             },
             "server": {
                 "port": 0,
-                "device_number": 0,
                 "discovery_port": null,
             },
         })

--- a/services/filemonitor/tests/config.json
+++ b/services/filemonitor/tests/config.json
@@ -29,7 +29,6 @@
     "case_sensitive": false
   },
   "server": {
-    "port": 11111,
-    "device_number": 0
+    "port": 11111
   }
 }

--- a/services/filemonitor/tests/conformu_integration.rs
+++ b/services/filemonitor/tests/conformu_integration.rs
@@ -46,8 +46,7 @@ async fn conformu_compliance_tests() -> Result<(), Box<dyn std::error::Error>> {
             "case_sensitive": false
         },
         "server": {
-            "port": 0,
-            "device_number": 0
+            "port": 0
         }
     });
 

--- a/services/filemonitor/tests/test_reload.rs
+++ b/services/filemonitor/tests/test_reload.rs
@@ -35,8 +35,7 @@ async fn test_server_loop_stop_and_reload() {
                 "case_sensitive": false
             },
             "server": {
-                "port": 0,
-                "device_number": 0
+                "port": 0
             }
         });
 
@@ -80,8 +79,7 @@ async fn test_server_loop_stop_and_reload() {
                 "case_sensitive": false
             },
             "server": {
-                "port": 0,
-                "device_number": 0
+                "port": 0
             }
         });
 

--- a/services/filemonitor/tests/test_server.rs
+++ b/services/filemonitor/tests/test_server.rs
@@ -26,7 +26,6 @@ async fn test_start_server_creation() {
         },
         server: ServerConfig {
             port: 0,
-            device_number: 0,
             discovery_port: None,
             tls: None,
             auth: None,

--- a/services/ppba-driver/config.json
+++ b/services/ppba-driver/config.json
@@ -12,14 +12,12 @@
     "name": "Pegasus PPBA Switch",
     "unique_id": "ppba-switch-001",
     "description": "Pegasus Astro PPBA Gen2 Power Control",
-    "device_number": 0,
     "enabled": true
   },
   "observingconditions": {
     "name": "Pegasus PPBA Weather",
     "unique_id": "ppba-observingconditions-001",
     "description": "Pegasus Astro PPBA Environmental Sensors",
-    "device_number": 0,
     "enabled": true,
     "averaging_period": "5m"
   }

--- a/services/ppba-driver/examples/config-linux.json
+++ b/services/ppba-driver/examples/config-linux.json
@@ -11,7 +11,6 @@
     "timeout": "2s"
   },
   "server": {
-    "port": 11112,
-    "device_number": 0
+    "port": 11112
   }
 }

--- a/services/ppba-driver/examples/config-linux.json
+++ b/services/ppba-driver/examples/config-linux.json
@@ -1,9 +1,4 @@
 {
-  "device": {
-    "name": "Pegasus PPBA",
-    "unique_id": "ppba-switch-001",
-    "description": "Pegasus Astro Pocket Powerbox Advance Gen2"
-  },
   "serial": {
     "port": "/dev/ttyUSB0",
     "baud_rate": 9600,
@@ -12,5 +7,18 @@
   },
   "server": {
     "port": 11112
+  },
+  "switch": {
+    "name": "Pegasus PPBA Switch",
+    "unique_id": "ppba-switch-001",
+    "description": "Pegasus Astro PPBA Gen2 Power Control",
+    "enabled": true
+  },
+  "observingconditions": {
+    "name": "Pegasus PPBA Weather",
+    "unique_id": "ppba-observingconditions-001",
+    "description": "Pegasus Astro PPBA Environmental Sensors",
+    "enabled": true,
+    "averaging_period": "5m"
   }
 }

--- a/services/ppba-driver/examples/config-macos.json
+++ b/services/ppba-driver/examples/config-macos.json
@@ -11,7 +11,6 @@
     "timeout": "2s"
   },
   "server": {
-    "port": 11112,
-    "device_number": 0
+    "port": 11112
   }
 }

--- a/services/ppba-driver/examples/config-macos.json
+++ b/services/ppba-driver/examples/config-macos.json
@@ -1,9 +1,4 @@
 {
-  "device": {
-    "name": "Pegasus PPBA",
-    "unique_id": "ppba-switch-001",
-    "description": "Pegasus Astro Pocket Powerbox Advance Gen2"
-  },
   "serial": {
     "port": "/dev/tty.usbserial-10",
     "baud_rate": 9600,
@@ -12,5 +7,18 @@
   },
   "server": {
     "port": 11112
+  },
+  "switch": {
+    "name": "Pegasus PPBA Switch",
+    "unique_id": "ppba-switch-001",
+    "description": "Pegasus Astro PPBA Gen2 Power Control",
+    "enabled": true
+  },
+  "observingconditions": {
+    "name": "Pegasus PPBA Weather",
+    "unique_id": "ppba-observingconditions-001",
+    "description": "Pegasus Astro PPBA Environmental Sensors",
+    "enabled": true,
+    "averaging_period": "5m"
   }
 }

--- a/services/ppba-driver/examples/config-windows.json
+++ b/services/ppba-driver/examples/config-windows.json
@@ -1,9 +1,4 @@
 {
-  "device": {
-    "name": "Pegasus PPBA",
-    "unique_id": "ppba-switch-001",
-    "description": "Pegasus Astro Pocket Powerbox Advance Gen2"
-  },
   "serial": {
     "port": "COM3",
     "baud_rate": 9600,
@@ -12,5 +7,18 @@
   },
   "server": {
     "port": 11112
+  },
+  "switch": {
+    "name": "Pegasus PPBA Switch",
+    "unique_id": "ppba-switch-001",
+    "description": "Pegasus Astro PPBA Gen2 Power Control",
+    "enabled": true
+  },
+  "observingconditions": {
+    "name": "Pegasus PPBA Weather",
+    "unique_id": "ppba-observingconditions-001",
+    "description": "Pegasus Astro PPBA Environmental Sensors",
+    "enabled": true,
+    "averaging_period": "5m"
   }
 }

--- a/services/ppba-driver/examples/config-windows.json
+++ b/services/ppba-driver/examples/config-windows.json
@@ -11,7 +11,6 @@
     "timeout": "2s"
   },
   "server": {
-    "port": 11112,
-    "device_number": 0
+    "port": 11112
   }
 }

--- a/services/ppba-driver/src/config.rs
+++ b/services/ppba-driver/src/config.rs
@@ -47,8 +47,6 @@ pub struct SwitchConfig {
     pub name: String,
     pub unique_id: String,
     pub description: String,
-    #[serde(default)]
-    pub device_number: u32,
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
@@ -59,8 +57,6 @@ pub struct ObservingConditionsConfig {
     pub name: String,
     pub unique_id: String,
     pub description: String,
-    #[serde(default)]
-    pub device_number: u32,
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default = "default_averaging_period", with = "humantime_serde")]
@@ -115,7 +111,6 @@ impl Default for SwitchConfig {
             name: "Pegasus PPBA Switch".to_string(),
             unique_id: "ppba-switch-001".to_string(),
             description: "Pegasus Astro PPBA Gen2 Power Control".to_string(),
-            device_number: 0,
             enabled: true,
         }
     }
@@ -127,7 +122,6 @@ impl Default for ObservingConditionsConfig {
             name: "Pegasus PPBA Weather".to_string(),
             unique_id: "ppba-observingconditions-001".to_string(),
             description: "Pegasus Astro PPBA Environmental Sensors".to_string(),
-            device_number: 0,
             enabled: true,
             averaging_period: default_averaging_period(),
         }
@@ -179,7 +173,6 @@ mod tests {
         assert_eq!(config.name, "Pegasus PPBA Switch");
         assert_eq!(config.unique_id, "ppba-switch-001");
         assert!(!config.description.is_empty());
-        assert_eq!(config.device_number, 0);
         assert!(config.enabled);
     }
 
@@ -190,7 +183,6 @@ mod tests {
         assert_eq!(config.name, "Pegasus PPBA Weather");
         assert_eq!(config.unique_id, "ppba-observingconditions-001");
         assert!(!config.description.is_empty());
-        assert_eq!(config.device_number, 0);
         assert!(config.enabled);
         assert_eq!(config.averaging_period, Duration::from_secs(300)); // 5 minutes
     }
@@ -239,14 +231,12 @@ mod tests {
                 "name": "Test Switch",
                 "unique_id": "test-switch-001",
                 "description": "Test switch description",
-                "device_number": 1,
                 "enabled": true
             },
             "observingconditions": {
                 "name": "Test Weather",
                 "unique_id": "test-weather-001",
                 "description": "Test weather description",
-                "device_number": 2,
                 "enabled": false,
                 "averaging_period": "120s"
             }
@@ -256,11 +246,9 @@ mod tests {
 
         assert_eq!(config.switch.name, "Test Switch");
         assert_eq!(config.switch.unique_id, "test-switch-001");
-        assert_eq!(config.switch.device_number, 1);
         assert!(config.switch.enabled);
 
         assert_eq!(config.observingconditions.name, "Test Weather");
-        assert_eq!(config.observingconditions.device_number, 2);
         assert!(!config.observingconditions.enabled);
         assert_eq!(
             config.observingconditions.averaging_period,
@@ -304,9 +292,7 @@ mod tests {
         assert_eq!(config.serial.baud_rate, 9600);
         assert_eq!(config.serial.polling_interval, Duration::from_millis(5000));
         assert_eq!(config.serial.timeout, Duration::from_secs(2));
-        assert_eq!(config.switch.device_number, 0);
         assert!(config.switch.enabled);
-        assert_eq!(config.observingconditions.device_number, 0);
         assert!(config.observingconditions.enabled);
         assert_eq!(
             config.observingconditions.averaging_period,

--- a/services/ppba-driver/src/lib.rs
+++ b/services/ppba-driver/src/lib.rs
@@ -78,10 +78,7 @@ impl ServerBuilder {
             let switch_device =
                 PpbaSwitchDevice::new(self.config.switch.clone(), Arc::clone(&serial_manager));
             server.devices.register(switch_device);
-            info!(
-                "Registered Switch device: {} (device number {})",
-                self.config.switch.name, self.config.switch.device_number
-            );
+            info!("Registered Switch device: {}", self.config.switch.name);
         }
 
         if self.config.observingconditions.enabled {
@@ -91,8 +88,8 @@ impl ServerBuilder {
             );
             server.devices.register(oc_device);
             info!(
-                "Registered ObservingConditions device: {} (device number {})",
-                self.config.observingconditions.name, self.config.observingconditions.device_number
+                "Registered ObservingConditions device: {}",
+                self.config.observingconditions.name
             );
         }
 

--- a/services/ppba-driver/tests/bdd/steps/auth_steps.rs
+++ b/services/ppba-driver/tests/bdd/steps/auth_steps.rs
@@ -33,8 +33,8 @@ fn ppba_configured_with_tls_and_auth(world: &mut PpbaWorld) {
                 "password_hash": hash
             }
         },
-        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "device_number": 0, "enabled": true },
-        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "device_number": 0, "enabled": false }
+        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "enabled": true },
+        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "enabled": false }
     });
 
     world.auth_password = Some(AUTH_PASSWORD.to_string());
@@ -45,8 +45,8 @@ fn ppba_configured_without_auth(world: &mut PpbaWorld) {
     world.config = serde_json::json!({
         "serial": { "port": "/dev/mock", "baud_rate": 9600, "polling_interval": "60s", "timeout": "2s" },
         "server": { "port": 0 },
-        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "device_number": 0, "enabled": true },
-        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "device_number": 0, "enabled": false }
+        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "enabled": true },
+        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "enabled": false }
     });
 }
 

--- a/services/ppba-driver/tests/bdd/steps/infrastructure.rs
+++ b/services/ppba-driver/tests/bdd/steps/infrastructure.rs
@@ -22,15 +22,13 @@ pub fn default_test_config() -> serde_json::Value {
             "enabled": true,
             "name": "Pegasus PPBA Switch",
             "unique_id": "ppba-switch-001",
-            "description": "Pegasus Astro PPBA Gen2 Power Control",
-            "device_number": 0
+            "description": "Pegasus Astro PPBA Gen2 Power Control"
         },
         "observingconditions": {
             "enabled": true,
             "name": "Pegasus PPBA Weather",
             "unique_id": "ppba-observingconditions-001",
             "description": "Pegasus Astro PPBA Environmental Sensors",
-            "device_number": 0,
             "averaging_period": "5m"
         }
     })

--- a/services/ppba-driver/tests/bdd/steps/tls_steps.rs
+++ b/services/ppba-driver/tests/bdd/steps/tls_steps.rs
@@ -36,8 +36,8 @@ fn ppba_configured_with_tls(world: &mut PpbaWorld) {
                 "key": certs_dir.join("ppba-driver-key.pem").to_string_lossy().to_string()
             }
         },
-        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "device_number": 0, "enabled": true },
-        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "device_number": 0, "enabled": false }
+        "switch": { "name": "Test Switch", "unique_id": "test-switch", "description": "Test", "enabled": true },
+        "observingconditions": { "name": "Test OC", "unique_id": "test-oc", "description": "Test", "enabled": false }
     });
 }
 

--- a/services/ppba-driver/tests/conformu_integration.rs
+++ b/services/ppba-driver/tests/conformu_integration.rs
@@ -99,15 +99,13 @@ async fn conformu_compliance_tests() -> Result<(), Box<dyn std::error::Error>> {
             "enabled": true,
             "name": "ConformU Test PPBA",
             "unique_id": "conformu-ppba-001",
-            "description": "Test PPBA Switch for ConformU compliance",
-            "device_number": 0
+            "description": "Test PPBA Switch for ConformU compliance"
         },
         "observingconditions": {
             "enabled": false,
             "name": "ConformU Test PPBA Weather",
             "unique_id": "conformu-ppba-weather-001",
-            "description": "Test PPBA ObservingConditions",
-            "device_number": 0
+            "description": "Test PPBA ObservingConditions"
         }
     });
 
@@ -240,15 +238,13 @@ async fn conformu_compliance_tests_observingconditions() -> Result<(), Box<dyn s
             "enabled": false,
             "name": "ConformU Test PPBA Switch",
             "unique_id": "conformu-ppba-switch-001",
-            "description": "Test PPBA Switch",
-            "device_number": 0
+            "description": "Test PPBA Switch"
         },
         "observingconditions": {
             "enabled": true,
             "name": "ConformU Test PPBA Weather",
             "unique_id": "conformu-ppba-weather-001",
-            "description": "Test PPBA ObservingConditions for ConformU compliance",
-            "device_number": 0
+            "description": "Test PPBA ObservingConditions for ConformU compliance"
         }
     });
 

--- a/services/qhy-focuser/config.json
+++ b/services/qhy-focuser/config.json
@@ -12,7 +12,6 @@
     "name": "QHY Q-Focuser",
     "unique_id": "qhy-focuser-001",
     "description": "QHY Q-Focuser (EAF) Stepper Motor Controller",
-    "device_number": 0,
     "enabled": true,
     "max_step": 64000,
     "speed": 0,

--- a/services/qhy-focuser/examples/config-linux.json
+++ b/services/qhy-focuser/examples/config-linux.json
@@ -12,7 +12,6 @@
     "name": "QHY Q-Focuser",
     "unique_id": "qhy-focuser-001",
     "description": "QHY Q-Focuser (EAF) Stepper Motor Controller",
-    "device_number": 0,
     "enabled": true,
     "max_step": 64000,
     "speed": 0,

--- a/services/qhy-focuser/examples/config-macos.json
+++ b/services/qhy-focuser/examples/config-macos.json
@@ -12,7 +12,6 @@
     "name": "QHY Q-Focuser",
     "unique_id": "qhy-focuser-001",
     "description": "QHY Q-Focuser (EAF) Stepper Motor Controller",
-    "device_number": 0,
     "enabled": true,
     "max_step": 64000,
     "speed": 0,

--- a/services/qhy-focuser/examples/config-windows.json
+++ b/services/qhy-focuser/examples/config-windows.json
@@ -12,7 +12,6 @@
     "name": "QHY Q-Focuser",
     "unique_id": "qhy-focuser-001",
     "description": "QHY Q-Focuser (EAF) Stepper Motor Controller",
-    "device_number": 0,
     "enabled": true,
     "max_step": 64000,
     "speed": 0,

--- a/services/qhy-focuser/src/config.rs
+++ b/services/qhy-focuser/src/config.rs
@@ -46,8 +46,6 @@ pub struct FocuserConfig {
     pub name: String,
     pub unique_id: String,
     pub description: String,
-    #[serde(default)]
-    pub device_number: u32,
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default = "default_max_step")]
@@ -106,7 +104,6 @@ impl Default for FocuserConfig {
             name: "QHY Q-Focuser".to_string(),
             unique_id: "qhy-focuser-001".to_string(),
             description: "QHY Q-Focuser (EAF) Stepper Motor Controller".to_string(),
-            device_number: 0,
             enabled: true,
             max_step: default_max_step(),
             speed: 0,
@@ -152,7 +149,6 @@ mod tests {
         assert_eq!(config.name, "QHY Q-Focuser");
         assert_eq!(config.unique_id, "qhy-focuser-001");
         assert!(!config.description.is_empty());
-        assert_eq!(config.device_number, 0);
         assert!(config.enabled);
         assert_eq!(config.max_step, 64_000);
         assert_eq!(config.speed, 0);
@@ -203,7 +199,6 @@ mod tests {
                 "name": "Test Focuser",
                 "unique_id": "test-focuser-001",
                 "description": "Test focuser description",
-                "device_number": 1,
                 "enabled": true,
                 "max_step": 100000,
                 "speed": 3,
@@ -215,7 +210,6 @@ mod tests {
 
         assert_eq!(config.focuser.name, "Test Focuser");
         assert_eq!(config.focuser.unique_id, "test-focuser-001");
-        assert_eq!(config.focuser.device_number, 1);
         assert!(config.focuser.enabled);
         assert_eq!(config.focuser.max_step, 100000);
         assert_eq!(config.focuser.speed, 3);
@@ -251,7 +245,6 @@ mod tests {
         assert_eq!(config.serial.baud_rate, 9600);
         assert_eq!(config.serial.polling_interval, Duration::from_millis(1000));
         assert_eq!(config.serial.timeout, Duration::from_secs(2));
-        assert_eq!(config.focuser.device_number, 0);
         assert!(config.focuser.enabled);
         assert_eq!(config.focuser.max_step, 64_000);
         assert_eq!(config.focuser.speed, 0);

--- a/services/qhy-focuser/src/lib.rs
+++ b/services/qhy-focuser/src/lib.rs
@@ -80,10 +80,7 @@ impl ServerBuilder {
             let focuser_device =
                 QhyFocuserDevice::new(self.config.focuser.clone(), Arc::clone(&serial_manager));
             server.devices.register(focuser_device);
-            info!(
-                "Registered Focuser device: {} (device number {})",
-                self.config.focuser.name, self.config.focuser.device_number
-            );
+            info!("Registered Focuser device: {}", self.config.focuser.name);
         }
 
         info!("Serial port: {}", self.config.serial.port);

--- a/services/qhy-focuser/tests/bdd/world.rs
+++ b/services/qhy-focuser/tests/bdd/world.rs
@@ -57,7 +57,6 @@ impl QhyFocuserWorld {
                 "name": config.focuser.name,
                 "unique_id": config.focuser.unique_id,
                 "description": config.focuser.description,
-                "device_number": config.focuser.device_number,
                 "enabled": config.focuser.enabled,
                 "max_step": config.focuser.max_step,
                 "speed": config.focuser.speed,

--- a/services/qhy-focuser/tests/conformu_integration.rs
+++ b/services/qhy-focuser/tests/conformu_integration.rs
@@ -85,7 +85,6 @@ async fn conformu_compliance_tests() -> Result<(), Box<dyn std::error::Error>> {
             "name": "ConformU Test QHY Focuser",
             "unique_id": "conformu-qhy-focuser-001",
             "description": "Test QHY Q-Focuser for ConformU compliance",
-            "device_number": 0,
             "max_step": 64000,
             "speed": 0,
             "reverse": false

--- a/services/sky-survey-camera/src/camera.rs
+++ b/services/sky-survey-camera/src/camera.rs
@@ -680,10 +680,7 @@ mod tests {
                 cache_dir: std::env::temp_dir().join("sky-survey-camera-tests"),
                 endpoint: "http://placeholder/".into(),
             },
-            server: ServerConfig {
-                port: 0,
-                device_number: 0,
-            },
+            server: ServerConfig { port: 0 },
         }
     }
 

--- a/services/sky-survey-camera/src/config.rs
+++ b/services/sky-survey-camera/src/config.rs
@@ -56,7 +56,6 @@ fn default_survey_endpoint() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub port: u16,
-    pub device_number: u32,
 }
 
 pub async fn load_config(path: &Path) -> Result<Config, SkySurveyCameraError> {

--- a/services/sky-survey-camera/tests/bdd/steps/exposure_survey_steps.rs
+++ b/services/sky-survey-camera/tests/bdd/steps/exposure_survey_steps.rs
@@ -66,10 +66,7 @@ fn cache_hit(world: &mut SkySurveyCameraWorld) {
             cache_dir: world.cache_dir(),
             endpoint: "http://placeholder/".to_string(),
         },
-        server: ServerConfig {
-            port: 0,
-            device_number: 0,
-        },
+        server: ServerConfig { port: 0 },
     };
     let req = build_full_sensor_request(&config, pointing, 1, 1);
     let key = req.cache_key();

--- a/services/sky-survey-camera/tests/bdd/world.rs
+++ b/services/sky-survey-camera/tests/bdd/world.rs
@@ -170,7 +170,6 @@ impl SkySurveyCameraWorld {
             "survey": survey,
             "server": {
                 "port": 0,
-                "device_number": 0,
             },
         })
     }


### PR DESCRIPTION
## Summary
Closes #106. Picked **Option B** (remove the field). `device_number` was declared in `ServerConfig` / device sub-configs across filemonitor, ppba-driver, qhy-focuser, and sky-survey-camera but was never wired into device registration — `ascom_alpaca::Server::devices.register()` auto-assigns indices from `0` per device-type, so the value was silently inert. The only consumers were three log lines that echoed the configured value back.

Wiring it through (Option A) would only meaningfully apply once a service registers more than one device of the same ASCOM type; today every service registers exactly one. The future multi-device PR can re-introduce a properly-wired version with a BDD scenario that actually exercises non-zero indices.

## Scope
- **filemonitor** — `ServerConfig` field, 6 in-tree `.json` configs (root, `pkg/`, `tests/`, 3 `examples/`), tests (`test_server`, `test_reload`, `conformu_integration`, BDD `world.rs`), `examples/README.md`, design doc.
- **ppba-driver** — `SwitchConfig` + `ObservingConditionsConfig` fields (separate per device type), two `info!` log lines, `config.json`, 3 `examples/`, `tests/conformu_integration.rs`, BDD `auth_steps`/`infrastructure`/`tls_steps`, design doc table + JSON sample.
- **qhy-focuser** — `FocuserConfig` field, one `info!` log line, `config.json`, 3 `examples/`, `tests/conformu_integration.rs`, BDD `world.rs`, design doc.
- **sky-survey-camera** — `ServerConfig` field, struct literals in `camera.rs` + BDD `world.rs` + step file, design doc.

## Untouched on purpose
- `services/rp/src/{config,equipment,mcp}.rs` — `device_number` is **client-side** here, used to match remote ASCOM devices on multi-device servers (URL building).
- `services/sentinel/src/{config,alpaca_client}.rs` — same: client-side field that builds `/api/v1/safetymonitor/{device_number}/...` URLs.
- `docs/references/ascom-alpaca.md` — describes ASCOM URL grammar, not a config field.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo rail run --profile commit -q` (291/291 passing, exit 0)
- [x] Pre-commit hook: clippy `-D warnings` clean, fmt `--check` clean
- [x] CI green
- [x] No regressions in BDD suites for the four touched services

🤖 Generated with [Claude Code](https://claude.com/claude-code)