### PR TITLE
docs: rp-plate-solver service design doc (Phase 1)

### DIFF
--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -211,6 +211,47 @@ skip with no error noise. The nightly job sets it via
 `install-astap` → tagged scenarios fire. The same pattern generalizes
 to any future service with a real-binary backstop.
 
+### WCS parsing via `fitsrs` + `wcs`, not hand-rolled
+
+ASTAP's `.wcs` sidecar is a FITS-style header file. The workspace
+already depends on **`fitsrs` v0.4.1** (via `rp-fits`) for FITS I/O
+and on **`wcs` v0.4.2** (a transitive dep of `fitsrs`, same author
+— [cds-astro/wcs-rs](https://github.com/cds-astro/wcs-rs/),
+MIT/Apache). The wrapper uses both:
+
+- **`fitsrs`** parses the `.wcs` file as a FITS header.
+- **`wcs::params::WCSParams`** is the deserialization target — its
+  fields cover every standard FITS WCS keyword (CRVAL1/2, CDELT1/2,
+  CROTA2, full CD/PC matrices, SIP polynomial terms). `Deserialize`
+  is derived.
+- **`wcs::WCS::new(&WCSParams)`** wraps the params in a
+  projection-capable solution with `proj()` / `unproj()` /
+  `field_of_view()`. Not strictly needed for the four fields the
+  HTTP contract returns, but cheap to construct and useful for any
+  future consumer (`center_on_target` will want `WCS::proj` for
+  great-circle residuals).
+
+Why this beats a hand-rolled parser:
+
+- No new dep — `wcs` is already in `Cargo.lock` transitively. Adding
+  it to `rp-plate-solver`'s direct deps just makes the dependency
+  explicit.
+- Library handles CD-matrix vs CDELT/CROTA representation
+  differences. ASTAP today writes CDELT+CROTA2; if a future solver
+  swap-in writes CD matrices, the wrapper code is unchanged.
+- SIP distortion terms parsed automatically — relevant if a future
+  caller wants accurate corner pixel projections.
+- Forward-compatibility: when `center_on_target` (Phase 6c-3)
+  computes residual arcsec, it can use `WCS::proj` instead of
+  reimplementing the trigonometry.
+
+The Phase 2 implementation includes a spike to verify `fitsrs`
+parses a real ASTAP `.wcs` cleanly — ASTAP's sidecar is FITS-style
+but may have quirks (line endings, padding, ASTAP-specific
+non-standard keys). If quirks surface, a thin pre-processor stays
+inside `runner/wcs.rs`; the parser/deserializer pipeline does not
+change.
+
 ### HTTP, not MCP
 
 The wrapper exposes a narrow REST surface over HTTP, not an MCP
@@ -448,11 +489,23 @@ Status: **not started.**
       matches expected. No spawning. This is the only unit-level
       coverage of the hint-flag pass-through contract; BDD asserts
       end-to-end behavior, not argv shape.
-- [ ] `runner/wcs.rs` — `.wcs` file parser. Pure function over a
-      string slice. Returns the four fields + the solver banner from
-      the file's `COMMENT` line, or a parse error naming the missing
-      key. Unit-tested exhaustively (every required key absent, every
-      key present, malformed numeric, unexpected key order).
+- [ ] `runner/wcs.rs` — thin adapter that reads the `.wcs` sidecar
+      via the existing `fitsrs` (`wcs.cargo.toml` deps: `fitsrs`,
+      `wcs`; both already transitive via `rp-fits`) and deserializes
+      the FITS header into `wcs::params::WCSParams`. Returns the four
+      fields the HTTP contract requires (CRVAL1, CRVAL2, |CDELT1|,
+      CROTA2), pulled either directly from `WCSParams` or via a
+      `wcs::WCS::new(&params)` projection wrapper (the latter buys
+      `field_of_view()` / `proj()` / `unproj()` for any future
+      consumer; see [Decisions resolved](#decisions-resolved-during-design)
+      §"WCS parsing"). Banner string read from the file's `COMMENT`
+      line via `WCSParams` debug or a separate header lookup.
+      **Phase 2 spike:** verify `fitsrs` parses an actual ASTAP
+      `.wcs` cleanly (line endings, ASTAP-specific keys). If quirks
+      surface, a thin pre-processor stays inside this module. Unit
+      tests cover: valid ASTAP `.wcs` → expected fields; missing
+      required key → named error; ASTAP-specific extra keys →
+      ignored; the spike's specific quirk path if any.
 - [ ] `supervision.rs` — `spawn_with_deadline()` helper. Spawns a
       `tokio::process::Command`, races `child.wait()` against
       `tokio::time::sleep(deadline)`. On deadline expiry, sends

--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -66,7 +66,7 @@ independently bounded by an explicit supervisor:
 |--------|-----------|-----------|-----------|
 | `rp` (gateway) | session-state owner | Sentinel | event-stream disconnect → operator-configured restart command |
 | `rp-plate-solver` (wrapper) | one solver process; no session state | Sentinel | operator-configured restart command (e.g. `systemctl restart rp-plate-solver`) |
-| `astap_cli` (child) | one solve attempt | the wrapper itself | per-request wall-clock deadline → SIGTERM → SIGKILL after 2 s grace |
+| `astap_cli` (child) | one solve attempt | the wrapper itself | per-request wall-clock deadline → graceful signal → 2 s grace → force-kill. Unix: `SIGTERM` then `SIGKILL`. Windows: `CTRL_BREAK_EVENT` (with `CREATE_NEW_PROCESS_GROUP` at spawn) then `TerminateProcess`. Pattern follows `crates/bdd-infra/src/lib.rs`. |
 
 Belt and suspenders: **rp's HTTP client to the wrapper has its own
 outer timeout** (`plate_solver.timeout_secs` in rp config). Even if the
@@ -124,9 +124,13 @@ for scenarios that want to assert the full request → subprocess pipeline
 preserves what the runner builds.
 
 `mock_astap` is not feature-gated — same as `mock_phd2`, it's a regular
-`[[bin]]` that always builds. BDD discovers it via
-`env!("CARGO_BIN_EXE_mock_astap")` (cleaner than the path-walking
-`mock_phd2` does, because BDD lives in the same crate).
+`[[bin]]` that always builds. BDD discovers it in this order:
+explicit `MOCK_ASTAP_BINARY` env var (Bazel test targets set it) →
+`option_env!("CARGO_BIN_EXE_mock_astap")` (Cargo defines it for
+`[[test]]` crates including `tests/bdd.rs`). Both fallbacks let the
+suite run under Cargo and Bazel without divergent code paths. Pure
+`env!()` is intentionally avoided because `CARGO_BIN_EXE_*` is unset
+under Bazel.
 
 This pattern unifies what would otherwise be three separate test
 artifacts (shell scripts for happy-path / failure / hang, plus a
@@ -362,7 +366,9 @@ Phase 5 below addresses the gap.
 - Single endpoint `POST /api/v1/solve` and `GET /health`.
 - ASTAP runner only.
 - Single-flight solves (configurable max concurrency, default 1).
-- Per-request timeout with SIGTERM → SIGKILL escalation.
+- Per-request timeout with graceful → 2 s grace → force-kill
+  escalation (Unix: `SIGTERM` → `SIGKILL`; Windows:
+  `CTRL_BREAK_EVENT` → `TerminateProcess`).
 - Startup config validation.
 - Sentinel-friendly: prints `bound_addr=` to stdout (per
   `bdd-infra` convention), responds to SIGTERM cleanly, exits non-zero
@@ -428,10 +434,12 @@ services/rp-plate-solver/
                                 # surface with named MOCK_ASTAP_MODE modes
                                 # (normal | exit_failure | hang |
                                 # ignore_sigterm | malformed_wcs | no_wcs).
-                                # Discovered by BDD via
-                                # env!("CARGO_BIN_EXE_mock_astap"). Not
-                                # feature-gated — always built. Pattern
-                                # mirrors services/phd2-guider/src/bin/mock_phd2.rs.
+                                # Discovered by BDD/integration tests
+                                # via MOCK_ASTAP_BINARY env var (Bazel)
+                                # → option_env!("CARGO_BIN_EXE_mock_astap")
+                                # (Cargo). Not feature-gated — always
+                                # built. Pattern mirrors
+                                # services/phd2-guider/src/bin/mock_phd2.rs.
 ```
 
 The closest workspace reference is `services/phd2-guider/`. Note the
@@ -490,9 +498,10 @@ Status: **not started.**
       coverage of the hint-flag pass-through contract; BDD asserts
       end-to-end behavior, not argv shape.
 - [ ] `runner/wcs.rs` — thin adapter that reads the `.wcs` sidecar
-      via the existing `fitsrs` (`wcs.cargo.toml` deps: `fitsrs`,
-      `wcs`; both already transitive via `rp-fits`) and deserializes
-      the FITS header into `wcs::params::WCSParams`. Returns the four
+      via the existing `fitsrs` (add `fitsrs` and `wcs` to the new
+      crate's `Cargo.toml`; both are already transitive via
+      `rp-fits`, so no new download) and deserializes the FITS
+      header into `wcs::params::WCSParams`. Returns the four
       fields the HTTP contract requires (CRVAL1, CRVAL2, |CDELT1|,
       CROTA2), pulled either directly from `WCSParams` or via a
       `wcs::WCS::new(&params)` projection wrapper (the latter buys
@@ -507,23 +516,42 @@ Status: **not started.**
       required key → named error; ASTAP-specific extra keys →
       ignored; the spike's specific quirk path if any.
 - [ ] `supervision.rs` — `spawn_with_deadline()` helper. Spawns a
-      `tokio::process::Command`, races `child.wait()` against
-      `tokio::time::sleep(deadline)`. On deadline expiry, sends
-      SIGTERM, waits 2 s, sends SIGKILL. Returns a typed outcome
-      (`Exited(status)` / `TimedOutTerminated` / `TimedOutKilled`).
-      Unit tests use `mock_astap` (built in this same phase, see
-      below):
-      - **Exited** — `MOCK_ASTAP_MODE=normal` with a generous deadline.
-      - **TimedOutTerminated** — `MOCK_ASTAP_MODE=hang` with a 100 ms
-        deadline; mock_astap responds to SIGTERM cleanly.
-      - **TimedOutKilled** — `MOCK_ASTAP_MODE=ignore_sigterm` with a
-        100 ms deadline; mock_astap traps SIGTERM, must be SIGKILLed
-        after the 2 s grace.
+      `tokio::process::Command` configured with `kill_on_drop(true)`
+      (and on Windows also placed in a job object via the `windows`
+      crate so OS cleanup catches dropped handles), races
+      `child.wait()` against `tokio::time::sleep(deadline)`. On
+      deadline expiry, sends the platform's graceful signal
+      (`SIGTERM` on Unix; `CTRL_BREAK_EVENT` on Windows via
+      `GenerateConsoleCtrlEvent`, requiring `CREATE_NEW_PROCESS_GROUP`
+      at spawn). Waits 2 s, then sends the platform's force-kill
+      (`SIGKILL` on Unix; `TerminateProcess` on Windows). Returns a
+      typed outcome (`Exited(status)` / `TimedOutTerminated` /
+      `TimedOutKilled`). The pure-logic side of supervision
+      (deadline arithmetic, outcome decoding) is unit-tested
+      `#[cfg(test)] mod tests` in-source.
+- [ ] `tests/supervision_integration.rs` — integration tests for
+      the spawn-based supervision arms (the only place real child
+      processes are spawned in this crate's test surface). Three
+      arms drive `mock_astap`:
+      - **Exited** — `MOCK_ASTAP_MODE=normal` with a generous
+        deadline.
+      - **TimedOutTerminated** — `MOCK_ASTAP_MODE=hang` with a
+        100 ms deadline; mock_astap responds to the graceful signal
+        cleanly.
+      - **TimedOutKilled** — `MOCK_ASTAP_MODE=ignore_sigterm` with
+        a 100 ms deadline; mock_astap traps the graceful signal,
+        must be force-killed after the 2 s grace.
 
-      Resolved via `env!("CARGO_BIN_EXE_mock_astap")`. Same binary
-      drives both supervision unit tests and BDD scenarios — one
-      artifact, one set of named modes, one place to extend when new
-      failure modes need coverage.
+      Binary discovery in this order: explicit `MOCK_ASTAP_BINARY`
+      env var (set by the Bazel test target) → `option_env!(
+      "CARGO_BIN_EXE_mock_astap")` (set by Cargo for `[[test]]`
+      crates). Test fails with a diagnostic pointing at both
+      mechanisms when neither resolves. Same shape
+      `services/phd2-guider/tests/test_integration.rs` uses for
+      `mock_phd2`. **`env!()` does not work** here because
+      `CARGO_BIN_EXE_*` is unset for `#[cfg(test)] mod tests`
+      inside `src/` and unset under Bazel entirely — the `option_env!
+      ` + `MOCK_ASTAP_BINARY` fallback handles both.
 - [ ] `src/bin/mock_astap.rs` — the `[[bin]]` itself. Implements the
       six `MOCK_ASTAP_MODE` modes from the design decision above. On
       Windows, `ignore_sigterm` uses `SetConsoleCtrlHandler` to
@@ -601,9 +629,12 @@ scenario targets. Real ASTAP is not in the loop here; that's Phase 6.
       `docs/skills/testing.md` §2.7.
 - [ ] `tests/bdd/world.rs` — `PlateSolverWorld` with
       `service_handle: Option<ServiceHandle>`, `last_response:
-      Option<reqwest::Response>`, `temp_dir: Option<TempDir>`. Resolves
-      the `mock_astap` path from `env!("CARGO_BIN_EXE_mock_astap")` at
-      compile time — no env vars to set, no path walking.
+      Option<reqwest::Response>`, `temp_dir: Option<TempDir>`.
+      Resolves the `mock_astap` path in this order:
+      `MOCK_ASTAP_BINARY` env var (Bazel) →
+      `option_env!("CARGO_BIN_EXE_mock_astap")` (Cargo). Same
+      lookup the supervision integration tests use; falls back
+      cleanly across both build systems.
 - [ ] `tests/bdd/steps/*.rs` — step definitions. Reuse the
       `bdd-infra` `ServiceHandle` for the wrapper spawn/stop. No new
       feature flag on `bdd-infra` is needed — the wrapper does not

--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -197,10 +197,10 @@ unless the `ASTAP_BINARY` env var is set:
 
 ```rust
 .filter_run("tests/features", |feat, _rule, sc| {
-    let is_wip = feat.tags.iter().any(|t| t == "@wip")
-        || sc.tags.iter().any(|t| t == "@wip");
-    let needs_astap = feat.tags.iter().any(|t| t == "@requires-astap")
-        || sc.tags.iter().any(|t| t == "@requires-astap");
+    let is_wip = feat.tags.iter().any(|t| t == "wip" || t == "@wip")
+        || sc.tags.iter().any(|t| t == "wip" || t == "@wip");
+    let needs_astap = feat.tags.iter().any(|t| t == "requires-astap" || t == "@requires-astap")
+        || sc.tags.iter().any(|t| t == "requires-astap" || t == "@requires-astap");
     let astap_available = std::env::var("ASTAP_BINARY").is_ok();
     !is_wip && (!needs_astap || astap_available)
 })
@@ -253,8 +253,8 @@ Request body (JSON):
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `fits_path` | absolute path string | yes | Must be readable by the wrapper process. Path-based input matches ADR-005's "rp and the plate solver share a filesystem" contract — no pixel bytes over HTTP. |
-| `ra_hint` | f64 (decimal hours, 0–24) | no | Maps to ASTAP `-ra`. |
-| `dec_hint` | f64 (decimal degrees, −90–90) | no | Maps to ASTAP `-spd` after south-pole-distance conversion. |
+| `ra_hint` | f64 (decimal degrees, 0–360) | no | Wrapper converts to decimal hours (`degrees / 15`) before passing to ASTAP `-ra`. Degrees on the wire matches the `ra_center` response field (sourced from `CRVAL1`, also degrees). |
+| `dec_hint` | f64 (decimal degrees, −90–90) | no | Wrapper converts to south-pole-distance (`90 + dec`) before passing to ASTAP `-spd`. |
 | `fov_hint_deg` | f64 (degrees, image height) | no | Maps to ASTAP `-fov`. |
 | `search_radius_deg` | f64 (degrees) | no | Maps to ASTAP `-r`. Defaults to ASTAP's own default when omitted. |
 | `timeout` | humantime string | no | Wrapper's wall-clock deadline for the ASTAP child. Defaults to `30s`. Bounded by wrapper-config max. |
@@ -303,8 +303,16 @@ Error codes (frozen):
 
 Returns `200 OK` with `{"status": "ok"}` when the wrapper has passed
 startup config validation and the ASTAP binary is still executable on
-disk. `503` otherwise. Sentinel's "Responsive but stuck" check at
-`rp.md` line 2143 uses this endpoint.
+disk. `503` otherwise.
+
+This is the standard HTTP health-probe pattern, exposed for
+operational tooling and any future Sentinel probe path. Today,
+Sentinel's documented watchdog flow (`rp.md` §"Sentinel Watchdog
+Integration") only describes pinging Alpaca service endpoints, and
+`rp-plate-solver` is not Alpaca. Whether Sentinel is wired to use
+this `/health` (vs relying purely on event-stream signals and
+configured restart commands) is a Sentinel-side design question.
+Phase 5 below addresses the gap.
 
 ## MVP scope
 
@@ -594,9 +602,17 @@ Status: **not started.**
       service entry for `rp-plate-solver` without code changes. If it
       does, this phase is docs-only; if it does not, the gap is
       called out in a follow-up issue.
-- [ ] Sentinel's "Responsive but stuck" check uses `GET /health` on
-      this service. The check happens via Sentinel's existing health
-      probe machinery; no per-service code in `rp-plate-solver`.
+- [ ] Decide whether Sentinel should probe `rp-plate-solver`'s
+      `/health` or rely on event-stream + restart-command alone. The
+      currently-documented Sentinel watchdog flow only pings Alpaca
+      service endpoints; `rp-plate-solver` is not Alpaca. Two paths:
+      (a) extend Sentinel's health-probe surface to support
+      configurable HTTP `/health` per rp-managed service (Sentinel
+      design change); (b) rely on event-stream-derived deadline
+      signals from rp's compound tools and configured restart
+      commands, leaving `/health` as operator-only. Pick one in this
+      phase; the wrapper exposes `/health` either way so option (a)
+      stays available for later.
 
 **Exit criteria:** an operator can configure Sentinel to restart
 `rp-plate-solver` on hang/crash by following the README. No regression

--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -1,0 +1,743 @@
+# Plan: `rp-plate-solver` service
+
+**Date:** 2026-05-02
+**Branch:** `worktree-astap`
+**ADR:** [005-plate-solver](../decisions/005-plate-solver.md)
+**Parent plan:** [image-evaluation-tools.md Phase 6c-1](image-evaluation-tools.md#phase-6c-1--rp-plate-solver-rp-managed-service)
+
+## Background
+
+ADR-005 adopted ASTAP, executed as a subprocess by a new
+`rp-plate-solver` rp-managed service, with the binary and index database
+supplied by the operator (BYO). The ADR explicitly defers
+implementation sequencing to a separate plan — this is that plan.
+
+`rp-plate-solver` is the second rp-managed service in the workspace
+(after `phd2-guider`) and the first one stood up entirely under the
+design-first / test-first workflow established in
+`docs/skills/development-workflow.md`. It exists so the upcoming
+`plate_solve` built-in MCP tool in rp (Phase 6c-2) and the
+`center_on_target` compound tool (Phase 6c-3) have a stable HTTP target
+to call against.
+
+## Goals
+
+1. **MVP:** stand up `rp-plate-solver` as a Sentinel-supervised wrapper
+   around ASTAP, exposing one HTTP solve endpoint plus a health probe,
+   with all three failure domains (rp, wrapper, ASTAP child)
+   independently bounded.
+2. **Freeze the HTTP contract here** so Phase 6c-2 can build the rp-side
+   client against a stub server while this service is still in flight.
+3. **Retire ADR-005 open questions 1–6** (per-platform end-to-end solve
+   passes, LGPL §4/§6 review under BYO, hint plumbing).
+4. **Establish the rp-managed-service template** for any future
+   external-process wrapper — module shape, trait-isolated subprocess
+   surface, supervision contract, BDD test-double pattern.
+
+## Decisions resolved (during design)
+
+These belong in `docs/services/rp-plate-solver.md` once Phase 1 lands
+and should not be re-litigated.
+
+### Stability and supervision — the load-bearing rationale
+
+`rp-plate-solver` is an **rp-managed service**, not a plugin, because
+Tenet 1 ("robustness above all else") demands that ASTAP — a
+single-maintainer LGPL Pascal binary that can SIGSEGV on pathological
+star fields, wedge on a too-small `-r` search radius with bad hints, or
+deadlock on flaky storage — cannot threaten `rp`'s liveness. The
+discriminator from `rp.md` §"Component Categories" is the supervision
+default:
+
+| Category | Sentinel restart on hang/crash |
+|----------|-------------------------------|
+| rp-managed services | **default** |
+| Plugins | opt-in ("may restart configurable plugins") |
+
+For ASTAP's failure profile, default supervision is the right posture.
+Plugin shape would force operators to opt into Sentinel coverage and
+write the restart command themselves — a footgun for a component that
+*will* hang in the field.
+
+The architecture defines **three nested failure domains**, each
+independently bounded by an explicit supervisor:
+
+| Domain | What dies | Supervisor | Mechanism |
+|--------|-----------|-----------|-----------|
+| `rp` (gateway) | session-state owner | Sentinel | event-stream disconnect → operator-configured restart command |
+| `rp-plate-solver` (wrapper) | one solver process; no session state | Sentinel | operator-configured restart command (e.g. `systemctl restart rp-plate-solver`) |
+| `astap_cli` (child) | one solve attempt | the wrapper itself | per-request wall-clock deadline → SIGTERM → SIGKILL after 2 s grace |
+
+Belt and suspenders: **rp's HTTP client to the wrapper has its own
+outer timeout** (`plate_solver.timeout_secs` in rp config). Even if the
+wrapper's internal timeout regresses, rp does not hang on a
+`plate_solve` call.
+
+### Stateless across requests
+
+The wrapper holds no per-solve state. No solve cache, no warm process
+pool, no shared mutable structures across requests. Restart is always
+cheap and never costs more than the in-flight request. This is what
+makes Sentinel's restart strategy safe: "kill it" is the recovery, not
+"kill it and restore session state."
+
+### Single-flight solve, queued at the wrapper
+
+ASTAP is CPU-bound on a single core during a solve. Concurrency at the
+wrapper would just thrash the core and double per-solve wall time. The
+wrapper accepts overlapping HTTP requests but processes them serially
+behind a `tokio::sync::Semaphore::new(1)`. Configurable via
+`max_concurrency`, default 1. v1 ships with the default.
+
+### Trait-isolated subprocess surface; `mock_astap` for BDD; real ASTAP only in Phase 6 e2e
+
+Three layers of isolation, each with a distinct purpose.
+
+**Layer 1 — `AstapRunner` trait + `mockall` for upstream-of-runner unit
+tests.** The `Command::new("astap_cli")` boundary is wrapped in an
+`AstapRunner` trait gated by `#[cfg_attr(test, mockall::automock)]`, per
+ADR-004's mock-strategy rule for narrow service-boundary traits (≤ 10
+methods). The trait lets the HTTP handler, single-flight semaphore, and
+error-mapping logic be unit-tested without spawning anything.
+
+**Layer 2 — `mock_astap` `[[bin]]` for BDD.** Following the `mock_phd2`
+precedent in `services/phd2-guider/src/bin/mock_phd2.rs`, the wrapper
+ships a small in-tree binary that mimics the ASTAP CLI surface
+(reads `-f <path>`, writes a sidecar `.wcs`, exits) with **named
+behavior modes** selected via `MOCK_ASTAP_MODE`:
+
+| Mode | Behavior | Drives BDD scenario |
+|------|----------|---------------------|
+| `normal` (default) | Read `-f` arg, write a canned `.wcs` next to it, exit 0 | Happy path |
+| `exit_failure` | Print to stderr, exit 1 (no `.wcs` written) | `solve_failed` |
+| `hang` | Sleep indefinitely; respond cleanly to SIGTERM | `solve_timeout` (terminated) |
+| `ignore_sigterm` | Install a SIGTERM-ignore handler, then sleep | `solve_timeout` (killed) — exercises the SIGKILL escalation through the full HTTP-to-process pipeline |
+| `malformed_wcs` | Write a `.wcs` missing `CRVAL2`, exit 0 | Wrapper's `.wcs` parser must reject cleanly |
+| `no_wcs` | Exit 0 without writing any `.wcs` | Wrapper must not return success when the sidecar is missing |
+
+`MOCK_ASTAP_ARGV_OUT=<path>` (any mode) writes the received argv to the
+named file, so steps that need to assert end-to-end argv flow can do so
+without touching the trait. The argv-mapping *contract* still gets its
+focused coverage at unit-test level on `runner/astap.rs` (build
+`Command`, inspect `args()` slice, no spawn) — `MOCK_ASTAP_ARGV_OUT` is
+for scenarios that want to assert the full request → subprocess pipeline
+preserves what the runner builds.
+
+`mock_astap` is not feature-gated — same as `mock_phd2`, it's a regular
+`[[bin]]` that always builds. BDD discovers it via
+`env!("CARGO_BIN_EXE_mock_astap")` (cleaner than the path-walking
+`mock_phd2` does, because BDD lives in the same crate).
+
+This pattern unifies what would otherwise be three separate test
+artifacts (shell scripts for happy-path / failure / hang, plus a
+separate `sigterm_trap` `[[bin]]`) into one self-documenting Rust
+binary whose modes are the test contract.
+
+**Layer 3 — Real ASTAP via `install-astap`, only in Phase 6.** The
+cross-platform end-to-end workflow installs real ASTAP on each target
+platform and runs a single solve through the full wrapper to validate
+that the CLI surface, hint-flag mapping, and `.wcs` parser haven't
+silently diverged from upstream. ASTAP upstream regressions
+themselves are caught by the existing `install-astap` smoke workflow
+(per ADR-005's `cache-key-suffix: github.run_id` posture); Phase 6
+catches *integration* regressions specifically.
+
+**Local developer experience:** running `cargo test -p rp-plate-solver
+--test bdd` requires nothing beyond `cargo build -p rp-plate-solver
+--all-targets` (which builds `mock_astap` automatically). No ASTAP
+install needed for routine work. Same DX bar as phd2-guider with
+`mock_phd2`.
+
+### BYO ASTAP per ADR-005, validated at startup
+
+The wrapper's config requires `astap_binary_path` and
+`astap_db_directory`. Both are validated at startup:
+
+- `astap_binary_path` must exist, be a regular file, and be executable
+  by the current user.
+- `astap_db_directory` must exist and be a directory.
+
+Validation failures produce a structured error that names the field
+and links to the README's per-platform install instructions, then exit
+non-zero (so Sentinel's restart loop surfaces the misconfiguration
+rather than masking it).
+
+### Solver-swap path kept architecturally available, not built in v1
+
+The `AstapRunner` trait is the swap-out point: a future `SolveFieldRunner`
+implementation lets operators flip to astrometry.net's `solve-field`
+via configuration, no rebuild required. v1 ships only the ASTAP
+implementation. The trait shape is informed by both solvers' shared
+contract (FITS-in / WCS-out subprocess) so the swap is mechanical.
+
+### Real-ASTAP coverage: cadence and gating
+
+Real ASTAP runs **nightly, on all three target OSes** as a small
+tagged smoke that backstops the mock-based BDD. PR jobs install
+nothing and run only the `mock_astap`-backed scenarios; nightly
+installs ASTAP via `install-astap` on each runner and lets the
+`@requires-astap` scenarios fire.
+
+| Concern | Where it's caught |
+|---------|-------------------|
+| Wrapper contract correctness (every error code, every supervision arm, every `.wcs` edge case) | mock-backed BDD on every affected PR |
+| Mock vs. real divergence — does real ASTAP still behave the way `mock_astap` claims? | Phase 6 nightly cross-platform smoke (~2 scenarios per OS) |
+| Per-platform integration — does the wrapper actually work on macOS / Windows? | Same Phase 6 nightly job — runs on `ubuntu-latest`, `macos-latest`, `windows-latest` |
+| ASTAP upstream regressions independent of our code | The existing `install-astap` smoke workflow (already in repo) |
+
+A single nightly cross-platform smoke is enough: the scenarios are
+narrow (happy path + one error), the install-astap action handles
+per-OS bytes, and nightly cadence is fast enough to catch divergence
+before it pollutes a release. No separate weekly tier.
+
+**Gating mechanism — `@requires-astap` cucumber tag.** The pattern
+mirrors `@wip` (already in `bdd.rs` per `docs/skills/testing.md` §2.7).
+The runner's `filter_run` skips any scenario tagged `@requires-astap`
+unless the `ASTAP_BINARY` env var is set:
+
+```rust
+.filter_run("tests/features", |feat, _rule, sc| {
+    let is_wip = feat.tags.iter().any(|t| t == "@wip")
+        || sc.tags.iter().any(|t| t == "@wip");
+    let needs_astap = feat.tags.iter().any(|t| t == "@requires-astap")
+        || sc.tags.iter().any(|t| t == "@requires-astap");
+    let astap_available = std::env::var("ASTAP_BINARY").is_ok();
+    !is_wip && (!needs_astap || astap_available)
+})
+```
+
+PR `required` jobs never set `ASTAP_BINARY` → tagged scenarios silently
+skip with no error noise. The nightly job sets it via
+`install-astap` → tagged scenarios fire. The same pattern generalizes
+to any future service with a real-binary backstop.
+
+### HTTP, not MCP
+
+The wrapper exposes a narrow REST surface over HTTP, not an MCP
+server. Justification:
+
+- Exactly one operation. Wrapping rmcp's session/discovery machinery
+  around a single endpoint is overkill.
+- The caller (`rp`) is the only consumer ever planned; rp owns the
+  `plate_solve` MCP tool name, not the wrapper.
+- Health probing is trivial in REST and more involved in MCP.
+
+### No `wcs` section persistence in this service
+
+The wrapper returns the WCS solution in the HTTP response and stops
+there. Writing a `wcs` section onto the exposure document is rp's job
+(in Phase 6c-2's `plate_solve` MCP tool), because rp owns the
+exposure-document store.
+
+## HTTP contract (frozen)
+
+This contract is fixed in this plan so Phase 6c-2 can mock it
+immediately. Changes after the freeze require a follow-up PR with
+explicit consumer notice.
+
+### `POST /api/v1/solve`
+
+Request body (JSON):
+
+```json
+{
+  "fits_path": "/data/lights/M31/M31_L_300s_001.fits",
+  "ra_hint": 10.6847,
+  "dec_hint": 41.2689,
+  "fov_hint_deg": 1.5,
+  "search_radius_deg": 5.0,
+  "timeout": "30s"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `fits_path` | absolute path string | yes | Must be readable by the wrapper process. Path-based input matches ADR-005's "rp and the plate solver share a filesystem" contract — no pixel bytes over HTTP. |
+| `ra_hint` | f64 (decimal hours, 0–24) | no | Maps to ASTAP `-ra`. |
+| `dec_hint` | f64 (decimal degrees, −90–90) | no | Maps to ASTAP `-spd` after south-pole-distance conversion. |
+| `fov_hint_deg` | f64 (degrees, image height) | no | Maps to ASTAP `-fov`. |
+| `search_radius_deg` | f64 (degrees) | no | Maps to ASTAP `-r`. Defaults to ASTAP's own default when omitted. |
+| `timeout` | humantime string | no | Wrapper's wall-clock deadline for the ASTAP child. Defaults to `30s`. Bounded by wrapper-config max. |
+
+Success response (`200 OK`, JSON):
+
+```json
+{
+  "ra_center": 10.6848,
+  "dec_center": 41.2690,
+  "pixel_scale_arcsec": 1.05,
+  "rotation_deg": 12.3,
+  "solver": "astap-cli-2026.04.28"
+}
+```
+
+| Field | Notes |
+|-------|-------|
+| `ra_center` | Decimal degrees (0–360). Sourced from `.wcs` `CRVAL1`. |
+| `dec_center` | Decimal degrees (−90–90). Sourced from `.wcs` `CRVAL2`. |
+| `pixel_scale_arcsec` | Computed from `CDELT1` (absolute value, arcsec/pixel). |
+| `rotation_deg` | Sourced from `.wcs` `CROTA2`. |
+| `solver` | Banner string parsed at wrapper startup, cached. |
+
+Error response (non-2xx, JSON):
+
+```json
+{
+  "error": "solve_failed",
+  "message": "ASTAP exited 1: insufficient stars detected",
+  "details": { "exit_code": 1, "stderr_tail": "..." }
+}
+```
+
+Error codes (frozen):
+
+| Code | HTTP status | When |
+|------|-------------|------|
+| `invalid_request` | 400 | Schema-invalid body, unparseable `timeout`, `fits_path` not absolute. |
+| `fits_not_found` | 404 | `fits_path` does not exist or is not readable. |
+| `solve_failed` | 422 | ASTAP returned non-zero or did not produce a `.wcs`. |
+| `solve_timeout` | 504 | Wrapper's wall-clock deadline expired before ASTAP returned. |
+| `internal` | 500 | Unexpected wrapper failure (broken pipe, parser bug, etc.). |
+
+### `GET /health`
+
+Returns `200 OK` with `{"status": "ok"}` when the wrapper has passed
+startup config validation and the ASTAP binary is still executable on
+disk. `503` otherwise. Sentinel's "Responsive but stuck" check at
+`rp.md` line 2143 uses this endpoint.
+
+## MVP scope
+
+### In scope for v1
+
+- Single endpoint `POST /api/v1/solve` and `GET /health`.
+- ASTAP runner only.
+- Single-flight solves (configurable max concurrency, default 1).
+- Per-request timeout with SIGTERM → SIGKILL escalation.
+- Startup config validation.
+- Sentinel-friendly: prints `bound_addr=` to stdout (per
+  `bdd-infra` convention), responds to SIGTERM cleanly, exits non-zero
+  on misconfiguration.
+
+### Out of scope for v1 (deferred or never)
+
+- `solve-field` (astrometry.net) runner — architecturally swappable, not
+  built.
+- Background solving by subscribing to `exposure_complete` events. The
+  ADR mentions this as a possibility; v1 is request/response only.
+- A solve cache or warm process pool — explicitly excluded by the
+  stateless-across-requests decision.
+- An MCP server surface — REST only.
+- Pixel transport over HTTP — file-path only, per ADR-005.
+
+## Module structure
+
+```
+services/rp-plate-solver/
+  Cargo.toml
+  BUILD.bazel
+  README.md                     # Per-platform install pointers, ops guide
+  src/
+    main.rs                     # CLI entry (clap), prints bound_addr=
+    lib.rs                      # ServerBuilder + BoundServer, public API
+    config.rs                   # Config + load_config + startup validation
+    error.rs                    # AppError (thiserror), HTTP error mapping
+    api.rs                      # axum routes + request/response types
+    runner/
+      mod.rs                    # AstapRunner trait + #[automock]
+      astap.rs                  # Real impl: builds Command, parses .wcs
+      wcs.rs                    # .wcs file parser (CRVAL1/2, CDELT1/2, CROTA2)
+    supervision.rs              # Per-request timeout + signal escalation
+  tests/
+    bdd.rs                      # Entry point (uses bdd_main!)
+    bdd/
+      world.rs                  # PlateSolverWorld + service handle + script paths
+      steps/
+        mod.rs
+        config_steps.rs
+        solve_steps.rs
+        supervision_steps.rs
+        health_steps.rs
+    features/
+      configuration.feature
+      solve_request.feature
+      subprocess_supervision.feature
+      health.feature
+    fixtures/
+      m31_known.fits            # Small (~2 MB) known-solution FITS — used
+                                # by the @requires-astap nightly smoke
+                                # (Phase 6) and by Phase 7's cross-platform
+                                # e2e workflow. mock_astap-backed BDD
+                                # scenarios don't read pixel content.
+      degenerate_no_stars.fits  # Small all-zeros FITS for the real
+                                # solve_failed scenario in the
+                                # @requires-astap smoke
+      sample.wcs                # Canned .wcs that mock_astap's "normal"
+                                # mode copies into place
+  src/bin/
+    mock_astap.rs               # [[bin]] test double mimicking ASTAP's CLI
+                                # surface with named MOCK_ASTAP_MODE modes
+                                # (normal | exit_failure | hang |
+                                # ignore_sigterm | malformed_wcs | no_wcs).
+                                # Discovered by BDD via
+                                # env!("CARGO_BIN_EXE_mock_astap"). Not
+                                # feature-gated — always built. Pattern
+                                # mirrors services/phd2-guider/src/bin/mock_phd2.rs.
+```
+
+The closest workspace reference is `services/phd2-guider/`. Note the
+shape borrows: `config.rs`, `error.rs`, `lib.rs` (`ServerBuilder`), and
+the `bdd_main!` BDD entry. It diverges where the domain differs:
+`runner/` replaces `process.rs`/`connection.rs`/`rpc.rs` because the
+external-program contract is fundamentally different (one short-lived
+subprocess per request vs. one long-lived TCP peer).
+
+## Phases
+
+Each phase is its own PR.
+
+### Phase 1 — Service design doc
+
+Status: **not started.**
+
+- [ ] `docs/services/rp-plate-solver.md` (new). Sections: Overview,
+      Architecture, Behavioral contracts (per HTTP endpoint, per error
+      code, per supervision domain), Configuration, Subprocess test
+      doubles, MVP scope, Out of scope.
+- [ ] Update `docs/services/rp.md` §"Plate Solver" to point at the new
+      service doc and to drop the "decision pending" note (now retired
+      by ADR-005).
+- [ ] Update `docs/workspace.md` if the services index lives there.
+
+**Exit criteria:** new doc reviewed and merged. No code yet.
+
+### Phase 2 — Crate scaffolding + `AstapRunner` trait + `.wcs` parser
+
+Status: **not started.**
+
+- [ ] New workspace member `services/rp-plate-solver` registered in root
+      `Cargo.toml`. Standard crate metadata (workspace inheritance for
+      version, edition, rust-version, lints).
+- [ ] `BUILD.bazel` for the new crate; `CARGO_BAZEL_REPIN=1 bazel mod
+      tidy` if any new crates.io deps land here.
+- [ ] `config.rs` — `Config` with `astap_binary_path`,
+      `astap_db_directory`, `bind_address`, `port`, `max_concurrency`,
+      `default_solve_timeout`, `max_solve_timeout`. `load_config(path)`
+      + startup validation. Unit-tested.
+- [ ] `error.rs` — `AppError` enum + `ErrorResponse` shape + axum
+      `IntoResponse` mapping to the frozen error code table.
+- [ ] `runner/mod.rs` — `AstapRunner` trait with one method:
+      `async fn solve(&self, request: SolveRequest) -> Result<SolveOutcome, RunnerError>`.
+      `#[cfg_attr(test, mockall::automock)]`. The trait abstracts the
+      subprocess; `SolveRequest` carries the parsed config + hints,
+      `SolveOutcome` carries the parsed `.wcs` values + solver banner.
+- [ ] `runner/astap.rs` — real implementation. Builds the `Command`
+      argument vector (mapping HTTP fields to ASTAP flags per the
+      contract table), spawns under the supervision module, reads the
+      sidecar `.wcs`, returns `SolveOutcome`. **Argv-mapping unit
+      tests** here: given a `SolveRequest` with each combination of
+      hint flags set/unset, assert the resulting `Command` argv slice
+      matches expected. No spawning. This is the only unit-level
+      coverage of the hint-flag pass-through contract; BDD asserts
+      end-to-end behavior, not argv shape.
+- [ ] `runner/wcs.rs` — `.wcs` file parser. Pure function over a
+      string slice. Returns the four fields + the solver banner from
+      the file's `COMMENT` line, or a parse error naming the missing
+      key. Unit-tested exhaustively (every required key absent, every
+      key present, malformed numeric, unexpected key order).
+- [ ] `supervision.rs` — `spawn_with_deadline()` helper. Spawns a
+      `tokio::process::Command`, races `child.wait()` against
+      `tokio::time::sleep(deadline)`. On deadline expiry, sends
+      SIGTERM, waits 2 s, sends SIGKILL. Returns a typed outcome
+      (`Exited(status)` / `TimedOutTerminated` / `TimedOutKilled`).
+      Unit tests use `mock_astap` (built in this same phase, see
+      below):
+      - **Exited** — `MOCK_ASTAP_MODE=normal` with a generous deadline.
+      - **TimedOutTerminated** — `MOCK_ASTAP_MODE=hang` with a 100 ms
+        deadline; mock_astap responds to SIGTERM cleanly.
+      - **TimedOutKilled** — `MOCK_ASTAP_MODE=ignore_sigterm` with a
+        100 ms deadline; mock_astap traps SIGTERM, must be SIGKILLed
+        after the 2 s grace.
+
+      Resolved via `env!("CARGO_BIN_EXE_mock_astap")`. Same binary
+      drives both supervision unit tests and BDD scenarios — one
+      artifact, one set of named modes, one place to extend when new
+      failure modes need coverage.
+- [ ] `src/bin/mock_astap.rs` — the `[[bin]]` itself. Implements the
+      six `MOCK_ASTAP_MODE` modes from the design decision above. On
+      Windows, `ignore_sigterm` uses `SetConsoleCtrlHandler` to
+      ignore `CTRL_BREAK_EVENT` (the closest equivalent the
+      supervision module's Windows signal path will exercise);
+      document the platform-specific signal semantics in the binary's
+      source. Argv-out side-channel implemented via
+      `MOCK_ASTAP_ARGV_OUT`. Registered as a `[[bin]]` in
+      `Cargo.toml`; not feature-gated.
+
+**Exit criteria:** `cargo build -p rp-plate-solver --all-features
+--all-targets` clean. Unit tests for `config.rs`, `error.rs`,
+`runner/wcs.rs`, `supervision.rs` pass. The crate produces a `lib.rs`
+re-export surface but no `main.rs` yet (Phase 4 wires the binary).
+
+### Phase 3 — BDD scenarios (with `@wip`)
+
+Status: **not started.**
+
+All four feature files run against **`mock_astap`**. Each scenario
+configures `MOCK_ASTAP_MODE` for the wrapper's `astap_binary_path`
+config so the wrapper spawns a mock that produces the failure mode the
+scenario targets. Real ASTAP is not in the loop here; that's Phase 6.
+
+- [ ] `tests/features/configuration.feature` — startup validation:
+      missing binary path → exit non-zero with field-naming error;
+      binary path not executable → ditto; database directory missing
+      → ditto; happy-path validation accepts `mock_astap` as a valid
+      binary path. Target ~6 scenarios.
+- [ ] `tests/features/solve_request.feature` — happy path
+      (`MOCK_ASTAP_MODE=normal` returns the four expected fields from
+      the canned `.wcs`); each error code from the frozen table
+      (`solve_failed` via `exit_failure`, `solve_timeout` via `hang`,
+      `fits_not_found` and `invalid_request` via the wrapper's
+      pre-spawn rejection); the two `.wcs`-edge-case modes
+      (`malformed_wcs` → `solve_failed` with parser-detail message;
+      `no_wcs` → `solve_failed` with sidecar-missing message). End-to-end
+      argv-flow assertion via `MOCK_ASTAP_ARGV_OUT` for one scenario
+      per hint flag. Target ~10 scenarios.
+- [ ] `tests/features/subprocess_supervision.feature` — `solve_timeout`
+      (terminated) via `MOCK_ASTAP_MODE=hang` with `timeout: 100ms`;
+      `solve_timeout` (killed) via `MOCK_ASTAP_MODE=ignore_sigterm`
+      with the same deadline (the SIGKILL-escalation path now lives
+      in BDD, not punted to a unit test); single-flight serialization
+      (two concurrent `hang`-mode requests; assert second observed
+      start time is after first observed end time, via mock_astap
+      timestamp side-channel writes). Target ~5 scenarios.
+- [ ] `tests/features/health.feature` — `/health` returns `200` after
+      startup validation; returns `503` if the configured binary path
+      is removed between startup and the probe (use a temp-dir copy
+      of `mock_astap`, then delete the copy). Target ~3 scenarios.
+- [ ] `tests/features/real_astap_smoke.feature` — tagged
+      `@requires-astap` at the feature level, so PR jobs skip it
+      automatically and the nightly job (Phase 6) runs it. Target ~2
+      scenarios:
+      1. **Happy path** — real solve through the wrapper using
+         `tests/fixtures/m31_known.fits`; assert RA/Dec within
+         tolerance of the known solution. This is the "is the mock
+         honest" assertion: if real ASTAP starts producing a `.wcs`
+         shape `mock_astap` doesn't, this scenario catches it before
+         the next Phase 7 weekly cron run.
+      2. **Real `solve_failed`** — real ASTAP on a degenerate FITS
+         (committed alongside `m31_known.fits`); assert
+         `solve_failed` with non-empty stderr embedded.
+- [ ] `bdd.rs` — `filter_run` extends the existing `@wip` filter to
+      also filter `@requires-astap` based on `ASTAP_BINARY`
+      presence (snippet in the design decision section above).
+- [ ] `tests/fixtures/degenerate_no_stars.fits` — small all-zeros
+      FITS for the real `solve_failed` scenario. Re-uses the existing
+      `m31_known.fits` for the happy path so we don't ship two
+      multi-MB fixtures.
+- [ ] All four feature files tagged `@wip`. `bdd.rs` uses
+      `filter_run` to skip `@wip` so the workspace BDD suite stays
+      green until Phase 4 lands. Convention per
+      `docs/skills/testing.md` §2.7.
+- [ ] `tests/bdd/world.rs` — `PlateSolverWorld` with
+      `service_handle: Option<ServiceHandle>`, `last_response:
+      Option<reqwest::Response>`, `temp_dir: Option<TempDir>`. Resolves
+      the `mock_astap` path from `env!("CARGO_BIN_EXE_mock_astap")` at
+      compile time — no env vars to set, no path walking.
+- [ ] `tests/bdd/steps/*.rs` — step definitions. Reuse the
+      `bdd-infra` `ServiceHandle` for the wrapper spawn/stop. No new
+      feature flag on `bdd-infra` is needed — the wrapper does not
+      host an MCP server, so `rp-harness` is irrelevant.
+- [ ] **No CI install changes for BDD**: the BDD suite is fully
+      self-contained because `mock_astap` is built by `cargo build
+      --all-targets -p rp-plate-solver`. cargo-rail's existing
+      change-detection logic handles the rest. The `install-astap`
+      action stays scoped to its existing smoke workflow and to
+      Phase 6's cross-platform e2e workflow.
+
+**Exit criteria:** `cargo test -p rp-plate-solver --all-features --test
+bdd` compiles and runs cleanly with `@wip` filtering all scenarios out
+(0 scenarios run, 0 failures). The compiled BDD harness is the gate
+that the next phase's implementation has to satisfy.
+
+### Phase 4 — HTTP server + supervision impl + remove `@wip`
+
+Status: **not started.**
+
+- [ ] `api.rs` — axum router with `POST /api/v1/solve` and
+      `GET /health`. Request body deserialization via `serde_json`,
+      response serialization to the frozen schema, error mapping per
+      the frozen table. Single-flight semaphore wired here.
+- [ ] `lib.rs` — `ServerBuilder`/`BoundServer` two-phase API
+      mirroring `phd2-guider`'s shape (avoids port-TOCTOU race called
+      out in `docs/skills/development-workflow.md` §"Phase 4
+      Stabilization").
+- [ ] `main.rs` — CLI (clap), reads `--config`, prints
+      `bound_addr=<host>:<port>` to stdout (per `bdd-infra` convention
+      so `parse_bound_port` works), installs SIGTERM handler for
+      graceful shutdown.
+- [ ] Remove `@wip` from all four feature files in the same commit
+      that lands the implementation.
+
+**Exit criteria:** all BDD scenarios pass. `cargo rail run --profile
+commit -q` clean. `cargo fmt` clean.
+
+### Phase 5 — Sentinel integration
+
+Status: **not started.**
+
+- [ ] Document the per-service Sentinel restart command in
+      `services/rp-plate-solver/README.md`. Linux/systemd:
+      `systemctl restart rp-plate-solver`. Mention macOS launchd /
+      Windows service-manager equivalents.
+- [ ] Confirm Sentinel's existing per-service restart-command config
+      surface (per `rp.md` §"Sentinel Watchdog Integration") accepts a
+      service entry for `rp-plate-solver` without code changes. If it
+      does, this phase is docs-only; if it does not, the gap is
+      called out in a follow-up issue.
+- [ ] Sentinel's "Responsive but stuck" check uses `GET /health` on
+      this service. The check happens via Sentinel's existing health
+      probe machinery; no per-service code in `rp-plate-solver`.
+
+**Exit criteria:** an operator can configure Sentinel to restart
+`rp-plate-solver` on hang/crash by following the README. No regression
+in Sentinel's existing tests.
+
+### Phase 6 — Nightly cross-platform real-ASTAP smoke (retires ADR-005 OQ 1–4)
+
+Status: **not started.**
+
+The `@requires-astap`-tagged smoke scenarios from Phase 3 are wired
+to run nightly on all three target OSes. This is the only place real
+ASTAP runs against the real wrapper; the existing `install-astap`
+smoke workflow catches ASTAP-upstream regressions independently of
+our code.
+
+The scenarios already exist after Phase 3 — this phase is CI plumbing
+plus the macOS / Windows-ARM64 specifics ADR-005 calls out.
+
+- [ ] `.github/workflows/rp-plate-solver-smoke.yml` — `schedule:
+      cron` nightly trigger plus `workflow_dispatch` for manual runs.
+      Matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`.
+      Each leg installs ASTAP + D05 via
+      `.github/actions/install-astap` with
+      `download-database: true`, exports `ASTAP_BINARY` and
+      `ASTAP_DB_DIR`, then runs
+      `cargo test -p rp-plate-solver --all-features --test bdd`.
+      The `@requires-astap` filter in `bdd.rs` lets the tagged
+      scenarios fire because `ASTAP_BINARY` is set; the rest of the
+      BDD suite runs against `mock_astap` as usual.
+- [ ] Capture median solve time per platform in the workflow log;
+      assert the upper bound stays inside the "few seconds with
+      hint" budget the ADR commits to. Failing this assertion is a
+      regression signal, not a flake — investigate before landing.
+- [ ] macOS leg: the workflow does the
+      `xattr -d com.apple.quarantine` step explicitly so we know
+      whether it suffices vs. requiring Developer ID re-signing.
+- [ ] Windows ARM64: no GitHub-hosted runner. Close the ADR's open
+      question by either a one-off manual-machine pass or by
+      removing the `Windows-ARM64` row from `install-astap`'s per-OS
+      table — pick one in this phase.
+- [ ] On failure, the job opens (or updates) a tracking issue named
+      `nightly: rp-plate-solver real-ASTAP smoke failing on <os>` so
+      divergence is visible without depending on someone reading
+      scheduled-workflow logs. Same pattern as `scheduled.yml`'s
+      `update` job behavior on dependency-update breakage.
+- [ ] Update ADR-005's open-questions section to mark items 1–4
+      retired, citing this workflow.
+
+**Exit criteria:** workflow green on all three runners on its first
+nightly fire after merge. ADR-005 OQ 1–4 marked retired in the same
+PR.
+
+### Phase 7 — Hint-plumbing verification (retires ADR-005 OQ 6)
+
+Status: **not started.**
+
+- [ ] Confirm via `services/rp/src/equipment/mount.rs` (Phase 6c-prep
+      lands this) that the mount wrapper exposes RA/Dec with enough
+      accuracy to seed `-ra` / `-spd` and that mount pointing
+      uncertainty is bounded enough to seed `-r`. If pointing
+      uncertainty is not currently observable from the Alpaca
+      surface, document the gap and the operator-supplied default
+      that fills it.
+- [ ] Add a hinted-vs-blind perf comparison to Phase 6's nightly
+      smoke workflow: run the happy-path scenario twice (hints
+      supplied, hints omitted) and capture the solve-time delta in
+      the workflow log. Observation, not contract enforcement —
+      surfaces drift in the speed advantage the ADR promises without
+      failing the build.
+- [ ] Update ADR-005 open-question 6 to retired with a pointer to
+      the workflow run that demonstrated it.
+
+**Exit criteria:** ADR-005 OQ 6 marked retired.
+
+### Phase 8 — LGPL §4/§6 review under BYO (retires ADR-005 OQ 5)
+
+Status: **not started.**
+
+- [ ] Add a short legal-review note under
+      `docs/decisions/005-plate-solver.md` §"License Treatment"
+      converting the working assumption into a closed item: confirm
+      that subprocess execution of an operator-installed binary
+      engages neither §4 (Conveying Verbatim Copies) nor §6 (Combined
+      Works); confirm that the `install-astap` GH action's per-run
+      fresh download does not constitute conveyance; confirm the
+      GH-Actions cache layer is scoped narrowly enough to count as
+      ephemeral build infrastructure.
+- [ ] If any of those three sub-items returns the opposite finding,
+      open a follow-up issue capturing the remediation (e.g., move the
+      install-astap action's cache scope to per-PR, or drop caching
+      entirely).
+
+**Exit criteria:** ADR-005 OQ 5 marked retired or a remediation
+issue is open.
+
+## Sequencing notes
+
+**All eight phases land before `rp-plate-solver` is considered
+complete.** Phases 5–8 are not "harden later" work — they retire the
+six open questions ADR-005 explicitly defers to this plan, and Phase 5
+makes the supervision tenet (the load-bearing rationale for choosing
+rp-managed-service over plugin) actually hold in production. None of
+them is optional.
+
+Within that fixed total scope, the phases have two distinct
+dependency structures:
+
+**Strict order, blocks downstream rp work:**
+
+- Phases 1 → 2 → 3 → 4 land sequentially. This is the critical path
+  for unblocking 6c-2 and 6c-3. Each phase is its own PR.
+
+**Independent of each other, all required, can interleave with rp work:**
+
+- Phases 5, 6, 7, 8 land in any order after Phase 4. None of them
+  blocks the others; none of them blocks 6c-2 or 6c-3 from starting.
+  They do block declaring `rp-plate-solver` complete.
+
+**Cross-plan unblocking** (consumers of this plan's output):
+
+- **6c-2 (rp-side `plate_solve` MCP tool) can begin as soon as Phase
+  1 of this plan lands** — the HTTP contract is frozen there, and
+  6c-2's BDD uses an in-test axum stub returning canned WCS payloads
+  (per PR #124). 6c-2 does not block on this plan's Phases 2–8.
+- **6c-3 (`center_on_target` compound tool) unblocks once 6c-2's
+  `PlateSolveOps` adapter exists**, not on this plan directly.
+- **6c-prep (telescope primitives) is independent** of this entire
+  chain and can land in parallel with anything here.
+
+## References
+
+- ADR-005 — `docs/decisions/005-plate-solver.md`
+- Image-evaluation-tools plan, Phase 6c-1 — `docs/plans/image-evaluation-tools.md`
+- rp design doc, §"Component Categories" / §"Plate Solver" /
+  §"Sentinel Watchdog Integration" — `docs/services/rp.md`
+- ADR-004 — `docs/decisions/004-testing-strategy-for-http-client-error-paths.md`
+  (mock-strategy rule for the `AstapRunner` trait)
+- Reference service shape — `services/phd2-guider/`
+- Mock-binary precedent — `services/phd2-guider/src/bin/mock_phd2.rs`
+  (named `MOCK_PHD2_MODE` modes, `[[bin]]` always built, used for
+  integration tests without depending on real PHD2)
+- BDD harness conventions — `docs/skills/testing.md`,
+  `crates/bdd-infra`
+- Install action — `.github/actions/install-astap/action.yml`

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -171,8 +171,8 @@ Optional pointing and FOV hints map directly to ASTAP CLI flags:
 
 | Request field | ASTAP flag | Notes |
 |---------------|-----------|-------|
-| `ra_hint` | `-ra <decimal hours>` | Pass-through. |
-| `dec_hint` | `-spd <degrees>` | Wrapper converts decimal degrees → south-pole-distance (90 + dec) before passing. |
+| `ra_hint` | `-ra <decimal hours>` | Wire format is decimal degrees (0–360) for consistency with `ra_center`; wrapper converts to hours (`degrees / 15`) before passing to ASTAP. |
+| `dec_hint` | `-spd <degrees>` | Wire format is decimal degrees (−90–90); wrapper converts to south-pole-distance (`90 + dec`) before passing to ASTAP. |
 | `fov_hint_deg` | `-fov <degrees>` | Pass-through (image height, per ASTAP CLI documentation). |
 | `search_radius_deg` | `-r <degrees>` | Pass-through. Defaults to ASTAP's own default when omitted. |
 

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -276,8 +276,8 @@ the test sets before spawning the wrapper:
 |------|----------|--------|
 | `normal` | Read `-f <path>`, write a canned `.wcs` next to it, exit 0 | Happy path |
 | `exit_failure` | Write to stderr, exit 1 (no `.wcs`) | `solve_failed` (non-zero exit branch) |
-| `hang` | Sleep indefinitely; respond to SIGTERM cleanly | `solve_timeout` (terminated) |
-| `ignore_sigterm` | Trap SIGTERM, sleep anyway | `solve_timeout` (killed via SIGKILL) |
+| `hang` | Sleep indefinitely; respond cleanly to the platform's graceful signal (Unix `SIGTERM`; Windows `CTRL_BREAK_EVENT`) | `solve_timeout` (terminated) |
+| `ignore_sigterm` | Trap and ignore the graceful signal; sleep anyway. Mode name kept for stability — semantics are platform-neutral. | `solve_timeout` (killed via the platform's force-kill) |
 | `malformed_wcs` | Write a `.wcs` missing `CRVAL2`, exit 0 | `solve_failed` (parser-detected branch) |
 | `no_wcs` | Exit 0 without writing any `.wcs` | `solve_failed` (sidecar-missing branch) |
 
@@ -285,8 +285,15 @@ Setting `MOCK_ASTAP_ARGV_OUT=<file>` (any mode) writes the received
 argv to the named file, used for end-to-end argv-flow assertions.
 
 This binary is **not feature-gated** — it builds with every
-`cargo build --all-targets`. BDD discovers it via
-`env!("CARGO_BIN_EXE_mock_astap")`.
+`cargo build --all-targets`. BDD and supervision integration tests
+discover it in this order: explicit `MOCK_ASTAP_BINARY` env var
+(set by Bazel test targets) → `option_env!("CARGO_BIN_EXE_mock_astap")`
+(set by Cargo for `[[test]]` crates). Both fallbacks let the suite
+run under Cargo and Bazel without divergent code paths. Pure
+`env!()` is intentionally avoided because `CARGO_BIN_EXE_*` is
+unset under Bazel and unset for `#[cfg(test)] mod tests` inside
+`src/`. Same lookup `services/phd2-guider/tests/test_integration.rs`
+uses for `mock_phd2`.
 
 ### Real-ASTAP Coverage Cadence
 
@@ -311,7 +318,7 @@ rp-managed-service supervision flow described in `rp.md`
 |--------|-----------|-----------|--------|
 | `rp` (gateway) | Sentinel | event-stream disconnect | Operator-configured restart command |
 | `rp-plate-solver` (this service) | Sentinel | `GET /health` non-200 or no response within Sentinel's HTTP timeout | Operator-configured restart command (e.g., `systemctl restart rp-plate-solver`) |
-| `astap_cli` (child) | This service | per-request wall-clock deadline | SIGTERM → 2 s grace → SIGKILL |
+| `astap_cli` (child) | This service | per-request wall-clock deadline | graceful signal → 2 s grace → force-kill. Unix: `SIGTERM` → `SIGKILL`. Windows: `CTRL_BREAK_EVENT` (with `CREATE_NEW_PROCESS_GROUP` at spawn) → `TerminateProcess`. |
 
 ### Belt-and-Suspenders Outer Timeout
 

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -115,42 +115,70 @@ operator can diagnose without console access to the wrapper.
 
 #### `GET /health`
 
-Returns `200 OK` with `{"status": "ok"}` when:
+Returns `200 OK` with `{"status": "ok"}` when **all** of:
 
-- Startup config validation passed, AND
+- Startup config validation passed.
 - The configured `astap_binary_path` is still a regular file and
   still executable by the wrapper process at probe time.
+- The configured `astap_db_directory` still exists and is still a
+  directory at probe time.
 
-Returns `503 Service Unavailable` otherwise. Sentinel uses this
-endpoint as the "Responsive but stuck" probe described in `rp.md`
-§"Sentinel Watchdog Integration" — a `503` (or no response within
-Sentinel's HTTP timeout) is the trigger for Sentinel to escalate to
-the configured restart command.
+Returns `503 Service Unavailable` if any of those checks fail. Both
+runtime checks must pass: a binary present without its database
+cannot solve, and a database without an executable binary cannot
+either. The probe set matches the startup-validation set so
+"healthy at probe time" means "still capable of solving."
 
-The probe is intentionally cheap: a stat on the binary path, no
-subprocess spawn. Sentinel may probe at high frequency without
-costing wrapper performance.
+The probe is intentionally cheap: two filesystem stats, no
+subprocess spawn. Sentinel (or any operational tooling) may probe
+at high frequency without costing wrapper performance.
+
+How Sentinel uses this endpoint — vs. relying purely on event-stream
+signals and the operator-configured restart command — is a
+Sentinel-side design question. The currently-documented Sentinel
+watchdog flow in `rp.md` only describes Alpaca service health
+probes; whether to extend it to non-Alpaca rp-managed services is
+addressed by the implementation plan's Phase 5.
 
 ### Subprocess Supervision
 
 Every solve request is bounded by a wall-clock deadline. The
 escalation sequence on deadline expiry is:
 
-1. **t = deadline:** send SIGTERM (or `TerminateProcess` on Windows).
+1. **t = deadline (graceful stage):**
+   - Unix: `SIGTERM` to the child.
+   - Windows: `CTRL_BREAK_EVENT` delivered via
+     `GenerateConsoleCtrlEvent` to the child's process group. The
+     child is spawned with `CREATE_NEW_PROCESS_GROUP` so the event
+     reaches it without affecting the wrapper. Pattern follows
+     `crates/bdd-infra/src/lib.rs`.
+
    ASTAP normally responds cleanly within ~100 ms.
-2. **t = deadline + 2 s:** if the child has not exited, send SIGKILL
-   (or the Windows equivalent). The 2 s grace is a fixed constant,
-   not configurable — chosen to dominate any signal-handling latency
-   ASTAP might exhibit while staying short enough that a wedged child
-   doesn't tie up the single-flight semaphore.
+2. **t = deadline + 2 s (force-kill stage):** if the child has not
+   exited, escalate:
+   - Unix: `SIGKILL`.
+   - Windows: `TerminateProcess`.
+
+   The 2 s grace is a fixed constant, not configurable — chosen to
+   dominate any signal-handling latency ASTAP might exhibit while
+   staying short enough that a wedged child doesn't tie up the
+   single-flight semaphore.
 3. The service waits for the child to fully exit (via `wait()`)
    before returning the `solve_timeout` error. The semaphore is
    released only after exit. This guarantees that a `solve_timeout`
    response is always followed by a free slot for the next request.
 
-The service never leaks child processes. The `tokio::process::Child`
-drop guard is the safety net; the explicit `wait()` is the
-correctness contract.
+The service does not leak child processes. The explicit `wait()` is
+the **correctness contract** — it guarantees no leak on the normal
+deadline path. The wrapper additionally spawns every child with
+`Command::kill_on_drop(true)` (and, on Windows, places the child in
+a job object that auto-terminates members on handle close) as the
+**safety net** for unexpected wrapper-side failures: a panic before
+`wait()`, a future-cancellation that abandons the child, or any
+other code path that drops the `Child` without explicit termination.
+Tokio's default `Child` drop *detaches* the process, which is why
+`kill_on_drop(true)` is required for the safety-net guarantee to
+hold.
 
 ### Single-Flight Concurrency
 

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -94,8 +94,13 @@ states the behavior, not the wire format details.
 5. Service waits for the child under the request's `timeout`
    (defaulting to `default_solve_timeout` from config).
 6. On clean exit with zero status, service reads the `.wcs` sidecar
-   ASTAP wrote next to the FITS, parses the four required fields,
-   and returns them.
+   ASTAP wrote next to the FITS via `fitsrs` (the workspace's
+   existing FITS library), deserializes the header into
+   `wcs::params::WCSParams` (cds-astro/wcs-rs, already a transitive
+   dep), and extracts the four fields the response requires (CRVAL1,
+   CRVAL2, |CDELT1|, CROTA2). The wrapper does not hand-roll
+   FITS-header parsing — see the implementation plan §"WCS parsing
+   via `fitsrs` + `wcs`, not hand-rolled".
 7. Service releases the semaphore.
 
 **Error paths** all return the structured error envelope frozen in

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -1,0 +1,328 @@
+# rp-plate-solver — Service Design
+
+## Overview
+
+`rp-plate-solver` is an **rp-managed service** that wraps an
+operator-supplied ASTAP CLI install and exposes a narrow HTTP solve
+API to `rp`. It exists so plate solving — a hang-prone, crash-prone
+external binary — runs in its own supervised process where its
+failure modes cannot threaten `rp`'s liveness.
+
+The service is **stateless across requests**: every solve spawns a
+fresh `astap_cli` subprocess, waits for it under a wall-clock
+deadline, parses the resulting `.wcs` sidecar, and returns. There is
+no solve cache, no warm process pool, and no shared mutable state
+between requests. Restart is always cheap and never costs more than
+one in-flight request — which is what makes the supervision posture
+described below safe.
+
+Operators install ASTAP themselves (BYO per ADR-005). `rp-plate-solver`
+ships no ASTAP binary, no index database, and no install script;
+operators point it at their install via two required config fields.
+
+**Cross-platform support:** Linux x64, Linux aarch64 (Pi 5), macOS
+Apple Silicon, Windows x64 — matching ADR-005's hard constraints.
+
+## Architecture
+
+```mermaid
+graph LR
+    rp[rp gateway] -->|"POST /api/v1/solve"| solver[rp-plate-solver]
+    solver -->|"spawn astap_cli<br/>+ wall-clock deadline"| astap[ASTAP child process]
+    astap -->|writes| wcs[".wcs sidecar"]
+    solver -->|reads| wcs
+    sentinel[Sentinel] -->|"GET /health"| solver
+    sentinel -.->|configured restart command| solver
+    sentinel -.->|configured restart command| rp
+```
+
+Three independent processes, three independent failure domains,
+three independent supervisors. See [Sentinel
+Integration](#sentinel-integration) below for the detail.
+
+### Inputs and Outputs
+
+- **Input:** an absolute filesystem path to a FITS file (rp and the
+  service share a filesystem per `docs/services/rp.md` §"File
+  Accessibility"), plus optional pointing and FOV hints.
+- **Output:** a WCS solution (RA/Dec at image center, pixel scale,
+  rotation) parsed from the `.wcs` sidecar ASTAP writes alongside
+  the FITS, or a structured error.
+
+No pixel bytes traverse HTTP. `rp` and the service trust each other
+to read from a shared filesystem; this is the same trust assumption
+`rp` already makes about its plugins (see `rp.md` §"File
+Accessibility").
+
+## Alignment with rp's Tenets
+
+- **Tenet 1 — Robustness above all else.** The service exists *only*
+  to honor this tenet. Wrapping ASTAP in its own process means an
+  ASTAP SIGSEGV, hang, or deadlock cannot threaten `rp`'s session
+  state. This rationale is the load-bearing argument for choosing
+  rp-managed-service over plugin shape; see
+  `docs/plans/rp-plate-solver.md` §"Stability and supervision" for
+  the full discriminator.
+- **Tenet 4 — Remote interfaces only.** HTTP between rp and the
+  service. The service-to-ASTAP boundary is a CLI subprocess, not an
+  in-process FFI link — same shape that ADR-005 evaluates and ADR-001's
+  predecessor explicitly rejected for sep-sys.
+- **Tenet 5 — Minimal footprint.** No long-running ASTAP processes,
+  no warm caches, no embedded star database. The service holds only
+  the request currently in flight.
+
+## Behavioral Contracts
+
+### HTTP API
+
+The service exposes exactly two endpoints. The contract is frozen by
+`docs/plans/rp-plate-solver.md` §"HTTP contract"; this section
+states the behavior, not the wire format details.
+
+#### `POST /api/v1/solve`
+
+**Happy path:**
+
+1. Service deserializes the request body. `fits_path` must be an
+   absolute path; `timeout` must parse as humantime; hint fields are
+   optional.
+2. Service confirms `fits_path` exists and is readable.
+3. Service acquires the single-flight semaphore (default
+   concurrency = 1). Overlapping requests queue; they do not error.
+4. Service spawns `astap_cli` with argv mapped from the request body
+   (see [hint mapping](#hint-mapping) below).
+5. Service waits for the child under the request's `timeout`
+   (defaulting to `default_solve_timeout` from config).
+6. On clean exit with zero status, service reads the `.wcs` sidecar
+   ASTAP wrote next to the FITS, parses the four required fields,
+   and returns them.
+7. Service releases the semaphore.
+
+**Error paths** all return the structured error envelope frozen in
+the plan. Each error code corresponds to one failure scenario:
+
+| Code | Trigger |
+|------|---------|
+| `invalid_request` | Schema-invalid body, non-absolute `fits_path`, unparseable `timeout`. Rejected before any subprocess work. |
+| `fits_not_found` | `fits_path` does not exist or is not readable. Rejected before any subprocess work. |
+| `solve_failed` | ASTAP exited non-zero, OR exited zero but did not write a `.wcs`, OR wrote a `.wcs` missing required keys. The error message names which sub-condition triggered. |
+| `solve_timeout` | Wall-clock deadline expired. Service signaled the child (see [supervision](#subprocess-supervision)) and returned this error after the child exited (clean or forced). |
+| `internal` | Unexpected wrapper failure: broken pipe, `.wcs` parse panic, file-system error reading the sidecar. Should be rare; surfacing as a distinct code keeps it visible in monitoring. |
+
+`rp` always sees one of these five codes on failure. ASTAP's stderr
+tail is included in the `details` field for `solve_failed` so the
+operator can diagnose without console access to the wrapper.
+
+#### `GET /health`
+
+Returns `200 OK` with `{"status": "ok"}` when:
+
+- Startup config validation passed, AND
+- The configured `astap_binary_path` is still a regular file and
+  still executable by the wrapper process at probe time.
+
+Returns `503 Service Unavailable` otherwise. Sentinel uses this
+endpoint as the "Responsive but stuck" probe described in `rp.md`
+§"Sentinel Watchdog Integration" — a `503` (or no response within
+Sentinel's HTTP timeout) is the trigger for Sentinel to escalate to
+the configured restart command.
+
+The probe is intentionally cheap: a stat on the binary path, no
+subprocess spawn. Sentinel may probe at high frequency without
+costing wrapper performance.
+
+### Subprocess Supervision
+
+Every solve request is bounded by a wall-clock deadline. The
+escalation sequence on deadline expiry is:
+
+1. **t = deadline:** send SIGTERM (or `TerminateProcess` on Windows).
+   ASTAP normally responds cleanly within ~100 ms.
+2. **t = deadline + 2 s:** if the child has not exited, send SIGKILL
+   (or the Windows equivalent). The 2 s grace is a fixed constant,
+   not configurable — chosen to dominate any signal-handling latency
+   ASTAP might exhibit while staying short enough that a wedged child
+   doesn't tie up the single-flight semaphore.
+3. The service waits for the child to fully exit (via `wait()`)
+   before returning the `solve_timeout` error. The semaphore is
+   released only after exit. This guarantees that a `solve_timeout`
+   response is always followed by a free slot for the next request.
+
+The service never leaks child processes. The `tokio::process::Child`
+drop guard is the safety net; the explicit `wait()` is the
+correctness contract.
+
+### Single-Flight Concurrency
+
+ASTAP is CPU-bound on a single core during a solve. The service
+serializes overlapping requests behind a `tokio::sync::Semaphore`
+with capacity equal to `max_concurrency` (default 1).
+
+Overlapping requests **queue, not error**. The HTTP request stays
+open while waiting on the semaphore. Each request's `timeout`
+applies to its solve only — time spent waiting in the queue is not
+counted against the deadline. Operators who need to bound queue
+depth do so at rp's HTTP-client layer (`plate_solver.timeout_secs`
+in rp config), not here.
+
+### Hint Mapping
+
+Optional pointing and FOV hints map directly to ASTAP CLI flags:
+
+| Request field | ASTAP flag | Notes |
+|---------------|-----------|-------|
+| `ra_hint` | `-ra <decimal hours>` | Pass-through. |
+| `dec_hint` | `-spd <degrees>` | Wrapper converts decimal degrees → south-pole-distance (90 + dec) before passing. |
+| `fov_hint_deg` | `-fov <degrees>` | Pass-through (image height, per ASTAP CLI documentation). |
+| `search_radius_deg` | `-r <degrees>` | Pass-through. Defaults to ASTAP's own default when omitted. |
+
+Omitted fields produce no flag — ASTAP falls back to blind solve.
+The wrapper does not synthesize hints; it never invents data the
+caller did not provide.
+
+### Configuration Validation at Startup
+
+The service validates its config before binding the HTTP listener.
+On any validation failure, it logs a structured error naming the
+field and exits non-zero. Sentinel's restart loop then surfaces the
+misconfiguration to the operator rather than masking it with a
+silent retry.
+
+Validation rules:
+
+- `astap_binary_path` must exist, be a regular file, and be executable
+  by the current user.
+- `astap_db_directory` must exist and be a directory.
+- `bind_address` must parse as an IP address.
+- `default_solve_timeout` must be ≤ `max_solve_timeout` (otherwise
+  the request-supplied timeout could exceed `max_solve_timeout`,
+  defeating the bound).
+
+The `astap_binary_path` validation runs again on every `/health`
+probe, so a binary removed after startup is detected.
+
+## Configuration
+
+The service reads a single JSON config file passed via `--config`.
+
+```json
+{
+  "bind_address": "127.0.0.1",
+  "port": 11131,
+  "astap_binary_path": "/opt/astap/astap_cli",
+  "astap_db_directory": "/opt/astap/d05",
+  "max_concurrency": 1,
+  "default_solve_timeout": "30s",
+  "max_solve_timeout": "120s"
+}
+```
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `bind_address` | no | `127.0.0.1` | Bind to `0.0.0.0` only when rp runs on a different machine. |
+| `port` | no | `11131` | Matches the placeholder rp config in `rp.md` §"Configuration". |
+| `astap_binary_path` | **yes** | — | No default. Wrapper must be told where ASTAP is. |
+| `astap_db_directory` | **yes** | — | No default. ASTAP needs an index database to solve; the operator picks D05 / D80 / etc. for their FOV. |
+| `max_concurrency` | no | `1` | Capacity of the single-flight semaphore. v1 ships at 1; tuning above 1 is operator-driven and unsupported by the v1 budget assertions. |
+| `default_solve_timeout` | no | `30s` | Applies when the request body omits `timeout`. |
+| `max_solve_timeout` | no | `120s` | Caps any caller-supplied `timeout`. |
+
+Required fields exit the process on absence (no implicit defaults
+for "where is ASTAP" — see [Configuration Validation](#configuration-validation-at-startup)).
+
+## Subprocess Test Doubles
+
+The service ships an in-tree `mock_astap` `[[bin]]` that mimics the
+ASTAP CLI surface and is used in BDD and supervision unit tests. The
+pattern mirrors `services/phd2-guider/src/bin/mock_phd2.rs`.
+
+Behavior is selected via the `MOCK_ASTAP_MODE` environment variable
+the test sets before spawning the wrapper:
+
+| Mode | Behavior | Drives |
+|------|----------|--------|
+| `normal` | Read `-f <path>`, write a canned `.wcs` next to it, exit 0 | Happy path |
+| `exit_failure` | Write to stderr, exit 1 (no `.wcs`) | `solve_failed` (non-zero exit branch) |
+| `hang` | Sleep indefinitely; respond to SIGTERM cleanly | `solve_timeout` (terminated) |
+| `ignore_sigterm` | Trap SIGTERM, sleep anyway | `solve_timeout` (killed via SIGKILL) |
+| `malformed_wcs` | Write a `.wcs` missing `CRVAL2`, exit 0 | `solve_failed` (parser-detected branch) |
+| `no_wcs` | Exit 0 without writing any `.wcs` | `solve_failed` (sidecar-missing branch) |
+
+Setting `MOCK_ASTAP_ARGV_OUT=<file>` (any mode) writes the received
+argv to the named file, used for end-to-end argv-flow assertions.
+
+This binary is **not feature-gated** — it builds with every
+`cargo build --all-targets`. BDD discovers it via
+`env!("CARGO_BIN_EXE_mock_astap")`.
+
+### Real-ASTAP Coverage Cadence
+
+A small set of `@requires-astap`-tagged BDD scenarios runs against
+the real ASTAP binary, gated by a runtime check on the
+`ASTAP_BINARY` environment variable. Scenarios skip silently when
+the env var is unset (the PR-required path). They fire when the env
+var is set, which is the dedicated nightly cross-platform smoke
+workflow's job. See `docs/plans/rp-plate-solver.md` §"Real-ASTAP
+coverage: cadence and gating" for the rationale and the `bdd.rs`
+filter snippet.
+
+## Sentinel Integration
+
+The service is supervised by Sentinel via the standard
+rp-managed-service supervision flow described in `rp.md`
+§"Sentinel Watchdog Integration".
+
+### Failure Domains
+
+| Domain | Supervisor | Detection | Action |
+|--------|-----------|-----------|--------|
+| `rp` (gateway) | Sentinel | event-stream disconnect | Operator-configured restart command |
+| `rp-plate-solver` (this service) | Sentinel | `GET /health` non-200 or no response within Sentinel's HTTP timeout | Operator-configured restart command (e.g., `systemctl restart rp-plate-solver`) |
+| `astap_cli` (child) | This service | per-request wall-clock deadline | SIGTERM → 2 s grace → SIGKILL |
+
+### Belt-and-Suspenders Outer Timeout
+
+`rp`'s HTTP client to this service has its own outer timeout
+(`plate_solver.timeout_secs` in rp config). Even if the wrapper's
+internal timeout regresses, `rp` does not hang on a `plate_solve`
+call. The wrapper's deadline is the primary control; rp's is the
+backstop.
+
+### What Sentinel Restart Recovers From
+
+Stateless-across-requests is the property that makes restart safe.
+Restarting the wrapper costs the in-flight request (which gets a
+transient error and may be retried by the orchestrator) and nothing
+else — no session state, no warm caches, no in-memory artifacts the
+operator cares about.
+
+## MVP Scope
+
+### In scope for v1
+
+- One solve endpoint, one health endpoint, one config file.
+- Single ASTAP runner. Architecturally swappable for `solve-field`
+  (per ADR-005), but only ASTAP is implemented.
+- Single-flight default; queueing is built in but unused at default.
+- BYO ASTAP per ADR-005. No bundled binary, no install scripts.
+
+### Out of scope for v1
+
+- `solve-field` runner. Trait shape exists; impl deferred.
+- Background solving by subscribing to rp's `exposure_complete`
+  events. The wrapper is request/response only.
+- Solve cache or warm process pool. Explicitly excluded by
+  stateless-across-requests.
+- An MCP server surface. The wrapper speaks HTTP only; rp owns the
+  `plate_solve` MCP tool name.
+- Pixel transport over HTTP. File path only, per ADR-005.
+
+## References
+
+- ADR-005 — `docs/decisions/005-plate-solver.md`
+- Implementation plan — `docs/plans/rp-plate-solver.md`
+- rp design doc, §"Plate Solver" — `docs/services/rp.md`
+- rp design doc, §"Sentinel Watchdog Integration" — `docs/services/rp.md`
+- rp design doc, §"File Accessibility" — `docs/services/rp.md`
+- Reference service shape — `docs/services/phd2-guider.md`
+- Mock-binary precedent — `services/phd2-guider/src/bin/mock_phd2.rs`

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1573,23 +1573,25 @@ service that implements the same HTTP endpoints.
 ### Plate Solver
 
 The plate solver is an **rp-managed service** — a separate process that
-wraps an external solver binary (ASTAP or astrometry.net). The MCP tool
-surface (`plate_solve`) is a built-in tool that proxies to the service;
-the wrapped binary lives in the supervised process.
+wraps the operator-installed ASTAP CLI binary. The MCP tool surface
+(`plate_solve`) is a built-in tool that proxies to the service; ASTAP
+lives in the supervised wrapper process.
 
 This shape (service rather than built-in Rust code) is chosen because:
-- The solvers are external programs `rp` cannot link against.
-- They can hang or crash independently of `rp`.
-- Sentinel can restart them via the standard rp-managed-service
+- ASTAP is an external program `rp` cannot link against.
+- It can hang or crash independently of `rp`.
+- Sentinel can restart the wrapper via the standard rp-managed-service
   supervision flow (see [Sentinel Watchdog Integration](#sentinel-watchdog-integration)).
 
 The plate solver can also subscribe to `exposure_complete` events for
-background solving.
+background solving (deferred to v2; v1 is request/response only).
 
-> **Note:** The choice of plate solving engine requires further research.
-> The first implementation should wrap an open-source, cross-platform, locally
-> available solver. Candidates include ASTAP and a local astrometry.net
-> installation. This decision will be captured in a separate ADR.
+The choice of solver and the supervision posture are settled by
+[ADR-005](../decisions/005-plate-solver.md). The service's own design
+doc — HTTP contract, supervision contract, configuration, mock test
+double — lives at [`docs/services/rp-plate-solver.md`](rp-plate-solver.md).
+Implementation sequencing is in
+[`docs/plans/rp-plate-solver.md`](../plans/rp-plate-solver.md).
 
 ### File Accessibility
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -14,6 +14,7 @@ belong in any single service design doc.
 | [phd2-guider](services/phd2-guider.md) | — (client library) | — | `docs/services/phd2-guider.md` |
 | [sentinel](services/sentinel.md) | — (monitoring service) | 11114 | `docs/services/sentinel.md` |
 | [rp](services/rp.md) | — (orchestrator) | 11115 | `docs/services/rp.md` |
+| [rp-plate-solver](services/rp-plate-solver.md) | — (rp-managed service wrapping ASTAP) | 11131 | `docs/services/rp-plate-solver.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |
@@ -34,12 +35,15 @@ belong in any single service design doc.
 | [ADR-001](decisions/001-fits-file-support.md) | FITS file support |
 | [ADR-002](decisions/002-tls-for-inter-service-communication.md) | TLS for inter-service communication |
 | [ADR-003](decisions/003-authentication-for-device-access.md) | Authentication for device access |
+| [ADR-004](decisions/004-testing-strategy-for-http-client-error-paths.md) | Testing strategy for HTTP-client error paths |
+| [ADR-005](decisions/005-plate-solver.md) | Plate solver: ASTAP via subprocess + verification spike |
 | **Plans** (in-flight initiatives — see [docs/plans/](plans/)) | |
 | [bazel-migration.md](plans/bazel-migration.md) | Bazel build alongside Cargo (shadow mode) |
 | [build-optimization-test-reorganization.md](plans/build-optimization-test-reorganization.md) | Build/test reorganization |
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
 | [image-evaluation-tools.md](plans/image-evaluation-tools.md) | rp image-evaluation MCP tool surface |
 | [fits-library-consolidation.md](plans/fits-library-consolidation.md) | FITS library evaluation across the workspace |
+| [rp-plate-solver.md](plans/rp-plate-solver.md) | rp-plate-solver rp-managed service implementation (ADR-005 sequencing) |
 
 ## Shared Crates
 


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/plans/rp-plate-solver.md`](docs/plans/rp-plate-solver.md) — the service-specific design doc.

**New:** `docs/services/rp-plate-solver.md` covers
- HTTP API behavior, per endpoint, per error code (the wire-format details live in the plan; this doc states the *behavior*).
- Subprocess supervision contract: per-request wall-clock deadline → SIGTERM → 2s grace → SIGKILL. Service guarantees no leaked children and that the single-flight semaphore is released only after child exit.
- Single-flight queueing semantics (queue, don't error; queue wait does not count against the deadline).
- Hint-flag mapping (request fields → ASTAP CLI argv).
- Configuration validation at startup; the rules each required field must satisfy.
- `mock_astap` test-double modes (six named modes via `MOCK_ASTAP_MODE`) and the `@requires-astap` cadence-and-gating pattern.
- Sentinel integration: three nested failure domains, belt-and-suspenders outer timeout in rp's HTTP client.
- Explicit MVP scope (in / out).

**Modified:** `docs/services/rp.md` §"Plate Solver" — drops the "decision pending" note (ADR-005 retired it), links to the new service doc and the plan.

**Modified:** `docs/workspace.md` — adds `rp-plate-solver` to the services index. Also fills two stale gaps in the doc index: ADR-004 and ADR-005 were missing from the decisions list.

## Dependency

Depends on #125 (the plan PR). Merge order: **#125 first, then this PR**. Cross-references from this PR to `docs/plans/rp-plate-solver.md` resolve once both land. (Independent diff against main, no rebase needed.)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo rail run --profile commit -q` reports no test targets (docs-only)
- [x] Pre-commit hook (clippy + fmt-check) clean
- [ ] CI green
- [ ] Copilot review addressed (request via UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)