### PR TITLE
feat(rp-plate-solver): Phase 4 — HTTP server + supervision + remove @wip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,7 +3692,9 @@ dependencies = [
  "axum",
  "bdd-infra",
  "cargo-husky",
+ "clap",
  "cucumber",
+ "humantime",
  "humantime-serde",
  "libc",
  "mockall",
@@ -3704,6 +3706,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3694,7 +3694,6 @@ dependencies = [
  "cargo-husky",
  "clap",
  "cucumber",
- "humantime",
  "humantime-serde",
  "libc",
  "mockall",

--- a/services/rp-plate-solver/Cargo.toml
+++ b/services/rp-plate-solver/Cargo.toml
@@ -12,15 +12,15 @@ description = "rp-managed plate solver service: HTTP wrapper around the ASTAP CL
 workspace = true
 
 [dependencies]
-# Phase 2 minimal: only the deps actually referenced by current source.
-# fitsrs, wcs, clap, tracing-subscriber rejoin in Phase 4 when main.rs
-# initialises logging and the .wcs spike retires (both per the plan).
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+humantime = { workspace = true }
 humantime-serde = { workspace = true }
 axum = { workspace = true }
+clap = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }

--- a/services/rp-plate-solver/Cargo.toml
+++ b/services/rp-plate-solver/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-humantime = { workspace = true }
 humantime-serde = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }

--- a/services/rp-plate-solver/src/api.rs
+++ b/services/rp-plate-solver/src/api.rs
@@ -1,0 +1,196 @@
+//! Axum router and HTTP handlers for `POST /api/v1/solve` and
+//! `GET /health`.
+//!
+//! Frozen contract details live in
+//! `docs/plans/rp-plate-solver.md` §"HTTP contract" and the
+//! behavior contract is in `docs/services/rp-plate-solver.md`.
+
+use crate::error::AppError;
+use crate::runner::{AstapRunner, RunnerError, SolveOutcome, SolveRequest};
+use axum::{extract::State, response::IntoResponse, routing::get, routing::post, Json, Router};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+/// Shared application state held by axum handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub runner: Arc<dyn AstapRunner>,
+    /// Single-flight semaphore. Capacity = `max_concurrency`. Default 1
+    /// per the design contract; serializes overlapping solves.
+    pub semaphore: Arc<Semaphore>,
+    pub default_solve_timeout: Duration,
+    pub max_solve_timeout: Duration,
+    /// Paths re-validated by `/health` on every probe.
+    pub astap_binary_path: PathBuf,
+    pub astap_db_directory: PathBuf,
+}
+
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/v1/solve", post(solve))
+        .route("/health", get(health))
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SolveRequestBody {
+    fits_path: PathBuf,
+    #[serde(default)]
+    ra_hint: Option<f64>,
+    #[serde(default)]
+    dec_hint: Option<f64>,
+    #[serde(default)]
+    fov_hint_deg: Option<f64>,
+    #[serde(default)]
+    search_radius_deg: Option<f64>,
+    #[serde(default, with = "humantime_serde::option")]
+    timeout: Option<Duration>,
+}
+
+#[derive(Debug, Serialize)]
+struct SolveResponseBody {
+    ra_center: f64,
+    dec_center: f64,
+    pixel_scale_arcsec: f64,
+    rotation_deg: f64,
+    solver: String,
+}
+
+impl From<SolveOutcome> for SolveResponseBody {
+    fn from(o: SolveOutcome) -> Self {
+        Self {
+            ra_center: o.ra_center,
+            dec_center: o.dec_center,
+            pixel_scale_arcsec: o.pixel_scale_arcsec,
+            rotation_deg: o.rotation_deg,
+            solver: o.solver,
+        }
+    }
+}
+
+async fn solve(
+    State(state): State<AppState>,
+    body: Result<Json<SolveRequestBody>, axum::extract::rejection::JsonRejection>,
+) -> Result<Json<SolveResponseBody>, AppError> {
+    // 1. JSON parse / schema validation.
+    let body = body.map_err(|e| AppError::InvalidRequest(format!("malformed body: {e}")))?;
+    let body = body.0;
+
+    // 2. fits_path must be absolute.
+    if !body.fits_path.is_absolute() {
+        return Err(AppError::InvalidRequest(format!(
+            "fits_path must be absolute: {}",
+            body.fits_path.display()
+        )));
+    }
+
+    // 3. fits_path must exist and be readable.
+    if !body.fits_path.exists() {
+        return Err(AppError::FitsNotFound(body.fits_path.display().to_string()));
+    }
+
+    // 4. Determine timeout. Caller-supplied is capped at max; missing
+    //    falls back to default.
+    let timeout = body
+        .timeout
+        .unwrap_or(state.default_solve_timeout)
+        .min(state.max_solve_timeout);
+
+    // 5. Acquire semaphore. Overlapping requests queue behind this; the
+    //    queue wait is not counted against the per-request timeout.
+    let _permit = state
+        .semaphore
+        .acquire()
+        .await
+        .map_err(|e| AppError::Internal(format!("semaphore closed: {e}")))?;
+
+    // 6. Drive the runner. Map RunnerError → AppError per the frozen
+    //    error-code table.
+    let request = SolveRequest {
+        fits_path: body.fits_path,
+        ra_hint: body.ra_hint,
+        dec_hint: body.dec_hint,
+        fov_hint_deg: body.fov_hint_deg,
+        search_radius_deg: body.search_radius_deg,
+        timeout,
+    };
+
+    match state.runner.solve(request).await {
+        Ok(outcome) => Ok(Json(SolveResponseBody::from(outcome))),
+        Err(RunnerError::ExitStatus {
+            status,
+            stderr_tail,
+        }) => Err(AppError::SolveFailed {
+            message: format!("ASTAP exited with code {status}"),
+            exit_code: Some(status),
+            stderr_tail: Some(stderr_tail),
+        }),
+        Err(RunnerError::NoWcs) => Err(AppError::SolveFailed {
+            message: "ASTAP did not write a .wcs sidecar (exit was clean)".to_string(),
+            exit_code: None,
+            stderr_tail: None,
+        }),
+        Err(RunnerError::MalformedWcs(msg)) => Err(AppError::SolveFailed {
+            message: format!("malformed .wcs: {msg}"),
+            exit_code: None,
+            stderr_tail: None,
+        }),
+        Err(RunnerError::TimedOutTerminated) => Err(AppError::SolveTimeoutTerminated),
+        Err(RunnerError::TimedOutKilled) => Err(AppError::SolveTimeoutKilled),
+        Err(RunnerError::Io(e)) => Err(AppError::Internal(format!("io: {e}"))),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct HealthBody {
+    status: &'static str,
+}
+
+/// Cheap readiness probe: stats both runtime dependencies. Returns 200
+/// with `{"status": "ok"}` when both pass; 503 otherwise.
+async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    if !path_is_executable_file(&state.astap_binary_path) {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Json(HealthBody {
+                status: "binary_unavailable",
+            }),
+        )
+            .into_response();
+    }
+    if !state.astap_db_directory.is_dir() {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Json(HealthBody {
+                status: "db_unavailable",
+            }),
+        )
+            .into_response();
+    }
+    (
+        axum::http::StatusCode::OK,
+        Json(HealthBody { status: "ok" }),
+    )
+        .into_response()
+}
+
+fn path_is_executable_file(path: &std::path::Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if meta.permissions().mode() & 0o111 == 0 {
+            return false;
+        }
+    }
+    true
+}

--- a/services/rp-plate-solver/src/api.rs
+++ b/services/rp-plate-solver/src/api.rs
@@ -88,9 +88,25 @@ async fn solve(
         )));
     }
 
-    // 3. fits_path must exist and be readable.
-    if !body.fits_path.exists() {
-        return Err(AppError::FitsNotFound(body.fits_path.display().to_string()));
+    // 3. fits_path must exist, be a regular file (not a directory),
+    //    and be readable. Each failure surfaces as `fits_not_found`
+    //    with a message describing which check failed — `internal` is
+    //    reserved for genuine wrapper bugs.
+    let fits_meta = std::fs::metadata(&body.fits_path)
+        .map_err(|e| AppError::FitsNotFound(format!("{}: {}", body.fits_path.display(), e)))?;
+    if !fits_meta.is_file() {
+        return Err(AppError::FitsNotFound(format!(
+            "{}: not a regular file",
+            body.fits_path.display()
+        )));
+    }
+    // Open-check confirms read permissions without reading content.
+    if let Err(e) = std::fs::File::open(&body.fits_path) {
+        return Err(AppError::FitsNotFound(format!(
+            "{}: {}",
+            body.fits_path.display(),
+            e
+        )));
     }
 
     // 4. Determine timeout. Caller-supplied is capped at max; missing
@@ -153,6 +169,11 @@ struct HealthBody {
 /// Cheap readiness probe: stats both runtime dependencies. Returns 200
 /// with `{"status": "ok"}` when both pass; 503 otherwise.
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    // SECURITY: `state.astap_binary_path` and `state.astap_db_directory`
+    // come from operator-supplied config, validated at startup. Health
+    // re-validates them against the same rules. The wrapper isn't
+    // multi-tenant; "user-controlled path" alerts on these fields are
+    // by-design and dismissed.
     if !path_is_executable_file(&state.astap_binary_path) {
         return (
             axum::http::StatusCode::SERVICE_UNAVAILABLE,
@@ -179,6 +200,9 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 fn path_is_executable_file(path: &std::path::Path) -> bool {
+    // SECURITY: `path` is operator-supplied via config; see comment in
+    // `health()`. CodeQL's "user-controlled data in path expression"
+    // alert on this `metadata` call is by-design.
     let Ok(meta) = std::fs::metadata(path) else {
         return false;
     };

--- a/services/rp-plate-solver/src/config.rs
+++ b/services/rp-plate-solver/src/config.rs
@@ -5,6 +5,7 @@
 //! `configuration.feature`.
 
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::{net::IpAddr, path::Path, path::PathBuf, time::Duration};
 use thiserror::Error;
 
@@ -29,6 +30,14 @@ pub struct Config {
 
     #[serde(default = "default_max_solve_timeout", with = "humantime_serde")]
     pub max_solve_timeout: Duration,
+
+    /// Environment variables set on every spawned `astap_cli` child.
+    /// Useful for operator-controlled tunables (locale, library
+    /// paths) and for BDD tests that drive `mock_astap`'s
+    /// `MOCK_ASTAP_MODE` per-scenario without process-wide
+    /// `env::set_var` races.
+    #[serde(default)]
+    pub astap_extra_env: HashMap<String, String>,
 }
 
 fn default_bind_address() -> IpAddr {
@@ -52,7 +61,11 @@ pub enum ConfigError {
     #[error("config file: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("config parse error: {0}")]
+    #[error(
+        "config parse error: {0}. \
+         See services/rp-plate-solver/README.md for install instructions \
+         and the configuration field reference."
+    )]
     Parse(#[from] serde_json::Error),
 
     #[error(
@@ -228,6 +241,7 @@ mod tests {
             max_concurrency: default_max_concurrency(),
             default_solve_timeout: default_solve_timeout(),
             max_solve_timeout: default_max_solve_timeout(),
+            astap_extra_env: Default::default(),
         };
         let err = cfg.validate().unwrap_err();
         let msg = err.to_string();
@@ -248,6 +262,7 @@ mod tests {
             max_concurrency: default_max_concurrency(),
             default_solve_timeout: default_solve_timeout(),
             max_solve_timeout: default_max_solve_timeout(),
+            astap_extra_env: Default::default(),
         };
         let err = cfg.validate().unwrap_err();
         assert!(matches!(err, ConfigError::InvalidDbDirectory { .. }));
@@ -267,6 +282,7 @@ mod tests {
             max_concurrency: 1,
             default_solve_timeout: Duration::from_secs(60),
             max_solve_timeout: Duration::from_secs(30),
+            astap_extra_env: Default::default(),
         };
         let err = cfg.validate().unwrap_err();
         assert!(matches!(err, ConfigError::TimeoutOrder { .. }));
@@ -285,6 +301,7 @@ mod tests {
             max_concurrency: 0,
             default_solve_timeout: default_solve_timeout(),
             max_solve_timeout: default_max_solve_timeout(),
+            astap_extra_env: Default::default(),
         };
         assert!(matches!(
             cfg.validate().unwrap_err(),
@@ -310,6 +327,7 @@ mod tests {
             max_concurrency: 1,
             default_solve_timeout: default_solve_timeout(),
             max_solve_timeout: default_max_solve_timeout(),
+            astap_extra_env: Default::default(),
         };
         let err = cfg.validate().unwrap_err();
         assert!(matches!(err, ConfigError::InvalidBinaryPath { .. }));

--- a/services/rp-plate-solver/src/lib.rs
+++ b/services/rp-plate-solver/src/lib.rs
@@ -1,14 +1,138 @@
 //! rp-plate-solver — rp-managed service wrapping the ASTAP CLI.
 //!
-//! Phase 2 scaffold: library surface only. The HTTP server (`api`) and
-//! `main.rs` arrive in Phase 4 per `docs/plans/rp-plate-solver.md`.
+//! See `docs/services/rp-plate-solver.md` for the design contract and
+//! `docs/plans/rp-plate-solver.md` for sequencing.
 
+pub mod api;
 pub mod config;
 pub mod error;
 pub mod runner;
 pub mod supervision;
 
+pub use api::AppState;
 pub use config::{load_config, Config, ConfigError};
 pub use error::{AppError, ErrorCode, ErrorResponse};
 pub use runner::astap::AstapCliRunner;
 pub use runner::{AstapRunner, RunnerError, SolveOutcome, SolveRequest};
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+
+/// Two-phase server builder. Use `build()` to bind the TCP listener
+/// (so the bound port is known up-front), then `start()` to serve.
+/// Mirrors `services/rp::ServerBuilder` and avoids the port-TOCTOU
+/// race noted in `docs/skills/development-workflow.md` §"Phase 4
+/// Stabilization".
+pub struct ServerBuilder {
+    config: Option<Config>,
+    runner: Option<Arc<dyn AstapRunner>>,
+}
+
+impl ServerBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            runner: None,
+        }
+    }
+
+    pub fn with_config(mut self, config: Config) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Override the runner (tests inject mocks; production uses
+    /// `AstapCliRunner` constructed from config).
+    pub fn with_runner(mut self, runner: Arc<dyn AstapRunner>) -> Self {
+        self.runner = Some(runner);
+        self
+    }
+
+    pub async fn build(self) -> Result<BoundServer, std::io::Error> {
+        let config = self.config.expect("ServerBuilder: config is required");
+        config
+            .validate()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let runner = self.runner.unwrap_or_else(|| {
+            let mut runner = AstapCliRunner::new(
+                config.astap_binary_path.clone(),
+                config.astap_db_directory.clone(),
+            );
+            for (k, v) in &config.astap_extra_env {
+                runner = runner.with_env(k, v);
+            }
+            Arc::new(runner)
+        });
+
+        let semaphore = Arc::new(Semaphore::new(config.max_concurrency));
+
+        let state = AppState {
+            runner,
+            semaphore,
+            default_solve_timeout: config.default_solve_timeout,
+            max_solve_timeout: config.max_solve_timeout,
+            astap_binary_path: config.astap_binary_path.clone(),
+            astap_db_directory: config.astap_db_directory.clone(),
+        };
+
+        let router = api::build_router(state);
+
+        let bind_addr = SocketAddr::new(config.bind_address, config.port);
+        let listener = TcpListener::bind(bind_addr).await?;
+        let local_addr = listener.local_addr()?;
+
+        Ok(BoundServer {
+            listener,
+            router,
+            local_addr,
+        })
+    }
+}
+
+impl Default for ServerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A fully bound server ready to accept connections.
+pub struct BoundServer {
+    listener: TcpListener,
+    router: axum::Router,
+    local_addr: SocketAddr,
+}
+
+impl BoundServer {
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Run the server until shutdown. Listens for SIGTERM (Unix) or
+    /// CTRL_BREAK_EVENT (Windows) and shuts down gracefully.
+    pub async fn start(self) -> Result<(), std::io::Error> {
+        axum::serve(self.listener, self.router)
+            .with_graceful_shutdown(shutdown_signal())
+            .await
+    }
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+        let mut sigint = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+        tokio::select! {
+            _ = sigterm.recv() => tracing::debug!("SIGTERM received, shutting down"),
+            _ = sigint.recv() => tracing::debug!("SIGINT received, shutting down"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::debug!("CTRL_C received, shutting down");
+    }
+}

--- a/services/rp-plate-solver/src/main.rs
+++ b/services/rp-plate-solver/src/main.rs
@@ -1,0 +1,65 @@
+//! rp-plate-solver service binary.
+//!
+//! Reads a JSON config file passed via `--config`, validates it, builds
+//! the HTTP server, prints `bound_addr=<host>:<port>` to stdout (so
+//! `bdd-infra::ServiceHandle` can discover the bound port), and serves
+//! until SIGTERM / Ctrl-C.
+
+use clap::Parser;
+use rp_plate_solver::{load_config, ServerBuilder};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rp-plate-solver",
+    version,
+    about = "rp-managed plate solver service"
+)]
+struct Cli {
+    /// Path to the JSON config file.
+    #[arg(short, long)]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+
+    let cli = Cli::parse();
+
+    let config = match load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("rp-plate-solver: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let server = match ServerBuilder::new().with_config(config).build().await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("rp-plate-solver: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let addr = server.listen_addr();
+    // `bound_addr=` is parsed by `bdd-infra::parse_bound_port` to
+    // discover the test-spawned service's port. Must be on stdout.
+    println!("bound_addr={addr}");
+    tracing::info!(%addr, "rp-plate-solver listening");
+
+    if let Err(e) = server.start().await {
+        eprintln!("rp-plate-solver: server error: {e}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::SUCCESS
+}

--- a/services/rp-plate-solver/tests/bdd.rs
+++ b/services/rp-plate-solver/tests/bdd.rs
@@ -49,7 +49,15 @@ bdd_infra::bdd_main! {
                     .iter()
                     .any(|t| t == "requires-astap" || t == "@requires-astap");
             let astap_available = std::env::var("ASTAP_BINARY").is_ok();
-            !is_wip && (!needs_astap || astap_available)
+            // `@unix` gates scenarios that depend on Unix-specific
+            // filesystem semantics (e.g., `chmod 000` to deny read).
+            // Windows file-permission denial requires DENY ACLs or
+            // file locks — not worth the complexity until a real
+            // Windows-specific failure mode surfaces.
+            let unix_only = feat.tags.iter().any(|t| t == "unix" || t == "@unix")
+                || sc.tags.iter().any(|t| t == "unix" || t == "@unix");
+            let is_unix = cfg!(unix);
+            !is_wip && (!needs_astap || astap_available) && (!unix_only || is_unix)
         })
         .await;
 }

--- a/services/rp-plate-solver/tests/bdd/steps/config_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/config_steps.rs
@@ -1,76 +1,179 @@
 //! Step definitions for `configuration.feature`.
-//!
-//! Phase 3 stubs. Bodies arrive in Phase 4.
 
 use crate::world::PlateSolverWorld;
 use cucumber::{given, then, when};
+use std::path::PathBuf;
 
 #[given("a config without astap_binary_path")]
-async fn given_config_without_binary_path(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: write a config file omitting astap_binary_path into world.temp_dir")
+async fn given_config_without_binary_path(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let db = make_db_dir(&dir);
+    world
+        .pending_config
+        .insert("astap_db_directory".into(), db.to_string_lossy().into());
 }
 
 #[given("a config without astap_db_directory")]
-async fn given_config_without_db_directory(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4")
+async fn given_config_without_db_directory(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let bin = copy_mock_astap(&dir);
+    world
+        .pending_config
+        .insert("astap_binary_path".into(), bin.to_string_lossy().into());
 }
 
 #[given(expr = "a config with astap_binary_path {string}")]
-async fn given_config_with_binary_path(_world: &mut PlateSolverWorld, _path: String) {
-    todo!("Phase 4")
+async fn given_config_with_binary_path(world: &mut PlateSolverWorld, path: String) {
+    world
+        .pending_config
+        .insert("astap_binary_path".into(), path.into());
 }
 
 #[given(expr = "a config with astap_db_directory {string}")]
-async fn given_config_with_db_directory(_world: &mut PlateSolverWorld, _path: String) {
-    todo!("Phase 4")
+async fn given_config_with_db_directory(world: &mut PlateSolverWorld, path: String) {
+    world
+        .pending_config
+        .insert("astap_db_directory".into(), path.into());
 }
 
 #[given("a config with astap_binary_path pointing at a non-executable file")]
-async fn given_non_executable_binary_path(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: write a 0o644 file into temp_dir, point config at it")
+async fn given_non_executable_binary_path(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let bin = dir.join("not_executable");
+    std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").expect("write");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod 644");
+    }
+    world
+        .pending_config
+        .insert("astap_binary_path".into(), bin.to_string_lossy().into());
 }
 
 #[given("a valid astap_binary_path")]
-async fn given_valid_binary_path(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: copy mock_astap into temp_dir")
+async fn given_valid_binary_path(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let bin = copy_mock_astap(&dir);
+    world
+        .pending_config
+        .insert("astap_binary_path".into(), bin.to_string_lossy().into());
 }
 
 #[given("a valid astap_db_directory")]
-async fn given_valid_db_directory(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: mkdir temp_dir/d05")
+async fn given_valid_db_directory(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let db = make_db_dir(&dir);
+    world
+        .pending_config
+        .insert("astap_db_directory".into(), db.to_string_lossy().into());
 }
 
 #[given("a config with mock_astap as the binary path")]
-async fn given_config_with_mock_astap(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: PlateSolverWorld::mock_astap_path() into config")
+async fn given_config_with_mock_astap(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let bin = copy_mock_astap(&dir);
+    world
+        .pending_config
+        .insert("astap_binary_path".into(), bin.to_string_lossy().into());
 }
 
 #[when("the wrapper starts")]
-async fn when_wrapper_starts(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: spawn the wrapper binary; capture stdout/stderr")
+async fn when_wrapper_starts(world: &mut PlateSolverWorld) {
+    // Inject port: 0 so concurrent test runs don't collide on the
+    // default port; ServiceHandle parses the actual bound port from
+    // the wrapper's stdout.
+    world
+        .pending_config
+        .entry("port".to_string())
+        .or_insert_with(|| serde_json::Value::from(0));
+
+    let dir = world.temp_dir_path();
+    let cfg_path = dir.join("config.json");
+    let body = serde_json::Value::Object(world.pending_config.clone()).to_string();
+    std::fs::write(&cfg_path, body).expect("write config");
+
+    // Try to start the wrapper non-fatally. If it boots and prints
+    // bound_addr, ServiceHandle is held and Then-steps probe /health.
+    // If the wrapper exits during validation (the failure scenarios),
+    // try_start returns Err and we fall back to running it to exit
+    // again so we can capture stderr / exit code for the assertions.
+    let cfg_str = cfg_path.to_string_lossy().into_owned();
+    match bdd_infra::ServiceHandle::try_start(env!("CARGO_PKG_NAME"), &cfg_str).await {
+        Ok(handle) => {
+            world.service_handle = Some(handle);
+        }
+        Err(_) => {
+            world.run_wrapper_to_exit(cfg_path).await;
+        }
+    }
 }
 
 #[then("the wrapper exits non-zero")]
-async fn then_wrapper_exits_nonzero(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: assert world.last_wrapper_exit_code is Some(non-zero)")
+async fn then_wrapper_exits_nonzero(world: &mut PlateSolverWorld) {
+    let code = world
+        .last_wrapper_exit_code
+        .expect("wrapper exit code missing — did the When step run?");
+    assert_ne!(code, 0, "expected non-zero exit, got {code}");
 }
 
 #[then(expr = "the wrapper stderr names {string}")]
-async fn then_wrapper_stderr_names(_world: &mut PlateSolverWorld, _needle: String) {
-    todo!("Phase 4: assert world.last_wrapper_stderr.contains(needle)")
+async fn then_wrapper_stderr_names(world: &mut PlateSolverWorld, needle: String) {
+    let stderr = world
+        .last_wrapper_stderr
+        .as_deref()
+        .expect("wrapper stderr missing");
+    assert!(
+        stderr.contains(&needle),
+        "expected stderr to contain {needle:?}, got:\n{stderr}"
+    );
 }
 
 #[then("the wrapper stderr references the README")]
-async fn then_wrapper_stderr_references_readme(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: assert stderr contains 'README' or 'install instructions'")
+async fn then_wrapper_stderr_references_readme(world: &mut PlateSolverWorld) {
+    let stderr = world
+        .last_wrapper_stderr
+        .as_deref()
+        .expect("wrapper stderr missing");
+    assert!(
+        stderr.contains("README") || stderr.contains("install"),
+        "expected stderr to reference README/install, got:\n{stderr}"
+    );
 }
 
 #[then("the wrapper prints bound_addr to stdout")]
-async fn then_wrapper_prints_bound_addr(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: assert ServiceHandle parsed bound port from stdout")
+async fn then_wrapper_prints_bound_addr(world: &mut PlateSolverWorld) {
+    // ServiceHandle::start only returns when bound_addr was parsed
+    // from stdout — its presence in world.service_handle is the
+    // assertion. The .port field is a u16 set by parse_bound_port.
+    let handle = world
+        .service_handle
+        .as_ref()
+        .expect("service handle missing — wrapper didn't start?");
+    assert!(handle.port > 0, "expected non-zero bound port");
 }
 
 #[then("the wrapper /health returns 200")]
-async fn then_wrapper_health_returns_200(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: GET /health, assert 200")
+async fn then_wrapper_health_returns_200(world: &mut PlateSolverWorld) {
+    let url = format!("{}/health", world.wrapper_url());
+    let resp = reqwest::get(&url).await.expect("GET /health");
+    assert_eq!(resp.status(), 200);
+}
+
+fn copy_mock_astap(dir: &std::path::Path) -> PathBuf {
+    let src = PlateSolverWorld::mock_astap_path();
+    let dst = dir.join("astap_cli_mock");
+    std::fs::copy(&src, &dst).expect("copy mock_astap");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+    }
+    dst
+}
+
+fn make_db_dir(dir: &std::path::Path) -> PathBuf {
+    let p = dir.join("db");
+    std::fs::create_dir_all(&p).expect("mkdir db");
+    p
 }

--- a/services/rp-plate-solver/tests/bdd/steps/health_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/health_steps.rs
@@ -1,31 +1,53 @@
 //! Step definitions for `health.feature`.
-//!
-//! Phase 3 stubs. Bodies arrive in Phase 4.
 
-use crate::world::PlateSolverWorld;
+use crate::world::{HttpResponse, PlateSolverWorld};
 use cucumber::{given, when};
+use std::time::Instant;
 
 #[given("the wrapper is running with a temp-dir copy of mock_astap as its binary path")]
-async fn given_wrapper_running_with_temp_copy(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: copy mock_astap into world.temp_dir, point config at the copy, spawn wrapper")
+async fn given_wrapper_running_with_temp_copy(world: &mut PlateSolverWorld) {
+    world.start_wrapper_with_mock_copy().await;
 }
 
 #[given("the wrapper is running with a temp astap_db_directory")]
-async fn given_wrapper_running_with_temp_db(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: mkdir temp_dir/d05, point config there, spawn wrapper")
+async fn given_wrapper_running_with_temp_db(world: &mut PlateSolverWorld) {
+    // Same as the above — the temp-dir copy already uses a temp db.
+    world.start_wrapper_with_mock_copy().await;
 }
 
 #[when("I delete the configured astap_binary_path")]
-async fn when_delete_configured_binary(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: std::fs::remove_file(world.astap_binary_path)")
+async fn when_delete_configured_binary(world: &mut PlateSolverWorld) {
+    let p = world
+        .astap_binary_path
+        .as_ref()
+        .expect("astap_binary_path not set");
+    std::fs::remove_file(p).expect("remove configured binary");
 }
 
 #[when("I delete the configured astap_db_directory")]
-async fn when_delete_configured_db(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: std::fs::remove_dir_all(world.astap_db_directory)")
+async fn when_delete_configured_db(world: &mut PlateSolverWorld) {
+    let p = world
+        .astap_db_directory
+        .as_ref()
+        .expect("astap_db_directory not set");
+    std::fs::remove_dir_all(p).expect("remove configured db dir");
 }
 
 #[when("I GET /health")]
-async fn when_get_health(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: GET wrapper.base_url + /health, capture into world.last_response")
+async fn when_get_health(world: &mut PlateSolverWorld) {
+    // Lazy spawn for scenarios whose only "Given" was the marker
+    // "the wrapper is running with mock_astap as its solver"
+    // (defined in solve_steps.rs as a no-op). Health scenarios that
+    // use `start_wrapper_with_mock_copy` already have a handle.
+    if world.service_handle.is_none() {
+        world.start_wrapper_with_mock().await;
+    }
+    let url = format!("{}/health", world.wrapper_url());
+    let started = Instant::now();
+    let resp = reqwest::get(&url).await.expect("GET /health");
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.expect("read body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    world.last_response_elapsed = Some(started.elapsed());
+    world.last_response = Some(HttpResponse { status, body });
 }

--- a/services/rp-plate-solver/tests/bdd/steps/real_astap_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/real_astap_steps.rs
@@ -1,26 +1,75 @@
 //! Step definitions for `real_astap_smoke.feature`.
 //!
-//! Phase 3 stubs. Bodies arrive in Phase 4. Note that
 //! `@requires-astap` keeps these from running in PR jobs even after
-//! Phase 4 removes `@wip`.
+//! Phase 4 removed `@wip` — the dedicated nightly cross-platform
+//! workflow (Phase 6) sets `ASTAP_BINARY` so they fire there only.
+//! Phase 4 ships the test bodies; Phase 6 wires the cron + matrix.
 
 use crate::world::PlateSolverWorld;
+use bdd_infra::ServiceHandle;
 use cucumber::given;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[given("the wrapper is running with the real ASTAP_BINARY as its solver")]
-async fn given_wrapper_with_real_astap(_world: &mut PlateSolverWorld) {
-    todo!(
-        "Phase 4: read ASTAP_BINARY env var (set by the nightly install-astap workflow); \
-         start the wrapper pointing at it"
-    )
+async fn given_wrapper_with_real_astap(world: &mut PlateSolverWorld) {
+    let astap_path = std::env::var("ASTAP_BINARY")
+        .map(PathBuf::from)
+        .expect("ASTAP_BINARY env var must be set for @requires-astap scenarios");
+    let astap_db = std::env::var("ASTAP_DB_DIR")
+        .map(PathBuf::from)
+        .expect("ASTAP_DB_DIR env var must be set for @requires-astap scenarios");
+
+    let dir = world.temp_dir_path();
+    let extra_env: HashMap<String, String> = HashMap::new();
+    let cfg_path = write_real_config(&dir, &astap_path, &astap_db, &extra_env);
+
+    world.astap_binary_path = Some(astap_path);
+    world.astap_db_directory = Some(astap_db);
+    let cfg_str = cfg_path.to_string_lossy().into_owned();
+    let handle = ServiceHandle::start(env!("CARGO_PKG_NAME"), &cfg_str).await;
+    world.service_handle = Some(handle);
 }
 
 #[given("the m31_known.fits fixture is on disk")]
-async fn given_m31_fixture(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: copy tests/fixtures/m31_known.fits into temp_dir, store path in world")
+async fn given_m31_fixture(world: &mut PlateSolverWorld) {
+    let fixture_src = fixture_path("m31_known.fits");
+    let dir = world.temp_dir_path();
+    let dst = dir.join("m31_known.fits");
+    std::fs::copy(&fixture_src, &dst).expect("copy m31 fixture");
+    world.fits_path = Some(dst);
 }
 
 #[given("the degenerate_no_stars.fits fixture is on disk")]
-async fn given_degenerate_fixture(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: same shape as m31; the degenerate fixture exists for solve_failed coverage")
+async fn given_degenerate_fixture(world: &mut PlateSolverWorld) {
+    let fixture_src = fixture_path("degenerate_no_stars.fits");
+    let dir = world.temp_dir_path();
+    let dst = dir.join("degenerate_no_stars.fits");
+    std::fs::copy(&fixture_src, &dst).expect("copy degenerate fixture");
+    world.fits_path = Some(dst);
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    let manifest =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set; run via cargo");
+    PathBuf::from(manifest).join("tests/fixtures").join(name)
+}
+
+fn write_real_config(
+    dir: &std::path::Path,
+    binary: &std::path::Path,
+    db: &std::path::Path,
+    extra_env: &HashMap<String, String>,
+) -> PathBuf {
+    let body = serde_json::json!({
+        "bind_address": "127.0.0.1",
+        "port": 0,
+        "astap_binary_path": binary.to_string_lossy(),
+        "astap_db_directory": db.to_string_lossy(),
+        "astap_extra_env": extra_env,
+    })
+    .to_string();
+    let p = dir.join("config.json");
+    std::fs::write(&p, body).expect("write config");
+    p
 }

--- a/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
@@ -1,138 +1,281 @@
-//! Step definitions for `solve_request.feature` — and shared HTTP /
+//! Step definitions for `solve_request.feature` and shared HTTP /
 //! response-assertion phrases reused by other feature files.
 //!
-//! Phase 3 stubs. Bodies arrive in Phase 4.
+//! Wrapper-startup is lazy: the "Given the wrapper is running…" step
+//! marks intent only; the real spawn happens on first HTTP request,
+//! by which time per-scenario `mock_astap_mode` / `argv_out_path` /
+//! `astap_extra_env` state has been accumulated.
 
-use crate::world::PlateSolverWorld;
+use crate::world::{HttpResponse, PlateSolverWorld};
 use cucumber::{given, then, when};
+use std::time::Instant;
 
 // ----- shared "Given the wrapper is running" used across features -----
 
 #[given("the wrapper is running with mock_astap as its solver")]
 async fn given_wrapper_running_with_mock(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: write config pointing at mock_astap, spawn wrapper, store handle in world")
+    // Lazy: real spawn happens on first HTTP request.
 }
 
 // ----- mock_astap mode setup -----
 
 #[given(expr = "mock_astap is configured for {string} mode")]
-async fn given_mock_astap_mode(_world: &mut PlateSolverWorld, _mode: String) {
-    todo!("Phase 4: store the mode for the next solve request to set MOCK_ASTAP_MODE on the spawned child")
+async fn given_mock_astap_mode(world: &mut PlateSolverWorld, mode: String) {
+    world.mock_astap_mode = Some(mode);
 }
 
 #[given("mock_astap is configured to write argv to a side-channel file")]
-async fn given_mock_astap_argv_out(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: set MOCK_ASTAP_ARGV_OUT on the spawned child to a temp file path; store path in world.argv_out_path")
+async fn given_mock_astap_argv_out(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let p = dir.join("argv_out.txt");
+    world.argv_out_path = Some(p);
 }
 
 #[given("a writable FITS path")]
-async fn given_writable_fits_path(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: create a unique FITS file under world.temp_dir, store path in world")
+async fn given_writable_fits_path(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let p = dir.join("test.fits");
+    std::fs::write(&p, b"placeholder").expect("touch FITS");
+    world.fits_path = Some(p);
 }
 
 #[given("a non-existent FITS path")]
-async fn given_non_existent_fits_path(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: build an absolute path under world.temp_dir that we never create")
+async fn given_non_existent_fits_path(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let p = dir.join("does_not_exist.fits");
+    // Intentionally do NOT create the file.
+    world.fits_path = Some(p);
 }
 
 // ----- when: HTTP requests -----
 //
 // Note on the `\\/` escapes in `expr = "..."` patterns below: cucumber
-// expressions interpret bare `/` as alternation (e.g., `red/blue`
-// matches `red` or `blue`). A literal `/api/v1/solve` triggers a
-// compile error: "An alternation can not be empty." `\\/` in the Rust
-// string yields `\/` in the cucumber expression, the documented
-// escape for a literal `/`. The literal-string form (no `expr =`) is
-// not a cucumber expression and accepts bare `/`, which is why the
-// next step works without escaping.
+// expressions interpret bare `/` as alternation (`red/blue` matches
+// `red` or `blue`). A literal `/api/v1/solve` triggers a compile
+// error: "An alternation can not be empty." `\\/` in the Rust
+// string yields `\/` in the cucumber expression — the documented
+// escape for a literal `/`. The literal-string form (no `expr =`)
+// is not a cucumber expression and accepts bare `/`, which is why
+// the next step works without escaping.
 
 #[when("I POST to /api/v1/solve with that fits_path")]
-async fn when_post_solve_with_fits_path(_world: &mut PlateSolverWorld) {
-    todo!(
-        "Phase 4: build solve request, POST to wrapper, capture response into world.last_response"
-    )
+async fn when_post_solve_with_fits_path(world: &mut PlateSolverWorld) {
+    ensure_wrapper(world).await;
+    let body = serde_json::json!({
+        "fits_path": world.fits_path.as_ref().expect("fits_path"),
+    });
+    do_post(world, body).await;
 }
 
 #[when(expr = "I POST to \\/api\\/v1\\/solve with fits_path {string}")]
-async fn when_post_solve_with_explicit_path(_world: &mut PlateSolverWorld, _path: String) {
-    todo!("Phase 4")
+async fn when_post_solve_with_explicit_path(world: &mut PlateSolverWorld, path: String) {
+    ensure_wrapper(world).await;
+    let body = serde_json::json!({
+        "fits_path": path,
+    });
+    do_post(world, body).await;
 }
 
 #[when(expr = "I POST to \\/api\\/v1\\/solve with raw body {string}")]
-async fn when_post_solve_with_raw_body(_world: &mut PlateSolverWorld, _body: String) {
-    todo!("Phase 4: POST raw bytes (no JSON wrapping) to test invalid_request decode path")
+async fn when_post_solve_with_raw_body(world: &mut PlateSolverWorld, raw: String) {
+    ensure_wrapper(world).await;
+    let url = format!("{}/api/v1/solve", world.wrapper_url());
+    let started = Instant::now();
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .body(raw)
+        .send()
+        .await
+        .expect("POST");
+    record_response(world, resp, started).await;
 }
 
 #[when(expr = "I POST to \\/api\\/v1\\/solve with that fits_path and timeout {string}")]
-async fn when_post_solve_with_timeout(_world: &mut PlateSolverWorld, _timeout: String) {
-    todo!("Phase 4")
+async fn when_post_solve_with_timeout(world: &mut PlateSolverWorld, timeout: String) {
+    ensure_wrapper(world).await;
+    let body = serde_json::json!({
+        "fits_path": world.fits_path.as_ref().expect("fits_path"),
+        "timeout": timeout,
+    });
+    do_post(world, body).await;
 }
 
 #[when(expr = "I POST to \\/api\\/v1\\/solve with that fits_path and hint {word} set to {word}")]
-async fn when_post_solve_with_hint(_world: &mut PlateSolverWorld, _field: String, _value: String) {
-    todo!("Phase 4: parse field/value, build request with that hint set, POST")
+async fn when_post_solve_with_hint(world: &mut PlateSolverWorld, field: String, value: String) {
+    ensure_wrapper(world).await;
+    let value_f: f64 = value
+        .parse()
+        .unwrap_or_else(|_| panic!("hint value not f64: {value}"));
+    world.pending_hint = Some((field.clone(), value_f));
+    let mut body = serde_json::json!({
+        "fits_path": world.fits_path.as_ref().expect("fits_path"),
+    });
+    body[field] = serde_json::Value::from(value_f);
+    do_post(world, body).await;
 }
 
 // ----- then: response assertions (shared across feature files) -----
 
 #[then(expr = "the response status is {int}")]
-async fn then_response_status_is(_world: &mut PlateSolverWorld, _status: u16) {
-    todo!("Phase 4: assert world.last_response.status == status")
+async fn then_response_status_is(world: &mut PlateSolverWorld, status: u16) {
+    let actual = world
+        .last_response
+        .as_ref()
+        .expect("no response captured")
+        .status;
+    assert_eq!(
+        actual,
+        status,
+        "expected {status}, got {actual}; body={:?}",
+        world.last_response.as_ref().unwrap().body
+    );
 }
 
 #[then(expr = "the response field {string} is {string}")]
 async fn then_response_field_is_string(
-    _world: &mut PlateSolverWorld,
-    _path: String,
-    _expected: String,
+    world: &mut PlateSolverWorld,
+    path: String,
+    expected: String,
 ) {
-    todo!("Phase 4: jsonpath into world.last_response.body, assert equals expected")
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_s = actual.as_str().expect("not a string");
+    assert_eq!(
+        actual_s, expected,
+        "field {path}: expected {expected:?}, got {actual_s:?}"
+    );
 }
 
 #[then(expr = "the response field {string} is {int}")]
-async fn then_response_field_is_int(_world: &mut PlateSolverWorld, _path: String, _expected: i64) {
-    todo!("Phase 4")
+async fn then_response_field_is_int(world: &mut PlateSolverWorld, path: String, expected: i64) {
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_i = actual.as_i64().expect("not an int");
+    assert_eq!(actual_i, expected);
 }
 
 #[then(expr = "the response field {string} is approximately {float}")]
-async fn then_response_field_approx(_world: &mut PlateSolverWorld, _path: String, _expected: f64) {
-    todo!("Phase 4: assert |actual - expected| < default tolerance (e.g., 1e-3)")
+async fn then_response_field_approx(world: &mut PlateSolverWorld, path: String, expected: f64) {
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_f = actual.as_f64().expect("not a float");
+    let tol = 1e-2;
+    assert!(
+        (actual_f - expected).abs() < tol,
+        "field {path}: expected ~{expected}, got {actual_f}"
+    );
 }
 
 #[then(expr = "the response field {string} is approximately {float} within {float} degrees")]
 async fn then_response_field_approx_within(
-    _world: &mut PlateSolverWorld,
-    _path: String,
-    _expected: f64,
-    _tolerance: f64,
+    world: &mut PlateSolverWorld,
+    path: String,
+    expected: f64,
+    tolerance: f64,
 ) {
-    todo!("Phase 4: assert |actual - expected| < tolerance")
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_f = actual.as_f64().expect("not a float");
+    assert!(
+        (actual_f - expected).abs() < tolerance,
+        "field {path}: expected {expected} ± {tolerance}, got {actual_f}"
+    );
 }
 
 #[then(expr = "the response field {string} contains {string}")]
-async fn then_response_field_contains(
-    _world: &mut PlateSolverWorld,
-    _path: String,
-    _needle: String,
-) {
-    todo!("Phase 4")
+async fn then_response_field_contains(world: &mut PlateSolverWorld, path: String, needle: String) {
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_s = actual.as_str().expect("not a string");
+    assert!(
+        actual_s.contains(&needle),
+        "field {path}: expected to contain {needle:?}, got {actual_s:?}"
+    );
 }
 
 #[then(expr = "the response field {string} contains {string} case-insensitively")]
 async fn then_response_field_contains_ci(
-    _world: &mut PlateSolverWorld,
-    _path: String,
-    _needle: String,
+    world: &mut PlateSolverWorld,
+    path: String,
+    needle: String,
 ) {
-    todo!("Phase 4: lowercase both sides and compare; matches both ASTAP and astap")
+    let actual = json_at(world, &path).expect("path missing");
+    let actual_s = actual.as_str().expect("not a string");
+    assert!(
+        actual_s.to_lowercase().contains(&needle.to_lowercase()),
+        "field {path}: expected to contain {needle:?} (case-insensitive), got {actual_s:?}"
+    );
 }
 
 #[then(expr = "the spawned argv contains the flag {string}")]
-async fn then_argv_contains_flag(_world: &mut PlateSolverWorld, _flag: String) {
-    todo!("Phase 4: read world.argv_out_path, parse argv, assert presence of flag")
+async fn then_argv_contains_flag(world: &mut PlateSolverWorld, flag: String) {
+    let argv = read_argv(world);
+    assert!(
+        argv.iter().any(|a| a == &flag),
+        "argv missing flag {flag:?}: {argv:?}"
+    );
 }
 
 #[then(expr = "the spawned argv value after {string} is approximately {float}")]
-async fn then_argv_value_after_flag(_world: &mut PlateSolverWorld, _flag: String, _expected: f64) {
-    todo!("Phase 4: read argv, find flag, parse the next token as f64, compare")
+async fn then_argv_value_after_flag(world: &mut PlateSolverWorld, flag: String, expected: f64) {
+    let argv = read_argv(world);
+    let idx = argv
+        .iter()
+        .position(|a| a == &flag)
+        .unwrap_or_else(|| panic!("argv missing flag {flag:?}: {argv:?}"));
+    let value: f64 = argv
+        .get(idx + 1)
+        .expect("no value after flag")
+        .parse()
+        .expect("non-numeric value");
+    assert!(
+        (value - expected).abs() < 1e-3,
+        "argv value after {flag:?}: expected ~{expected}, got {value}"
+    );
+}
+
+// ----- helpers -----
+
+async fn ensure_wrapper(world: &mut PlateSolverWorld) {
+    if world.service_handle.is_none() {
+        world.start_wrapper_with_mock().await;
+    }
+}
+
+async fn do_post(world: &mut PlateSolverWorld, body: serde_json::Value) {
+    let url = format!("{}/api/v1/solve", world.wrapper_url());
+    let started = Instant::now();
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .expect("POST");
+    record_response(world, resp, started).await;
+}
+
+async fn record_response(world: &mut PlateSolverWorld, resp: reqwest::Response, started: Instant) {
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.expect("read body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    world.last_response_elapsed = Some(started.elapsed());
+    world.last_response = Some(HttpResponse { status, body });
+}
+
+/// Walk a dotted JSON path into the response body.
+fn json_at<'a>(world: &'a PlateSolverWorld, path: &str) -> Option<&'a serde_json::Value> {
+    let body = &world.last_response.as_ref()?.body;
+    let mut cur = body;
+    for seg in path.split('.') {
+        cur = cur.get(seg)?;
+    }
+    Some(cur)
+}
+
+fn read_argv(world: &PlateSolverWorld) -> Vec<String> {
+    let p = world
+        .argv_out_path
+        .as_ref()
+        .expect("argv_out_path not set — Given step missing?");
+    let s = std::fs::read_to_string(p).expect("read argv_out");
+    s.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
 }

--- a/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/solve_steps.rs
@@ -47,6 +47,33 @@ async fn given_non_existent_fits_path(world: &mut PlateSolverWorld) {
     world.fits_path = Some(p);
 }
 
+#[given("a fits_path pointing at a directory")]
+async fn given_fits_path_is_directory(world: &mut PlateSolverWorld) {
+    let dir = world.temp_dir_path();
+    let p = dir.join("not_a_file.fits");
+    std::fs::create_dir_all(&p).expect("mkdir fits-as-dir");
+    world.fits_path = Some(p);
+}
+
+// The "unreadable FITS" scenario is gated `@unix` in the feature file.
+// On Windows the simple `chmod 000` trick doesn't deny read (file ACLs
+// override mode bits, and the test runner typically has override
+// privileges); covering that branch reliably would need DENY ACLs or
+// file locks, which isn't worth the complexity until a real Windows
+// failure mode surfaces.
+#[given("an unreadable FITS path")]
+#[cfg(unix)]
+async fn given_unreadable_fits_path(world: &mut PlateSolverWorld) {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = world.temp_dir_path();
+    let p = dir.join("unreadable.fits");
+    std::fs::write(&p, b"placeholder").expect("touch FITS");
+    // Mode 000: no read for owner/group/other. `File::open` returns
+    // EACCES on the wrapper's open-check.
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+    world.fits_path = Some(p);
+}
+
 // ----- when: HTTP requests -----
 //
 // Note on the `\\/` escapes in `expr = "..."` patterns below: cucumber

--- a/services/rp-plate-solver/tests/bdd/steps/supervision_steps.rs
+++ b/services/rp-plate-solver/tests/bdd/steps/supervision_steps.rs
@@ -1,31 +1,82 @@
 //! Step definitions for `subprocess_supervision.feature`.
-//!
-//! Phase 3 stubs. Bodies arrive in Phase 4.
 
-use crate::world::PlateSolverWorld;
+use crate::world::{ConcurrentResult, PlateSolverWorld};
 use cucumber::{then, when};
+use std::time::{Duration, Instant};
 
 #[when(expr = "I POST two concurrent solve requests with timeout {string} each")]
-async fn when_two_concurrent_solves(_world: &mut PlateSolverWorld, _timeout: String) {
-    todo!("Phase 4: spawn two solve tasks via tokio::join!; capture both responses + timing into world")
+async fn when_two_concurrent_solves(world: &mut PlateSolverWorld, timeout: String) {
+    // Make sure the wrapper is up before launching parallel requests.
+    if world.service_handle.is_none() {
+        world.start_wrapper_with_mock().await;
+    }
+    let url = format!("{}/api/v1/solve", world.wrapper_url());
+    let fits = world.fits_path.as_ref().expect("fits_path").clone();
+    let body = serde_json::json!({ "fits_path": fits, "timeout": timeout });
+
+    let client = reqwest::Client::new();
+    let make_request = || {
+        let url = url.clone();
+        let body = body.clone();
+        let client = client.clone();
+        async move {
+            let resp = client.post(&url).json(&body).send().await.expect("POST");
+            ConcurrentResult {
+                status: resp.status().as_u16(),
+                completed_at: Instant::now(),
+            }
+        }
+    };
+
+    let (a, b) = tokio::join!(make_request(), make_request());
+    world.concurrent_results = vec![a, b];
 }
 
 #[then("both responses have status 504")]
-async fn then_both_responses_504(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4")
+async fn then_both_responses_504(world: &mut PlateSolverWorld) {
+    assert_eq!(world.concurrent_results.len(), 2);
+    for r in &world.concurrent_results {
+        assert_eq!(r.status, 504, "expected both 504, got {r:?}");
+    }
 }
 
 #[then("the second request's spawn time is after the first request's exit time")]
-async fn then_second_after_first(_world: &mut PlateSolverWorld) {
-    todo!("Phase 4: read MOCK_ASTAP_ARGV_OUT timestamps from each spawn; assert ordering")
+async fn then_second_after_first(world: &mut PlateSolverWorld) {
+    // The two HTTP requests are launched ~simultaneously by the test
+    // — `started_at` is the test's send-time, not when the wrapper
+    // started processing. The semaphore's serialization is observable
+    // instead via the gap between completion times: a serialized
+    // pair completes ~per_request_time apart, while a parallel pair
+    // completes within a few ms.
+    //
+    // With `mock_astap=hang` and timeout=100ms, each request takes
+    // ~100ms wall-clock (timeout fires, mock_astap exits on SIGTERM
+    // promptly). Serialized → ~100ms gap; parallel → near 0.
+    let mut sorted = world.concurrent_results.clone();
+    sorted.sort_by_key(|r| r.completed_at);
+    let first = &sorted[0];
+    let second = &sorted[1];
+    let gap = second.completed_at.duration_since(first.completed_at);
+    assert!(
+        gap >= Duration::from_millis(50),
+        "single-flight failed: completion gap {gap:?} too small (parallel?)"
+    );
 }
 
 #[then(expr = "the response time is at most {int} milliseconds")]
-async fn then_response_time_at_most(_world: &mut PlateSolverWorld, _ms: u64) {
-    todo!("Phase 4")
+async fn then_response_time_at_most(world: &mut PlateSolverWorld, ms: u64) {
+    let elapsed = world.last_response_elapsed.expect("no elapsed");
+    assert!(
+        elapsed <= Duration::from_millis(ms),
+        "elapsed {elapsed:?} > {ms}ms"
+    );
 }
 
 #[then(expr = "the response time is at least {int} milliseconds")]
-async fn then_response_time_at_least(_world: &mut PlateSolverWorld, _ms: u64) {
-    todo!("Phase 4")
+async fn then_response_time_at_least(world: &mut PlateSolverWorld, ms: u64) {
+    let elapsed = world.last_response_elapsed.expect("no elapsed");
+    assert!(
+        elapsed >= Duration::from_millis(ms),
+        "elapsed {elapsed:?} < {ms}ms"
+    );
 }

--- a/services/rp-plate-solver/tests/bdd/world.rs
+++ b/services/rp-plate-solver/tests/bdd/world.rs
@@ -196,10 +196,24 @@ impl PlateSolverWorld {
     }
 }
 
-/// Locate the `rp-plate-solver` binary. Mirrors
-/// `bdd_infra::find_binary` (whose impl is private) because
-/// `ServiceHandle::start` waits for `bound_addr=` on stdout, which
-/// the configuration-error scenarios never reach.
+/// Locate the `rp-plate-solver` binary. Mirrors `bdd_infra::find_binary`
+/// (whose impl is private) including the precedence rules the original
+/// uses for cross-compile / coverage / sanitizer builds:
+///
+/// 1. Explicit `RP_PLATE_SOLVER_BINARY` env var.
+/// 2. `CARGO_TARGET_DIR` or `CARGO_LLVM_COV_TARGET_DIR` (whichever
+///    is set), with `CARGO_BUILD_TARGET` triple subdir prepended when
+///    set. When either is set we honor it *exclusively* — falling
+///    through to walk-up could silently pick up a stale,
+///    non-instrumented binary at `target/debug/<pkg>` and skip
+///    coverage data collection.
+/// 3. Walk up from cwd looking for `target/debug/<bin>` (and the
+///    `CARGO_BUILD_TARGET`-qualified variant).
+///
+/// `ServiceHandle::start` waits for `bound_addr=` on stdout, which the
+/// configuration-error scenarios never reach — that's why
+/// configuration scenarios spawn the wrapper themselves via this
+/// helper rather than going through `ServiceHandle`.
 fn find_wrapper_binary() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("RP_PLATE_SOLVER_BINARY") {
         let p = PathBuf::from(path);
@@ -212,18 +226,35 @@ fn find_wrapper_binary() -> Option<PathBuf> {
     } else {
         "rp-plate-solver"
     };
-    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR") {
-        let p = PathBuf::from(dir).join("debug").join(bin_name);
+    let triple = std::env::var("CARGO_BUILD_TARGET").ok();
+
+    let candidate = |target_dir: &std::path::Path| -> Option<PathBuf> {
+        if let Some(triple) = triple.as_deref() {
+            let p = target_dir.join(triple).join("debug").join(bin_name);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+        let p = target_dir.join("debug").join(bin_name);
         if p.exists() {
             return Some(p);
         }
+        None
+    };
+
+    // Honor CARGO_TARGET_DIR / CARGO_LLVM_COV_TARGET_DIR exclusively
+    // when set (matches bdd_infra::find_binary's behavior).
+    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR")
+        .or_else(|| std::env::var_os("CARGO_LLVM_COV_TARGET_DIR"))
+    {
+        return candidate(std::path::Path::new(&dir));
     }
+
     // Walk up from cwd looking for target/debug/<bin>.
     let mut cur = std::env::current_dir().ok()?;
     loop {
-        let candidate = cur.join("target").join("debug").join(bin_name);
-        if candidate.exists() {
-            return Some(candidate);
+        if let Some(p) = candidate(&cur.join("target")) {
+            return Some(p);
         }
         if !cur.pop() {
             return None;

--- a/services/rp-plate-solver/tests/bdd/world.rs
+++ b/services/rp-plate-solver/tests/bdd/world.rs
@@ -3,22 +3,14 @@
 //! The world accumulates state across Given / When / Then steps:
 //! the spawned wrapper handle, the temp directory holding fixtures and
 //! configs, and the most recent HTTP response body / status / timing.
-//!
-//! All scenarios under `tests/features/` are tagged `@wip` for Phase 3
-//! per `docs/plans/rp-plate-solver.md`; the `@wip` filter in
-//! `tests/bdd.rs` skips them at runtime so the default suite stays
-//! green until Phase 4 wires the wrapper binary.
 
 use bdd_infra::ServiceHandle;
 use cucumber::World;
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
-#[allow(dead_code)]
-// Phase 3 stubs touch every field via `todo!()`-bodied
-// step definitions but never *use* them at runtime.
-// Phase 4 wires the bodies and these allows go away.
 #[derive(Debug, Default, World)]
 pub struct PlateSolverWorld {
     /// Handle to the spawned `rp-plate-solver` binary. None until a
@@ -27,55 +19,69 @@ pub struct PlateSolverWorld {
     pub service_handle: Option<ServiceHandle>,
 
     /// Per-scenario temp dir holding the config file, FITS placeholder,
-    /// and any temp-dir copy of `mock_astap`. Dropped at scenario end
-    /// (cleans up via `tempfile::TempDir`).
+    /// and any temp-dir copy of `mock_astap`.
     pub temp_dir: Option<TempDir>,
 
-    /// Path to the `astap_binary_path` the wrapper was started with.
-    /// Some scenarios rewrite or delete this between steps (e.g.,
-    /// `health.feature`'s "I delete the configured binary").
+    /// `astap_binary_path` the wrapper was started with. Some scenarios
+    /// rewrite or delete this between steps.
     pub astap_binary_path: Option<PathBuf>,
 
-    /// Path to the `astap_db_directory` the wrapper was started with.
-    /// Same lifecycle as above.
+    /// `astap_db_directory` the wrapper was started with.
     pub astap_db_directory: Option<PathBuf>,
 
+    /// FITS path the most recent solve request used.
+    pub fits_path: Option<PathBuf>,
+
     /// Path that `mock_astap` writes received argv to when
-    /// `MOCK_ASTAP_ARGV_OUT` is set on its env. Read by argv-flow
-    /// assertions in `solve_request.feature`.
+    /// `MOCK_ASTAP_ARGV_OUT` is set on its env.
     pub argv_out_path: Option<PathBuf>,
+
+    /// Mode for the next wrapper spawn (passed via `astap_extra_env`).
+    pub mock_astap_mode: Option<String>,
 
     /// Result of the most recent HTTP request (status + body).
     pub last_response: Option<HttpResponse>,
 
-    /// Elapsed wall time of the most recent request, used by
-    /// `subprocess_supervision.feature`'s timing assertions.
+    /// Elapsed wall time of the most recent request.
     pub last_response_elapsed: Option<Duration>,
 
-    /// Wrapper stderr after exit — populated by configuration
-    /// scenarios that probe non-zero-exit error messages.
+    /// Wrapper stderr after exit (configuration scenarios that wait
+    /// for the wrapper to exit non-zero).
     pub last_wrapper_stderr: Option<String>,
 
-    /// Wrapper exit status, when the scenario waited for the wrapper
-    /// to exit (vs. starting it and leaving it running).
+    /// Wrapper exit status when the scenario waited for the wrapper to
+    /// exit (vs. starting it and leaving it running).
     pub last_wrapper_exit_code: Option<i32>,
+
+    /// For the Scenario Outline that POSTs with a single hint set,
+    /// step state populated by the "with that fits_path and hint X
+    /// set to Y" When step.
+    pub pending_hint: Option<(String, f64)>,
+
+    /// Concurrent-request timings for the supervision feature.
+    pub concurrent_results: Vec<ConcurrentResult>,
+
+    /// Configuration JSON being accumulated by `configuration.feature`'s
+    /// composing Given steps. Materialized to disk by the
+    /// `When the wrapper starts` step.
+    pub pending_config: serde_json::Map<String, serde_json::Value>,
 }
 
-#[allow(dead_code)] // Phase 3 stubs; populated and read in Phase 4.
 #[derive(Debug, Clone)]
 pub struct HttpResponse {
     pub status: u16,
     pub body: serde_json::Value,
 }
 
+#[derive(Debug, Clone)]
+pub struct ConcurrentResult {
+    pub status: u16,
+    pub completed_at: Instant,
+}
+
 impl PlateSolverWorld {
     /// Locate the in-tree `mock_astap` binary the same way
-    /// `tests/supervision_integration.rs` does: `MOCK_ASTAP_BINARY`
-    /// env var (Bazel) → `option_env!("CARGO_BIN_EXE_mock_astap")`
-    /// (Cargo). Panics with a diagnostic if neither resolves —
-    /// matches the supervision integration test's hard-failure
-    /// posture.
-    #[allow(dead_code)] // Used by Phase 4 step bodies.
+    /// `tests/supervision_integration.rs` does.
     pub fn mock_astap_path() -> PathBuf {
         if let Ok(p) = std::env::var("MOCK_ASTAP_BINARY") {
             let path = PathBuf::from(p);
@@ -94,4 +100,153 @@ impl PlateSolverWorld {
              CARGO_BIN_EXE_mock_astap. Run `cargo build --tests -p rp-plate-solver`."
         )
     }
+
+    /// Lazily create the per-scenario temp dir.
+    pub fn temp_dir_path(&mut self) -> PathBuf {
+        if self.temp_dir.is_none() {
+            self.temp_dir = Some(TempDir::new().expect("create temp dir"));
+        }
+        self.temp_dir.as_ref().unwrap().path().to_path_buf()
+    }
+
+    /// Wrapper base URL (e.g., `http://127.0.0.1:11131`). Panics if
+    /// the wrapper hasn't been started.
+    pub fn wrapper_url(&self) -> String {
+        let handle = self
+            .service_handle
+            .as_ref()
+            .expect("wrapper not started — Given step missing?");
+        format!("http://127.0.0.1:{}", handle.port)
+    }
+
+    /// Build a config pointing at `mock_astap` with the configured
+    /// mode (if any), write it under temp_dir, and start the wrapper
+    /// via `ServiceHandle`. Stores all paths in the world.
+    pub async fn start_wrapper_with_mock(&mut self) {
+        let mock_path = Self::mock_astap_path();
+        let dir = self.temp_dir_path();
+        let db_dir = dir.join("db");
+        std::fs::create_dir_all(&db_dir).expect("mkdir db");
+
+        let mut extra_env: HashMap<String, String> = HashMap::new();
+        if let Some(mode) = self.mock_astap_mode.clone() {
+            extra_env.insert("MOCK_ASTAP_MODE".to_string(), mode);
+        }
+        if let Some(p) = self.argv_out_path.clone() {
+            extra_env.insert("MOCK_ASTAP_ARGV_OUT".to_string(), p.display().to_string());
+        }
+
+        self.astap_binary_path = Some(mock_path.clone());
+        self.astap_db_directory = Some(db_dir.clone());
+
+        let config_path = write_config(&dir, &mock_path, &db_dir, &extra_env);
+        let config_str = config_path.to_string_lossy().into_owned();
+        let handle = ServiceHandle::start(env!("CARGO_PKG_NAME"), &config_str).await;
+        self.service_handle = Some(handle);
+    }
+
+    /// Variant for `health.feature` scenarios that need to mutate the
+    /// configured paths after startup. Copies `mock_astap` into the
+    /// temp dir and points the config at the copy.
+    pub async fn start_wrapper_with_mock_copy(&mut self) {
+        let dir = self.temp_dir_path();
+        let mock_src = Self::mock_astap_path();
+        let mock_dst = dir.join("mock_astap_copy");
+        std::fs::copy(&mock_src, &mock_dst).expect("copy mock_astap");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&mock_dst, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod mock_astap copy");
+        }
+        let db_dir = dir.join("db");
+        std::fs::create_dir_all(&db_dir).expect("mkdir db");
+
+        self.astap_binary_path = Some(mock_dst.clone());
+        self.astap_db_directory = Some(db_dir.clone());
+
+        let extra_env: HashMap<String, String> = HashMap::new();
+        let config_path = write_config(&dir, &mock_dst, &db_dir, &extra_env);
+        let config_str = config_path.to_string_lossy().into_owned();
+        let handle = ServiceHandle::start(env!("CARGO_PKG_NAME"), &config_str).await;
+        self.service_handle = Some(handle);
+    }
+
+    /// Run the wrapper to completion (rather than leaving it
+    /// running). Used by configuration scenarios that assert on
+    /// validation-failure exit codes.
+    ///
+    /// `ServiceHandle` is wrong for this case because it waits for
+    /// `bound_addr=` on stdout, which never arrives if the wrapper
+    /// exits during config validation. So we replicate `bdd-infra`'s
+    /// binary-discovery logic inline and run the binary to completion
+    /// via `tokio::process::Command::output()`.
+    pub async fn run_wrapper_to_exit(&mut self, config_path: PathBuf) {
+        let binary = find_wrapper_binary().expect(
+            "rp-plate-solver binary not found. Run `cargo build -p rp-plate-solver` first.",
+        );
+        let output = tokio::process::Command::new(binary)
+            .arg("--config")
+            .arg(&config_path)
+            .output()
+            .await
+            .expect("spawn wrapper");
+        self.last_wrapper_exit_code = Some(output.status.code().unwrap_or(-1));
+        self.last_wrapper_stderr = Some(String::from_utf8_lossy(&output.stderr).into_owned());
+    }
+}
+
+/// Locate the `rp-plate-solver` binary. Mirrors
+/// `bdd_infra::find_binary` (whose impl is private) because
+/// `ServiceHandle::start` waits for `bound_addr=` on stdout, which
+/// the configuration-error scenarios never reach.
+fn find_wrapper_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("RP_PLATE_SOLVER_BINARY") {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let bin_name = if cfg!(target_os = "windows") {
+        "rp-plate-solver.exe"
+    } else {
+        "rp-plate-solver"
+    };
+    if let Some(dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let p = PathBuf::from(dir).join("debug").join(bin_name);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    // Walk up from cwd looking for target/debug/<bin>.
+    let mut cur = std::env::current_dir().ok()?;
+    loop {
+        let candidate = cur.join("target").join("debug").join(bin_name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+/// Write a JSON config to `dir/config.json` and return the path.
+fn write_config(
+    dir: &std::path::Path,
+    binary_path: &std::path::Path,
+    db_directory: &std::path::Path,
+    extra_env: &HashMap<String, String>,
+) -> PathBuf {
+    let body = serde_json::json!({
+        "bind_address": "127.0.0.1",
+        "port": 0,  // OS picks a free port; ServiceHandle parses it from stdout
+        "astap_binary_path": binary_path.to_string_lossy(),
+        "astap_db_directory": db_directory.to_string_lossy(),
+        "astap_extra_env": extra_env,
+    })
+    .to_string();
+    let p = dir.join("config.json");
+    std::fs::write(&p, body).expect("write config");
+    p
 }

--- a/services/rp-plate-solver/tests/features/configuration.feature
+++ b/services/rp-plate-solver/tests/features/configuration.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Configuration validation at startup
 
   The wrapper validates its config before binding the HTTP listener. On

--- a/services/rp-plate-solver/tests/features/configuration.feature
+++ b/services/rp-plate-solver/tests/features/configuration.feature
@@ -24,6 +24,7 @@ Feature: Configuration validation at startup
     Then the wrapper exits non-zero
     And the wrapper stderr names "astap_binary_path"
 
+  @unix
   Scenario: astap_binary_path pointing at a non-executable file rejects the config
     Given a config with astap_binary_path pointing at a non-executable file
     And a valid astap_db_directory

--- a/services/rp-plate-solver/tests/features/health.feature
+++ b/services/rp-plate-solver/tests/features/health.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: GET /health — readiness probe
 
   The /health endpoint is the standard HTTP health-probe pattern,

--- a/services/rp-plate-solver/tests/features/real_astap_smoke.feature
+++ b/services/rp-plate-solver/tests/features/real_astap_smoke.feature
@@ -1,4 +1,4 @@
-@wip @requires-astap
+@requires-astap
 Feature: Real-ASTAP smoke (mock-honesty backstop)
 
   Two scenarios exercise the wrapper against the operator's real ASTAP

--- a/services/rp-plate-solver/tests/features/solve_request.feature
+++ b/services/rp-plate-solver/tests/features/solve_request.feature
@@ -28,6 +28,20 @@ Feature: POST /api/v1/solve — request handling and error surface
     Then the response status is 404
     And the response field "error" is "fits_not_found"
 
+  Scenario: fits_path pointing at a directory returns fits_not_found
+    Given a fits_path pointing at a directory
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 404
+    And the response field "error" is "fits_not_found"
+    And the response field "message" contains "not a regular file"
+
+  @unix
+  Scenario: fits_path with read permission denied returns fits_not_found
+    Given an unreadable FITS path
+    When I POST to /api/v1/solve with that fits_path
+    Then the response status is 404
+    And the response field "error" is "fits_not_found"
+
   Scenario: Non-absolute fits_path returns invalid_request
     When I POST to /api/v1/solve with fits_path "relative/path.fits"
     Then the response status is 400

--- a/services/rp-plate-solver/tests/features/solve_request.feature
+++ b/services/rp-plate-solver/tests/features/solve_request.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: POST /api/v1/solve — request handling and error surface
 
   The solve endpoint accepts a FITS path plus optional pointing/FOV/

--- a/services/rp-plate-solver/tests/features/solve_request.feature
+++ b/services/rp-plate-solver/tests/features/solve_request.feature
@@ -53,7 +53,7 @@ Feature: POST /api/v1/solve — request handling and error surface
     And the response field "error" is "invalid_request"
 
   Scenario: Unparseable timeout returns invalid_request
-    Given a writable FITS path "/tmp/m31.fits"
+    Given a writable FITS path
     When I POST to /api/v1/solve with that fits_path and timeout "not-a-duration"
     Then the response status is 400
     And the response field "error" is "invalid_request"

--- a/services/rp-plate-solver/tests/features/subprocess_supervision.feature
+++ b/services/rp-plate-solver/tests/features/subprocess_supervision.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Subprocess supervision (timeout escalation, single-flight queueing)
 
   Every solve is bounded by a wall-clock deadline. On expiry the wrapper


### PR DESCRIPTION
## Summary

Phase 4 of [`docs/plans/rp-plate-solver.md`](docs/plans/rp-plate-solver.md) — wires up the production HTTP surface that Phase 3's BDD suite was written against. All 23 PR-relevant scenarios now pass end-to-end; the `@requires-astap` real-ASTAP scenario is correctly skipped (fires only on Phase 6's nightly cross-platform workflow).

## Production code

- **`src/api.rs`** — axum router with `POST /api/v1/solve` and `GET /health`. Solve handler validates body / fits_path absolute / fits_path existence in order; acquires the single-flight semaphore; drives `runner.solve()`; maps every `RunnerError` variant to `AppError` per the frozen error-code table. Health probe stats both runtime dependencies (binary executable + db dir present) — matches the startup-validation set so "healthy" means "still capable of solving".
- **`src/lib.rs`** — `ServerBuilder`/`BoundServer` two-phase shape mirroring `services/rp::ServerBuilder`, avoiding the port-TOCTOU race. SIGTERM/SIGINT (Unix) and Ctrl-C (Windows) installed as graceful-shutdown signals.
- **`src/main.rs`** — clap CLI (`--config <path>`); reads + validates config; prints `bound_addr=<host>:<port>` to stdout (parsed by `bdd-infra::parse_bound_port`); installs `tracing-subscriber` to stderr.

## Config addition

- New **`astap_extra_env: HashMap<String, String>`** field on `Config`, threaded through `ServerBuilder` into `AstapCliRunner`. Operators get control over LANG/locale on the spawned ASTAP child; BDD uses it to set `MOCK_ASTAP_MODE` per scenario without process-wide `env::set_var` races.
- `ConfigError::Parse` now includes a README pointer in its Display so missing-field errors are self-helping.
- Restored deps removed in Phase 2: `clap`, `tracing-subscriber`.

## BDD step bodies

- World gains: temp-dir helper, `mock_astap_path` discovery, `start_wrapper_with_mock` (for solve/supervision scenarios) and `start_wrapper_with_mock_copy` (for health scenarios that mutate configured paths after spawn), `run_wrapper_to_exit` (configuration scenarios use this since `ServiceHandle::start` would hang waiting for `bound_addr` the failing wrapper never prints; uses a private `find_wrapper_binary` helper).
- Bodies for all 24 scenarios across 5 feature files.
- Wrapper-start is lazy in `solve_steps` so per-scenario state (mock mode, argv-out path) is captured before the actual spawn. Health scenarios eager-spawn.
- Configuration scenarios use `ServiceHandle::try_start` to distinguish "valid → boots" from "invalid → exits" without pre-deciding based on heuristics.

## @wip removed

From `configuration.feature`, `solve_request.feature`, `subprocess_supervision.feature`, `health.feature`. Kept `@requires-astap` on `real_astap_smoke.feature` — that's the permanent cadence gate (Phase 6 wires the nightly).

## Test plan

- [x] `cargo build / nextest` (38 unit + integration tests pass)
- [x] `cargo test --test bdd`: 4 features, 24 scenarios, **23 passed, 1 skipped** (the `@requires-astap` scenario, correctly gated)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo rail run --profile commit -q` clean
- [ ] CI green
- [ ] Copilot review (request via UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)