### PR TITLE
Phase 6b: auto_focus design + BDD + impl

### DIFF
--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -411,7 +411,7 @@ tests passing workspace-wide. `cargo fmt` clean.
 
 #### Phase 6b — `auto_focus` design + BDD + impl
 
-Standard design→BDD→impl sequence. Blocked on Phase 6a.
+Status: **complete.**
 
 - [x] **Design:** `auto_focus` Contract added to `rp.md` Compound
       Tools (parallel to `measure_basic` Contract). Decisions
@@ -457,21 +457,42 @@ Standard design→BDD→impl sequence. Blocked on Phase 6a.
       - **`min_area` / `max_area` pass-through:** required at the
         `auto_focus` level, same as `measure_basic` — pixel scale
         varies per rig.
-- [ ] `services/rp/tests/features/auto_focus.feature` — catalog,
-      happy path (V-curve converges, returns best_position), each
-      error path (camera/focuser not found, not connected, all
-      captures starless, monotonic curve, sweep-grid too small
-      after clamp, `step_size <= 0`, `half_width <= 0`,
-      `min_fit_points < 3`), persistence (per-step
-      `image_analysis` written; no aggregate `auto_focus`
-      section).
-- [ ] `services/rp/src/imaging/tools/auto_focus.rs` — pure function
-      taking trait objects for focuser / camera / measure_basic so
-      it's unit-testable without hardware. The MCP tool in
-      `mcp.rs` is a thin wrapper.
-- [ ] Unit tests on the parabola fit (synthetic HFR vs. position
-      data; assert `best_position` to ±1 step) and on the
-      monotonic-curve rejection.
+- [x] `services/rp/tests/features/auto_focus.feature` — 17 scenarios:
+      catalog, four device-resolution errors (nonexistent and
+      disconnected camera/focuser), seven missing-parameter
+      examples via Scenario Outline, three numeric-range rejections
+      (step_size=0, half_width=0, min_fit_points<3), grid-too-small
+      after focuser-bounds clamp, sweep-completion + per-step
+      `image_analysis` persistence anchor (5 FITS + 5 sidecars
+      written; every sidecar carries `image_analysis`; no sidecar
+      carries an aggregate `auto_focus` section). The
+      "happy-path V-curve converges to known best_position" was
+      deliberately omitted — OmniSim produces position-independent
+      images, so a real V-curve never materializes in the simulator;
+      numerical fit correctness is unit-tested instead.
+- [x] `services/rp/src/imaging/tools/auto_focus.rs` — pure driver
+      over `FocuserOps` / `CaptureOps` / `MeasureOps` traits so the
+      loop and math are unit-testable without hardware. Validates
+      params, builds the sweep grid (clamping out-of-range points
+      rather than coercing — coercion would create duplicate samples
+      at the bound), runs move/capture/measure for each grid point,
+      fits a parabola via Cramer's rule on the 3×3 weighted
+      least-squares system, validates that the fitted vertex falls
+      inside the sampled grid (an `a > 0` parabola with vertex
+      outside the grid is still monotonic over the sampled range),
+      and moves the focuser to the fitted minimum on success. The
+      MCP wrapper in `mcp.rs` is the thin adapter shell, sharing
+      capture and move semantics with the primitive tools via two
+      newly-extracted helpers (`do_capture`,
+      `do_move_focuser_blocking`).
+- [x] Unit tests on the parabola fit and the run loop. 17 unit
+      tests cover validate_params (4), build_grid (5),
+      fit_parabola (5 — known-vertex recovery to ±1 step,
+      flat-input rejection, concave-down rejection,
+      too-few-samples, zero-weight-sample skipping), and
+      run_auto_focus end-to-end with synthetic adapters (3 —
+      known-vertex recovery, grid-too-small-after-clamp,
+      not-enough-stars-after-skips).
 
 #### Phase 6c — `center_on_target` design + BDD + impl
 

--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -413,36 +413,65 @@ tests passing workspace-wide. `cargo fmt` clean.
 
 Standard design→BDD→impl sequence. Blocked on Phase 6a.
 
-- [ ] **Design:** new `auto_focus` Contract section in `rp.md`
-      (parallel to `measure_basic` Contract, ~70 lines). Decide:
-      sweep range (absolute window vs. ± steps from current),
-      step size (fixed vs. adaptive), exposure duration (parameter
-      vs. derived from `measure_basic` star count), V-curve fit
-      (parabolic vs. piecewise-linear vs. asymmetric V),
-      abort policy on no-stars at extreme defocus, retry policy on
-      monotonic-not-V curve, output shape
-      (`{best_position, best_hfr, curve_points: [{position, hfr,
-      star_count}]}`), persistence section name in the exposure
-      document (probably `auto_focus` on the *final* document,
-      with intermediate captures linked by their own `image_analysis`
-      sections).
+- [x] **Design:** `auto_focus` Contract added to `rp.md` Compound
+      Tools (parallel to `measure_basic` Contract). Decisions
+      resolved during design:
+      - **Sweep range:** ± steps from `current_position`
+        (`half_width: i32`), clamped to operator-supplied
+        `min_position`/`max_position` from the `FocuserConfig`.
+        Out-of-range grid points are dropped (not coerced) so the
+        sweep does not produce duplicate samples at the bound.
+      - **Step size:** required parameter, fixed across the sweep
+        (no adaptive zoom in V1 — adaptive doubles BDD complexity
+        for marginal benefit on amateur rigs; can ship later as a
+        shadow tool).
+      - **Exposure duration:** required `humantime` parameter (no
+        default, no probe-derived heuristic — a probe that itself
+        runs at unknown focus is unreliable as a driver for the
+        rest of the sweep).
+      - **V-curve fit:** parabolic in raw HFR, weighted by
+        `star_count`. Closed-form least-squares — no rmpfit needed.
+        Asymmetric-V / piecewise-linear listed as a future shadow
+        alternative.
+      - **Abort policy on starless captures:** skip-and-continue
+        — record `hfr: null` in `curve_points` but exclude from
+        the fit. Fail with `not_enough_stars` only if fewer than
+        `min_fit_points` (default `5`) survive.
+      - **Retry policy on monotonic curve:** none — fail with a
+        `monotonic_curve` error and let the caller widen
+        `half_width` or coarse-focus externally before retrying.
+        No automatic move to the lowest observed sample.
+      - **Output shape:** `{best_position, best_hfr,
+        final_position, samples_used, curve_points,
+        temperature_c}`. `curve_points[i]` is
+        `{position, hfr|null, star_count, document_id}` so callers
+        can fetch per-step provenance via the existing document
+        API.
+      - **Persistence:** `auto_focus` does *not* write a section
+        on any single document. Each per-step capture's
+        `image_analysis` section is written by the embedded
+        `measure_basic` call as it normally would be. The
+        compound result is returned in the MCP response and
+        emitted as `focus_complete`. The `focus_complete` event
+        payload is enriched with `focuser_id` and `samples_used`.
+      - **`min_area` / `max_area` pass-through:** required at the
+        `auto_focus` level, same as `measure_basic` — pixel scale
+        varies per rig.
 - [ ] `services/rp/tests/features/auto_focus.feature` — catalog,
       happy path (V-curve converges, returns best_position), each
       error path (camera/focuser not found, not connected, all
-      captures starless, monotonic curve), persistence.
-- [ ] `services/rp/src/imaging/tools/auto_focus.rs` — pure function on
-      `(focuser, camera, measure_basic_fn)` so it's unit-testable
-      without hardware. The MCP tool in `mcp.rs` is a thin wrapper.
-- [ ] Unit tests on the V-curve fit (synthetic HFR vs. position
-      data; assert `best_position` to ±1 step).
-- [ ] Document `auto_focus` shadow semantics in the contract (one
-      line — "a plugin may shadow this tool; see Config-Time
-      Validation").
-
-Open question for the contract: does `auto_focus` accept
-`min_area` / `max_area` (passed through to `measure_basic`) or pick
-defaults? Probably explicit, since pixel scale varies per-rig — but
-finalize during design.
+      captures starless, monotonic curve, sweep-grid too small
+      after clamp, `step_size <= 0`, `half_width <= 0`,
+      `min_fit_points < 3`), persistence (per-step
+      `image_analysis` written; no aggregate `auto_focus`
+      section).
+- [ ] `services/rp/src/imaging/tools/auto_focus.rs` — pure function
+      taking trait objects for focuser / camera / measure_basic so
+      it's unit-testable without hardware. The MCP tool in
+      `mcp.rs` is a thin wrapper.
+- [ ] Unit tests on the parabola fit (synthetic HFR vs. position
+      data; assert `best_position` to ±1 step) and on the
+      monotonic-curve rejection.
 
 #### Phase 6c — `center_on_target` design + BDD + impl
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1783,10 +1783,17 @@ without having to know the focus algorithm.
   starless capture: the entry is preserved as a record but does
   not contribute to the fit.
 - `temperature_c` (f64 | null) — focuser temperature read once at
-  the start of the run, or `null` when the focuser does not
-  implement temperature readout. Useful for downstream
+  the start of the run. `null` when the focuser does not implement
+  temperature readout (`NOT_IMPLEMENTED`) **or** when the read
+  itself fails for any other reason. Temperature is informational
+  on the result and never load-bearing on the sweep, so a transient
+  read failure does not abort the run — the field is just
+  surrendered to `null`. Useful for downstream
   temperature-compensation logic that records
-  `(position, temperature)` pairs across runs.
+  `(position, temperature)` pairs across runs (callers that need
+  absolute temperature confidence should fall back to
+  `get_focuser_temperature` per call rather than relying on this
+  field).
 
 **Algorithm**:
 1. Resolve `camera_id` and `focuser_id`. Read the focuser's current

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -661,7 +661,7 @@ boundary — but expose the same MCP tool surface as any other tool.
 
 | Action | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
-| `auto_focus` | camera_id, focuser_id, duration, step_size, half_width, min_area, max_area, threshold_sigma (optional), min_fit_points (optional) | best_position, best_hfr, final_position, samples_used, curve_points, temperature_c | Parabolic-fit V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. *Planned — see [`auto_focus` Contract](#auto_focus-contract).* |
+| `auto_focus` | camera_id, focuser_id, duration, step_size, half_width, min_area, max_area, threshold_sigma (optional), min_fit_points (optional) | best_position, best_hfr, final_position, samples_used, curve_points, temperature_c | Parabolic-fit V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. See [`auto_focus` Contract](#auto_focus-contract). Implemented. |
 | `center_on_target` | ra, dec, tolerance_arcsec | final_error_arcsec, attempts | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until tolerance reached. *Planned.* |
 
 **Planner**
@@ -1778,7 +1778,7 @@ without having to know the focus algorithm.
   to the fit (i.e. captures with `star_count > 0` and a non-null
   HFR). `≤ curve_points.length`.
 - `curve_points` — array of
-  `{position: i32, hfr: f64 | null, star_count: usize, document_id: string}`,
+  `{position: i32, hfr: f64 | null, star_count: u32, document_id: string}`,
   one entry per capture, in sweep order. `hfr: null` flags a
   starless capture: the entry is preserved as a record but does
   not contribute to the fit.

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -272,7 +272,7 @@ The application does not know or care what subscribers do with events.
 | `slew_complete` | target coordinates, actual coordinates | Mount reports slew done |
 | `centering_started` | target, attempt number | Plate solve + correct begins |
 | `centering_complete` | target, error arcsec | Centering converged |
-| `focus_started` | camera_id, focuser_id, temperature | Auto-focus begins |
+| `focus_started` | camera_id, focuser_id, position, temperature | Auto-focus begins |
 | `focus_complete` | camera_id, focuser_id, position, hfr, samples_used | Auto-focus result |
 | `guide_started` | guider_id | Guiding loop started |
 | `guide_settled` | rms_ra, rms_dec | Guiding RMS below threshold |
@@ -1789,10 +1789,11 @@ without having to know the focus algorithm.
   `(position, temperature)` pairs across runs.
 
 **Algorithm**:
-1. Resolve `camera_id` and `focuser_id`; emit `focus_started` with
-   the current focuser position and temperature.
-2. Read the focuser temperature once; record on the result.
-3. Compute the sweep grid:
+1. Resolve `camera_id` and `focuser_id`. Read the focuser's current
+   position and temperature once each; record both on the result.
+   Emit `focus_started` carrying the resolved ids, the current
+   position, and the temperature.
+2. Compute the sweep grid:
    `start = current_position − half_width`; positions are
    `start, start + step_size, start + 2·step_size, …`, continuing
    while `≤ current_position + half_width`. Clamp the grid to
@@ -1800,7 +1801,7 @@ without having to know the focus algorithm.
    not coerced — coercion would create duplicate sweep positions
    at the bound). Reject before any motion if the clamped grid has
    fewer than `min_fit_points` positions.
-4. For each grid position, in order:
+3. For each grid position, in order:
    1. `move_focuser(position)` — block until the focuser reports
       idle (same poll loop the primitive `move_focuser` tool uses).
    2. `capture(camera_id, duration)` — yields `document_id`. The
@@ -1812,21 +1813,21 @@ without having to know the focus algorithm.
       `curve_points`. A capture with `star_count == 0` (or a
       `null` HFR for any reason) is recorded with `hfr: null` and
       contributes nothing to the fit.
-5. If fewer than `min_fit_points` entries have a non-null HFR,
+4. If fewer than `min_fit_points` entries have a non-null HFR,
    abort with a `not_enough_stars` error. The focuser is left at
    the last sweep position; `auto_focus` does not auto-recover
    the original position.
-6. Fit a parabola in raw HFR vs. position by least squares,
+5. Fit a parabola in raw HFR vs. position by least squares,
    weighted by `star_count` per point. From the fit
    `hfr = a·position² + b·position + c`:
    `best_position = round(−b / 2a)`; `best_hfr = c − b²/(4a)`.
    Reject the fit if `a ≤ 0` (the curve is monotonic or
    concave-down — the sampled range does not contain a true
    minimum) and abort with a `monotonic_curve` error.
-7. Move the focuser to `best_position` (already inside the sweep
+6. Move the focuser to `best_position` (already inside the sweep
    range by construction, so the operator-supplied
    `min_position`/`max_position` bounds are guaranteed to hold).
-8. Emit `focus_complete` with
+7. Emit `focus_complete` with
    `{camera_id, focuser_id, position: best_position, hfr: best_hfr, samples_used}`.
 
 **Error cases**:
@@ -1841,7 +1842,9 @@ without having to know the focus algorithm.
   least 3 non-collinear points).
 - Sweep grid (after clamping to `min_position`/`max_position`)
   has fewer than `min_fit_points` positions → MCP error before
-  any motion or exposure.
+  any motion or exposure. The error message names `min_fit_points`
+  so the caller can tell the grid-size failure apart from a
+  parameter-validation failure.
 - A `move_focuser`, `capture`, or `measure_basic` call inside
   the sweep returns an error → `auto_focus` propagates that
   error and stops sweeping. Captures already taken are persisted

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1828,9 +1828,15 @@ without having to know the focus algorithm.
    weighted by `star_count` per point. From the fit
    `hfr = a·position² + b·position + c`:
    `best_position = round(−b / 2a)`; `best_hfr = c − b²/(4a)`.
-   Reject the fit if `a ≤ 0` (the curve is monotonic or
-   concave-down — the sampled range does not contain a true
-   minimum) and abort with a `monotonic_curve` error.
+   Abort with a `monotonic_curve` error in any of three cases:
+   (i) the design matrix is singular at fit time (essentially
+   flat HFR over the sweep — no parabola can be fitted), (ii)
+   `a ≤ 0` (the curve is monotonic or concave-down — no minimum
+   exists), or (iii) `a > 0` but the fitted vertex falls outside
+   `[min(grid), max(grid)]` (a true minimum exists somewhere
+   off-grid, so the visible curve is monotonic *over the sampled
+   range* — the caller needs to widen the sweep or coarse-focus
+   first).
 6. Move the focuser to `best_position` (already inside the sweep
    range by construction, so the operator-supplied
    `min_position`/`max_position` bounds are guaranteed to hold).
@@ -1847,6 +1853,13 @@ without having to know the focus algorithm.
 - `step_size <= 0`, `half_width <= 0`, or `min_fit_points < 3`
   → MCP error naming the bad parameter (a parabolic fit needs at
   least 3 non-collinear points).
+- Estimated unclamped grid size (`2·half_width / step_size + 1`)
+  exceeds the safety cap (1000 points) → MCP error before any
+  motion or exposure. The cap is purely a guardrail against
+  operator misconfiguration that would otherwise produce
+  thousands of captures and tie up the rig for hours; any
+  plausible auto-focus run fits well inside it (typical 10–30
+  points).
 - Sweep grid (after clamping to `min_position`/`max_position`)
   has fewer than `min_fit_points` positions → MCP error before
   any motion or exposure. The error message names `min_fit_points`
@@ -1859,11 +1872,17 @@ without having to know the focus algorithm.
   `auto_focus`); the focuser is left at its current position.
 - Fewer than `min_fit_points` non-null HFR samples after the
   sweep completes → `not_enough_stars` error.
-- Parabolic fit yields `a ≤ 0` → `monotonic_curve` error. The
-  caller is expected to widen `half_width`, coarse-focus
-  externally, or both, then retry. The focuser is **not**
-  automatically moved to the lowest observed sample, because
-  that point is unverified as a true minimum.
+- Parabolic fit yields no meaningful minimum within the sampled
+  range → `monotonic_curve` error. This fires when the design
+  matrix is singular (the input is essentially flat HFR), when
+  `a ≤ 0` (the curve is monotonic or concave-down — no minimum
+  exists), or when `a > 0` but the fitted vertex falls outside
+  `[min(grid), max(grid)]` (a true minimum exists somewhere
+  off-grid, so the *visible* curve over the sampled range is
+  monotonic). The caller is expected to widen `half_width`,
+  coarse-focus externally, or both, then retry. The focuser is
+  **not** automatically moved to the lowest observed sample,
+  because that point is unverified as a true minimum.
 
 **Persistence**: `auto_focus` does **not** write a section on any
 single exposure document — its result spans the sweep. Each capture

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -273,7 +273,7 @@ The application does not know or care what subscribers do with events.
 | `centering_started` | target, attempt number | Plate solve + correct begins |
 | `centering_complete` | target, error arcsec | Centering converged |
 | `focus_started` | camera_id, focuser_id, temperature | Auto-focus begins |
-| `focus_complete` | camera_id, position, hfr | Auto-focus result |
+| `focus_complete` | camera_id, focuser_id, position, hfr, samples_used | Auto-focus result |
 | `guide_started` | guider_id | Guiding loop started |
 | `guide_settled` | rms_ra, rms_dec | Guiding RMS below threshold |
 | `guide_stopped` | reason | Guiding stopped |
@@ -661,7 +661,7 @@ boundary — but expose the same MCP tool surface as any other tool.
 
 | Action | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
-| `auto_focus` | camera_id, focuser_id | best_position, best_hfr, curve_points | V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. *Planned.* |
+| `auto_focus` | camera_id, focuser_id, duration, step_size, half_width, min_area, max_area, threshold_sigma (optional), min_fit_points (optional) | best_position, best_hfr, final_position, samples_used, curve_points, temperature_c | Parabolic-fit V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. *Planned — see [`auto_focus` Contract](#auto_focus-contract).* |
 | `center_on_target` | ra, dec, tolerance_arcsec | final_error_arcsec, attempts | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until tolerance reached. *Planned.* |
 
 **Planner**
@@ -1729,18 +1729,195 @@ Orchestrator                    rp (single process)
 No MCP-over-HTTP hop, no FITS re-decode (the in-process call resolves
 each capture's pixels via the image cache).
 
+#### `auto_focus` Contract
+
+A built-in compound tool that drives a V-curve focus sweep using
+`move_focuser`, `capture`, and `measure_basic` internally. The
+orchestrator calls one tool and gets back the best focuser position
+without having to know the focus algorithm.
+
+**Input**:
+- `camera_id` — required.
+- `focuser_id` — required.
+- `duration` — required, humantime string (same shape as `capture`'s
+  `duration`, e.g. `"3s"`, `"500ms"`). Per-frame exposure for every
+  point in the sweep. No default: the right value depends on focal
+  ratio, sky brightness, and target field, none of which `auto_focus`
+  can infer. Deriving it from a probe `measure_basic` star count was
+  considered and rejected — the probe itself runs at unknown focus,
+  so its star count is unreliable as a driver for the rest of the
+  sweep.
+- `step_size` — required, positive integer focuser steps. Required
+  for the same reason `min_area`/`max_area` are required on
+  `measure_basic`: focuser step → µm and rig depth-of-focus vary per
+  setup and `rp` cannot infer them.
+- `half_width` — required, positive integer. The sweep covers
+  `[current_position − half_width, current_position + half_width]`
+  in `step_size` increments. The grid is then clamped to the
+  focuser's `min_position`/`max_position` from the `FocuserConfig`.
+- `min_area` and `max_area` — required, passed through to each
+  per-frame `measure_basic` call. At extreme defocus, donut-shaped
+  PSFs from the secondary obstruction can span many hundreds of
+  pixels — set `max_area` accordingly so the wings of the V-curve
+  remain measurable.
+- Optional `threshold_sigma` (default `5.0`) — passed through to
+  `measure_basic`.
+- Optional `min_fit_points` (default `5`) — minimum number of
+  non-null HFR samples required to fit the V-curve. Also enforced
+  on the *grid size* before any motion happens — a sweep that
+  cannot produce at least this many capture positions errors before
+  moving the focuser.
+
+**Output**:
+- `best_position` (i32) — focuser position at the fitted V-curve
+  minimum, rounded to the nearest integer step.
+- `best_hfr` (f64) — fitted HFR at `best_position`, in pixels.
+- `final_position` (i32) — position the focuser was actually moved
+  to at the end of the run. Equal to `best_position` on success.
+- `samples_used` (usize) — number of HFR samples that contributed
+  to the fit (i.e. captures with `star_count > 0` and a non-null
+  HFR). `≤ curve_points.length`.
+- `curve_points` — array of
+  `{position: i32, hfr: f64 | null, star_count: usize, document_id: string}`,
+  one entry per capture, in sweep order. `hfr: null` flags a
+  starless capture: the entry is preserved as a record but does
+  not contribute to the fit.
+- `temperature_c` (f64 | null) — focuser temperature read once at
+  the start of the run, or `null` when the focuser does not
+  implement temperature readout. Useful for downstream
+  temperature-compensation logic that records
+  `(position, temperature)` pairs across runs.
+
+**Algorithm**:
+1. Resolve `camera_id` and `focuser_id`; emit `focus_started` with
+   the current focuser position and temperature.
+2. Read the focuser temperature once; record on the result.
+3. Compute the sweep grid:
+   `start = current_position − half_width`; positions are
+   `start, start + step_size, start + 2·step_size, …`, continuing
+   while `≤ current_position + half_width`. Clamp the grid to
+   `[min_position, max_position]` (any point outside is dropped,
+   not coerced — coercion would create duplicate sweep positions
+   at the bound). Reject before any motion if the clamped grid has
+   fewer than `min_fit_points` positions.
+4. For each grid position, in order:
+   1. `move_focuser(position)` — block until the focuser reports
+      idle (same poll loop the primitive `move_focuser` tool uses).
+   2. `capture(camera_id, duration)` — yields `document_id`. The
+      pixels populate the image cache as a side effect.
+   3. `measure_basic(document_id, min_area, max_area, threshold_sigma)`
+      — yields `hfr` and `star_count`. The cache hit avoids any
+      FITS decode.
+   4. Append `{position, hfr, star_count, document_id}` to
+      `curve_points`. A capture with `star_count == 0` (or a
+      `null` HFR for any reason) is recorded with `hfr: null` and
+      contributes nothing to the fit.
+5. If fewer than `min_fit_points` entries have a non-null HFR,
+   abort with a `not_enough_stars` error. The focuser is left at
+   the last sweep position; `auto_focus` does not auto-recover
+   the original position.
+6. Fit a parabola in raw HFR vs. position by least squares,
+   weighted by `star_count` per point. From the fit
+   `hfr = a·position² + b·position + c`:
+   `best_position = round(−b / 2a)`; `best_hfr = c − b²/(4a)`.
+   Reject the fit if `a ≤ 0` (the curve is monotonic or
+   concave-down — the sampled range does not contain a true
+   minimum) and abort with a `monotonic_curve` error.
+7. Move the focuser to `best_position` (already inside the sweep
+   range by construction, so the operator-supplied
+   `min_position`/`max_position` bounds are guaranteed to hold).
+8. Emit `focus_complete` with
+   `{camera_id, focuser_id, position: best_position, hfr: best_hfr, samples_used}`.
+
+**Error cases**:
+- `camera_id` not found → MCP error naming the camera.
+- `focuser_id` not found → MCP error naming the focuser.
+- Camera or focuser not connected → MCP error.
+- `duration`, `step_size`, `half_width`, `min_area`, `max_area`
+  missing → MCP error naming the missing parameter (validated in
+  body in input order, same convention as `measure_basic`).
+- `step_size <= 0`, `half_width <= 0`, or `min_fit_points < 3`
+  → MCP error naming the bad parameter (a parabolic fit needs at
+  least 3 non-collinear points).
+- Sweep grid (after clamping to `min_position`/`max_position`)
+  has fewer than `min_fit_points` positions → MCP error before
+  any motion or exposure.
+- A `move_focuser`, `capture`, or `measure_basic` call inside
+  the sweep returns an error → `auto_focus` propagates that
+  error and stops sweeping. Captures already taken are persisted
+  on disk normally (that path is owned by `capture`, not
+  `auto_focus`); the focuser is left at its current position.
+- Fewer than `min_fit_points` non-null HFR samples after the
+  sweep completes → `not_enough_stars` error.
+- Parabolic fit yields `a ≤ 0` → `monotonic_curve` error. The
+  caller is expected to widen `half_width`, coarse-focus
+  externally, or both, then retry. The focuser is **not**
+  automatically moved to the lowest observed sample, because
+  that point is unverified as a true minimum.
+
+**Persistence**: `auto_focus` does **not** write a section on any
+single exposure document — its result spans the sweep. Each capture
+inside the sweep gets its own `image_analysis` section written by
+the embedded `measure_basic` call exactly as if `measure_basic` had
+been called directly. The compound result is returned in the MCP
+response and emitted as `focus_complete`. Each entry in
+`curve_points` carries the per-step `document_id`, so callers that
+need per-step provenance can fetch the individual exposure documents
+and read their `image_analysis` sections.
+
+**Caveats**:
+- Parabolic fit is the V1 choice for simplicity. Real V-curves are
+  often slightly asymmetric (extra-focal vs. intra-focal slopes
+  differ); a parabola fits an effective vertex that may sit one
+  or two steps off the true minimum. Acceptable for amateur rigs.
+  An asymmetric V or piecewise-linear fit can ship later either
+  side-by-side under a different tool name (e.g.
+  `auto_focus_asymmetric_v`) or as a drop-in replacement that
+  shadows the built-in — see [Third-party alternatives](#third-party-alternatives).
+- No automatic re-sweep on a monotonic curve. The caller already
+  knows what coarse-focus heuristic they prefer; `auto_focus`
+  reports the failure cleanly and lets the caller widen
+  `half_width` or coarse-focus externally before retrying.
+  Adding re-sweep state-machine logic would double the BDD
+  surface for marginal benefit.
+- Saturated stars are included in `star_count` and contribute to
+  the fit through their HFR, mirroring `measure_basic`'s policy.
+  Filtering them at the auto-focus layer would reintroduce the
+  HFR-vs-focus monotonicity break the policy was designed to
+  avoid (see `measure_basic` Contract). Callers that need a
+  per-curve saturation aggregate can fetch each
+  `curve_points[i].document_id` and read its `image_analysis`
+  section.
+- `auto_focus` is a built-in compound tool and may be **shadowed**
+  by a tool-provider plugin advertising the same `auto_focus`
+  name; the plugin wins per Config-Time Validation, with the
+  shadow logged at startup. Two plugins both claiming
+  `auto_focus` remains a config-time error.
+
 #### Example: `auto_focus` (V-curve)
 
+See [`auto_focus` Contract](#auto_focus-contract) for the full parameter
+set, error policy, and persistence rules. The pseudo-code below
+illustrates the loop shape only.
+
 ```
-Orchestrator: tools/call auto_focus {camera_id: "main-cam", focuser_id: "main-focuser"}
-  rp's auto_focus implementation:
-    move_focuser(position=10000) → 10000
-    capture(camera_id="main-cam", duration_ms=2000) → {document_id: "doc-001", ...}
-    measure_basic(document_id="doc-001")           → {hfr: 5.2, star_count: 340}
-    move_focuser(position=10200) → 10200
-    ... 12 more iterations on the V-curve ...
-    move_focuser(position=12450) → 12450
-  ← {best_position: 12450, best_hfr: 2.1, curve_points: 15}
+Orchestrator: tools/call auto_focus {
+    camera_id: "main-cam",  focuser_id: "main-focuser",
+    duration: "2s",         step_size: 200,          half_width: 1500,
+    min_area: 8,            max_area: 400
+}
+  rp's auto_focus implementation (current_position = 11000):
+    move_focuser(position=9500) → 9500
+    capture(camera_id="main-cam", duration="2s") → {document_id: "doc-001"}
+    measure_basic(document_id="doc-001", min_area=8, max_area=400)
+                                                   → {hfr: 6.8, star_count: 220}
+    move_focuser(position=9700) → 9700
+    ... 14 more sweep points (15 total) ...
+    move_focuser(position=12500) → 12500   # last sweep point
+    fit parabola → best_position = 11212
+    move_focuser(position=11212) → 11212   # final move to fitted vertex
+  ← {best_position: 11212, best_hfr: 2.1, final_position: 11212,
+     samples_used: 15, curve_points: [...], temperature_c: 4.3}
 ```
 
 #### Example: `center_on_target`

--- a/services/rp/src/imaging/mod.rs
+++ b/services/rp/src/imaging/mod.rs
@@ -1,12 +1,25 @@
-//! Image analysis: pure kernels and the compositional tools that bind
-//! them together. FITS I/O, the image cache, and exposure-document
-//! storage live in [`crate::persistence`] — this module is async- and
-//! I/O-free so kernels can be unit-tested in isolation.
+//! Image analysis: pure kernels, compositional analyzers, and compound
+//! equipment-driving tools. FITS I/O, the image cache, and
+//! exposure-document storage live in [`crate::persistence`] —
+//! [`analysis`] kernels and the pure compositional analyzers in
+//! [`tools`] (`measure_basic`, `measure_stars`) are async- and
+//! I/O-free so they can be unit-tested in isolation.
+//!
+//! Compound tools that drive equipment loops (`auto_focus` and the
+//! planned `center_on_target`) also live under [`tools`]. They are
+//! async and they take device-trait objects, so they are *not*
+//! async-/I/O-free at the top level — but the math and grid logic
+//! they bundle (`build_grid`, `fit_parabola`, `validate_params`) are
+//! still pure helpers that test independently. The MCP wrappers in
+//! `mcp.rs` provide concrete adapters that bind the equipment traits
+//! to live Alpaca clients; tests substitute synthetic adapters.
 //!
 //! Submodules:
 //! - [`analysis`]: single-purpose math (background, stars, hfr, fwhm,
-//!   snr, stats, pixel trait).
-//! - [`tools`]: compositional analyzers (measure_basic, measure_stars).
+//!   snr, stats, pixel trait). Pure, generic over [`Pixel`], no I/O.
+//! - [`tools`]: compositional analyzers (`measure_basic`,
+//!   `measure_stars`) plus compound equipment-driving tools
+//!   (`auto_focus`).
 //!
 //! The flat re-exports below preserve the previous `crate::imaging::*`
 //! call-site shape so MCP wiring doesn't have to know which submodule

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -75,12 +75,7 @@ pub enum AutoFocusError {
 
 #[async_trait]
 pub trait FocuserOps {
-    async fn position(&self) -> Result<i32, String>;
     async fn move_to(&self, position: i32) -> Result<i32, String>;
-    /// Returns `None` for `NOT_IMPLEMENTED` or any transient read failure
-    /// — temperature is informational on the result, never load-bearing
-    /// on the sweep, so a single failure does not abort the run.
-    async fn temperature(&self) -> Option<f64>;
 }
 
 #[async_trait]
@@ -237,21 +232,29 @@ pub fn fit_parabola(samples: &[(i32, f64, u32)]) -> Result<ParabolaFit, AutoFocu
 /// Drive the V-curve sweep against the supplied focuser/capturer/measurer
 /// adapters. See `docs/services/rp.md` → `auto_focus` Contract for the
 /// behavioral spec; this function is the reference implementation.
+///
+/// `starting_position` and `starting_temperature_c` must be the values the
+/// caller already read from the focuser for the `focus_started` event.
+/// The contract guarantees a single read of each — passing them in keeps
+/// the event payload and the result strictly consistent and avoids extra
+/// Alpaca round-trips inside the loop.
 pub async fn run_auto_focus<F: FocuserOps + Sync, C: CaptureOps + Sync, M: MeasureOps + Sync>(
     focuser: &F,
     capturer: &C,
     measurer: &M,
     bounds: (Option<i32>, Option<i32>),
+    starting_position: i32,
+    starting_temperature_c: Option<f64>,
     params: AutoFocusParams,
 ) -> Result<AutoFocusResult, AutoFocusError> {
     validate_params(&params)?;
 
-    let current = focuser
-        .position()
-        .await
-        .map_err(AutoFocusError::Equipment)?;
-
-    let grid = build_grid(current, params.step_size, params.half_width, bounds);
+    let grid = build_grid(
+        starting_position,
+        params.step_size,
+        params.half_width,
+        bounds,
+    );
     if grid.len() < params.min_fit_points {
         return Err(AutoFocusError::GridTooSmall {
             available: grid.len(),
@@ -259,9 +262,9 @@ pub async fn run_auto_focus<F: FocuserOps + Sync, C: CaptureOps + Sync, M: Measu
         });
     }
 
-    let temperature_c = focuser.temperature().await;
+    let temperature_c = starting_temperature_c;
     debug!(
-        current_position = current,
+        current_position = starting_position,
         grid_len = grid.len(),
         temperature_c = ?temperature_c,
         "auto_focus sweep starting"
@@ -520,15 +523,9 @@ mod tests {
 
     #[async_trait]
     impl FocuserOps for StubFocuser {
-        async fn position(&self) -> Result<i32, String> {
-            Ok(*self.position.lock().unwrap())
-        }
         async fn move_to(&self, position: i32) -> Result<i32, String> {
             *self.position.lock().unwrap() = position;
             Ok(position)
-        }
-        async fn temperature(&self) -> Option<f64> {
-            Some(4.5)
         }
     }
 
@@ -601,6 +598,8 @@ mod tests {
             &cap,
             &meas,
             (None, None),
+            1234,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(100),
                 step_size: 100,
@@ -645,6 +644,8 @@ mod tests {
             &cap,
             &meas,
             (Some(4900), Some(5100)),
+            5000,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(100),
                 step_size: 100,
@@ -709,6 +710,8 @@ mod tests {
             &cap,
             &Sparse,
             (None, None),
+            1234,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(100),
                 step_size: 100,
@@ -724,70 +727,6 @@ mod tests {
             err,
             Err(AutoFocusError::NotEnoughStars { needed: 5, .. })
         ));
-    }
-
-    /// `focuser.position()` errors at the very start of the sweep —
-    /// the run aborts cleanly with `Equipment(_)` carrying the
-    /// underlying message.
-    #[tokio::test]
-    async fn run_auto_focus_propagates_focuser_position_error() {
-        struct FailingPosition;
-        #[async_trait]
-        impl FocuserOps for FailingPosition {
-            async fn position(&self) -> Result<i32, String> {
-                Err("alpaca disconnected".to_string())
-            }
-            async fn move_to(&self, _: i32) -> Result<i32, String> {
-                Ok(0)
-            }
-            async fn temperature(&self) -> Option<f64> {
-                None
-            }
-        }
-        struct UnreachableCapturer;
-        #[async_trait]
-        impl CaptureOps for UnreachableCapturer {
-            async fn capture(&self, _: Duration) -> Result<String, String> {
-                panic!("capture must not be reached when position() fails")
-            }
-        }
-        struct UnreachableMeasurer;
-        #[async_trait]
-        impl MeasureOps for UnreachableMeasurer {
-            async fn measure(
-                &self,
-                _: &str,
-                _: usize,
-                _: usize,
-                _: f64,
-            ) -> Result<HfrSample, String> {
-                panic!("measure must not be reached")
-            }
-        }
-        let err = run_auto_focus(
-            &FailingPosition,
-            &UnreachableCapturer,
-            &UnreachableMeasurer,
-            (None, None),
-            AutoFocusParams {
-                duration: Duration::from_millis(10),
-                step_size: 100,
-                half_width: 400,
-                min_area: 5,
-                max_area: 1000,
-                threshold_sigma: 5.0,
-                min_fit_points: 5,
-            },
-        )
-        .await;
-        match err {
-            Err(AutoFocusError::Equipment(msg)) => assert!(
-                msg.contains("alpaca disconnected"),
-                "expected propagated message, got: {}",
-                msg
-            ),
-            other => panic!("expected Equipment, got {:?}", other),
-        }
     }
 
     /// `capture()` errors mid-sweep on the second grid point — the
@@ -826,6 +765,8 @@ mod tests {
             &cap,
             &meas,
             (None, None),
+            1234,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(10),
                 step_size: 100,
@@ -876,6 +817,8 @@ mod tests {
             &cap,
             &FailingMeasurer,
             (None, None),
+            1234,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(10),
                 step_size: 100,
@@ -922,6 +865,8 @@ mod tests {
             &cap,
             &meas,
             (None, None),
+            1234,
+            Some(4.5),
             AutoFocusParams {
                 duration: Duration::from_millis(10),
                 step_size: 100,
@@ -945,45 +890,17 @@ mod tests {
         }
     }
 
-    /// When the focuser does not implement temperature readout the
-    /// adapter returns `None`; the result's `temperature_c` is also
-    /// `None` and the rest of the run proceeds normally.
+    /// When the caller passes `None` for the starting temperature
+    /// (e.g. the focuser doesn't implement Temperature, or the read
+    /// failed), the result's `temperature_c` is also `None`. The
+    /// rest of the sweep proceeds normally.
     #[tokio::test]
     async fn run_auto_focus_records_none_temperature() {
-        struct NoTemperature {
-            position: Mutex<i32>,
-        }
-        #[async_trait]
-        impl FocuserOps for NoTemperature {
-            async fn position(&self) -> Result<i32, String> {
-                Ok(*self.position.lock().unwrap())
-            }
-            async fn move_to(&self, p: i32) -> Result<i32, String> {
-                *self.position.lock().unwrap() = p;
-                Ok(p)
-            }
-            async fn temperature(&self) -> Option<f64> {
-                None
-            }
-        }
-        struct PosCapturer<'a> {
-            foc: &'a NoTemperature,
-            counter: Mutex<u64>,
-        }
-        #[async_trait]
-        impl CaptureOps for PosCapturer<'_> {
-            async fn capture(&self, _: Duration) -> Result<String, String> {
-                let pos = *self.foc.position.lock().unwrap();
-                let mut c = self.counter.lock().unwrap();
-                *c += 1;
-                Ok(format!("doc-{:05}-pos{}", *c, pos))
-            }
-        }
-        let foc = NoTemperature {
+        let foc = StubFocuser {
             position: Mutex::new(1234),
         };
-        let cap = PosCapturer {
-            foc: &foc,
+        let cap = StubCapturer {
+            focuser: &foc,
             counter: Mutex::new(0),
         };
         let meas = StubMeasurer {
@@ -997,6 +914,8 @@ mod tests {
             &cap,
             &meas,
             (None, None),
+            1234,
+            None,
             AutoFocusParams {
                 duration: Duration::from_millis(10),
                 step_size: 100,

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -1,0 +1,728 @@
+//! `auto_focus`: V-curve focus sweep compound tool.
+//!
+//! The driving logic — sweep grid construction, the move/capture/measure
+//! loop, parabolic least-squares fit, vertex-in-range validation — is
+//! pure Rust and fully unit-testable via the [`FocuserOps`],
+//! [`CaptureOps`], [`MeasureOps`] traits. The MCP wrapper in `mcp.rs`
+//! provides concrete adapters that bind to the real Alpaca focuser /
+//! camera and the image cache; tests substitute synthetic adapters
+//! that drive the loop with deterministic per-position HFR data.
+//!
+//! Behavioral contract: `docs/services/rp.md` → Compound Tools →
+//! `auto_focus` Contract.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::debug;
+
+#[derive(Debug, Clone)]
+pub struct AutoFocusParams {
+    pub duration: Duration,
+    pub step_size: i32,
+    pub half_width: i32,
+    pub min_area: usize,
+    pub max_area: usize,
+    pub threshold_sigma: f64,
+    pub min_fit_points: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CurvePoint {
+    pub position: i32,
+    pub hfr: Option<f64>,
+    pub star_count: u32,
+    pub document_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AutoFocusResult {
+    pub best_position: i32,
+    pub best_hfr: f64,
+    pub final_position: i32,
+    pub samples_used: usize,
+    pub curve_points: Vec<CurvePoint>,
+    pub temperature_c: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HfrSample {
+    pub hfr: Option<f64>,
+    pub star_count: u32,
+}
+
+#[derive(Debug, Error)]
+pub enum AutoFocusError {
+    #[error("step_size must be positive (got {0})")]
+    InvalidStepSize(i32),
+    #[error("half_width must be positive (got {0})")]
+    InvalidHalfWidth(i32),
+    #[error("min_fit_points must be at least 3 (got {0})")]
+    InvalidMinFitPoints(usize),
+    #[error(
+        "sweep grid has {available} positions after clamping to focuser bounds; \
+         min_fit_points={requested}"
+    )]
+    GridTooSmall { available: usize, requested: usize },
+    #[error("not enough stars: only {got} of {needed} required samples have non-null HFR")]
+    NotEnoughStars { got: usize, needed: usize },
+    #[error("monotonic curve: {0}")]
+    MonotonicCurve(String),
+    #[error("equipment error during sweep: {0}")]
+    Equipment(String),
+}
+
+#[async_trait]
+pub trait FocuserOps {
+    async fn position(&self) -> Result<i32, String>;
+    async fn move_to(&self, position: i32) -> Result<i32, String>;
+    /// Returns `None` for `NOT_IMPLEMENTED` or any transient read failure
+    /// — temperature is informational on the result, never load-bearing
+    /// on the sweep, so a single failure does not abort the run.
+    async fn temperature(&self) -> Option<f64>;
+}
+
+#[async_trait]
+pub trait CaptureOps {
+    /// Capture an exposure of `duration` and return its `document_id`.
+    async fn capture(&self, duration: Duration) -> Result<String, String>;
+}
+
+#[async_trait]
+pub trait MeasureOps {
+    async fn measure(
+        &self,
+        document_id: &str,
+        min_area: usize,
+        max_area: usize,
+        threshold_sigma: f64,
+    ) -> Result<HfrSample, String>;
+}
+
+pub fn validate_params(params: &AutoFocusParams) -> Result<(), AutoFocusError> {
+    if params.step_size <= 0 {
+        return Err(AutoFocusError::InvalidStepSize(params.step_size));
+    }
+    if params.half_width <= 0 {
+        return Err(AutoFocusError::InvalidHalfWidth(params.half_width));
+    }
+    if params.min_fit_points < 3 {
+        return Err(AutoFocusError::InvalidMinFitPoints(params.min_fit_points));
+    }
+    Ok(())
+}
+
+/// Build the sweep grid `[start, start+step, …, end]` clamped to
+/// `[min_bound, max_bound]`. Out-of-range points are dropped (not
+/// coerced) — coercion would produce duplicate samples at a bound and
+/// distort the parabola fit.
+pub fn build_grid(
+    current: i32,
+    step: i32,
+    half_width: i32,
+    bounds: (Option<i32>, Option<i32>),
+) -> Vec<i32> {
+    let start = current.saturating_sub(half_width);
+    let end = current.saturating_add(half_width);
+    let mut grid = Vec::new();
+    let mut p = start;
+    loop {
+        let in_min = bounds.0.is_none_or(|min| p >= min);
+        let in_max = bounds.1.is_none_or(|max| p <= max);
+        if in_min && in_max {
+            grid.push(p);
+        }
+        let next = p.saturating_add(step);
+        if p == end || next <= p {
+            break;
+        }
+        if next > end {
+            break;
+        }
+        p = next;
+    }
+    grid
+}
+
+/// Result of fitting `hfr = a·x² + b·x + c` with vertex at
+/// `(round(−b/2a), c − b²/(4a))`.
+#[derive(Debug, Clone, Copy)]
+pub struct ParabolaFit {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+}
+
+impl ParabolaFit {
+    pub fn vertex_position(&self) -> i32 {
+        (-self.b / (2.0 * self.a)).round() as i32
+    }
+
+    pub fn vertex_value(&self) -> f64 {
+        self.c - (self.b * self.b) / (4.0 * self.a)
+    }
+}
+
+/// Weighted least-squares fit of a parabola `y = a·x² + b·x + c` to
+/// `(position, hfr, weight)` samples. `weight` is typically the
+/// per-frame `star_count`; samples with `weight == 0` are dropped.
+///
+/// Returns `MonotonicCurve` if `a ≤ 0` (the curve has no minimum) or if
+/// the design matrix is too ill-conditioned to invert (essentially
+/// flat input, where the vertex is undefined).
+pub fn fit_parabola(samples: &[(i32, f64, u32)]) -> Result<ParabolaFit, AutoFocusError> {
+    let filtered: Vec<(f64, f64, f64)> = samples
+        .iter()
+        .filter(|(_, _, w)| *w > 0)
+        .map(|(x, y, w)| (*x as f64, *y, *w as f64))
+        .collect();
+    if filtered.len() < 3 {
+        return Err(AutoFocusError::NotEnoughStars {
+            got: filtered.len(),
+            needed: 3,
+        });
+    }
+    // Normal equations Aᵀ W A · [a, b, c]ᵀ = Aᵀ W y, with
+    // A = [x², x, 1] per row, W = diag(weights). Solved via Cramer's
+    // rule on the 3×3 system below.
+    let mut m4 = 0.0;
+    let mut m3 = 0.0;
+    let mut m2 = 0.0;
+    let mut m1 = 0.0;
+    let mut m0 = 0.0;
+    let mut t2 = 0.0;
+    let mut t1 = 0.0;
+    let mut t0 = 0.0;
+    for (x, y, w) in &filtered {
+        let x2 = x * x;
+        let x3 = x2 * x;
+        let x4 = x3 * x;
+        m4 += w * x4;
+        m3 += w * x3;
+        m2 += w * x2;
+        m1 += w * x;
+        m0 += w;
+        t2 += w * x2 * y;
+        t1 += w * x * y;
+        t0 += w * y;
+    }
+    let det = m4 * (m2 * m0 - m1 * m1) - m3 * (m3 * m0 - m1 * m2) + m2 * (m3 * m1 - m2 * m2);
+    // Scale-invariant ill-conditioning check: the normal-equation
+    // determinant is roughly O(m4·m2·m0) for the problem; require the
+    // actual det to be at least ~1e-12 of that ceiling. Below this, the
+    // input is effectively flat and the vertex is meaningless.
+    let det_scale = (m4.abs() * m2.abs() * m0.abs()).max(1.0);
+    if det.abs() < det_scale * 1e-12 {
+        return Err(AutoFocusError::MonotonicCurve(format!(
+            "design matrix is singular (det={:.3e}, scale={:.3e})",
+            det, det_scale
+        )));
+    }
+    let det_a = t2 * (m2 * m0 - m1 * m1) - m3 * (t1 * m0 - m1 * t0) + m2 * (t1 * m1 - m2 * t0);
+    let det_b = m4 * (t1 * m0 - m1 * t0) - t2 * (m3 * m0 - m1 * m2) + m2 * (m3 * t0 - t1 * m2);
+    let det_c = m4 * (m2 * t0 - t1 * m1) - m3 * (m3 * t0 - t1 * m2) + t2 * (m3 * m1 - m2 * m2);
+    let a = det_a / det;
+    let b = det_b / det;
+    let c = det_c / det;
+    if a <= 0.0 {
+        return Err(AutoFocusError::MonotonicCurve(format!(
+            "non-positive leading coefficient (a={:.3e})",
+            a
+        )));
+    }
+    Ok(ParabolaFit { a, b, c })
+}
+
+/// Drive the V-curve sweep against the supplied focuser/capturer/measurer
+/// adapters. See `docs/services/rp.md` → `auto_focus` Contract for the
+/// behavioral spec; this function is the reference implementation.
+pub async fn run_auto_focus<F: FocuserOps + Sync, C: CaptureOps + Sync, M: MeasureOps + Sync>(
+    focuser: &F,
+    capturer: &C,
+    measurer: &M,
+    bounds: (Option<i32>, Option<i32>),
+    params: AutoFocusParams,
+) -> Result<AutoFocusResult, AutoFocusError> {
+    validate_params(&params)?;
+
+    let current = focuser
+        .position()
+        .await
+        .map_err(AutoFocusError::Equipment)?;
+
+    let grid = build_grid(current, params.step_size, params.half_width, bounds);
+    if grid.len() < params.min_fit_points {
+        return Err(AutoFocusError::GridTooSmall {
+            available: grid.len(),
+            requested: params.min_fit_points,
+        });
+    }
+
+    let temperature_c = focuser.temperature().await;
+    debug!(
+        current_position = current,
+        grid_len = grid.len(),
+        temperature_c = ?temperature_c,
+        "auto_focus sweep starting"
+    );
+
+    let mut curve_points = Vec::with_capacity(grid.len());
+    for position in &grid {
+        focuser
+            .move_to(*position)
+            .await
+            .map_err(AutoFocusError::Equipment)?;
+        let document_id = capturer
+            .capture(params.duration)
+            .await
+            .map_err(AutoFocusError::Equipment)?;
+        let sample = measurer
+            .measure(
+                &document_id,
+                params.min_area,
+                params.max_area,
+                params.threshold_sigma,
+            )
+            .await
+            .map_err(AutoFocusError::Equipment)?;
+        curve_points.push(CurvePoint {
+            position: *position,
+            hfr: sample.hfr,
+            star_count: sample.star_count,
+            document_id,
+        });
+    }
+
+    let valid_samples: Vec<(i32, f64, u32)> = curve_points
+        .iter()
+        .filter_map(|p| p.hfr.map(|h| (p.position, h, p.star_count)))
+        .collect();
+    if valid_samples.len() < params.min_fit_points {
+        return Err(AutoFocusError::NotEnoughStars {
+            got: valid_samples.len(),
+            needed: params.min_fit_points,
+        });
+    }
+
+    let fit = fit_parabola(&valid_samples)?;
+    let best_position = fit.vertex_position();
+    let grid_min = *grid.first().expect("grid non-empty by construction");
+    let grid_max = *grid.last().expect("grid non-empty by construction");
+    if best_position < grid_min || best_position > grid_max {
+        return Err(AutoFocusError::MonotonicCurve(format!(
+            "fitted vertex {} is outside sampled grid [{}, {}]",
+            best_position, grid_min, grid_max
+        )));
+    }
+    let best_hfr = fit.vertex_value();
+
+    let final_position = focuser
+        .move_to(best_position)
+        .await
+        .map_err(AutoFocusError::Equipment)?;
+
+    Ok(AutoFocusResult {
+        best_position,
+        best_hfr,
+        final_position,
+        samples_used: valid_samples.len(),
+        curve_points,
+        temperature_c,
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // ---- pure helpers ----
+
+    #[test]
+    fn validate_params_accepts_minimum_valid_input() {
+        let p = AutoFocusParams {
+            duration: Duration::from_millis(100),
+            step_size: 1,
+            half_width: 1,
+            min_area: 1,
+            max_area: 1,
+            threshold_sigma: 5.0,
+            min_fit_points: 3,
+        };
+        validate_params(&p).unwrap();
+    }
+
+    #[test]
+    fn validate_params_rejects_zero_step_size() {
+        let p = AutoFocusParams {
+            duration: Duration::from_millis(100),
+            step_size: 0,
+            half_width: 100,
+            min_area: 5,
+            max_area: 1000,
+            threshold_sigma: 5.0,
+            min_fit_points: 5,
+        };
+        assert!(matches!(
+            validate_params(&p),
+            Err(AutoFocusError::InvalidStepSize(0))
+        ));
+    }
+
+    #[test]
+    fn validate_params_rejects_negative_half_width() {
+        let p = AutoFocusParams {
+            duration: Duration::from_millis(100),
+            step_size: 50,
+            half_width: -1,
+            min_area: 5,
+            max_area: 1000,
+            threshold_sigma: 5.0,
+            min_fit_points: 5,
+        };
+        assert!(matches!(
+            validate_params(&p),
+            Err(AutoFocusError::InvalidHalfWidth(-1))
+        ));
+    }
+
+    #[test]
+    fn validate_params_rejects_min_fit_points_below_3() {
+        let p = AutoFocusParams {
+            duration: Duration::from_millis(100),
+            step_size: 50,
+            half_width: 100,
+            min_area: 5,
+            max_area: 1000,
+            threshold_sigma: 5.0,
+            min_fit_points: 2,
+        };
+        assert!(matches!(
+            validate_params(&p),
+            Err(AutoFocusError::InvalidMinFitPoints(2))
+        ));
+    }
+
+    // ---- grid construction ----
+
+    #[test]
+    fn build_grid_unbounded_is_symmetric() {
+        let g = build_grid(1000, 100, 200, (None, None));
+        assert_eq!(g, vec![800, 900, 1000, 1100, 1200]);
+    }
+
+    #[test]
+    fn build_grid_clamps_below_min_position() {
+        let g = build_grid(5000, 100, 500, (Some(4900), None));
+        assert_eq!(g, vec![4900, 5000, 5100, 5200, 5300, 5400, 5500]);
+    }
+
+    #[test]
+    fn build_grid_clamps_above_max_position() {
+        let g = build_grid(5000, 100, 500, (None, Some(5100)));
+        assert_eq!(g, vec![4500, 4600, 4700, 4800, 4900, 5000, 5100]);
+    }
+
+    #[test]
+    fn build_grid_clamps_both_sides() {
+        let g = build_grid(5000, 100, 500, (Some(4900), Some(5100)));
+        assert_eq!(g, vec![4900, 5000, 5100]);
+    }
+
+    #[test]
+    fn build_grid_step_larger_than_half_width_yields_singleton() {
+        let g = build_grid(1000, 1000, 100, (None, None));
+        assert_eq!(g, vec![900]);
+    }
+
+    // ---- parabola fit ----
+
+    fn make_v_samples(vertex_x: i32, vertex_y: f64, curvature: f64) -> Vec<(i32, f64, u32)> {
+        (vertex_x - 200..=vertex_x + 200)
+            .step_by(50)
+            .map(|x| {
+                let dx = (x - vertex_x) as f64;
+                let y = curvature * dx * dx + vertex_y;
+                (x, y, 100)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fit_parabola_recovers_known_minimum_to_within_one_step() {
+        let samples = make_v_samples(1234, 1.5, 1e-4);
+        let fit = fit_parabola(&samples).unwrap();
+        let vx = fit.vertex_position();
+        assert!(
+            (vx - 1234).abs() <= 1,
+            "expected vertex_position within ±1 of 1234, got {}",
+            vx
+        );
+        let vy = fit.vertex_value();
+        assert!(
+            (vy - 1.5).abs() < 1e-6,
+            "expected vertex_value ≈ 1.5, got {}",
+            vy
+        );
+    }
+
+    #[test]
+    fn fit_parabola_rejects_flat_input() {
+        let samples: Vec<_> = (0..10).map(|i| (i * 100, 5.0, 100)).collect();
+        match fit_parabola(&samples) {
+            Err(AutoFocusError::MonotonicCurve(_)) => {}
+            other => panic!("expected MonotonicCurve, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fit_parabola_rejects_concave_down_curve() {
+        let samples: Vec<_> = (0..10)
+            .map(|i| {
+                let x = i * 50;
+                let dx = (x - 100) as f64;
+                (x, 5.0 - 1e-4 * dx * dx, 100)
+            })
+            .collect();
+        match fit_parabola(&samples) {
+            Err(AutoFocusError::MonotonicCurve(msg)) => {
+                assert!(msg.contains("non-positive"), "got msg: {}", msg);
+            }
+            other => panic!("expected MonotonicCurve, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fit_parabola_rejects_too_few_samples() {
+        let samples = vec![(0, 1.0, 100), (10, 2.0, 100)];
+        match fit_parabola(&samples) {
+            Err(AutoFocusError::NotEnoughStars { got: 2, needed: 3 }) => {}
+            other => panic!("expected NotEnoughStars, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fit_parabola_drops_zero_weight_samples() {
+        let mut samples = make_v_samples(1000, 2.0, 1e-4);
+        samples.push((100_000, 999.0, 0));
+        samples.push((-100_000, 999.0, 0));
+        let fit = fit_parabola(&samples).unwrap();
+        assert!((fit.vertex_position() - 1000).abs() <= 1);
+    }
+
+    // ---- end-to-end run_auto_focus over synthetic adapters ----
+
+    struct StubFocuser {
+        position: Mutex<i32>,
+    }
+
+    #[async_trait]
+    impl FocuserOps for StubFocuser {
+        async fn position(&self) -> Result<i32, String> {
+            Ok(*self.position.lock().unwrap())
+        }
+        async fn move_to(&self, position: i32) -> Result<i32, String> {
+            *self.position.lock().unwrap() = position;
+            Ok(position)
+        }
+        async fn temperature(&self) -> Option<f64> {
+            Some(4.5)
+        }
+    }
+
+    /// The capturer reads the focuser's current position and stamps it
+    /// into the synthetic `document_id`, so the measurer can recover
+    /// per-position HFR values without any shared state beyond the id.
+    struct StubCapturer<'a> {
+        focuser: &'a StubFocuser,
+        counter: Mutex<u64>,
+    }
+
+    #[async_trait]
+    impl CaptureOps for StubCapturer<'_> {
+        async fn capture(&self, _duration: Duration) -> Result<String, String> {
+            let pos = *self.focuser.position.lock().unwrap();
+            let mut c = self.counter.lock().unwrap();
+            *c += 1;
+            Ok(format!("doc-{:05}-pos{}", *c, pos))
+        }
+    }
+
+    /// Synthetic V-curve: `hfr = curvature·(pos − vertex)² + vertex_y`.
+    /// Recovers the position from the document id stamped by [`StubCapturer`].
+    struct StubMeasurer {
+        vertex: i32,
+        vertex_y: f64,
+        curvature: f64,
+        star_count: u32,
+    }
+
+    #[async_trait]
+    impl MeasureOps for StubMeasurer {
+        async fn measure(
+            &self,
+            document_id: &str,
+            _min_area: usize,
+            _max_area: usize,
+            _threshold_sigma: f64,
+        ) -> Result<HfrSample, String> {
+            let pos: i32 = document_id
+                .rsplit_once("pos")
+                .and_then(|(_, s)| s.parse().ok())
+                .ok_or_else(|| format!("bad document_id: {document_id}"))?;
+            let dx = (pos - self.vertex) as f64;
+            let hfr = self.curvature * dx * dx + self.vertex_y;
+            Ok(HfrSample {
+                hfr: Some(hfr),
+                star_count: self.star_count,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn run_auto_focus_recovers_known_vertex() {
+        let foc = StubFocuser {
+            position: Mutex::new(1234),
+        };
+        let cap = StubCapturer {
+            focuser: &foc,
+            counter: Mutex::new(0),
+        };
+        let meas = StubMeasurer {
+            vertex: 1234,
+            vertex_y: 2.0,
+            curvature: 1e-4,
+            star_count: 100,
+        };
+        let result = run_auto_focus(
+            &foc,
+            &cap,
+            &meas,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(100),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            (result.best_position - 1234).abs() <= 1,
+            "best_position {} not within ±1 of 1234",
+            result.best_position
+        );
+        assert!((result.best_hfr - 2.0).abs() < 1e-6);
+        assert_eq!(result.samples_used, 9);
+        assert_eq!(result.curve_points.len(), 9);
+        assert_eq!(result.final_position, result.best_position);
+        assert_eq!(result.temperature_c, Some(4.5));
+    }
+
+    #[tokio::test]
+    async fn run_auto_focus_errors_on_grid_too_small_after_clamp() {
+        let foc = StubFocuser {
+            position: Mutex::new(5000),
+        };
+        let cap = StubCapturer {
+            focuser: &foc,
+            counter: Mutex::new(0),
+        };
+        let meas = StubMeasurer {
+            vertex: 5000,
+            vertex_y: 2.0,
+            curvature: 1e-4,
+            star_count: 100,
+        };
+        let err = run_auto_focus(
+            &foc,
+            &cap,
+            &meas,
+            (Some(4900), Some(5100)),
+            AutoFocusParams {
+                duration: Duration::from_millis(100),
+                step_size: 100,
+                half_width: 500,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        assert!(matches!(
+            err,
+            Err(AutoFocusError::GridTooSmall {
+                available: 3,
+                requested: 5
+            })
+        ));
+    }
+
+    /// Sparse stars: only the central pair has detections. With 9 grid
+    /// points and only 2 useful samples, the run must error
+    /// `NotEnoughStars`.
+    #[tokio::test]
+    async fn run_auto_focus_errors_on_not_enough_stars_after_skips() {
+        struct Sparse;
+        #[async_trait]
+        impl MeasureOps for Sparse {
+            async fn measure(
+                &self,
+                document_id: &str,
+                _min_area: usize,
+                _max_area: usize,
+                _threshold_sigma: f64,
+            ) -> Result<HfrSample, String> {
+                let pos: i32 = document_id
+                    .rsplit_once("pos")
+                    .and_then(|(_, s)| s.parse().ok())
+                    .unwrap();
+                if (pos - 1234).abs() <= 50 {
+                    Ok(HfrSample {
+                        hfr: Some(2.5),
+                        star_count: 50,
+                    })
+                } else {
+                    Ok(HfrSample {
+                        hfr: None,
+                        star_count: 0,
+                    })
+                }
+            }
+        }
+        let foc = StubFocuser {
+            position: Mutex::new(1234),
+        };
+        let cap = StubCapturer {
+            focuser: &foc,
+            counter: Mutex::new(0),
+        };
+        let err = run_auto_focus(
+            &foc,
+            &cap,
+            &Sparse,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(100),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        assert!(matches!(
+            err,
+            Err(AutoFocusError::NotEnoughStars { needed: 5, .. })
+        ));
+    }
+}

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -725,4 +725,291 @@ mod tests {
             Err(AutoFocusError::NotEnoughStars { needed: 5, .. })
         ));
     }
+
+    /// `focuser.position()` errors at the very start of the sweep —
+    /// the run aborts cleanly with `Equipment(_)` carrying the
+    /// underlying message.
+    #[tokio::test]
+    async fn run_auto_focus_propagates_focuser_position_error() {
+        struct FailingPosition;
+        #[async_trait]
+        impl FocuserOps for FailingPosition {
+            async fn position(&self) -> Result<i32, String> {
+                Err("alpaca disconnected".to_string())
+            }
+            async fn move_to(&self, _: i32) -> Result<i32, String> {
+                Ok(0)
+            }
+            async fn temperature(&self) -> Option<f64> {
+                None
+            }
+        }
+        struct UnreachableCapturer;
+        #[async_trait]
+        impl CaptureOps for UnreachableCapturer {
+            async fn capture(&self, _: Duration) -> Result<String, String> {
+                panic!("capture must not be reached when position() fails")
+            }
+        }
+        struct UnreachableMeasurer;
+        #[async_trait]
+        impl MeasureOps for UnreachableMeasurer {
+            async fn measure(
+                &self,
+                _: &str,
+                _: usize,
+                _: usize,
+                _: f64,
+            ) -> Result<HfrSample, String> {
+                panic!("measure must not be reached")
+            }
+        }
+        let err = run_auto_focus(
+            &FailingPosition,
+            &UnreachableCapturer,
+            &UnreachableMeasurer,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(10),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        match err {
+            Err(AutoFocusError::Equipment(msg)) => assert!(
+                msg.contains("alpaca disconnected"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    /// `capture()` errors mid-sweep on the second grid point — the
+    /// run aborts and propagates the underlying message.
+    #[tokio::test]
+    async fn run_auto_focus_propagates_capture_error() {
+        let foc = StubFocuser {
+            position: Mutex::new(1234),
+        };
+        struct FailingCapturer {
+            counter: Mutex<u64>,
+        }
+        #[async_trait]
+        impl CaptureOps for FailingCapturer {
+            async fn capture(&self, _: Duration) -> Result<String, String> {
+                let mut c = self.counter.lock().unwrap();
+                *c += 1;
+                if *c == 2 {
+                    Err("readout aborted".to_string())
+                } else {
+                    Ok(format!("doc-{:05}-pos9999", *c))
+                }
+            }
+        }
+        let cap = FailingCapturer {
+            counter: Mutex::new(0),
+        };
+        let meas = StubMeasurer {
+            vertex: 1234,
+            vertex_y: 2.0,
+            curvature: 1e-4,
+            star_count: 100,
+        };
+        let err = run_auto_focus(
+            &foc,
+            &cap,
+            &meas,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(10),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        match err {
+            Err(AutoFocusError::Equipment(msg)) => assert!(
+                msg.contains("readout aborted"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    /// `measure()` errors on the first sample — the run aborts and
+    /// propagates the underlying message.
+    #[tokio::test]
+    async fn run_auto_focus_propagates_measure_error() {
+        struct FailingMeasurer;
+        #[async_trait]
+        impl MeasureOps for FailingMeasurer {
+            async fn measure(
+                &self,
+                _: &str,
+                _: usize,
+                _: usize,
+                _: f64,
+            ) -> Result<HfrSample, String> {
+                Err("FITS decode failed".to_string())
+            }
+        }
+        let foc = StubFocuser {
+            position: Mutex::new(1234),
+        };
+        let cap = StubCapturer {
+            focuser: &foc,
+            counter: Mutex::new(0),
+        };
+        let err = run_auto_focus(
+            &foc,
+            &cap,
+            &FailingMeasurer,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(10),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        match err {
+            Err(AutoFocusError::Equipment(msg)) => assert!(
+                msg.contains("FITS decode failed"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    /// `a > 0` but the fitted vertex falls outside the sampled grid
+    /// — the curve is monotonic over the sampled range, so the run
+    /// errors `MonotonicCurve` even though the parabola itself has
+    /// a minimum somewhere off-grid. Achieved by sweeping on one
+    /// arm of the V-curve only (vertex at 9999, sweep around 1234).
+    #[tokio::test]
+    async fn run_auto_focus_rejects_vertex_outside_sampled_grid() {
+        let foc = StubFocuser {
+            position: Mutex::new(1234),
+        };
+        let cap = StubCapturer {
+            focuser: &foc,
+            counter: Mutex::new(0),
+        };
+        let meas = StubMeasurer {
+            vertex: 9999,
+            vertex_y: 2.0,
+            curvature: 1e-4,
+            star_count: 100,
+        };
+        let err = run_auto_focus(
+            &foc,
+            &cap,
+            &meas,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(10),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await;
+        match err {
+            Err(AutoFocusError::MonotonicCurve(msg)) => {
+                assert!(
+                    msg.contains("outside sampled grid"),
+                    "expected vertex-outside-grid message, got: {}",
+                    msg
+                );
+            }
+            other => panic!("expected MonotonicCurve, got {:?}", other),
+        }
+    }
+
+    /// When the focuser does not implement temperature readout the
+    /// adapter returns `None`; the result's `temperature_c` is also
+    /// `None` and the rest of the run proceeds normally.
+    #[tokio::test]
+    async fn run_auto_focus_records_none_temperature() {
+        struct NoTemperature {
+            position: Mutex<i32>,
+        }
+        #[async_trait]
+        impl FocuserOps for NoTemperature {
+            async fn position(&self) -> Result<i32, String> {
+                Ok(*self.position.lock().unwrap())
+            }
+            async fn move_to(&self, p: i32) -> Result<i32, String> {
+                *self.position.lock().unwrap() = p;
+                Ok(p)
+            }
+            async fn temperature(&self) -> Option<f64> {
+                None
+            }
+        }
+        struct PosCapturer<'a> {
+            foc: &'a NoTemperature,
+            counter: Mutex<u64>,
+        }
+        #[async_trait]
+        impl CaptureOps for PosCapturer<'_> {
+            async fn capture(&self, _: Duration) -> Result<String, String> {
+                let pos = *self.foc.position.lock().unwrap();
+                let mut c = self.counter.lock().unwrap();
+                *c += 1;
+                Ok(format!("doc-{:05}-pos{}", *c, pos))
+            }
+        }
+        let foc = NoTemperature {
+            position: Mutex::new(1234),
+        };
+        let cap = PosCapturer {
+            foc: &foc,
+            counter: Mutex::new(0),
+        };
+        let meas = StubMeasurer {
+            vertex: 1234,
+            vertex_y: 2.0,
+            curvature: 1e-4,
+            star_count: 100,
+        };
+        let result = run_auto_focus(
+            &foc,
+            &cap,
+            &meas,
+            (None, None),
+            AutoFocusParams {
+                duration: Duration::from_millis(10),
+                step_size: 100,
+                half_width: 400,
+                min_area: 5,
+                max_area: 1000,
+                threshold_sigma: 5.0,
+                min_fit_points: 5,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.temperature_c, None);
+        assert!((result.best_position - 1234).abs() <= 1);
+    }
 }

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -65,6 +65,11 @@ pub enum AutoFocusError {
          min_fit_points={requested}"
     )]
     GridTooSmall { available: usize, requested: usize },
+    #[error(
+        "sweep grid would contain {requested} positions, exceeds the safety cap of \
+         {max} (raise step_size or lower half_width)"
+    )]
+    GridTooLarge { requested: usize, max: usize },
     #[error("not enough stars: only {got} of {needed} required samples have non-null HFR")]
     NotEnoughStars { got: usize, needed: usize },
     #[error("monotonic curve: {0}")]
@@ -95,6 +100,14 @@ pub trait MeasureOps {
     ) -> Result<HfrSample, String>;
 }
 
+/// Maximum number of grid points an `auto_focus` sweep is allowed to
+/// build. Generous enough that any plausible auto-focus run fits well
+/// inside the cap (typical 10–30 points; even an aggressively-fine
+/// sweep over a wide range stays under 200), so the cap is purely a
+/// guardrail against operator misconfiguration that would otherwise
+/// produce thousands of captures and tie up the rig for hours.
+pub const MAX_GRID_POINTS: usize = 1000;
+
 pub fn validate_params(params: &AutoFocusParams) -> Result<(), AutoFocusError> {
     if params.step_size <= 0 {
         return Err(AutoFocusError::InvalidStepSize(params.step_size));
@@ -105,13 +118,28 @@ pub fn validate_params(params: &AutoFocusParams) -> Result<(), AutoFocusError> {
     if params.min_fit_points < 3 {
         return Err(AutoFocusError::InvalidMinFitPoints(params.min_fit_points));
     }
+    // Upper bound on the unclamped grid size: 2·half_width steps from
+    // start to end, plus the start point itself. Computed in i64 so
+    // an extreme half_width can't overflow before the cap check fires.
+    let estimated = (2_i64 * params.half_width as i64 / params.step_size as i64) + 1;
+    if estimated > MAX_GRID_POINTS as i64 {
+        return Err(AutoFocusError::GridTooLarge {
+            requested: estimated.max(0) as usize,
+            max: MAX_GRID_POINTS,
+        });
+    }
     Ok(())
 }
 
-/// Build the sweep grid `[start, start+step, …, end]` clamped to
-/// `[min_bound, max_bound]`. Out-of-range points are dropped (not
-/// coerced) — coercion would produce duplicate samples at a bound and
-/// distort the parabola fit.
+/// Build the sweep grid `[start, start+step, …]` continuing while the
+/// position stays `≤ end`, then clamped to `[min_bound, max_bound]`.
+/// `start` is `current − half_width` and `end` is
+/// `current + half_width`, so `end` only appears as a grid point when
+/// `(end − start)` is an exact multiple of `step`; otherwise the
+/// last grid point is the largest `start + k·step` that's still
+/// `≤ end`. Out-of-range points (those failing the `[min_bound,
+/// max_bound]` clamp) are dropped, not coerced — coercion would
+/// produce duplicate samples at a bound and distort the parabola fit.
 pub fn build_grid(
     current: i32,
     step: i32,
@@ -406,6 +434,28 @@ mod tests {
             validate_params(&p),
             Err(AutoFocusError::InvalidMinFitPoints(2))
         ));
+    }
+
+    #[test]
+    fn validate_params_rejects_grid_size_above_safety_cap() {
+        // step_size=1, half_width=1_000_000 → 2_000_001 points,
+        // far beyond the 1000-point safety cap.
+        let p = AutoFocusParams {
+            duration: Duration::from_millis(100),
+            step_size: 1,
+            half_width: 1_000_000,
+            min_area: 5,
+            max_area: 1000,
+            threshold_sigma: 5.0,
+            min_fit_points: 5,
+        };
+        match validate_params(&p) {
+            Err(AutoFocusError::GridTooLarge { requested, max }) => {
+                assert!(requested > max, "expected requested > max");
+                assert_eq!(max, MAX_GRID_POINTS);
+            }
+            other => panic!("expected GridTooLarge, got {:?}", other),
+        }
     }
 
     // ---- grid construction ----

--- a/services/rp/src/imaging/tools/mod.rs
+++ b/services/rp/src/imaging/tools/mod.rs
@@ -1,7 +1,18 @@
-//! Compositional image-analysis tools: bind multiple
-//! [`crate::imaging::analysis`] kernels together to answer an end-user
-//! question (one MCP tool per file). Pure functions over `ArrayView2`;
-//! no I/O, no async.
+//! Compositional tools, one MCP tool per file. Two flavors:
+//!
+//! - **Pure compositional analyzers** (`measure_basic`,
+//!   `measure_stars`): bind multiple [`crate::imaging::analysis`]
+//!   kernels into one MCP-tool-shaped result. Pure functions over
+//!   `ArrayView2`, no I/O, no async — unit-testable without a runtime.
+//!
+//! - **Compound equipment-driving tools** (`auto_focus`; planned
+//!   `center_on_target`): drive a multi-step move/capture/measure
+//!   loop using primitive built-in tools. They expose async traits
+//!   for the equipment surface so the driving logic is testable
+//!   against synthetic adapters; the MCP wrapper in `mcp.rs` provides
+//!   live adapters that bind to the real Alpaca clients. The math and
+//!   grid logic these tools bundle (`build_grid`, `fit_parabola`,
+//!   `validate_params`) remain pure helpers.
 
 pub mod auto_focus;
 pub mod measure_basic;

--- a/services/rp/src/imaging/tools/mod.rs
+++ b/services/rp/src/imaging/tools/mod.rs
@@ -3,5 +3,6 @@
 //! question (one MCP tool per file). Pure functions over `ArrayView2`;
 //! no I/O, no async.
 
+pub mod auto_focus;
 pub mod measure_basic;
 pub mod measure_stars;

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -273,6 +273,48 @@ pub struct MoveFocuserParams {
     pub position: i32,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AutoFocusToolParams {
+    /// Camera device ID. Required (validated in body for deterministic
+    /// error ordering — see `docs/services/rp.md` `auto_focus` Contract).
+    #[serde(default)]
+    pub camera_id: Option<String>,
+    /// Focuser device ID. Required (validated in body).
+    #[serde(default)]
+    pub focuser_id: Option<String>,
+    /// Per-frame exposure duration as a humantime string (e.g. `"2s"`,
+    /// `"500ms"`). Required (validated in body).
+    #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "Option<String>")]
+    pub duration: Option<Duration>,
+    /// Step between adjacent sweep grid points, in absolute focuser
+    /// steps. Must be positive. Required (validated in body).
+    #[serde(default)]
+    pub step_size: Option<i32>,
+    /// Half-width of the sweep grid: positions are
+    /// `current_position ± half_width` in `step_size` increments,
+    /// clamped to the focuser's `min_position` / `max_position`. Must
+    /// be positive. Required (validated in body).
+    #[serde(default)]
+    pub half_width: Option<i32>,
+    /// Minimum component pixel area to admit as a star, passed through
+    /// to per-frame `measure_basic`. Required (validated in body).
+    #[serde(default)]
+    pub min_area: Option<usize>,
+    /// Maximum component pixel area, passed through to per-frame
+    /// `measure_basic`. Required (validated in body).
+    #[serde(default)]
+    pub max_area: Option<usize>,
+    /// Detection threshold above sky in stddev units, passed through to
+    /// per-frame `measure_basic`. Default `5.0`.
+    #[serde(default = "default_threshold_sigma")]
+    pub threshold_sigma: f64,
+    /// Minimum non-null HFR samples required for the parabola fit.
+    /// Must be at least 3. Default 5.
+    #[serde(default)]
+    pub min_fit_points: Option<usize>,
+}
+
 // ---------------------------------------------------------------------------
 // McpHandler
 // ---------------------------------------------------------------------------
@@ -695,20 +737,26 @@ impl McpHandler {
             }
         }
     }
-}
 
-#[tool_router(server_handler)]
-impl McpHandler {
-    // -------------------------------------------------------------------
-    // Camera tools
-    // -------------------------------------------------------------------
-
-    #[tool(description = "Capture an image, download image_array, save FITS file")]
-    async fn capture(
+    /// Run the full capture pipeline against the named camera and return
+    /// `(image_path, document_id)`. Shared body of the `capture` MCP tool
+    /// and the `auto_focus` compound tool's per-step capture call —
+    /// both want the same exposure / FITS-write / cache-insert / event
+    /// flow.
+    pub(crate) async fn do_capture(
         &self,
-        Parameters(params): Parameters<CaptureParams>,
-    ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let (_cam_entry, cam) = resolve_device!(self, find_camera, &params.camera_id, "camera");
+        camera_id: &str,
+        duration: Duration,
+    ) -> std::result::Result<(String, String), String> {
+        let cam_entry = self
+            .equipment
+            .find_camera(camera_id)
+            .ok_or_else(|| format!("camera not found: {}", camera_id))?;
+        let cam = cam_entry
+            .device
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| format!("camera not connected: {}", camera_id))?;
 
         let document_id = Uuid::new_v4().to_string();
         // The 8-char UUID suffix is the on-disk reverse-lookup key used by
@@ -723,43 +771,37 @@ impl McpHandler {
         self.event_bus.emit(
             "exposure_started",
             serde_json::json!({
-                "camera_id": params.camera_id,
-                "duration": humantime::format_duration(params.duration).to_string(),
+                "camera_id": camera_id,
+                "duration": humantime::format_duration(duration).to_string(),
             }),
         );
 
-        if let Err(e) = cam.start_exposure(params.duration, true).await {
-            return Ok(tool_error!("failed to start exposure: {}", e));
-        }
+        cam.start_exposure(duration, true)
+            .await
+            .map_err(|e| format!("failed to start exposure: {}", e))?;
 
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
             match cam.image_ready().await {
                 Ok(true) => break,
                 Ok(false) => continue,
-                Err(e) => {
-                    return Ok(tool_error!("error checking image ready: {}", e));
-                }
+                Err(e) => return Err(format!("error checking image ready: {}", e)),
             }
         }
 
-        let image_array = match cam.image_array().await {
-            Ok(arr) => arr,
-            Err(e) => {
-                return Ok(tool_error!("failed to download image array: {}", e));
-            }
-        };
+        let image_array = cam
+            .image_array()
+            .await
+            .map_err(|e| format!("failed to download image array: {}", e))?;
 
         let (dim_x, dim_y, _planes) = image_array.dim();
         let width = dim_x as u32;
         let height = dim_y as u32;
         let pixels: Vec<i32> = image_array.iter().copied().collect();
 
-        if let Err(e) =
-            persistence::write_fits(&image_path, &pixels, width, height, &document_id).await
-        {
-            return Ok(tool_error!("failed to write FITS file: {}", e));
-        }
+        persistence::write_fits(&image_path, &pixels, width, height, &document_id)
+            .await
+            .map_err(|e| format!("failed to write FITS file: {}", e))?;
 
         // Read max_adu once. The value feeds two consumers: the cache
         // variant choice (u16 vs i32) and the exposure document's
@@ -783,8 +825,8 @@ impl McpHandler {
             file_path: image_path.clone(),
             width,
             height,
-            camera_id: Some(params.camera_id.clone()),
-            duration: Some(params.duration),
+            camera_id: Some(camera_id.to_string()),
+            duration: Some(duration),
             max_adu: captured_max_adu,
             sections: serde_json::Map::new(),
         };
@@ -799,10 +841,89 @@ impl McpHandler {
             }),
         );
 
-        Ok(tool_success!({
-            "image_path": image_path,
-            "document_id": document_id,
-        }))
+        Ok((image_path, document_id))
+    }
+
+    /// Resolve a focuser, validate the requested `position` against the
+    /// operator-supplied `min_position`/`max_position` bounds, issue the
+    /// Alpaca move, poll `is_moving` until idle (with a 120 s deadline),
+    /// and return the focuser's reported `position` after settling.
+    ///
+    /// This is the shared body of the `move_focuser` MCP tool and the
+    /// `auto_focus` compound tool's per-step focuser drive — both want
+    /// the same bounds-check + blocking-poll semantics.
+    pub(crate) async fn do_move_focuser_blocking(
+        &self,
+        focuser_id: &str,
+        position: i32,
+    ) -> std::result::Result<i32, String> {
+        let foc_entry = self
+            .equipment
+            .find_focuser(focuser_id)
+            .ok_or_else(|| format!("focuser not found: {}", focuser_id))?;
+        let foc = foc_entry
+            .device
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| format!("focuser not connected: {}", focuser_id))?;
+
+        if let Some(min) = foc_entry.config.min_position {
+            if position < min {
+                return Err(format!(
+                    "position out of range: {} < min_position {}",
+                    position, min
+                ));
+            }
+        }
+        if let Some(max) = foc_entry.config.max_position {
+            if position > max {
+                return Err(format!(
+                    "position out of range: {} > max_position {}",
+                    position, max
+                ));
+            }
+        }
+
+        debug!(focuser_id, position, "moving focuser");
+        foc.move_(position)
+            .await
+            .map_err(|e| format!("failed to move focuser: {}", e))?;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            match foc.is_moving().await {
+                Ok(false) => break,
+                Ok(true) if tokio::time::Instant::now() < deadline => continue,
+                Ok(true) => return Err("timeout waiting for focuser to settle".to_string()),
+                Err(e) => return Err(format!("error polling focuser is_moving: {}", e)),
+            }
+        }
+
+        foc.position()
+            .await
+            .map_err(|e| format!("failed to read focuser position: {}", e))
+    }
+}
+
+#[tool_router(server_handler)]
+impl McpHandler {
+    // -------------------------------------------------------------------
+    // Camera tools
+    // -------------------------------------------------------------------
+
+    #[tool(description = "Capture an image, download image_array, save FITS file")]
+    async fn capture(
+        &self,
+        Parameters(params): Parameters<CaptureParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        match self.do_capture(&params.camera_id, params.duration).await {
+            Ok((image_path, document_id)) => Ok(tool_success!({
+                "image_path": image_path,
+                "document_id": document_id,
+            })),
+            Err(e) => Ok(tool_error!("{}", e)),
+        }
     }
 
     #[tool(description = "Read camera capabilities: max_adu, exposure limits, sensor dimensions")]
@@ -1474,54 +1595,16 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<MoveFocuserParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let (foc_entry, foc) = resolve_device!(self, find_focuser, &params.focuser_id, "focuser");
-
-        if let Some(min) = foc_entry.config.min_position {
-            if params.position < min {
-                return Ok(tool_error!(
-                    "position out of range: {} < min_position {}",
-                    params.position,
-                    min
-                ));
-            }
+        match self
+            .do_move_focuser_blocking(&params.focuser_id, params.position)
+            .await
+        {
+            Ok(actual_position) => Ok(tool_success!({
+                "focuser_id": params.focuser_id,
+                "actual_position": actual_position,
+            })),
+            Err(e) => Ok(tool_error!("{}", e)),
         }
-        if let Some(max) = foc_entry.config.max_position {
-            if params.position > max {
-                return Ok(tool_error!(
-                    "position out of range: {} > max_position {}",
-                    params.position,
-                    max
-                ));
-            }
-        }
-
-        debug!(focuser_id = %params.focuser_id, position = params.position, "moving focuser");
-        if let Err(e) = foc.move_(params.position).await {
-            return Ok(tool_error!("failed to move focuser: {}", e));
-        }
-
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
-        loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            match foc.is_moving().await {
-                Ok(false) => break,
-                Ok(true) if tokio::time::Instant::now() < deadline => continue,
-                Ok(true) => return Ok(tool_error!("timeout waiting for focuser to settle")),
-                Err(e) => {
-                    return Ok(tool_error!("error polling focuser is_moving: {}", e));
-                }
-            }
-        }
-
-        let actual_position = match foc.position().await {
-            Ok(p) => p,
-            Err(e) => return Ok(tool_error!("failed to read focuser position: {}", e)),
-        };
-
-        Ok(tool_success!({
-            "focuser_id": params.focuser_id,
-            "actual_position": actual_position,
-        }))
     }
 
     #[tool(description = "Read the current absolute position of the focuser")]
@@ -1565,6 +1648,192 @@ impl McpHandler {
             "focuser_id": params.focuser_id,
             "temperature_c": temperature_c,
         }))
+    }
+
+    // -------------------------------------------------------------------
+    // Compound: auto_focus (V-curve)
+    // -------------------------------------------------------------------
+
+    #[tool(
+        description = "V-curve auto-focus: sweep ± half_width around the focuser's current position, capture and run measure_basic at each step, fit a parabola in HFR, and move the focuser to the fitted minimum"
+    )]
+    async fn auto_focus(
+        &self,
+        Parameters(params): Parameters<AutoFocusToolParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Field-presence validation runs in input order so the error
+        // message always points at the first missing field — same
+        // pattern as `measure_basic`.
+        let camera_id = match params.camera_id.as_deref() {
+            Some(s) => s.to_string(),
+            None => return Ok(tool_error!("missing required parameter: camera_id")),
+        };
+        let focuser_id = match params.focuser_id.as_deref() {
+            Some(s) => s.to_string(),
+            None => return Ok(tool_error!("missing required parameter: focuser_id")),
+        };
+        let duration = match params.duration {
+            Some(d) => d,
+            None => return Ok(tool_error!("missing required parameter: duration")),
+        };
+        let step_size = match params.step_size {
+            Some(s) => s,
+            None => return Ok(tool_error!("missing required parameter: step_size")),
+        };
+        let half_width = match params.half_width {
+            Some(s) => s,
+            None => return Ok(tool_error!("missing required parameter: half_width")),
+        };
+        let min_area = match params.min_area {
+            Some(s) => s,
+            None => return Ok(tool_error!("missing required parameter: min_area")),
+        };
+        let max_area = match params.max_area {
+            Some(s) => s,
+            None => return Ok(tool_error!("missing required parameter: max_area")),
+        };
+
+        // Resolve devices early — emits the standard
+        // "<kind> not found" / "<kind> not connected" errors expected
+        // by the BDD device-resolution scenarios. Camera order before
+        // focuser matches input order in the contract.
+        let (_cam_entry, cam) = resolve_device!(self, find_camera, &camera_id, "camera");
+        let _ = cam; // resolved purely for the connection check; do_capture re-resolves.
+        let (foc_entry, foc) = resolve_device!(self, find_focuser, &focuser_id, "focuser");
+
+        let bounds = (foc_entry.config.min_position, foc_entry.config.max_position);
+        let af_params = imaging::tools::auto_focus::AutoFocusParams {
+            duration,
+            step_size,
+            half_width,
+            min_area,
+            max_area,
+            threshold_sigma: params.threshold_sigma,
+            min_fit_points: params.min_fit_points.unwrap_or(5),
+        };
+
+        let adapter = AutoFocusAdapter {
+            handler: self,
+            camera_id: camera_id.clone(),
+            focuser_id: focuser_id.clone(),
+            foc,
+        };
+
+        match imaging::tools::auto_focus::run_auto_focus(
+            &adapter, &adapter, &adapter, bounds, af_params,
+        )
+        .await
+        {
+            Ok(result) => {
+                self.event_bus.emit(
+                    "focus_complete",
+                    serde_json::json!({
+                        "camera_id": camera_id,
+                        "focuser_id": focuser_id,
+                        "position": result.best_position,
+                        "hfr": result.best_hfr,
+                        "samples_used": result.samples_used,
+                    }),
+                );
+                let curve_points =
+                    serde_json::to_value(&result.curve_points).unwrap_or(serde_json::Value::Null);
+                Ok(tool_success!({
+                    "best_position": result.best_position,
+                    "best_hfr": result.best_hfr,
+                    "final_position": result.final_position,
+                    "samples_used": result.samples_used,
+                    "curve_points": curve_points,
+                    "temperature_c": result.temperature_c,
+                }))
+            }
+            Err(e) => Ok(tool_error!("{}", e)),
+        }
+    }
+}
+
+/// Adapter that satisfies all three [`auto_focus`] traits
+/// (`FocuserOps`, `CaptureOps`, `MeasureOps`) by delegating to the
+/// existing [`McpHandler`] helpers (`do_move_focuser_blocking`,
+/// `do_capture`, `measure_via_document` + cache `put_section`).
+///
+/// Keeps the compound tool's wiring close to the corresponding
+/// primitive tools: same bounds-check / poll semantics on focuser
+/// motion, same FITS write / cache insert / event emission on
+/// capture, same `image_analysis` section persistence on measure.
+struct AutoFocusAdapter<'a> {
+    handler: &'a McpHandler,
+    camera_id: String,
+    focuser_id: String,
+    foc: Arc<dyn ascom_alpaca::api::Focuser>,
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::auto_focus::FocuserOps for AutoFocusAdapter<'_> {
+    async fn position(&self) -> std::result::Result<i32, String> {
+        self.foc
+            .position()
+            .await
+            .map_err(|e| format!("failed to read focuser position: {}", e))
+    }
+
+    async fn move_to(&self, position: i32) -> std::result::Result<i32, String> {
+        self.handler
+            .do_move_focuser_blocking(&self.focuser_id, position)
+            .await
+    }
+
+    async fn temperature(&self) -> Option<f64> {
+        // Non-fatal read: NOT_IMPLEMENTED → None; transient errors → None.
+        // The result's `temperature_c` field is informational; never
+        // load-bearing on the sweep, so we never abort the run on a
+        // temperature read.
+        self.foc.temperature().await.ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::auto_focus::CaptureOps for AutoFocusAdapter<'_> {
+    async fn capture(&self, duration: Duration) -> std::result::Result<String, String> {
+        let (_image_path, document_id) = self.handler.do_capture(&self.camera_id, duration).await?;
+        Ok(document_id)
+    }
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::auto_focus::MeasureOps for AutoFocusAdapter<'_> {
+    async fn measure(
+        &self,
+        document_id: &str,
+        min_area: usize,
+        max_area: usize,
+        threshold_sigma: f64,
+    ) -> std::result::Result<imaging::tools::auto_focus::HfrSample, String> {
+        let resolved = ResolvedParams {
+            threshold_sigma,
+            min_area,
+            max_area,
+        };
+        let result = self
+            .handler
+            .measure_via_document(document_id, &resolved)
+            .await
+            .map_err(|e| e.to_string())?;
+        // Persist the per-frame `image_analysis` section, matching the
+        // standalone `measure_basic` tool's side effect — auto_focus is
+        // explicitly composed of measure_basic calls per the contract.
+        let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+        if let Err(e) = self
+            .handler
+            .image_cache
+            .put_section(document_id, "image_analysis", value)
+            .await
+        {
+            debug!(error = %e, document_id, "failed to persist image_analysis section");
+        }
+        Ok(imaging::tools::auto_focus::HfrSample {
+            hfr: result.hfr,
+            star_count: result.star_count,
+        })
     }
 }
 

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -1701,6 +1701,27 @@ impl McpHandler {
         let _ = cam; // resolved purely for the connection check; do_capture re-resolves.
         let (foc_entry, foc) = resolve_device!(self, find_focuser, &focuser_id, "focuser");
 
+        // Read current focuser position + temperature once for the
+        // `focus_started` event (per the Contract algorithm step 1).
+        // run_auto_focus re-reads internally — two cheap Alpaca calls
+        // is fine; threading them through would require extending the
+        // FocuserOps trait or run_auto_focus's signature with no real
+        // benefit.
+        let starting_position = match foc.position().await {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("failed to read focuser position: {}", e)),
+        };
+        let starting_temperature_c: Option<f64> = foc.temperature().await.ok();
+        self.event_bus.emit(
+            "focus_started",
+            serde_json::json!({
+                "camera_id": camera_id,
+                "focuser_id": focuser_id,
+                "position": starting_position,
+                "temperature": starting_temperature_c,
+            }),
+        );
+
         let bounds = (foc_entry.config.min_position, foc_entry.config.max_position);
         let af_params = imaging::tools::auto_focus::AutoFocusParams {
             duration,

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -1701,12 +1701,14 @@ impl McpHandler {
         let _ = cam; // resolved purely for the connection check; do_capture re-resolves.
         let (foc_entry, foc) = resolve_device!(self, find_focuser, &focuser_id, "focuser");
 
-        // Read current focuser position + temperature once for the
-        // `focus_started` event (per the Contract algorithm step 1).
-        // run_auto_focus re-reads internally — two cheap Alpaca calls
-        // is fine; threading them through would require extending the
-        // FocuserOps trait or run_auto_focus's signature with no real
-        // benefit.
+        // Read the current focuser position + temperature exactly once
+        // each (per the Contract algorithm step 1) and thread the values
+        // through to both `focus_started` *and* `run_auto_focus` so the
+        // event payload and the result's `temperature_c`/sweep-grid
+        // origin can never disagree. Temperature is informational only:
+        // any read failure (NOT_IMPLEMENTED or transient) becomes
+        // `temperature_c: null`; we don't abort an auto-focus run over
+        // a missing thermistor.
         let starting_position = match foc.position().await {
             Ok(p) => p,
             Err(e) => return Ok(tool_error!("failed to read focuser position: {}", e)),
@@ -1737,11 +1739,16 @@ impl McpHandler {
             handler: self,
             camera_id: camera_id.clone(),
             focuser_id: focuser_id.clone(),
-            foc,
         };
 
         match imaging::tools::auto_focus::run_auto_focus(
-            &adapter, &adapter, &adapter, bounds, af_params,
+            &adapter,
+            &adapter,
+            &adapter,
+            bounds,
+            starting_position,
+            starting_temperature_c,
+            af_params,
         )
         .await
         {
@@ -1785,30 +1792,14 @@ struct AutoFocusAdapter<'a> {
     handler: &'a McpHandler,
     camera_id: String,
     focuser_id: String,
-    foc: Arc<dyn ascom_alpaca::api::Focuser>,
 }
 
 #[async_trait::async_trait]
 impl imaging::tools::auto_focus::FocuserOps for AutoFocusAdapter<'_> {
-    async fn position(&self) -> std::result::Result<i32, String> {
-        self.foc
-            .position()
-            .await
-            .map_err(|e| format!("failed to read focuser position: {}", e))
-    }
-
     async fn move_to(&self, position: i32) -> std::result::Result<i32, String> {
         self.handler
             .do_move_focuser_blocking(&self.focuser_id, position)
             .await
-    }
-
-    async fn temperature(&self) -> Option<f64> {
-        // Non-fatal read: NOT_IMPLEMENTED → None; transient errors → None.
-        // The result's `temperature_c` field is informational; never
-        // load-bearing on the sweep, so we never abort the run on a
-        // temperature read.
-        self.foc.temperature().await.ok()
     }
 }
 

--- a/services/rp/tests/bdd/steps/auto_focus_steps.rs
+++ b/services/rp/tests/bdd/steps/auto_focus_steps.rs
@@ -7,13 +7,19 @@
 //! - `the error message should contain {string}`
 //! - `an MCP client connected to rp`
 //!
-//! Focuser-bounds setup reuses `focuser_steps.rs::rp_running_with_focuser_bounded`.
+//! Focuser-config helpers (the `add_focuser` builder) are reused from
+//! `focuser_steps.rs`. The auto_focus-specific Given steps below add a
+//! camera *alongside* the focuser, which the focuser-only steps in
+//! `focuser_steps.rs` don't do — that's the only reason this module
+//! defines its own composition steps rather than reusing
+//! `rp_running_with_focuser` directly.
 
 use cucumber::{given, then, when};
 use serde_json::{Map, Value};
 
 use bdd_infra::rp_harness::{CameraConfig, FocuserConfig};
 
+use crate::steps::focuser_steps::add_focuser;
 use crate::steps::tool_steps::{add_camera, ensure_mcp_client, ensure_omnisim, start_rp};
 use crate::world::RpWorld;
 
@@ -219,19 +225,6 @@ async fn call_auto_focus(world: &mut RpWorld, args: Map<String, Value>) {
         Err(_) => world.last_auto_focus_result = None,
     }
     world.last_tool_result = Some(result);
-}
-
-fn add_focuser(world: &mut RpWorld, min_position: Option<i32>, max_position: Option<i32>) {
-    if world.focusers.is_empty() {
-        let url = world.omnisim_url();
-        world.focusers.push(FocuserConfig {
-            id: "main-focuser".to_string(),
-            alpaca_url: url,
-            device_number: 0,
-            min_position,
-            max_position,
-        });
-    }
 }
 
 async fn count_extension(dir: &str, ext: &str) -> usize {

--- a/services/rp/tests/bdd/steps/auto_focus_steps.rs
+++ b/services/rp/tests/bdd/steps/auto_focus_steps.rs
@@ -1,0 +1,268 @@
+//! BDD step definitions for the `auto_focus` MCP tool.
+//!
+//! Shared steps live in `tool_steps.rs`:
+//! - `the MCP client lists available tools`
+//! - `the tool list should include {string}`
+//! - `the tool call should return an error`
+//! - `the error message should contain {string}`
+//! - `an MCP client connected to rp`
+//!
+//! Focuser-bounds setup reuses `focuser_steps.rs::rp_running_with_focuser_bounded`.
+
+use cucumber::{given, then, when};
+use serde_json::{Map, Value};
+
+use bdd_infra::rp_harness::{CameraConfig, FocuserConfig};
+
+use crate::steps::tool_steps::{add_camera, ensure_mcp_client, ensure_omnisim, start_rp};
+use crate::world::RpWorld;
+
+// --- Given steps: equipment composition unique to auto_focus ---
+
+#[given("rp is running with a camera and a focuser on the simulator")]
+async fn rp_with_camera_and_focuser(world: &mut RpWorld) {
+    ensure_omnisim(world).await;
+    add_camera(world);
+    add_focuser(world, None, None);
+    start_rp(world).await;
+}
+
+#[given(
+    expr = "rp is running with a camera and a focuser on the simulator with bounds {int}..{int}"
+)]
+async fn rp_with_camera_and_bounded_focuser(world: &mut RpWorld, min: i32, max: i32) {
+    ensure_omnisim(world).await;
+    add_camera(world);
+    add_focuser(world, Some(min), Some(max));
+    start_rp(world).await;
+}
+
+#[given("rp is running with a camera on the simulator and an unreachable focuser")]
+async fn rp_with_camera_and_unreachable_focuser(world: &mut RpWorld) {
+    ensure_omnisim(world).await;
+    add_camera(world);
+    world.focusers.push(FocuserConfig {
+        id: "main-focuser".to_string(),
+        alpaca_url: "http://127.0.0.1:1".to_string(),
+        device_number: 0,
+        min_position: None,
+        max_position: None,
+    });
+    start_rp(world).await;
+}
+
+#[given("rp is running with a focuser on the simulator and an unreachable camera")]
+async fn rp_with_focuser_and_unreachable_camera(world: &mut RpWorld) {
+    ensure_omnisim(world).await;
+    add_focuser(world, None, None);
+    world.cameras.push(CameraConfig {
+        id: "main-cam".to_string(),
+        alpaca_url: "http://127.0.0.1:1".to_string(),
+        device_number: 0,
+    });
+    start_rp(world).await;
+}
+
+// --- When steps ---
+
+#[when(
+    expr = "the MCP client calls auto_focus with focuser {string} camera {string} duration {string} step_size {int} half_width {int} min_area {int} max_area {int}"
+)]
+#[allow(clippy::too_many_arguments)]
+async fn mcp_call_auto_focus_full(
+    world: &mut RpWorld,
+    focuser_id: String,
+    camera_id: String,
+    duration: String,
+    step_size: i64,
+    half_width: i64,
+    min_area: i64,
+    max_area: i64,
+) {
+    let mut args = baseline_args();
+    args.insert("focuser_id".into(), Value::String(focuser_id));
+    args.insert("camera_id".into(), Value::String(camera_id));
+    args.insert("duration".into(), Value::String(duration));
+    args.insert("step_size".into(), Value::from(step_size));
+    args.insert("half_width".into(), Value::from(half_width));
+    args.insert("min_area".into(), Value::from(min_area));
+    args.insert("max_area".into(), Value::from(max_area));
+    call_auto_focus(world, args).await;
+}
+
+#[when(expr = "the MCP client calls auto_focus with camera {string} and focuser {string}")]
+async fn mcp_call_auto_focus_devices(world: &mut RpWorld, camera_id: String, focuser_id: String) {
+    let mut args = baseline_args();
+    args.insert("camera_id".into(), Value::String(camera_id));
+    args.insert("focuser_id".into(), Value::String(focuser_id));
+    call_auto_focus(world, args).await;
+}
+
+#[when(expr = "the MCP client calls auto_focus omitting {string}")]
+async fn mcp_call_auto_focus_omitting(world: &mut RpWorld, missing_param: String) {
+    let mut args = baseline_args();
+    args.remove(missing_param.as_str());
+    call_auto_focus(world, args).await;
+}
+
+#[when(expr = "the MCP client calls auto_focus with step_size {int}")]
+async fn mcp_call_auto_focus_with_step_size(world: &mut RpWorld, step_size: i64) {
+    let mut args = baseline_args();
+    args.insert("step_size".into(), Value::from(step_size));
+    call_auto_focus(world, args).await;
+}
+
+#[when(expr = "the MCP client calls auto_focus with half_width {int}")]
+async fn mcp_call_auto_focus_with_half_width(world: &mut RpWorld, half_width: i64) {
+    let mut args = baseline_args();
+    args.insert("half_width".into(), Value::from(half_width));
+    call_auto_focus(world, args).await;
+}
+
+#[when(expr = "the MCP client calls auto_focus with min_fit_points {int}")]
+async fn mcp_call_auto_focus_with_min_fit_points(world: &mut RpWorld, min_fit_points: i64) {
+    let mut args = baseline_args();
+    args.insert("min_fit_points".into(), Value::from(min_fit_points));
+    call_auto_focus(world, args).await;
+}
+
+// --- Then steps ---
+
+#[then(expr = "{int} FITS files should exist in the pinned data directory")]
+async fn fits_files_in_pinned_dir(world: &mut RpWorld, expected: usize) {
+    let dir = world
+        .pinned_data_directory
+        .as_ref()
+        .expect("data_directory not pinned — add the 'pinned to a fresh tempdir' step");
+    let count = count_extension(dir, "fits").await;
+    assert_eq!(
+        count, expected,
+        "expected {} FITS files in {}, found {}",
+        expected, dir, count
+    );
+}
+
+#[then(expr = "every sidecar JSON in the pinned data directory should contain an {string} section")]
+async fn every_sidecar_has_section(world: &mut RpWorld, section_name: String) {
+    let dir = world
+        .pinned_data_directory
+        .as_ref()
+        .expect("data_directory not pinned");
+    let sidecars = read_sidecars(dir).await;
+    assert!(
+        !sidecars.is_empty(),
+        "no .json sidecars in {} — sweep did not run",
+        dir
+    );
+    for (path, body) in &sidecars {
+        let sections = body.get("sections").unwrap_or_else(|| {
+            panic!(
+                "sidecar {:?} has no 'sections' field, body: {:?}",
+                path, body
+            )
+        });
+        assert!(
+            sections.get(&section_name).is_some(),
+            "sidecar {:?} missing '{}' section, sections: {:?}",
+            path,
+            section_name,
+            sections
+        );
+    }
+}
+
+#[then(expr = "no sidecar JSON in the pinned data directory should contain an {string} section")]
+async fn no_sidecar_has_section(world: &mut RpWorld, section_name: String) {
+    let dir = world
+        .pinned_data_directory
+        .as_ref()
+        .expect("data_directory not pinned");
+    for (path, body) in read_sidecars(dir).await {
+        let sections = body.get("sections").unwrap_or(&Value::Null);
+        assert!(
+            sections.get(&section_name).is_none(),
+            "sidecar {:?} unexpectedly contains '{}' section: {:?}",
+            path,
+            section_name,
+            sections.get(&section_name)
+        );
+    }
+}
+
+// --- Helpers ---
+
+/// Baseline arg map representing a "valid" auto_focus call against the
+/// default camera + focuser. Individual scenarios mutate this baseline
+/// (insert override / remove field) before dispatching, so that the
+/// missing-parameter scenarios can each carve out exactly one field
+/// without re-stating the whole arg list.
+fn baseline_args() -> Map<String, Value> {
+    let mut m = Map::new();
+    m.insert("camera_id".into(), Value::String("main-cam".into()));
+    m.insert("focuser_id".into(), Value::String("main-focuser".into()));
+    m.insert("duration".into(), Value::String("100ms".into()));
+    m.insert("step_size".into(), Value::from(100));
+    m.insert("half_width".into(), Value::from(200));
+    m.insert("min_area".into(), Value::from(5));
+    m.insert("max_area".into(), Value::from(65_536));
+    m
+}
+
+async fn call_auto_focus(world: &mut RpWorld, args: Map<String, Value>) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("auto_focus", Value::Object(args))
+        .await;
+    match &result {
+        Ok(v) => world.last_auto_focus_result = Some(v.clone()),
+        Err(_) => world.last_auto_focus_result = None,
+    }
+    world.last_tool_result = Some(result);
+}
+
+fn add_focuser(world: &mut RpWorld, min_position: Option<i32>, max_position: Option<i32>) {
+    if world.focusers.is_empty() {
+        let url = world.omnisim_url();
+        world.focusers.push(FocuserConfig {
+            id: "main-focuser".to_string(),
+            alpaca_url: url,
+            device_number: 0,
+            min_position,
+            max_position,
+        });
+    }
+}
+
+async fn count_extension(dir: &str, ext: &str) -> usize {
+    let mut entries = tokio::fs::read_dir(dir)
+        .await
+        .unwrap_or_else(|e| panic!("failed to read pinned data directory {:?}: {}", dir, e));
+    let mut count = 0usize;
+    while let Some(entry) = entries.next_entry().await.expect("read_dir entry") {
+        if entry.path().extension().and_then(|s| s.to_str()) == Some(ext) {
+            count += 1;
+        }
+    }
+    count
+}
+
+async fn read_sidecars(dir: &str) -> Vec<(std::path::PathBuf, Value)> {
+    let mut entries = tokio::fs::read_dir(dir)
+        .await
+        .unwrap_or_else(|e| panic!("failed to read pinned data directory {:?}: {}", dir, e));
+    let mut out = Vec::new();
+    while let Some(entry) = entries.next_entry().await.expect("read_dir entry") {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = tokio::fs::read(&path)
+            .await
+            .unwrap_or_else(|e| panic!("failed to read sidecar {:?}: {}", path, e));
+        let body: Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|e| panic!("failed to parse sidecar {:?}: {}", path, e));
+        out.push((path, body));
+    }
+    out
+}

--- a/services/rp/tests/bdd/steps/focuser_steps.rs
+++ b/services/rp/tests/bdd/steps/focuser_steps.rs
@@ -153,7 +153,11 @@ fn get_focuser_temperature_field(world: &mut RpWorld, field: String) {
 
 // --- Helpers ---
 
-fn add_focuser(world: &mut RpWorld, min_position: Option<i32>, max_position: Option<i32>) {
+pub(super) fn add_focuser(
+    world: &mut RpWorld,
+    min_position: Option<i32>,
+    max_position: Option<i32>,
+) {
     if world.focusers.is_empty() {
         let url = world.omnisim_url();
         world.focusers.push(FocuserConfig {

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod acme_steps;
 pub mod auth_steps;
+pub mod auto_focus_steps;
 pub mod camera_info_steps;
 pub mod compute_snr_steps;
 pub mod cover_calibrator_steps;

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -83,6 +83,8 @@ pub struct RpWorld {
     pub last_measure_stars_result: Option<Value>,
     /// Last compute_snr result
     pub last_compute_snr_result: Option<Value>,
+    /// Last auto_focus result
+    pub last_auto_focus_result: Option<Value>,
     /// Last exposure document fetched via GET /api/documents/{id}
     pub last_exposure_document: Option<Value>,
     /// Last response status from GET /api/images/{id}

--- a/services/rp/tests/features/auto_focus.feature
+++ b/services/rp/tests/features/auto_focus.feature
@@ -1,4 +1,3 @@
-@wip
 @serial
 Feature: Auto-focus compound tool
   The auto_focus MCP tool drives a V-curve focus sweep using move_focuser,

--- a/services/rp/tests/features/auto_focus.feature
+++ b/services/rp/tests/features/auto_focus.feature
@@ -8,15 +8,21 @@ Feature: Auto-focus compound tool
   vertex. The sweep grid is clamped to the operator-supplied
   min_position / max_position bounds — points outside the bounds are
   dropped, not coerced. The tool errors before any motion when input
-  parameters are missing or invalid, when devices are unreachable, when
-  the clamped grid has fewer than min_fit_points positions, when the
-  sweep yields fewer than min_fit_points non-null HFR samples, or when
-  the parabolic fit's leading coefficient `a` is non-positive (the
-  curve is monotonic or concave-down, with no minimum inside the
-  sampled range). auto_focus does not write a section on any single
-  exposure document — the per-frame image_analysis section is written
-  by the embedded measure_basic call as it normally would be, and the
-  compound result is returned via MCP plus a focus_complete event.
+  parameters are missing or invalid, when the requested sweep would
+  exceed the safety cap on grid size, when devices are unreachable,
+  when the clamped grid has fewer than min_fit_points positions,
+  when the sweep yields fewer than min_fit_points non-null HFR
+  samples, or when the parabolic fit produces no meaningful minimum
+  inside the sampled range — that last case fires when the leading
+  coefficient `a` is non-positive (concave-down or flat), when the
+  design matrix is singular (essentially flat HFR over the sweep),
+  or when `a > 0` but the fitted vertex falls outside the sampled
+  grid (the visible curve is monotonic over the sampled range even
+  if a true minimum exists somewhere off-grid). auto_focus does not
+  write a section on any single exposure document — the per-frame
+  image_analysis section is written by the embedded measure_basic
+  call as it normally would be, and the compound result is returned
+  via MCP plus a focus_complete event.
 
   Scenario: Tool catalog includes auto_focus
     Given a running Alpaca simulator

--- a/services/rp/tests/features/auto_focus.feature
+++ b/services/rp/tests/features/auto_focus.feature
@@ -1,0 +1,119 @@
+@wip
+@serial
+Feature: Auto-focus compound tool
+  The auto_focus MCP tool drives a V-curve focus sweep using move_focuser,
+  capture, and measure_basic internally. It captures one frame at each
+  position in the grid current_position ± half_width (in step_size
+  increments), measures HFR for each via measure_basic, fits a parabola
+  weighted by per-frame star_count, and moves the focuser to the fitted
+  vertex. The sweep grid is clamped to the operator-supplied
+  min_position / max_position bounds — points outside the bounds are
+  dropped, not coerced. The tool errors before any motion when input
+  parameters are missing or invalid, when devices are unreachable, when
+  the clamped grid has fewer than min_fit_points positions, when the
+  sweep yields fewer than min_fit_points non-null HFR samples, or when
+  the parabolic fit's leading coefficient `a` is non-positive (the
+  curve is monotonic or concave-down, with no minimum inside the
+  sampled range). auto_focus does not write a section on any single
+  exposure document — the per-frame image_analysis section is written
+  by the embedded measure_basic call as it normally would be, and the
+  compound result is returned via MCP plus a focus_complete event.
+
+  Scenario: Tool catalog includes auto_focus
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client lists available tools
+    Then the tool list should include "auto_focus"
+
+  Scenario: auto_focus with nonexistent camera returns error
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with camera "nonexistent" and focuser "main-focuser"
+    Then the tool call should return an error
+    And the error message should contain "camera not found"
+
+  Scenario: auto_focus with nonexistent focuser returns error
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with camera "main-cam" and focuser "nonexistent"
+    Then the tool call should return an error
+    And the error message should contain "focuser not found"
+
+  Scenario: auto_focus with disconnected focuser returns error
+    Given rp is running with a camera on the simulator and an unreachable focuser
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with camera "main-cam" and focuser "main-focuser"
+    Then the tool call should return an error
+    And the error message should contain "focuser not connected"
+
+  Scenario: auto_focus with disconnected camera returns error
+    Given rp is running with a focuser on the simulator and an unreachable camera
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with camera "main-cam" and focuser "main-focuser"
+    Then the tool call should return an error
+    And the error message should contain "camera not connected"
+
+  Scenario Outline: auto_focus rejects calls missing required parameters
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus omitting "<missing_param>"
+    Then the tool call should return an error
+    And the error message should contain "<missing_param>"
+
+    Examples:
+      | missing_param |
+      | camera_id     |
+      | focuser_id    |
+      | duration      |
+      | step_size     |
+      | half_width    |
+      | min_area      |
+      | max_area      |
+
+  Scenario: auto_focus rejects step_size of 0
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with step_size 0
+    Then the tool call should return an error
+    And the error message should contain "step_size"
+
+  Scenario: auto_focus rejects half_width of 0
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with half_width 0
+    Then the tool call should return an error
+    And the error message should contain "half_width"
+
+  Scenario: auto_focus rejects min_fit_points below 3
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls auto_focus with min_fit_points 2
+    Then the tool call should return an error
+    And the error message should contain "min_fit_points"
+
+  Scenario: auto_focus rejects sweep grid too small after focuser bounds clamp
+    Given a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator with bounds 4900..5100
+    And an MCP client connected to rp
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 5000
+    And the MCP client calls auto_focus with focuser "main-focuser" camera "main-cam" duration "100ms" step_size 100 half_width 500 min_area 5 max_area 65536
+    Then the tool call should return an error
+    And the error message should contain "min_fit_points"
+
+  Scenario: auto_focus completes its sweep and persists per-step image_analysis sections
+    Given rp's data_directory is pinned to a fresh tempdir
+    And a running Alpaca simulator
+    And rp is running with a camera and a focuser on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 5000
+    And the MCP client calls auto_focus with focuser "main-focuser" camera "main-cam" duration "100ms" step_size 100 half_width 200 min_area 5 max_area 65536
+    Then 5 FITS files should exist in the pinned data directory
+    And every sidecar JSON in the pinned data directory should contain an "image_analysis" section
+    And no sidecar JSON in the pinned data directory should contain an "auto_focus" section


### PR DESCRIPTION
## Summary

Implements the V-curve `auto_focus` compound MCP tool — design, BDD, and impl, end-to-end. Phase 6b of [docs/plans/image-evaluation-tools.md](docs/plans/image-evaluation-tools.md).

### Design (commit 1)
- `auto_focus` Contract subsection in `docs/services/rp.md` Compound Tools, parallel in shape to `measure_basic`. Sweep is `± half_width` clamped to operator `min/max_position` (out-of-range points dropped, not coerced); required `step_size`, humantime `duration`, `min_area`, `max_area`; parabolic least-squares fit weighted by per-frame `star_count`; starless frames skip-and-continue with `min_fit_points` (default 5); fail-fast on monotonic-or-concave-down curves; output carries per-step `document_id` provenance plus focuser `temperature_c`. No aggregate `auto_focus` section is written — embedded `measure_basic` writes its `image_analysis` on each per-step document.
- Catalog row + `focus_complete` event payload enriched with `focuser_id` and `samples_used`.

### BDD (commit 1, `@wip`-tagged → commit 2, enabled)
- `services/rp/tests/features/auto_focus.feature` with 17 scenarios: catalog, 4 device-resolution errors, 7 missing-required-parameter examples, 3 numeric-range rejections (`step_size=0`, `half_width=0`, `min_fit_points<3`), grid-too-small-after-bounds-clamp, sweep-completion + persistence anchor.
- The "V-curve converges to known `best_position`" scenario is deliberately omitted from BDD — OmniSim produces position-independent images, so a real V-curve never materializes in the simulator. Numerical fit correctness is unit-tested instead.

### Impl (commit 2)
- `services/rp/src/imaging/tools/auto_focus.rs`: pure driver over `FocuserOps` / `CaptureOps` / `MeasureOps` traits. `validate_params`, `build_grid` (clamping rather than coercing), `fit_parabola` (3×3 weighted least squares via Cramer's rule with a scale-invariant determinant threshold so flat-HFR sweeps deterministically reject), and `run_auto_focus` (validates the fitted vertex falls inside the sampled grid — an `a > 0` parabola with vertex outside the grid is still monotonic over the sampled range).
- `services/rp/src/mcp.rs`: refactored `capture` and `move_focuser` tool methods to delegate to two new private helpers `do_capture` and `do_move_focuser_blocking`. The compound `auto_focus` adapter reuses those same helpers, so capture / move semantics (FITS write, cache insert, event emission, bounds check, blocking poll) stay identical between primitive and compound calls. `auto_focus` body is the thin adapter shell that constructs a single struct satisfying all three traits and delegates to `run_auto_focus`.

## Test plan

- [x] `cargo build --all-features --all-targets -p rp` — clean
- [x] `cargo test --all-features --lib -p rp` — 202/202 tests pass (was 185 — 17 new auto_focus unit tests)
- [x] `cargo test --all-features --test bdd -p rp` — 167/167 scenarios pass (was 150 — 17 new auto_focus scenarios all green)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-features --all-targets -p rp -- -D warnings` — clean
- [x] `cargo rail run --profile commit -q` — affected-package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)