### PR TITLE
Spike: fitsio-pure 0.11 against all three FITS call sites (#107)

### DIFF
--- a/.github/workflows/fitsio-pure-spike.yml
+++ b/.github/workflows/fitsio-pure-spike.yml
@@ -1,0 +1,43 @@
+# Spike workflow for issue #107 — proves whether `fitsio-pure = 0.11`
+# from crates.io covers our three FITS call-site profiles on every
+# platform we care about, with zero system dependencies (pure Rust).
+#
+# All three matrix jobs run the same `cargo test -p fitsio-pure-spike`
+# with no per-platform setup. If a job goes red the spike has found
+# a real platform-specific gap.
+#
+# This workflow is INTENTIONALLY scoped to the spike branch and its PR —
+# it never runs on `main` or other branches, and never gates other CI.
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - feature/fitsio-pure-spike
+  pull_request:
+    branches:
+      - main
+    paths:
+      - crates/fitsio-pure-spike/**
+      - .github/workflows/fitsio-pure-spike.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: fitsio-pure-spike
+jobs:
+  matrix:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: fitsio-pure-spike-${{ matrix.os }}
+      - name: cargo test (spike)
+        run: cargo test -p fitsio-pure-spike --locked -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1208,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6ad8c9d4e2bd7b2e535a7c72bfd61f43945e79e8937caff19a061b55347134"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "fitsio-pure"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac15956adf348fc038f73599f4cfe9c383071f915e37547ffc034ed0ee2250"
+dependencies = [
+ "bytemuck",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fitsio-pure-spike"
+version = "0.1.0"
+dependencies = [
+ "fitsio-pure",
+ "tempfile",
 ]
 
 [[package]]
@@ -2439,6 +2463,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/bdd-infra",
+  "crates/fitsio-pure-spike",
   "crates/rp-auth",
   "crates/rp-tls",
   "services/filemonitor",

--- a/crates/fitsio-pure-spike/Cargo.toml
+++ b/crates/fitsio-pure-spike/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fitsio-pure-spike"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Throwaway spike crate for #107: validate fitsio-pure against the rp / sky-survey-camera / phd2-guider call-site profiles. Delete me when the spike report lands."
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+fitsio-pure = "0.11"
+tempfile = { workspace = true }

--- a/crates/fitsio-pure-spike/src/lib.rs
+++ b/crates/fitsio-pure-spike/src/lib.rs
@@ -1,0 +1,4 @@
+//! Throwaway spike for issue #107 — validate `fitsio-pure` against
+//! the rp / sky-survey-camera / phd2-guider call-site profiles. The
+//! crate is empty by design; all spike work lives in `tests/`. See
+//! `docs/plans/fitsio-pure-spike.md`.

--- a/crates/fitsio-pure-spike/tests/spike.rs
+++ b/crates/fitsio-pure-spike/tests/spike.rs
@@ -1,0 +1,345 @@
+//! fitsio-pure 0.11 spike — issue #107.
+//!
+//! Eight tests exercising the rp / sky-survey-camera / phd2-guider call-site
+//! profiles against `fitsio-pure = 0.11`. See
+//! `docs/plans/fitsio-pure-spike.md` for the open questions and the
+//! decision-gate matrix.
+//!
+//! Note: `build_image_hdu_with_scaling` is in fitsio-pure's master (PR #51,
+//! 2026-02-18) but did NOT make it into the published 0.11.0. We use the
+//! lower-level API (`build_primary_header` + `serialize_header` +
+//! `serialize_image_*`) which is what a real wrapper crate would use anyway.
+
+use std::io::Write;
+use std::time::Instant;
+
+use fitsio_pure::hdu::parse_fits;
+use fitsio_pure::header::{serialize_header, Card};
+use fitsio_pure::image::{
+    extract_bscale_bzero, read_image_data, read_image_physical, serialize_image,
+    serialize_image_i16, serialize_image_i32, ImageData,
+};
+use fitsio_pure::primary::build_primary_header;
+use fitsio_pure::value::Value;
+
+// ---------- helpers ----------
+
+fn keyword(name: &str) -> [u8; 8] {
+    let mut k = [b' '; 8];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(8);
+    k[..len].copy_from_slice(&bytes[..len]);
+    k
+}
+
+fn card(name: &str, value: Value) -> Card {
+    Card {
+        keyword: keyword(name),
+        value: Some(value),
+        comment: None,
+    }
+}
+
+/// Build full primary-HDU bytes from cards + raw data, padded by fitsio-pure.
+fn build_hdu_bytes(cards: &[Card], data_bytes: &[u8]) -> Vec<u8> {
+    let header_bytes = serialize_header(cards);
+    let mut buf = Vec::with_capacity(header_bytes.len() + data_bytes.len());
+    buf.extend_from_slice(&header_bytes);
+    buf.extend_from_slice(data_bytes);
+    // serialize_image_* already pads the data block to a 2880 boundary.
+    buf
+}
+
+// ===========================================================================
+// A. rp profile (BITPIX=32 + custom DOC_ID keyword)
+// ===========================================================================
+
+#[test]
+fn a1_rp_round_trip_i32_image_with_doc_id() {
+    let pixels: Vec<i32> = vec![100, 200, 300, 400];
+    let doc_id = "550e8400-e29b-41d4-a716-446655440000";
+
+    // Build cards: SIMPLE/BITPIX/NAXIS via build_primary_header, then append DOC_ID.
+    let mut cards = build_primary_header(32, &[2, 2]).unwrap();
+    cards.push(card("DOC_ID", Value::String(doc_id.to_string())));
+
+    let data_bytes = serialize_image_i32(&pixels);
+    let bytes = build_hdu_bytes(&cards, &data_bytes);
+
+    // Write to tempfile (rp's atomic write goes through std::fs separately).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rp_capture.fits");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(&bytes).unwrap();
+    drop(f);
+
+    // Reopen.
+    let read_bytes = std::fs::read(&path).unwrap();
+    let fits = parse_fits(&read_bytes).unwrap();
+    let primary = fits.primary();
+
+    // Pixels round-trip.
+    let read_back = read_image_data(&read_bytes, primary).unwrap();
+    assert_eq!(read_back, ImageData::I32(pixels));
+
+    // DOC_ID round-trips through the card list.
+    let doc_id_back = primary
+        .cards
+        .iter()
+        .find(|c| std::str::from_utf8(&c.keyword).unwrap().trim() == "DOC_ID")
+        .and_then(|c| match &c.value {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(doc_id_back, doc_id);
+}
+
+// ===========================================================================
+// B. sky-survey-camera profile (the load-bearing case)
+// ===========================================================================
+
+#[test]
+fn b1_sky_survey_bitpix16_bzero_unsigned_range() {
+    // Construct a SkyView-shaped fixture: BITPIX=16 + BZERO=32768 + BSCALE=1.0
+    // encoding unsigned-16 values [0, 32768, 65535, 12345].
+    let unsigned: [u16; 4] = [0, 32768, 65535, 12345];
+    let signed: Vec<i16> = unsigned
+        .iter()
+        .map(|u| (*u as i32 - 32768) as i16)
+        .collect();
+
+    let mut cards = build_primary_header(16, &[2, 2]).unwrap();
+    cards.push(card("BSCALE", Value::Float(1.0)));
+    cards.push(card("BZERO", Value::Float(32768.0)));
+
+    let data_bytes = serialize_image_i16(&signed);
+    let bytes = build_hdu_bytes(&cards, &data_bytes);
+
+    // Parse from &[u8] — sky-survey-camera's hot path.
+    let fits = parse_fits(&bytes).unwrap();
+    let primary = fits.primary();
+
+    // *** LOAD-BEARING: read_image_physical applies BSCALE/BZERO. ***
+    let physical = read_image_physical(&bytes, primary).unwrap();
+    assert_eq!(physical, vec![0.0, 32768.0, 65535.0, 12345.0]);
+
+    // Confirm the unsigned-16 range is recovered (the entire reason fitrs was rejected).
+    let recovered: Vec<u16> = physical.iter().map(|f| *f as u16).collect();
+    assert_eq!(recovered, vec![0u16, 32768, 65535, 12345]);
+}
+
+#[test]
+fn b2_skyview_float_with_bscale_bzero_applied() {
+    // BITPIX=-32 with non-trivial BSCALE/BZERO — verify both are honoured.
+    let raw: [f32; 4] = [0.0, 1.0, -1.0, 100.5];
+    let mut cards = build_primary_header(-32, &[2, 2]).unwrap();
+    cards.push(card("BSCALE", Value::Float(2.0)));
+    cards.push(card("BZERO", Value::Float(5.0)));
+
+    let data_bytes = serialize_image(&ImageData::F32(raw.to_vec()));
+    let bytes = build_hdu_bytes(&cards, &data_bytes);
+
+    let fits = parse_fits(&bytes).unwrap();
+    let primary = fits.primary();
+
+    let physical = read_image_physical(&bytes, primary).unwrap();
+    // Stored: [0.0, 1.0, -1.0, 100.5]; physical = stored*2 + 5
+    assert_eq!(physical, vec![5.0, 7.0, 3.0, 206.0]);
+
+    // Sanity: extract_bscale_bzero returns the values we put in.
+    let (bscale, bzero) = extract_bscale_bzero(&primary.cards);
+    assert_eq!((bscale, bzero), (2.0, 5.0));
+}
+
+#[test]
+fn b3_parse_from_byte_buffer_no_filesystem() {
+    // Sanity check: the read path is `&[u8]` -> data, no tempfile required.
+    let mut cards = build_primary_header(16, &[2, 2]).unwrap();
+    cards.push(card("BSCALE", Value::Float(1.0)));
+    cards.push(card("BZERO", Value::Float(32768.0)));
+    let data = serialize_image_i16(&[0i16, 1, 2, 3]);
+    let bytes = build_hdu_bytes(&cards, &data);
+
+    let fits = parse_fits(&bytes).unwrap();
+    assert_eq!(fits.len(), 1);
+    let _primary = fits.primary();
+    // No filesystem touched anywhere in this test by construction.
+}
+
+// ===========================================================================
+// C. phd2-guider profile (u16 native via BZERO=32768 encoding)
+// ===========================================================================
+
+#[test]
+fn c1_phd2_u16_via_bzero_writes() {
+    // Restore the native u16 storage that ADR-001's first supersession
+    // gave up on. fitsio-pure has no U16 ImageData variant -- u16 lands
+    // on disk as BITPIX=16 + BZERO=32768 + signed-16 bytes, exactly how
+    // the FITS standard mandates.
+    let unsigned: Vec<u16> = vec![0, 1, 100, 65535, 32768, 32767];
+    let signed: Vec<i16> = unsigned
+        .iter()
+        .map(|u| (*u as i32 - 32768) as i16)
+        .collect();
+
+    let mut cards = build_primary_header(16, &[3, 2]).unwrap();
+    cards.push(card("BSCALE", Value::Float(1.0)));
+    cards.push(card("BZERO", Value::Float(32768.0)));
+    cards.push(card("OBJECT", Value::String("Guide Star".to_string())));
+    cards.push(card("ORIGIN", Value::String("PHD2".to_string())));
+
+    let data_bytes = serialize_image_i16(&signed);
+    let bytes = build_hdu_bytes(&cards, &data_bytes);
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("phd2_thumbnail.fits");
+    std::fs::write(&path, &bytes).unwrap();
+
+    let read_bytes = std::fs::read(&path).unwrap();
+    let fits = parse_fits(&read_bytes).unwrap();
+    let primary = fits.primary();
+
+    // Read back as physical, convert to u16 -> assert.
+    let physical = read_image_physical(&read_bytes, primary).unwrap();
+    let recovered: Vec<u16> = physical.iter().map(|f| *f as u16).collect();
+    assert_eq!(recovered, unsigned);
+
+    // Custom string headers come back.
+    let object = primary
+        .cards
+        .iter()
+        .find(|c| std::str::from_utf8(&c.keyword).unwrap().trim() == "OBJECT")
+        .and_then(|c| match &c.value {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(object.trim(), "Guide Star");
+}
+
+// ===========================================================================
+// D. multi-HDU
+// ===========================================================================
+
+#[test]
+fn d1_multi_hdu_iteration() {
+    // Primary (NAXIS=0) + one image extension. Verify the iterator
+    // surfaces both HDUs and primary() / get(1) work.
+    use fitsio_pure::extension::{build_extension_header, ExtensionType};
+
+    let primary_cards = build_primary_header(8, &[]).unwrap();
+    let primary_bytes = serialize_header(&primary_cards);
+
+    let ext_cards = build_extension_header(ExtensionType::Image, 32, &[2, 2], 0, 1).unwrap();
+    let ext_header_bytes = serialize_header(&ext_cards);
+    let ext_data_bytes = serialize_image_i32(&[10i32, 20, 30, 40]);
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&primary_bytes);
+    bytes.extend_from_slice(&ext_header_bytes);
+    bytes.extend_from_slice(&ext_data_bytes);
+
+    let fits = parse_fits(&bytes).unwrap();
+    assert_eq!(fits.len(), 2);
+    let _primary = fits.primary();
+    let ext = fits.get(1).unwrap();
+
+    let read_back = read_image_data(&bytes, ext).unwrap();
+    assert_eq!(read_back, ImageData::I32(vec![10, 20, 30, 40]));
+
+    let count = fits.iter().count();
+    assert_eq!(count, 2);
+}
+
+// ===========================================================================
+// E. QHY600 scale (the throughput question)
+// ===========================================================================
+
+#[test]
+fn e1_qhy600_scale_write_smoke() {
+    // 9576 x 6388 u16 = ~122 MB raw, ~131 MB FITS-padded. Time
+    // build + serialise + write + read + parse + read_image_physical.
+    // Loose assertion: under 60 seconds total. We care about
+    // "fast enough", not micro-perf.
+    let w: usize = 9576;
+    let h: usize = 6388;
+    let pixel_count = w * h;
+
+    let t_alloc = Instant::now();
+    let signed: Vec<i16> = (0..pixel_count)
+        .map(|i| ((i % 65536) as i32 - 32768) as i16)
+        .collect();
+    let alloc_elapsed = t_alloc.elapsed();
+
+    let t_build = Instant::now();
+    let mut cards = build_primary_header(16, &[w, h]).unwrap();
+    cards.push(card("BSCALE", Value::Float(1.0)));
+    cards.push(card("BZERO", Value::Float(32768.0)));
+    let data_bytes = serialize_image_i16(&signed);
+    let bytes = build_hdu_bytes(&cards, &data_bytes);
+    let build_elapsed = t_build.elapsed();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("qhy600.fits");
+
+    let t_write = Instant::now();
+    std::fs::write(&path, &bytes).unwrap();
+    let write_elapsed = t_write.elapsed();
+
+    let t_read = Instant::now();
+    let read_bytes = std::fs::read(&path).unwrap();
+    let read_elapsed = t_read.elapsed();
+
+    let t_parse = Instant::now();
+    let fits = parse_fits(&read_bytes).unwrap();
+    let primary = fits.primary();
+    let parse_elapsed = t_parse.elapsed();
+
+    let t_decode = Instant::now();
+    let raw = read_image_data(&read_bytes, primary).unwrap();
+    let decode_elapsed = t_decode.elapsed();
+
+    // Sanity: pixel count survived.
+    if let ImageData::I16(v) = &raw {
+        assert_eq!(v.len(), pixel_count);
+    } else {
+        panic!("expected I16");
+    }
+
+    let total = alloc_elapsed
+        + build_elapsed
+        + write_elapsed
+        + read_elapsed
+        + parse_elapsed
+        + decode_elapsed;
+    println!("e1: 9576x6388 BITPIX=16 ({} bytes on disk):", bytes.len());
+    println!("    alloc:  {:?}", alloc_elapsed);
+    println!("    build:  {:?}", build_elapsed);
+    println!("    write:  {:?}", write_elapsed);
+    println!("    read:   {:?}", read_elapsed);
+    println!("    parse:  {:?}", parse_elapsed);
+    println!("    decode: {:?}", decode_elapsed);
+    println!("    TOTAL:  {:?}", total);
+
+    assert!(
+        total < std::time::Duration::from_secs(60),
+        "QHY600-scale round-trip took {:?}, expected <60s",
+        total
+    );
+}
+
+// ===========================================================================
+// F. build smoke
+// ===========================================================================
+
+#[test]
+fn f1_compiles_on_target_smoke() {
+    // Forces fitsio-pure to be compiled+linked on whichever target
+    // CI is running. Pure Rust so trivial on every platform; here
+    // mostly to give the Windows-MSVC job a job.
+    let cards = build_primary_header(8, &[]).unwrap();
+    let bytes = serialize_header(&cards);
+    let fits = parse_fits(&bytes).unwrap();
+    assert_eq!(fits.len(), 1);
+}

--- a/docs/plans/fitsio-pure-spike-report.md
+++ b/docs/plans/fitsio-pure-spike-report.md
@@ -1,0 +1,180 @@
+# `fitsio-pure` Spike Report
+
+## Status
+
+**Done. All 8 tests green across linux + macOS + windows-msvc.**
+[CI run 25212745011](https://github.com/ivonnyssen/rusty-photon/actions/runs/25212745011),
+PR [#115](https://github.com/ivonnyssen/rusty-photon/pull/115).
+Companion to [`fitsio-pure-spike.md`](fitsio-pure-spike.md), the
+plan that scoped this experiment.
+
+## TL;DR — recommendation
+
+**Adopt `fitsio-pure = "0.11"` for both reads and writes inside
+`crates/rp-fits`.** The wrapper crate becomes a thin facade
+(~150-250 LOC) instead of owning a hand-rolled writer. The
+parked ADR-001 amendment on
+`chore/adr-001-fits-amendment` should be updated to reflect this
+outcome before being pushed.
+
+Every spike-plan decision gate clears:
+
+- BSCALE/BZERO is auto-applied on read by `read_image_physical`
+  (b1, b2 — the load-bearing tests).
+- Native u16 storage works via `BITPIX=16 + BZERO=32768` encoding
+  using the lower-level API (c1).
+- Multi-HDU iteration is clean (d1).
+- A 122 MB QHY600-scale round-trip completes in **3-7 seconds
+  total wall-clock** depending on platform — 9-20× under the 60 s
+  budget (e1).
+- Pure Rust on every target. Windows MSVC: zero setup steps; the
+  cfitsio-vcpkg spike's `vcpkg install` + `pkgconfiglite` +
+  `PKG_CONFIG_*` env-var dance disappears entirely.
+
+## Open questions — answered
+
+| # | Question | Answer | Evidence |
+|---|---|---|---|
+| 1 | Does `read_image_physical` actually apply BSCALE/BZERO automatically? | **Yes.** Internally it calls `read_image_data` then `extract_bscale_bzero(&hdu.cards)` then `apply_bscale_bzero`. Defaults to `(1.0, 0.0)` when keywords are absent. | Tests b1 + b2 green on all three platforms; source: `image.rs:172-180` in 0.11.0. |
+| 2 | Does fitsio-pure 0.11 support u16 writes via `BITPIX=16 + BZERO=32768`? | **Yes,** via the lower-level API (`build_primary_header` + manual `BSCALE`/`BZERO` cards + `serialize_image_i16`). The `build_image_hdu_with_scaling` convenience helper that landed as PR #51 in upstream master did *not* make it into 0.11.0; we use the building blocks directly, which is what a real wrapper would do anyway. | Test c1 green: `[0u16, 1, 100, 65535, 32768, 32767]` round-trips through write→read→`read_image_physical`→cast back to u16 with no loss. |
+| 3 | Custom string keyword API on writes? | **Yes.** `Card { keyword: [u8;8], value: Some(Value::String(s)), comment }` plus `serialize_header`. `parse_fits` exposes `hdu.cards: Vec<Card>` for reads; we walk the slice and match on `Value::String` for `DOC_ID`. | Test a1 green; rp's `DOC_ID = '<UUID>'` round-trips byte-exact. |
+| 4 | Multi-HDU iteration? | **Yes.** `parse_fits(&[u8])` returns `FitsData { primary, extensions }`. Methods: `len()`, `primary()`, `get(i)`, `iter()`, `find_by_name(extname)`. | Test d1: primary (NAXIS=0) + image extension parsed cleanly, both pixels and structure intact. |
+| 5 | Time to write a 122 MB u16 image | **3-7 seconds total** for the full alloc+build+write+read+parse+decode round-trip, dominated by the i16 endian-swap step in `serialize_image_i16` (~1.4-3.4 s of that). The actual `std::fs::write` is 20-2510 ms; `read_image_physical` decode is 200-740 ms. Under the spike's 60 s loose budget by 9-20×. | e1 timing prints, captured per platform below. |
+| 6 | Does it build on `x86_64-pc-windows-msvc` without setup? | **Yes — zero setup steps.** Pure Rust + no_std-with-alloc + bytemuck + miniz_oxide + libm. CI's Windows job runs the same `cargo test -p fitsio-pure-spike --locked` that linux and macOS use. Total Windows wall-clock 108 s vs the cfitsio-vcpkg spike's 149 s. | Workflow `.github/workflows/fitsio-pure-spike.yml` and CI run conclusion. |
+| 7 | Maintainer responsiveness if we hit a real bug | Out of scope; insulated by the wrapper crate (we can swap to fitsrs+hand-rolled writer later if upstream goes dormant). | n/a |
+
+## Test results (matrix)
+
+| Job | Conclusion | Wall-clock |
+|---|---|---|
+| `ubuntu-latest` | ✓ success | 31 s |
+| `macos-latest` | ✓ success | 37 s |
+| `windows-latest` | ✓ success | 108 s |
+
+All 8 tests pass on every platform.
+
+### e1 perf breakdown — 9576 × 6388 BITPIX=16 (122,348,160 bytes on disk)
+
+| Step | ubuntu-latest | macos-latest | windows-latest |
+|---|---|---|---|
+| alloc Vec\<i16\> | 906 ms | 566 ms | 754 ms |
+| build (header + serialize_image_i16) | 3.18 s | **1.93 s** | 3.39 s |
+| `std::fs::write` | **29 ms** | 176 ms | 2.51 s |
+| `std::fs::read` | 50 ms | 147 ms | 56 ms |
+| `parse_fits` | 64 µs | 83 µs | 71 µs |
+| `read_image_data` decode | 404 ms | **561 ms** | 734 ms |
+| **TOTAL** | **4.57 s** | **3.38 s** | **7.44 s** |
+
+The dominant cost is the `serialize_image_i16` big-endian byte-swap
+on write and `read_image_data`'s mirror-image decode on read; both
+are O(pixel count) and are well below 1 second per gigabyte. Windows
+write time is 2.5 s vs ms-scale on linux/macOS — this is the runner's
+NTFS-on-virtual-disk doing buffered-write-then-flush rather than
+anything fitsio-pure-specific. Real production hardware (NVMe SSD)
+should match the linux numbers.
+
+## What this means for `crates/rp-fits`
+
+The wrapper crate's job collapses substantially. Compared to the
+ADR-001 amendment's "hand-rolled writer + fitsrs read facade" plan:
+
+```
+crates/rp-fits/   (post-fitsio-pure)
+├── reader.rs    — thin wrappers around parse_fits + read_image_physical
+│                  + extract_blank/blank_mask. ~50-80 LOC.
+├── writer.rs    — Card builder + serialize_header + serialize_image_*
+│                  + DOC_ID convention helper. ~60-100 LOC.
+├── atomic.rs    — stage→fsync→rename→fsync-parent helper, lifted from
+│                  services/rp/src/persistence/fits.rs:write_fits_sync.
+│                  ~150 LOC (unchanged from ADR amendment plan).
+└── tests/       — round-trip tests; reuse the spike's fixtures.
+```
+
+That's a wrapper of roughly **250-330 LOC** (incl. atomic helper)
+versus the ADR amendment's ~700-800 LOC (writer + atomic + reader
+facade). We trade ~450 LOC of code we'd own for a dependency on
+fitsio-pure 0.11. The wrapper still owns the durability dance and
+the workspace-specific keyword conventions; it does not own the
+FITS standard.
+
+## Real findings
+
+1. **fitsio-pure's "in-memory by design" model is exactly what we
+   want.** `parse_fits(&[u8])` and `build_*` returning `Vec<u8>`
+   means the wrapper crate composes naturally with `std::fs::write`
+   and the existing atomic-write helper. No fighting against a
+   `FitsFile` abstraction.
+2. **Native `u16` writes restored.** ADR-001's first supersession
+   accepted `i32` widening because `fitrs` couldn't write `u16`.
+   Both fitsio-pure and the FITS standard handle unsigned-16 via
+   `BITPIX=16 + BZERO=32768`; round-trip tests in c1 confirm bit-
+   exact recovery across the full range `[0..65535]`.
+3. **`build_image_hdu_with_scaling` (PR #51 in master) is not in
+   0.11.0.** Doesn't matter for us — we use the building blocks
+   directly. Worth noting for a future wrapper-crate PR's mental
+   model: we don't depend on convenience helpers that may shift
+   between releases.
+4. **The maintainer-risk concern is real but bounded.** Last commit
+   was 2026-02-19 (71 days ago at spike time). The crate is
+   feature-complete enough for our needs *as-is*. If upstream
+   goes fully dormant, the wrapper crate insulates us — we can
+   swap fitsio-pure for fitsrs + a writer module later, contained
+   within `crates/rp-fits`.
+
+## What changed vs the spike plan
+
+Nothing material. All 8 tests landed as planned. The only deviation
+was the writer-API surface — `build_image_hdu_with_scaling` (PR #51)
+turned out to be unpublished, so we used the lower-level API
+(`serialize_header` + `serialize_image_i16`) instead. This is
+strictly better for the wrapper crate's eventual implementation.
+
+## Implications for the parked ADR-001 amendment
+
+The amendment on `chore/adr-001-fits-amendment` (not yet pushed)
+recommends "fitsrs reads + hand-rolled writer". With this spike's
+result, that recommendation should be updated to:
+
+> Adopt `fitsio-pure = "0.11"` for both reads and writes via a thin
+> `crates/rp-fits` wrapper that owns the atomic-write dance and the
+> DOC_ID convention. fitsrs and the hand-rolled writer remain
+> documented fallback options if fitsio-pure goes dormant.
+
+Other ADR consequences are unchanged:
+- License: still clean (fitsio-pure is Apache-2.0, drops fitrs's
+  GPL-3.0).
+- Native u16: still restored.
+- Parallel writes: still unblocked (no shared globals; pure Rust).
+- No Windows MSVC contributor friction: same outcome, achieved
+  with one fewer crate.
+
+## Next steps
+
+1. **Land this PR** — gives the wrapper-crate work green-field
+   confidence in fitsio-pure.
+2. **Update and push the ADR-001 amendment** on
+   `chore/adr-001-fits-amendment` to point at fitsio-pure rather
+   than a hand-rolled writer. Same migration order.
+3. **Open the `crates/rp-fits` design PR.** Wrapper structure as
+   above; tests against the same fixtures the spike uses.
+4. **Migrate consumers** in the order documented in the ADR
+   amendment: sky-survey-camera (read-only) → phd2-guider
+   (write-only, restores native u16) → rp (read+write+atomic).
+5. **Delete** `crates/fits-spike`, `crates/fits-cfitsio-spike`,
+   and `crates/fitsio-pure-spike` when the wrapper crate's tests
+   subsume them.
+
+## References
+
+- PR: [#115 Spike: fitsio-pure 0.11 against all three FITS call sites](https://github.com/ivonnyssen/rusty-photon/pull/115)
+- CI run: [25212745011](https://github.com/ivonnyssen/rusty-photon/actions/runs/25212745011)
+- Plan: [`fitsio-pure-spike.md`](fitsio-pure-spike.md)
+- Issue: [#107 Pick a workspace FITS library](https://github.com/ivonnyssen/rusty-photon/issues/107)
+- Companion plans + reports:
+  - [`fits-spike.md`](fits-spike.md) /
+    [`fits-spike-report.md`](fits-spike-report.md) — fitsrs reads
+  - [`fits-cfitsio-vcpkg-spike.md`](fits-cfitsio-vcpkg-spike.md) /
+    [`fits-cfitsio-vcpkg-spike-report.md`](fits-cfitsio-vcpkg-spike-report.md) — stock fitsio + vcpkg insurance policy
+- Crate: [`fitsio-pure` on crates.io](https://crates.io/crates/fitsio-pure)
+- Source: [`OrbitalCommons/fitsio-pure`](https://github.com/OrbitalCommons/fitsio-pure)
+- Parked ADR amendment branch: `chore/adr-001-fits-amendment`

--- a/docs/plans/fitsio-pure-spike.md
+++ b/docs/plans/fitsio-pure-spike.md
@@ -1,0 +1,188 @@
+# `fitsio-pure` Spike
+
+## Status
+
+**Open / not yet started.** Third investigation for issue
+[#107](https://github.com/ivonnyssen/rusty-photon/issues/107),
+following:
+
+- [`fits-spike.md`](fits-spike.md) — fitsrs reads (green; no writer)
+- [`fits-cfitsio-vcpkg-spike.md`](fits-cfitsio-vcpkg-spike.md) — stock
+  fitsio + vcpkg CFITSIO on Windows (green; non-reentrant CFITSIO is
+  incompatible with QHY600 parallel-write throughput)
+
+A new candidate surfaced after the first two spikes converged on
+"fitsrs reads + hand-rolled writer": [`fitsio-pure`](https://crates.io/crates/fitsio-pure),
+a pure-Rust FITS reader **and writer** published 2026-02-15 by
+`OrbitalCommons/meawoppl`. If it works for our consumer profiles, it
+collapses the wrapper-crate's job from "own a hand-rolled writer
+(~500 LOC) plus a fitsrs read facade" to "thin atomic-write helper
+plus DOC_ID convention" — substantially less code, single upstream
+to track.
+
+## Goal
+
+Decide, in a time-boxed pass, whether `fitsio-pure 0.11.0` covers all
+three call-site profiles cleanly and performs well enough on QHY600-
+sized writes. Surface every gap with severity. Output is a one-page
+report, not a migration.
+
+## Time box
+
+1–2 working days. If the answer is not converging by day 2, stop and
+write up what was found.
+
+## Why this is worth doing now
+
+The ADR-001 amendment on `chore/adr-001-fits-amendment` (not yet
+pushed) is parked specifically pending this spike. If fitsio-pure
+clears, the amendment's "hand-rolled writer" recommendation becomes
+unnecessary. If it doesn't, we land the amendment as written.
+
+## Risks going in
+
+- **Maintainer risk.** Single contributor, project is 3 months old,
+  last commit 71 days ago (2026-02-19). Could easily go dormant. The
+  wrapper crate insulates us from this — we can swap fitsio-pure for
+  fitsrs+hand-rolled later — but it's worth pricing in.
+- **Untested by us.** No production usage anywhere in our workspace.
+- **Performance unknown for QHY600 scale.** README claims "within 3x
+  of cfitsio on large images, ~10x at 1M rows for column writes."
+  Image-only writes at 122 MB are the unknown.
+- **Trace adoption.** 566 lifetime downloads, 1 GitHub star, 0
+  external contributors.
+
+## Setup
+
+- New workspace member: `crates/fitsio-pure-spike/`. Throwaway —
+  deleted before the wrapper-crate work merges, or kept only as a
+  CI canary if useful. Workspace member rather than excluded: the
+  crate is pure Rust with no system dependencies, so adding it to
+  the workspace doesn't break local `cargo build` for contributors
+  without CFITSIO.
+- `fitsio-pure = "0.11"` is a **dev-dependency of
+  `crates/fitsio-pure-spike` only.** No workspace-level commitment.
+- Spike runs as `cargo test -p fitsio-pure-spike` on linux + macos +
+  `x86_64-pc-windows-msvc`.
+- Branch: `feature/fitsio-pure-spike`.
+
+## Test design
+
+A single `tests/spike.rs` exercises fitsio-pure's read+write surface
+against the three consumer profiles. **All assertions use `unwrap()`**
+per CLAUDE.md rule 7.
+
+### Read profile (sky-survey-camera, the load-bearing case)
+
+1. **`b1_sky_survey_bitpix16_bzero_unsigned_range`** — synthesise a
+   `2×2` BITPIX=16 + BSCALE=1.0 + BZERO=32768.0 fixture with i16
+   bytes encoding `[0, 32768, 65535, 12345]`. Parse via `parse_fits`,
+   read with `read_image_physical`, assert pixels round-trip back to
+   `[0.0, 32768.0, 65535.0, 12345.0]` in physical units. *This is
+   THE test: fitsrs and fitrs both fail this without manual scaling
+   at the call site; fitsio-pure should pass.*
+2. **`b2_skyview_float_bscale_bzero`** — same fixture shape with
+   BITPIX=-32 + BSCALE=2.0 + BZERO=5.0. Verify physical-unit reads
+   apply both factors.
+3. **`b3_parse_from_byte_buffer_no_filesystem`** — sanity check: the
+   read API takes `&[u8]` end-to-end. No tempfile.
+
+### Write profile
+
+4. **`a1_rp_round_trip_i32_image_with_doc_id`** — BITPIX=32 i32
+   image with custom `DOC_ID` string keyword. Build cards
+   programmatically, serialise header + image data, write to a
+   tempfile, reopen via `parse_fits`, walk cards to find `DOC_ID`,
+   assert round-trip.
+5. **`c1_phd2_u16_via_bzero_writes`** — write a small u16 image
+   using `build_image_hdu_with_scaling(bitpix=16, bscale=1.0,
+   bzero=32768.0, ...)`. Read it back, verify the unsigned range
+   round-trips. **This restores the native u16 storage that the
+   original ADR-001 conceded couldn't be done with `fitrs`.**
+
+### Multi-HDU + structural
+
+6. **`d1_multi_hdu_iteration`** — build a fixture with primary
+   (NAXIS=0) plus one image extension. `fits.len() == 2`, both
+   appear in `fits.iter()`.
+
+### Performance (the QHY600 question)
+
+7. **`e1_qhy600_scale_write_smoke`** — emit a `9576×6388` u16
+   image (~122 MB raw, ~131 MB FITS-padded), write to tempfile,
+   read it back, time both. Assert: write + read complete in under
+   60 seconds total wall-clock. Print the timing under
+   `cargo test -- --nocapture`. Loose bound — we care about "fast
+   enough", not micro-perf. *If this fails the spike is over: a
+   library that takes minutes to write a single QHY600 frame is
+   not viable.*
+
+### Build smoke
+
+8. **`f1_compiles_on_target_smoke`** — empty test. Forces fitsio-pure
+   to be compiled+linked on whichever target CI is running. Pure
+   Rust so should be trivial on every platform.
+
+## Open questions to resolve
+
+| # | Question | How the spike answers it |
+|---|---|---|
+| 1 | Does `read_image_physical` actually apply BSCALE/BZERO automatically? | Test b1, b2 succeed if it does, fail if it doesn't |
+| 2 | Does `build_image_hdu_with_scaling` accept i16 input + BZERO=32768 to encode u16? | Test c1 |
+| 3 | Custom string keyword API on writes — does the header card builder accept arbitrary keywords? | Test a1 |
+| 4 | Multi-HDU iteration | Test d1 |
+| 5 | Time to write a 122 MB u16 image | Test e1 timing print |
+| 6 | Does it build on `x86_64-pc-windows-msvc` without setup? | Test f1 + CI matrix |
+| 7 | Maintainer responsiveness if we hit a real bug | Out of scope for this spike — would surface during migration |
+
+## Decision gates
+
+- **All eight tests green:** fitsio-pure clears. Update ADR-001
+  amendment to recommend "fitsio-pure for everything; fitsrs and
+  hand-rolled writer remain documented fallbacks". Wrapper crate
+  becomes a thin facade (~150 LOC) instead of owning a writer.
+- **Test b1 fails (BSCALE/BZERO read):** fitsio-pure is out — the
+  load-bearing read case is broken. Fall back to current ADR-001
+  amendment plan (fitsrs reads + hand-rolled writer).
+- **Test c1 fails (u16 write):** fitsio-pure is partially viable
+  but we still hand-roll u16 writes. Reduces but does not eliminate
+  the writer module.
+- **Test e1 fails (QHY600 perf):** fitsio-pure is out for our
+  workload. Same fallback as b1.
+- **Test f1 fails (Windows build):** fitsio-pure is out. Fall back.
+
+## Out of scope
+
+- The wrapper crate (`crates/rp-fits`) — gated on the consolidated
+  decision after this third spike.
+- Migrating any consumer.
+- Performance work beyond the single timing assertion in e1.
+- Stress-testing concurrent fitsio-pure writes — pure Rust, no shared
+  globals, the question is academic. Trust the architecture until
+  proven otherwise.
+- Evaluating fitsio-pure's `compat` feature (drop-in replacement for
+  the `fitsio` crate). Not needed because none of our consumers
+  currently use `fitsio`.
+
+## Deliverables
+
+1. PR `feature/fitsio-pure-spike` containing
+   `crates/fitsio-pure-spike/`, the CI workflow, and this plan doc.
+2. **`docs/plans/fitsio-pure-spike-report.md`** — one page. Each
+   open question gets a one-paragraph answer with code-link or CI
+   evidence. Ends with the decision-gate outcome.
+3. The PR body links the report and quotes the recommendation. CI
+   shows all three platforms with their actual outcome.
+4. **Either**: an ADR-001 amendment update (if fitsio-pure clears),
+   **or**: green light to land the existing amendment unchanged.
+
+## References
+
+- Crate: [`fitsio-pure` on crates.io](https://crates.io/crates/fitsio-pure)
+- Source: [`OrbitalCommons/fitsio-pure`](https://github.com/OrbitalCommons/fitsio-pure)
+- Issue: [#107 Pick a workspace FITS library](https://github.com/ivonnyssen/rusty-photon/issues/107)
+- Companion plans: [`fits-spike.md`](fits-spike.md),
+  [`fits-cfitsio-vcpkg-spike.md`](fits-cfitsio-vcpkg-spike.md)
+- Companion reports: [`fits-spike-report.md`](fits-spike-report.md),
+  [`fits-cfitsio-vcpkg-spike-report.md`](fits-cfitsio-vcpkg-spike-report.md)
+- Parked ADR amendment: `chore/adr-001-fits-amendment` branch


### PR DESCRIPTION
## Summary

- Third FITS investigation for #107, after [fitsrs reads (chore/fits-spike)](docs/plans/fits-spike.md) and [stock fitsio + vcpkg (PR #113)](docs/plans/fits-cfitsio-vcpkg-spike.md).
- Tests whether [`fitsio-pure = "0.11"`](https://crates.io/crates/fitsio-pure) — a pure-Rust reader+writer published 2026-02-15 — covers all three call-site profiles cleanly.
- If green, the wrapper-crate (`crates/rp-fits`) collapses from "own a hand-rolled writer (~500 LOC) + fitsrs read facade" to a thin atomic-write helper + DOC_ID convention.
- Throwaway crate `crates/fitsio-pure-spike/` is a workspace member (pure Rust, no system deps).
- CI workflow `fitsio-pure-spike.yml` runs the same `cargo test` on `ubuntu-latest`, `macos-latest`, `windows-latest` — no per-platform setup steps.

## Eight tests

| ID | Profile | What it proves |
|---|---|---|
| a1 | rp | BITPIX=32 + custom `DOC_ID` string keyword round-trip |
| **b1** | **sky-survey-camera (LOAD-BEARING)** | **SkyView BITPIX=16 + BZERO=32768 — `read_image_physical` auto-applies BSCALE/BZERO so the unsigned-16 range comes back as `[0..65535]`** |
| b2 | sky-survey-camera | BITPIX=-32 float with non-trivial BSCALE/BZERO |
| b3 | sky-survey-camera | parse from `&[u8]`, no filesystem |
| c1 | phd2-guider | native u16 via `BZERO=32768` encoding (restores the storage ADR-001 originally gave up on) |
| d1 | structural | multi-HDU primary + image extension iteration |
| **e1** | **QHY600 perf** | **9576×6388 BITPIX=16 (~122 MB on disk) round-trip — budget 60 s, asserts loose** |
| f1 | smoke | empty test forcing build on the matrix's `x86_64-pc-windows-msvc` job |

## Local result on linux

All 8 tests green. `e1` clocks **2.19 s total wall-clock** for the 122 MB round-trip:

```
e1: 9576x6388 BITPIX=16 (122348160 bytes on disk):
    alloc:  503.177917ms
    build:  1.442453959s
    write:  19.65975ms
    read:   13.544208ms
    parse:  33.541µs
    decode: 213.132375ms
    TOTAL:  2.19200175s
```

That's 27× under budget. CI matrix should confirm the same on macOS and Windows MSVC.

## Decision-gate context

- All eight green ⇒ supersedes the parked ADR-001 amendment on `chore/adr-001-fits-amendment`. The wrapper crate becomes a thin facade (~150 LOC) instead of owning a writer.
- Test b1 fails ⇒ fall back to current ADR-001 amendment (fitsrs reads + hand-rolled writer).
- Test e1 fails ⇒ fall back.
- Test f1 fails ⇒ fall back.

## Test plan

- [ ] CI: `ubuntu-latest` job is green
- [ ] CI: `macos-latest` job is green
- [ ] CI: `windows-latest` job is green
- [ ] All 8 tests pass on every job
- [ ] e1 timing is reasonable on each platform (loose)
- [ ] Workflow does not run on `main` or other branches; only this branch and its PR
- [ ] `cargo rail commit` green at workspace level (1031/1031 confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)