### PR TITLE
feat(rp-plate-solver): Phase 3 — BDD scenarios with @wip and @requires-astap filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,10 +3690,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "bdd-infra",
  "cargo-husky",
+ "cucumber",
  "humantime-serde",
  "libc",
  "mockall",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tempfile",

--- a/services/rp-plate-solver/Cargo.toml
+++ b/services/rp-plate-solver/Cargo.toml
@@ -34,3 +34,10 @@ tokio-test = { workspace = true }
 mockall = { workspace = true }
 tempfile = { workspace = true }
 cargo-husky = { workspace = true }
+cucumber = { workspace = true }
+bdd-infra = { workspace = true }
+reqwest = { workspace = true }
+
+[[test]]
+name = "bdd"
+harness = false

--- a/services/rp-plate-solver/tests/bdd.rs
+++ b/services/rp-plate-solver/tests/bdd.rs
@@ -1,0 +1,55 @@
+//! BDD test entry point for rp-plate-solver.
+//!
+//! Two filter conditions:
+//!
+//! - `@wip` — Phase 3 lands feature files and step stubs before Phase
+//!   4's HTTP server exists. All scenarios are tagged `@wip` until
+//!   then; Phase 4 removes the tag in the same commit that lands the
+//!   implementation. Convention per `docs/skills/testing.md` §2.7.
+//!
+//! - `@requires-astap` — gates a small cross-platform real-ASTAP
+//!   smoke that fires only when `ASTAP_BINARY` is set in the
+//!   environment. PR jobs do not set it; the dedicated nightly
+//!   workflow does. See `docs/plans/rp-plate-solver.md` §"Real-ASTAP
+//!   coverage: cadence and gating".
+//!
+//! Both filter forms accept the tag with or without a leading `@`,
+//! matching `services/rp/tests/bdd.rs`'s pattern (cucumber-rs may
+//! strip the leading sigil depending on parser version).
+
+#[path = "bdd/world.rs"]
+mod world;
+
+#[path = "bdd/steps/mod.rs"]
+mod steps;
+
+bdd_infra::bdd_main! {
+    use cucumber::World as _;
+    use world::PlateSolverWorld;
+
+    PlateSolverWorld::cucumber()
+        .after(|_feature, _rule, _scenario, _finished, maybe_world| {
+            Box::pin(async move {
+                if let Some(world) = maybe_world {
+                    if let Some(handle) = world.service_handle.as_mut() {
+                        handle.stop().await;
+                    }
+                }
+            })
+        })
+        .filter_run("tests/features", |feat, _rule, sc| {
+            let is_wip = feat.tags.iter().any(|t| t == "wip" || t == "@wip")
+                || sc.tags.iter().any(|t| t == "wip" || t == "@wip");
+            let needs_astap = feat
+                .tags
+                .iter()
+                .any(|t| t == "requires-astap" || t == "@requires-astap")
+                || sc
+                    .tags
+                    .iter()
+                    .any(|t| t == "requires-astap" || t == "@requires-astap");
+            let astap_available = std::env::var("ASTAP_BINARY").is_ok();
+            !is_wip && (!needs_astap || astap_available)
+        })
+        .await;
+}

--- a/services/rp-plate-solver/tests/bdd/steps/config_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/config_steps.rs
@@ -1,0 +1,76 @@
+//! Step definitions for `configuration.feature`.
+//!
+//! Phase 3 stubs. Bodies arrive in Phase 4.
+
+use crate::world::PlateSolverWorld;
+use cucumber::{given, then, when};
+
+#[given("a config without astap_binary_path")]
+async fn given_config_without_binary_path(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: write a config file omitting astap_binary_path into world.temp_dir")
+}
+
+#[given("a config without astap_db_directory")]
+async fn given_config_without_db_directory(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4")
+}
+
+#[given(expr = "a config with astap_binary_path {string}")]
+async fn given_config_with_binary_path(_world: &mut PlateSolverWorld, _path: String) {
+    todo!("Phase 4")
+}
+
+#[given(expr = "a config with astap_db_directory {string}")]
+async fn given_config_with_db_directory(_world: &mut PlateSolverWorld, _path: String) {
+    todo!("Phase 4")
+}
+
+#[given("a config with astap_binary_path pointing at a non-executable file")]
+async fn given_non_executable_binary_path(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: write a 0o644 file into temp_dir, point config at it")
+}
+
+#[given("a valid astap_binary_path")]
+async fn given_valid_binary_path(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: copy mock_astap into temp_dir")
+}
+
+#[given("a valid astap_db_directory")]
+async fn given_valid_db_directory(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: mkdir temp_dir/d05")
+}
+
+#[given("a config with mock_astap as the binary path")]
+async fn given_config_with_mock_astap(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: PlateSolverWorld::mock_astap_path() into config")
+}
+
+#[when("the wrapper starts")]
+async fn when_wrapper_starts(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: spawn the wrapper binary; capture stdout/stderr")
+}
+
+#[then("the wrapper exits non-zero")]
+async fn then_wrapper_exits_nonzero(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: assert world.last_wrapper_exit_code is Some(non-zero)")
+}
+
+#[then(expr = "the wrapper stderr names {string}")]
+async fn then_wrapper_stderr_names(_world: &mut PlateSolverWorld, _needle: String) {
+    todo!("Phase 4: assert world.last_wrapper_stderr.contains(needle)")
+}
+
+#[then("the wrapper stderr references the README")]
+async fn then_wrapper_stderr_references_readme(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: assert stderr contains 'README' or 'install instructions'")
+}
+
+#[then("the wrapper prints bound_addr to stdout")]
+async fn then_wrapper_prints_bound_addr(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: assert ServiceHandle parsed bound port from stdout")
+}
+
+#[then("the wrapper /health returns 200")]
+async fn then_wrapper_health_returns_200(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: GET /health, assert 200")
+}

--- a/services/rp-plate-solver/tests/bdd/steps/health_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/health_steps.rs
@@ -1,0 +1,31 @@
+//! Step definitions for `health.feature`.
+//!
+//! Phase 3 stubs. Bodies arrive in Phase 4.
+
+use crate::world::PlateSolverWorld;
+use cucumber::{given, when};
+
+#[given("the wrapper is running with a temp-dir copy of mock_astap as its binary path")]
+async fn given_wrapper_running_with_temp_copy(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: copy mock_astap into world.temp_dir, point config at the copy, spawn wrapper")
+}
+
+#[given("the wrapper is running with a temp astap_db_directory")]
+async fn given_wrapper_running_with_temp_db(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: mkdir temp_dir/d05, point config there, spawn wrapper")
+}
+
+#[when("I delete the configured astap_binary_path")]
+async fn when_delete_configured_binary(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: std::fs::remove_file(world.astap_binary_path)")
+}
+
+#[when("I delete the configured astap_db_directory")]
+async fn when_delete_configured_db(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: std::fs::remove_dir_all(world.astap_db_directory)")
+}
+
+#[when("I GET /health")]
+async fn when_get_health(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: GET wrapper.base_url + /health, capture into world.last_response")
+}

--- a/services/rp-plate-solver/tests/bdd/steps/mod.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/mod.rs
@@ -1,0 +1,18 @@
+//! Step definition modules. Each maps to one `.feature` file under
+//! `tests/features/`. Cucumber's `#[given]` / `#[when]` / `#[then]`
+//! macros register globally, so a step phrase declared here is
+//! resolved no matter which feature file references it — shared
+//! phrases (e.g., "the response status is N") live in
+//! `solve_steps.rs` and are reused across other feature files'
+//! scenarios.
+//!
+//! All step bodies are Phase 3 stubs (`todo!("Phase 4")`). The
+//! `@wip` filter in `tests/bdd.rs` skips every scenario at runtime,
+//! so the stubs compile but never panic. Phase 4 fills the bodies in
+//! and removes the `@wip` tag in the same commit.
+
+pub mod config_steps;
+pub mod health_steps;
+pub mod real_astap_steps;
+pub mod solve_steps;
+pub mod supervision_steps;

--- a/services/rp-plate-solver/tests/bdd/steps/real_astap_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/real_astap_steps.rs
@@ -1,0 +1,26 @@
+//! Step definitions for `real_astap_smoke.feature`.
+//!
+//! Phase 3 stubs. Bodies arrive in Phase 4. Note that
+//! `@requires-astap` keeps these from running in PR jobs even after
+//! Phase 4 removes `@wip`.
+
+use crate::world::PlateSolverWorld;
+use cucumber::given;
+
+#[given("the wrapper is running with the real ASTAP_BINARY as its solver")]
+async fn given_wrapper_with_real_astap(_world: &mut PlateSolverWorld) {
+    todo!(
+        "Phase 4: read ASTAP_BINARY env var (set by the nightly install-astap workflow); \
+         start the wrapper pointing at it"
+    )
+}
+
+#[given("the m31_known.fits fixture is on disk")]
+async fn given_m31_fixture(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: copy tests/fixtures/m31_known.fits into temp_dir, store path in world")
+}
+
+#[given("the degenerate_no_stars.fits fixture is on disk")]
+async fn given_degenerate_fixture(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: same shape as m31; the degenerate fixture exists for solve_failed coverage")
+}

--- a/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
@@ -25,12 +25,26 @@ async fn given_mock_astap_argv_out(_world: &mut PlateSolverWorld) {
     todo!("Phase 4: set MOCK_ASTAP_ARGV_OUT on the spawned child to a temp file path; store path in world.argv_out_path")
 }
 
-#[given(expr = "a writable FITS path {string}")]
-async fn given_writable_fits_path(_world: &mut PlateSolverWorld, _path: String) {
-    todo!("Phase 4: ensure parent dir exists; touch the file so wrapper's existence check passes")
+#[given("a writable FITS path")]
+async fn given_writable_fits_path(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: create a unique FITS file under world.temp_dir, store path in world")
+}
+
+#[given("a non-existent FITS path")]
+async fn given_non_existent_fits_path(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: build an absolute path under world.temp_dir that we never create")
 }
 
 // ----- when: HTTP requests -----
+//
+// Note on the `\\/` escapes in `expr = "..."` patterns below: cucumber
+// expressions interpret bare `/` as alternation (e.g., `red/blue`
+// matches `red` or `blue`). A literal `/api/v1/solve` triggers a
+// compile error: "An alternation can not be empty." `\\/` in the Rust
+// string yields `\/` in the cucumber expression, the documented
+// escape for a literal `/`. The literal-string form (no `expr =`) is
+// not a cucumber expression and accepts bare `/`, which is why the
+// next step works without escaping.
 
 #[when("I POST to /api/v1/solve with that fits_path")]
 async fn when_post_solve_with_fits_path(_world: &mut PlateSolverWorld) {
@@ -102,6 +116,15 @@ async fn then_response_field_contains(
     _needle: String,
 ) {
     todo!("Phase 4")
+}
+
+#[then(expr = "the response field {string} contains {string} case-insensitively")]
+async fn then_response_field_contains_ci(
+    _world: &mut PlateSolverWorld,
+    _path: String,
+    _needle: String,
+) {
+    todo!("Phase 4: lowercase both sides and compare; matches both ASTAP and astap")
 }
 
 #[then(expr = "the spawned argv contains the flag {string}")]

--- a/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
@@ -1,0 +1,115 @@
+//! Step definitions for `solve_request.feature` — and shared HTTP /
+//! response-assertion phrases reused by other feature files.
+//!
+//! Phase 3 stubs. Bodies arrive in Phase 4.
+
+use crate::world::PlateSolverWorld;
+use cucumber::{given, then, when};
+
+// ----- shared "Given the wrapper is running" used across features -----
+
+#[given("the wrapper is running with mock_astap as its solver")]
+async fn given_wrapper_running_with_mock(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: write config pointing at mock_astap, spawn wrapper, store handle in world")
+}
+
+// ----- mock_astap mode setup -----
+
+#[given(expr = "mock_astap is configured for {string} mode")]
+async fn given_mock_astap_mode(_world: &mut PlateSolverWorld, _mode: String) {
+    todo!("Phase 4: store the mode for the next solve request to set MOCK_ASTAP_MODE on the spawned child")
+}
+
+#[given("mock_astap is configured to write argv to a side-channel file")]
+async fn given_mock_astap_argv_out(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: set MOCK_ASTAP_ARGV_OUT on the spawned child to a temp file path; store path in world.argv_out_path")
+}
+
+#[given(expr = "a writable FITS path {string}")]
+async fn given_writable_fits_path(_world: &mut PlateSolverWorld, _path: String) {
+    todo!("Phase 4: ensure parent dir exists; touch the file so wrapper's existence check passes")
+}
+
+// ----- when: HTTP requests -----
+
+#[when("I POST to /api/v1/solve with that fits_path")]
+async fn when_post_solve_with_fits_path(_world: &mut PlateSolverWorld) {
+    todo!(
+        "Phase 4: build solve request, POST to wrapper, capture response into world.last_response"
+    )
+}
+
+#[when(expr = "I POST to \\/api\\/v1\\/solve with fits_path {string}")]
+async fn when_post_solve_with_explicit_path(_world: &mut PlateSolverWorld, _path: String) {
+    todo!("Phase 4")
+}
+
+#[when(expr = "I POST to \\/api\\/v1\\/solve with raw body {string}")]
+async fn when_post_solve_with_raw_body(_world: &mut PlateSolverWorld, _body: String) {
+    todo!("Phase 4: POST raw bytes (no JSON wrapping) to test invalid_request decode path")
+}
+
+#[when(expr = "I POST to \\/api\\/v1\\/solve with that fits_path and timeout {string}")]
+async fn when_post_solve_with_timeout(_world: &mut PlateSolverWorld, _timeout: String) {
+    todo!("Phase 4")
+}
+
+#[when(expr = "I POST to \\/api\\/v1\\/solve with that fits_path and hint {word} set to {word}")]
+async fn when_post_solve_with_hint(_world: &mut PlateSolverWorld, _field: String, _value: String) {
+    todo!("Phase 4: parse field/value, build request with that hint set, POST")
+}
+
+// ----- then: response assertions (shared across feature files) -----
+
+#[then(expr = "the response status is {int}")]
+async fn then_response_status_is(_world: &mut PlateSolverWorld, _status: u16) {
+    todo!("Phase 4: assert world.last_response.status == status")
+}
+
+#[then(expr = "the response field {string} is {string}")]
+async fn then_response_field_is_string(
+    _world: &mut PlateSolverWorld,
+    _path: String,
+    _expected: String,
+) {
+    todo!("Phase 4: jsonpath into world.last_response.body, assert equals expected")
+}
+
+#[then(expr = "the response field {string} is {int}")]
+async fn then_response_field_is_int(_world: &mut PlateSolverWorld, _path: String, _expected: i64) {
+    todo!("Phase 4")
+}
+
+#[then(expr = "the response field {string} is approximately {float}")]
+async fn then_response_field_approx(_world: &mut PlateSolverWorld, _path: String, _expected: f64) {
+    todo!("Phase 4: assert |actual - expected| < default tolerance (e.g., 1e-3)")
+}
+
+#[then(expr = "the response field {string} is approximately {float} within {float} degrees")]
+async fn then_response_field_approx_within(
+    _world: &mut PlateSolverWorld,
+    _path: String,
+    _expected: f64,
+    _tolerance: f64,
+) {
+    todo!("Phase 4: assert |actual - expected| < tolerance")
+}
+
+#[then(expr = "the response field {string} contains {string}")]
+async fn then_response_field_contains(
+    _world: &mut PlateSolverWorld,
+    _path: String,
+    _needle: String,
+) {
+    todo!("Phase 4")
+}
+
+#[then(expr = "the spawned argv contains the flag {string}")]
+async fn then_argv_contains_flag(_world: &mut PlateSolverWorld, _flag: String) {
+    todo!("Phase 4: read world.argv_out_path, parse argv, assert presence of flag")
+}
+
+#[then(expr = "the spawned argv value after {string} is approximately {float}")]
+async fn then_argv_value_after_flag(_world: &mut PlateSolverWorld, _flag: String, _expected: f64) {
+    todo!("Phase 4: read argv, find flag, parse the next token as f64, compare")
+}

--- a/services/rp-plate-solver/tests/bdd/steps/supervision_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/supervision_steps.rs
@@ -1,0 +1,31 @@
+//! Step definitions for `subprocess_supervision.feature`.
+//!
+//! Phase 3 stubs. Bodies arrive in Phase 4.
+
+use crate::world::PlateSolverWorld;
+use cucumber::{then, when};
+
+#[when(expr = "I POST two concurrent solve requests with timeout {string} each")]
+async fn when_two_concurrent_solves(_world: &mut PlateSolverWorld, _timeout: String) {
+    todo!("Phase 4: spawn two solve tasks via tokio::join!; capture both responses + timing into world")
+}
+
+#[then("both responses have status 504")]
+async fn then_both_responses_504(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4")
+}
+
+#[then("the second request's spawn time is after the first request's exit time")]
+async fn then_second_after_first(_world: &mut PlateSolverWorld) {
+    todo!("Phase 4: read MOCK_ASTAP_ARGV_OUT timestamps from each spawn; assert ordering")
+}
+
+#[then(expr = "the response time is at most {int} milliseconds")]
+async fn then_response_time_at_most(_world: &mut PlateSolverWorld, _ms: u64) {
+    todo!("Phase 4")
+}
+
+#[then(expr = "the response time is at least {int} milliseconds")]
+async fn then_response_time_at_least(_world: &mut PlateSolverWorld, _ms: u64) {
+    todo!("Phase 4")
+}

--- a/services/rp-plate-solver/tests/bdd/world.rs
+++ b/services/rp-plate-solver/tests/bdd/world.rs
@@ -1,0 +1,97 @@
+//! BDD World struct and helpers for the rp-plate-solver suite.
+//!
+//! The world accumulates state across Given / When / Then steps:
+//! the spawned wrapper handle, the temp directory holding fixtures and
+//! configs, and the most recent HTTP response body / status / timing.
+//!
+//! All scenarios under `tests/features/` are tagged `@wip` for Phase 3
+//! per `docs/plans/rp-plate-solver.md`; the `@wip` filter in
+//! `tests/bdd.rs` skips them at runtime so the default suite stays
+//! green until Phase 4 wires the wrapper binary.
+
+use bdd_infra::ServiceHandle;
+use cucumber::World;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+
+#[allow(dead_code)]
+// Phase 3 stubs touch every field via `todo!()`-bodied
+// step definitions but never *use* them at runtime.
+// Phase 4 wires the bodies and these allows go away.
+#[derive(Debug, Default, World)]
+pub struct PlateSolverWorld {
+    /// Handle to the spawned `rp-plate-solver` binary. None until a
+    /// Given step starts the wrapper. Stopped in the cucumber `after`
+    /// hook in `tests/bdd.rs`.
+    pub service_handle: Option<ServiceHandle>,
+
+    /// Per-scenario temp dir holding the config file, FITS placeholder,
+    /// and any temp-dir copy of `mock_astap`. Dropped at scenario end
+    /// (cleans up via `tempfile::TempDir`).
+    pub temp_dir: Option<TempDir>,
+
+    /// Path to the `astap_binary_path` the wrapper was started with.
+    /// Some scenarios rewrite or delete this between steps (e.g.,
+    /// `health.feature`'s "I delete the configured binary").
+    pub astap_binary_path: Option<PathBuf>,
+
+    /// Path to the `astap_db_directory` the wrapper was started with.
+    /// Same lifecycle as above.
+    pub astap_db_directory: Option<PathBuf>,
+
+    /// Path that `mock_astap` writes received argv to when
+    /// `MOCK_ASTAP_ARGV_OUT` is set on its env. Read by argv-flow
+    /// assertions in `solve_request.feature`.
+    pub argv_out_path: Option<PathBuf>,
+
+    /// Result of the most recent HTTP request (status + body).
+    pub last_response: Option<HttpResponse>,
+
+    /// Elapsed wall time of the most recent request, used by
+    /// `subprocess_supervision.feature`'s timing assertions.
+    pub last_response_elapsed: Option<Duration>,
+
+    /// Wrapper stderr after exit — populated by configuration
+    /// scenarios that probe non-zero-exit error messages.
+    pub last_wrapper_stderr: Option<String>,
+
+    /// Wrapper exit status, when the scenario waited for the wrapper
+    /// to exit (vs. starting it and leaving it running).
+    pub last_wrapper_exit_code: Option<i32>,
+}
+
+#[allow(dead_code)] // Phase 3 stubs; populated and read in Phase 4.
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub body: serde_json::Value,
+}
+
+impl PlateSolverWorld {
+    /// Locate the in-tree `mock_astap` binary the same way
+    /// `tests/supervision_integration.rs` does: `MOCK_ASTAP_BINARY`
+    /// env var (Bazel) → `option_env!("CARGO_BIN_EXE_mock_astap")`
+    /// (Cargo). Panics with a diagnostic if neither resolves —
+    /// matches the supervision integration test's hard-failure
+    /// posture.
+    #[allow(dead_code)] // Used by Phase 4 step bodies.
+    pub fn mock_astap_path() -> PathBuf {
+        if let Ok(p) = std::env::var("MOCK_ASTAP_BINARY") {
+            let path = PathBuf::from(p);
+            if path.exists() {
+                return path;
+            }
+        }
+        if let Some(p) = option_env!("CARGO_BIN_EXE_mock_astap") {
+            let path = PathBuf::from(p);
+            if path.exists() {
+                return path;
+            }
+        }
+        panic!(
+            "mock_astap binary not found. Tried MOCK_ASTAP_BINARY env var, then \
+             CARGO_BIN_EXE_mock_astap. Run `cargo build --tests -p rp-plate-solver`."
+        )
+    }
+}

--- a/services/rp-plate-solver/tests/features/configuration.feature
+++ b/services/rp-plate-solver/tests/features/configuration.feature
@@ -1,0 +1,53 @@
+@wip
+Feature: Configuration validation at startup
+
+  The wrapper validates its config before binding the HTTP listener. On
+  any validation failure it logs a structured error naming the offending
+  field and exits non-zero, so Sentinel surfaces the misconfiguration
+  rather than masking it with a silent retry.
+
+  Required fields exit on absence — `astap_binary_path` and
+  `astap_db_directory` have no implicit defaults. The validation rules
+  are listed in `docs/services/rp-plate-solver.md` §"Configuration
+  Validation at Startup".
+
+  Scenario: Missing astap_binary_path field rejects the config
+    Given a config without astap_binary_path
+    When the wrapper starts
+    Then the wrapper exits non-zero
+    And the wrapper stderr names "astap_binary_path"
+    And the wrapper stderr references the README
+
+  Scenario: astap_binary_path pointing at a non-existent file rejects the config
+    Given a config with astap_binary_path "/does/not/exist/astap_cli"
+    And a valid astap_db_directory
+    When the wrapper starts
+    Then the wrapper exits non-zero
+    And the wrapper stderr names "astap_binary_path"
+
+  Scenario: astap_binary_path pointing at a non-executable file rejects the config
+    Given a config with astap_binary_path pointing at a non-executable file
+    And a valid astap_db_directory
+    When the wrapper starts
+    Then the wrapper exits non-zero
+    And the wrapper stderr names "not executable"
+
+  Scenario: Missing astap_db_directory field rejects the config
+    Given a config without astap_db_directory
+    When the wrapper starts
+    Then the wrapper exits non-zero
+    And the wrapper stderr names "astap_db_directory"
+
+  Scenario: astap_db_directory pointing at a missing path rejects the config
+    Given a config with astap_db_directory "/does/not/exist/d05"
+    And a valid astap_binary_path
+    When the wrapper starts
+    Then the wrapper exits non-zero
+    And the wrapper stderr names "astap_db_directory"
+
+  Scenario: Valid config with mock_astap as binary path is accepted
+    Given a config with mock_astap as the binary path
+    And a valid astap_db_directory
+    When the wrapper starts
+    Then the wrapper prints bound_addr to stdout
+    And the wrapper /health returns 200

--- a/services/rp-plate-solver/tests/features/health.feature
+++ b/services/rp-plate-solver/tests/features/health.feature
@@ -1,0 +1,29 @@
+@wip
+Feature: GET /health — readiness probe
+
+  The /health endpoint is the standard HTTP health-probe pattern,
+  exposed for operational tooling and any future Sentinel probe path.
+  It checks both runtime dependencies — the configured ASTAP binary
+  and the configured database directory — match the startup-validation
+  set, so "healthy at probe time" means "still capable of solving."
+
+  The probe is intentionally cheap: two filesystem stats, no subprocess
+  spawn. Frequent polling does not cost wrapper performance.
+
+  Scenario: Health returns 200 with status ok after a clean start
+    Given the wrapper is running with mock_astap as its solver
+    When I GET /health
+    Then the response status is 200
+    And the response field "status" is "ok"
+
+  Scenario: Health returns 503 when the configured binary is removed
+    Given the wrapper is running with a temp-dir copy of mock_astap as its binary path
+    When I delete the configured astap_binary_path
+    And I GET /health
+    Then the response status is 503
+
+  Scenario: Health returns 503 when the configured db directory is removed
+    Given the wrapper is running with a temp astap_db_directory
+    When I delete the configured astap_db_directory
+    And I GET /health
+    Then the response status is 503

--- a/services/rp-plate-solver/tests/features/real_astap_smoke.feature
+++ b/services/rp-plate-solver/tests/features/real_astap_smoke.feature
@@ -1,0 +1,31 @@
+@wip @requires-astap
+Feature: Real-ASTAP smoke (mock-honesty backstop)
+
+  Two scenarios exercise the wrapper against the operator's real ASTAP
+  install. Gated by the `@requires-astap` tag — they fire only when
+  `ASTAP_BINARY` is set in the environment. The dedicated nightly
+  cross-platform workflow sets that var via the `install-astap` action;
+  PR jobs do not, so these scenarios are skipped on every PR.
+
+  See `docs/plans/rp-plate-solver.md` §"Real-ASTAP coverage: cadence
+  and gating" for the rationale and the bdd.rs filter snippet.
+
+  Note: the `@wip` tag is removed by Phase 4 along with all other
+  feature files'. The `@requires-astap` tag stays — it's the permanent
+  cadence gate.
+
+  Scenario: Real ASTAP solves the m31 fixture within tolerance
+    Given the wrapper is running with the real ASTAP_BINARY as its solver
+    And the m31_known.fits fixture is on disk
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 200
+    And the response field "ra_center" is approximately 10.6848 within 0.01 degrees
+    And the response field "dec_center" is approximately 41.2690 within 0.01 degrees
+    And the response field "solver" contains "astap"
+
+  Scenario: Real ASTAP returns solve_failed on a degenerate FITS
+    Given the wrapper is running with the real ASTAP_BINARY as its solver
+    And the degenerate_no_stars.fits fixture is on disk
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 422
+    And the response field "error" is "solve_failed"

--- a/services/rp-plate-solver/tests/features/real_astap_smoke.feature
+++ b/services/rp-plate-solver/tests/features/real_astap_smoke.feature
@@ -21,7 +21,7 @@ Feature: Real-ASTAP smoke (mock-honesty backstop)
     Then the response status is 200
     And the response field "ra_center" is approximately 10.6848 within 0.01 degrees
     And the response field "dec_center" is approximately 41.2690 within 0.01 degrees
-    And the response field "solver" contains "astap"
+    And the response field "solver" contains "astap" case-insensitively
 
   Scenario: Real ASTAP returns solve_failed on a degenerate FITS
     Given the wrapper is running with the real ASTAP_BINARY as its solver

--- a/services/rp-plate-solver/tests/features/solve_request.feature
+++ b/services/rp-plate-solver/tests/features/solve_request.feature
@@ -1,0 +1,86 @@
+@wip
+Feature: POST /api/v1/solve — request handling and error surface
+
+  The solve endpoint accepts a FITS path plus optional pointing/FOV/
+  search-radius hints, spawns ASTAP under the supervision module, and
+  returns the parsed WCS solution or one of the five frozen error codes.
+
+  The complete HTTP contract — request fields, response fields, error
+  code table — lives in `docs/plans/rp-plate-solver.md` §"HTTP contract".
+  Each scenario below exercises that contract one branch at a time.
+
+  Background:
+    Given the wrapper is running with mock_astap as its solver
+
+  Scenario: Happy path returns the four WCS fields
+    Given mock_astap is configured for "normal" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 200
+    And the response field "ra_center" is approximately 10.6848
+    And the response field "dec_center" is approximately 41.2690
+    And the response field "pixel_scale_arcsec" is approximately 1.05
+    And the response field "rotation_deg" is approximately 12.3
+    And the response field "solver" contains "ASTAP"
+
+  Scenario: Non-existent fits_path returns fits_not_found
+    When I POST to /api/v1/solve with fits_path "/tmp/does-not-exist.fits"
+    Then the response status is 404
+    And the response field "error" is "fits_not_found"
+
+  Scenario: Non-absolute fits_path returns invalid_request
+    When I POST to /api/v1/solve with fits_path "relative/path.fits"
+    Then the response status is 400
+    And the response field "error" is "invalid_request"
+
+  Scenario: Malformed JSON body returns invalid_request
+    When I POST to /api/v1/solve with raw body "{not json"
+    Then the response status is 400
+    And the response field "error" is "invalid_request"
+
+  Scenario: Unparseable timeout returns invalid_request
+    Given a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path and timeout "not-a-duration"
+    Then the response status is 400
+    And the response field "error" is "invalid_request"
+
+  Scenario: ASTAP exits non-zero returns solve_failed with stderr tail
+    Given mock_astap is configured for "exit_failure" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 422
+    And the response field "error" is "solve_failed"
+    And the response field "details.exit_code" is 1
+    And the response field "details.stderr_tail" contains "simulated solve failure"
+
+  Scenario: ASTAP exits clean but writes no .wcs returns solve_failed
+    Given mock_astap is configured for "no_wcs" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 422
+    And the response field "error" is "solve_failed"
+    And the response field "message" contains "did not write"
+
+  Scenario: ASTAP writes a malformed .wcs returns solve_failed naming the missing key
+    Given mock_astap is configured for "malformed_wcs" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 422
+    And the response field "error" is "solve_failed"
+    And the response field "message" contains "CRVAL2"
+
+  Scenario Outline: Hint flags pass through to ASTAP argv
+    Given mock_astap is configured for "normal" mode
+    And mock_astap is configured to write argv to a side-channel file
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path and hint <field> set to <value>
+    Then the response status is 200
+    And the spawned argv contains the flag "<flag>"
+    And the spawned argv value after "<flag>" is approximately <converted>
+
+    Examples:
+      | field             | value   | flag | converted |
+      | ra_hint           | 10.6848 | -ra  | 0.71232   |
+      | dec_hint          | 41.2690 | -spd | 131.2690  |
+      | fov_hint_deg      | 1.5     | -fov | 1.5       |
+      | search_radius_deg | 5.0     | -r   | 5.0       |

--- a/services/rp-plate-solver/tests/features/solve_request.feature
+++ b/services/rp-plate-solver/tests/features/solve_request.feature
@@ -14,17 +14,18 @@ Feature: POST /api/v1/solve — request handling and error surface
 
   Scenario: Happy path returns the four WCS fields
     Given mock_astap is configured for "normal" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path
     Then the response status is 200
     And the response field "ra_center" is approximately 10.6848
     And the response field "dec_center" is approximately 41.2690
     And the response field "pixel_scale_arcsec" is approximately 1.05
     And the response field "rotation_deg" is approximately 12.3
-    And the response field "solver" contains "ASTAP"
+    And the response field "solver" contains "astap" case-insensitively
 
   Scenario: Non-existent fits_path returns fits_not_found
-    When I POST to /api/v1/solve with fits_path "/tmp/does-not-exist.fits"
+    Given a non-existent FITS path
+    When I POST to /api/v1/solve with that fits_path
     Then the response status is 404
     And the response field "error" is "fits_not_found"
 
@@ -46,7 +47,7 @@ Feature: POST /api/v1/solve — request handling and error surface
 
   Scenario: ASTAP exits non-zero returns solve_failed with stderr tail
     Given mock_astap is configured for "exit_failure" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path
     Then the response status is 422
     And the response field "error" is "solve_failed"
@@ -55,7 +56,7 @@ Feature: POST /api/v1/solve — request handling and error surface
 
   Scenario: ASTAP exits clean but writes no .wcs returns solve_failed
     Given mock_astap is configured for "no_wcs" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path
     Then the response status is 422
     And the response field "error" is "solve_failed"
@@ -63,7 +64,7 @@ Feature: POST /api/v1/solve — request handling and error surface
 
   Scenario: ASTAP writes a malformed .wcs returns solve_failed naming the missing key
     Given mock_astap is configured for "malformed_wcs" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path
     Then the response status is 422
     And the response field "error" is "solve_failed"
@@ -72,7 +73,7 @@ Feature: POST /api/v1/solve — request handling and error surface
   Scenario Outline: Hint flags pass through to ASTAP argv
     Given mock_astap is configured for "normal" mode
     And mock_astap is configured to write argv to a side-channel file
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path and hint <field> set to <value>
     Then the response status is 200
     And the spawned argv contains the flag "<flag>"

--- a/services/rp-plate-solver/tests/features/subprocess_supervision.feature
+++ b/services/rp-plate-solver/tests/features/subprocess_supervision.feature
@@ -1,0 +1,39 @@
+@wip
+Feature: Subprocess supervision (timeout escalation, single-flight queueing)
+
+  Every solve is bounded by a wall-clock deadline. On expiry the wrapper
+  signals the child gracefully (SIGTERM on Unix, CTRL_BREAK_EVENT on
+  Windows), waits a fixed 2-second grace period, then force-kills
+  (SIGKILL / TerminateProcess). The wrapper always waits the child
+  fully before returning; no orphaned child processes.
+
+  Overlapping requests queue behind a single-flight semaphore (default
+  capacity 1). Queue wait time is not counted against the per-request
+  deadline.
+
+  Background:
+    Given the wrapper is running with mock_astap as its solver
+
+  Scenario: Hung child responding to graceful signal returns solve_timeout (terminated)
+    Given mock_astap is configured for "hang" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path and timeout "100ms"
+    Then the response status is 504
+    And the response field "error" is "solve_timeout"
+    And the response time is at most 2500 milliseconds
+
+  Scenario: Hung child ignoring graceful signal is force-killed after grace
+    Given mock_astap is configured for "ignore_sigterm" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST to /api/v1/solve with that fits_path and timeout "100ms"
+    Then the response status is 504
+    And the response field "error" is "solve_timeout"
+    And the response time is at least 2000 milliseconds
+    And the response time is at most 4500 milliseconds
+
+  Scenario: Single-flight semaphore serializes overlapping solves
+    Given mock_astap is configured for "hang" mode
+    And a writable FITS path "/tmp/m31.fits"
+    When I POST two concurrent solve requests with timeout "100ms" each
+    Then both responses have status 504
+    And the second request's spawn time is after the first request's exit time

--- a/services/rp-plate-solver/tests/features/subprocess_supervision.feature
+++ b/services/rp-plate-solver/tests/features/subprocess_supervision.feature
@@ -16,7 +16,7 @@ Feature: Subprocess supervision (timeout escalation, single-flight queueing)
 
   Scenario: Hung child responding to graceful signal returns solve_timeout (terminated)
     Given mock_astap is configured for "hang" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path and timeout "100ms"
     Then the response status is 504
     And the response field "error" is "solve_timeout"
@@ -24,7 +24,7 @@ Feature: Subprocess supervision (timeout escalation, single-flight queueing)
 
   Scenario: Hung child ignoring graceful signal is force-killed after grace
     Given mock_astap is configured for "ignore_sigterm" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST to /api/v1/solve with that fits_path and timeout "100ms"
     Then the response status is 504
     And the response field "error" is "solve_timeout"
@@ -33,7 +33,7 @@ Feature: Subprocess supervision (timeout escalation, single-flight queueing)
 
   Scenario: Single-flight semaphore serializes overlapping solves
     Given mock_astap is configured for "hang" mode
-    And a writable FITS path "/tmp/m31.fits"
+    And a writable FITS path
     When I POST two concurrent solve requests with timeout "100ms" each
     Then both responses have status 504
     And the second request's spawn time is after the first request's exit time


### PR DESCRIPTION
## Summary

Phase 3 of [`docs/plans/rp-plate-solver.md`](docs/plans/rp-plate-solver.md) — scaffolds the BDD test surface. Five feature files (≈30 scenarios) document the contract; step definitions are Phase 3 stubs (`todo!()` bodies). All scenarios tagged `@wip` so the default suite stays green until Phase 4 wires the wrapper binary and removes the tag.

## Feature files

- **`configuration.feature`** (6) — startup validation: missing fields, non-existent / non-executable binary, missing db dir, valid config.
- **`solve_request.feature`** (8 + 4-row Scenario Outline) — happy path; each frozen error code (`invalid_request`, `fits_not_found`, `solve_failed` via `exit_failure` / `no_wcs` / `malformed_wcs`); hint flags pass through to ASTAP argv via `mock_astap`'s `MOCK_ASTAP_ARGV_OUT` side-channel.
- **`subprocess_supervision.feature`** (3) — graceful-signal termination, force-kill escalation, single-flight serialization.
- **`health.feature`** (3) — `/health` 200 happy path; 503 when configured binary or db directory disappears at runtime.
- **`real_astap_smoke.feature`** (2, also tagged `@requires-astap`) — happy + error paths against the operator's real ASTAP install, gated by `ASTAP_BINARY` env var.

## Harness

- **`tests/bdd.rs`** — `bdd_main!` entry with `@wip` + `@requires-astap` filter (both tags accepted with or without leading `@`, matching `services/rp/tests/bdd.rs`).
- **`tests/bdd/world.rs`** — `PlateSolverWorld` carrying service handle, temp dir, configured paths, last response, timing. Mock binary discovery via `MOCK_ASTAP_BINARY` env var → `option_env!(CARGO_BIN_EXE_mock_astap)`.
- **`tests/bdd/steps/`** — five step files plus shared HTTP/JSON assertion phrases in `solve_steps.rs`. Bodies are `todo!("Phase 4")` — compile but never run because `@wip` filters every scenario at runtime.

## Note on Gherkin parsing

`solve_request.feature` originally had a description line starting with "Scenarios..." which Gherkin parses as the `Examples`-table keyword. Reworded per [testing.md §2.8](docs/skills/testing.md) (same family of pitfall as the `Rule` keyword).

## Test plan

- [x] `cargo build -p rp-plate-solver --all-features --all-targets` clean
- [x] `cargo nextest run -p rp-plate-solver --all-features --all-targets` — 38 unit/integration tests pass
- [x] `cargo test -p rp-plate-solver --all-features --test bdd` — 0 features / 0 scenarios / 0 steps run (all `@wip`-filtered)
- [x] `cargo clippy -p rp-plate-solver --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo rail run --profile commit -q` clean
- [ ] CI green
- [ ] Copilot review (request via UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)