### PR TITLE
ci: pin OMNISIM_PATH for stable Bazel test action keys on Windows

### DIFF
--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -78,8 +78,10 @@ runs:
       run: echo "${{ github.workspace }}/omnisim" >> "$GITHUB_PATH"
 
     # Export the absolute binary path so consumers (notably Bazel's
-    # `--test_env=OMNISIM_PATH` and `bdd-infra::OmniSimHandle`) can locate
-    # OmniSim without relying on the runner PATH.
+    # `--test_env=OMNISIM_PATH` and `bdd_infra::rp_harness::OmniSimHandle`,
+    # whose binary lookup lives in
+    # `crates/bdd-infra/src/rp_harness/omnisim.rs`) can locate OmniSim
+    # without relying on the runner PATH.
     #
     # Why this matters for Bazel: forwarding the runner's full PATH into
     # test actions via `--test_env=PATH` makes the host PATH part of every

--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -76,3 +76,25 @@ runs:
     - name: Add to PATH
       shell: bash
       run: echo "${{ github.workspace }}/omnisim" >> "$GITHUB_PATH"
+
+    # Export the absolute binary path so consumers (notably Bazel's
+    # `--test_env=OMNISIM_PATH` and `bdd-infra::OmniSimHandle`) can locate
+    # OmniSim without relying on the runner PATH.
+    #
+    # Why this matters for Bazel: forwarding the runner's full PATH into
+    # test actions via `--test_env=PATH` makes the host PATH part of every
+    # test action's cache key. On Windows the runner exposes different
+    # PATH entries on `pull_request` vs `push` events, which silently
+    # invalidates cache entries written by main pushes. A pinned
+    # `OMNISIM_PATH=<workspace>/omnisim/<binary>` is stable across event
+    # types, so Bazel cache hits work the same as on Linux/macOS. See
+    # docs/decisions/004-* for the analysis.
+    - name: Export OMNISIM_PATH
+      shell: bash
+      run: |
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          BIN="${{ github.workspace }}/omnisim/ascom.alpaca.simulators.exe"
+        else
+          BIN="${{ github.workspace }}/omnisim/ascom.alpaca.simulators"
+        fi
+        echo "OMNISIM_PATH=$BIN" >> "$GITHUB_ENV"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -113,9 +113,10 @@ jobs:
         # BDD cucumber tests spawn service binaries and take 30-150s each;
         # run them explicitly in their own step. `--test_env=OMNISIM_PATH`
         # forwards the install-omnisim composite action's pinned binary
-        # path into test sandboxes; `bdd-infra::OmniSimProcess::find_binary`
-        # consumes it (called from `OmniSimHandle::start`). We deliberately
-        # do NOT use `--test_env=PATH` here:
+        # path into test sandboxes; `bdd_infra::rp_harness::OmniSimHandle::start`
+        # consumes it via the binary lookup in
+        # `crates/bdd-infra/src/rp_harness/omnisim.rs`. We deliberately do
+        # NOT use `--test_env=PATH` here:
         # the runner's full PATH is large and on Windows differs between
         # `push` and `pull_request` events, which would bake unstable
         # values into every BDD test action's cache key and silently

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -111,9 +111,15 @@ jobs:
 
       - name: bazel test (BDD)
         # BDD cucumber tests spawn service binaries and take 30-150s each;
-        # run them explicitly in their own step. --test_env=PATH forwards
-        # the runner PATH (extended by the OmniSim install step) into
-        # test sandboxes so rp's scenarios can spawn ascom.alpaca.simulators.
+        # run them explicitly in their own step. `--test_env=OMNISIM_PATH`
+        # forwards the install-omnisim composite action's pinned binary
+        # path into test sandboxes; `bdd-infra::OmniSimHandle::find_binary`
+        # consumes it. We deliberately do NOT use `--test_env=PATH` here:
+        # the runner's full PATH is large and on Windows differs between
+        # `push` and `pull_request` events, which would bake unstable
+        # values into every BDD test action's cache key and silently
+        # invalidate every cache entry across event types. Pinning
+        # `OMNISIM_PATH` keeps the action key stable.
         # On macOS, darwin-sandbox blocks OmniSim from binding network
         # ports; --spawn_strategy=local bypasses the sandbox for tests.
         run: |
@@ -125,4 +131,4 @@ jobs:
           if [[ "$RUNNER_OS" != "Linux" ]]; then
             EXTRA_FLAGS="--spawn_strategy=local"
           fi
-          bazel test --config=ci $REMOTE_FLAGS --test_tag_filters=bdd --test_env=PATH $EXTRA_FLAGS //...
+          bazel test --config=ci $REMOTE_FLAGS --test_tag_filters=bdd --test_env=OMNISIM_PATH $EXTRA_FLAGS //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -113,8 +113,9 @@ jobs:
         # BDD cucumber tests spawn service binaries and take 30-150s each;
         # run them explicitly in their own step. `--test_env=OMNISIM_PATH`
         # forwards the install-omnisim composite action's pinned binary
-        # path into test sandboxes; `bdd-infra::OmniSimHandle::find_binary`
-        # consumes it. We deliberately do NOT use `--test_env=PATH` here:
+        # path into test sandboxes; `bdd-infra::OmniSimProcess::find_binary`
+        # consumes it (called from `OmniSimHandle::start`). We deliberately
+        # do NOT use `--test_env=PATH` here:
         # the runner's full PATH is large and on Windows differs between
         # `push` and `pull_request` events, which would bake unstable
         # values into every BDD test action's cache key and silently


### PR DESCRIPTION
## Summary

The Bazel CI workflow was forwarding the runner's full `PATH` into BDD test actions via `--test_env=PATH`. Bazel bakes the captured `PATH` value into every test action's cache key, so any host-PATH variation between runs invalidates cache entries. On Windows specifically, the runner exposes slightly different `PATH` content under `pull_request` events vs `push` events — every PR Windows run was a cache miss, re-executing all 6 BDD targets locally (~2m 41s) while Main Windows pushes hit cache (~17s).

This PR replaces `--test_env=PATH` with `--test_env=OMNISIM_PATH`, which forwards a deterministic single value (the workspace-relative path to the OmniSim binary) instead of the entire host PATH.

## Changes

- `.github/actions/install-omnisim/action.yml` — new step exports `OMNISIM_PATH=<workspace>/omnisim/<binary>` to `$GITHUB_ENV` (alongside the existing `$GITHUB_PATH` append). Workspace-relative, so the value is identical on every run and every event type. Adds a comment block explaining the cache-key rationale.
- `.github/workflows/bazel.yml` BDD step — `--test_env=PATH` → `--test_env=OMNISIM_PATH`.

No Rust changes needed — `bdd-infra::OmniSimHandle::find_binary` already prefers `OMNISIM_PATH` over its PATH-based fallback (`crates/bdd-infra/src/rp_harness/omnisim.rs:107`).

## Diagnostic evidence

From the [BuildBuddy invocation comparison](https://github.com/ivonnyssen/rusty-photon/pull/118) on the ADR PR (issue #111):

| Run | actionsCreated | BDD strategy | Wall time |
|---|---:|---|---:|
| PR Windows BDD (cache miss) | 2857 | `local` × 6 | 2m 41s |
| Main Windows BDD (cache hit) | 2857 | `remote cache hit` × 6 | 17s |
| PR Linux BDD (cache hit, control) | 2883 | `remote cache hit` × 6 | 6s |

Identical action graph shape on Windows push vs. PR runs. Difference was confined to the test action's cache key, which `--test_env=PATH` made dependent on the runner's full PATH.

## Test plan

- [ ] Watch the new run on this PR — Windows BDD step should still pass (this PR is the first run that produces cache entries with the new key shape, so it'll re-execute, ~2m 41s).
- [ ] After merge to main, the next main push will populate the cache with stable keys.
- [ ] On the *next* PR after that, Windows BDD step should drop to ~17s (cache hit) — the smoking-gun confirmation that the fix works.
- [ ] Verify Cargo workflows (`test.yml`, `safety.yml`, `scheduled.yml`) still pass — they don't use `--test_env=PATH`, only the install action, and the resolver's PATH-based fallback keeps working.

## Follow-up (not in this PR)

If full hermeticity matters later, OmniSim could be declared as a Bazel external repo with per-OS `http_archive`s and referenced via `$(rootpath ...)` data deps on each BDD `rust_test`. That removes the install-omnisim composite action entirely. Larger change (~5 OS/arch download rules + `select()`) — worth doing only if the env-var approach proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)