### PR TITLE
ci(bazel): capture BDD execution log for cache-miss investigation

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -133,4 +133,25 @@ jobs:
           if [[ "$RUNNER_OS" != "Linux" ]]; then
             EXTRA_FLAGS="--spawn_strategy=local"
           fi
-          bazel test --config=ci $REMOTE_FLAGS --test_tag_filters=bdd --test_env=OMNISIM_PATH $EXTRA_FLAGS //...
+          # --execution_log_compact_file dumps every spawned action's full
+          # input set, env, command, and platform properties — i.e. exactly
+          # the fields Bazel hashes into the action key. Uploaded as an
+          # artifact below so Windows-PR vs Windows-push runs can be diffed
+          # to find what's still varying for services/rp:bdd and
+          # services/sky-survey-camera:bdd (4/6 BDD targets cache-hit on
+          # Windows after PR #120; these 2 still miss). Compact format is
+          # zstd-compressed protobuf — small enough to upload (~MB-scale).
+          bazel test --config=ci $REMOTE_FLAGS --test_tag_filters=bdd --test_env=OMNISIM_PATH $EXTRA_FLAGS \
+            --execution_log_compact_file="${RUNNER_TEMP}/bdd-exec.log.zst" //...
+
+      # Diagnostic artifact for the Windows BDD cache-miss investigation.
+      # Drop this step (and the --execution_log_compact_file flag above)
+      # once the action-key delta is identified and fixed.
+      - name: Upload BDD execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdd-exec-log-${{ matrix.os }}-${{ github.event_name }}
+          path: ${{ runner.temp }}/bdd-exec.log.zst
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary
Diagnostic-only CI patch to identify why `services/rp:bdd` and `services/sky-survey-camera:bdd` still cache-miss on Windows-PR runs after #120.

- Add `--execution_log_compact_file=$RUNNER_TEMP/bdd-exec.log.zst` to the BDD `bazel test` step. This emits a zstd-compressed protobuf containing every spawned action's full input set, env, command, and platform properties — i.e. the exact fields Bazel hashes into the action key.
- Upload the file as a workflow artifact `bdd-exec-log-{os}-{event_name}` (14d retention) on every matrix combination, even on test failure.

## Why this and not the BuildBuddy API
BES events don't carry action-key fingerprints. BuildBuddy's REST `GetTarget`/`GetInvocation` endpoints expose target-level metadata but no per-action digest/command/env. The execution log is the only client-side source for the data Bazel actually hashes.

## How to use the artifact
After this lands and one push-to-main run + one PR run produce artifacts:
```bash
gh run download <push-run-id>  -n bdd-exec-log-windows-latest-push
gh run download <pr-run-id>    -n bdd-exec-log-windows-latest-pull_request
zstdcat bdd-exec.log.zst | <protoc/spawn-log decoder> | jq 'select(.targetLabel | test("services/rp:bdd|sky-survey-camera:bdd"))'
```
Diff the two for those targets — whatever field differs is the action-key delta. After the underlying issue is fixed, drop both this step and the `--execution_log_compact_file` flag (commit message and inline comments both note this).

## Test plan
- [x] `cargo rail run --profile commit -q` (no Rust to test — infra-only change)
- [x] `cargo fmt --all -- --check`
- [ ] CI runs on this PR (Linux + macOS + Windows) and produces `bdd-exec-log-*` artifacts
- [ ] Once merged, the auto-triggered push-to-main run also produces artifacts
- [ ] Compare Windows-PR vs Windows-push artifacts for the two miss targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)