### PR TITLE
docs(rp-plate-solver): Phase 5 — process-supervisor integration

### DIFF
--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -673,34 +673,54 @@ Status: **not started.**
 **Exit criteria:** all BDD scenarios pass. `cargo rail run --profile
 commit -q` clean. `cargo fmt` clean.
 
-### Phase 5 — Sentinel integration
+### Phase 5 — Process-supervisor integration (Sentinel forward work)
 
-Status: **not started.**
+Status: **complete.**
 
-- [ ] Document the per-service Sentinel restart command in
-      `services/rp-plate-solver/README.md`. Linux/systemd:
-      `systemctl restart rp-plate-solver`. Mention macOS launchd /
-      Windows service-manager equivalents.
-- [ ] Confirm Sentinel's existing per-service restart-command config
-      surface (per `rp.md` §"Sentinel Watchdog Integration") accepts a
-      service entry for `rp-plate-solver` without code changes. If it
-      does, this phase is docs-only; if it does not, the gap is
-      called out in a follow-up issue.
-- [ ] Decide whether Sentinel should probe `rp-plate-solver`'s
-      `/health` or rely on event-stream + restart-command alone. The
-      currently-documented Sentinel watchdog flow only pings Alpaca
-      service endpoints; `rp-plate-solver` is not Alpaca. Two paths:
-      (a) extend Sentinel's health-probe surface to support
-      configurable HTTP `/health` per rp-managed service (Sentinel
-      design change); (b) rely on event-stream-derived deadline
-      signals from rp's compound tools and configured restart
-      commands, leaving `/health` as operator-only. Pick one in this
-      phase; the wrapper exposes `/health` either way so option (a)
-      stays available for later.
+The plan's original framing assumed a Sentinel "configured
+restart-command per service" feature the existing Sentinel doesn't
+have — Sentinel today is an Alpaca SafetyMonitor poller and notifier
+([`docs/services/sentinel.md`](../services/sentinel.md)), not a
+generic HTTP service supervisor. The honest answer for v1: the
+operator's OS process supervisor (systemd / launchd / NSSM) is the
+recovery mechanism; future Sentinel work can layer on the `/health`
+endpoint the wrapper already exposes.
 
-**Exit criteria:** an operator can configure Sentinel to restart
-`rp-plate-solver` on hang/crash by following the README. No regression
-in Sentinel's existing tests.
+What this phase delivered:
+
+- [x] Per-OS process-supervisor recipes in
+      `services/rp-plate-solver/README.md` — systemd unit (Linux),
+      launchd plist (macOS), NSSM commands (Windows). Each entry
+      gives the install snippet plus the operator's restart and
+      log-tail commands.
+- [x] Honest "Sentinel integration" section in
+      `docs/services/rp-plate-solver.md` — drops the
+      "Sentinel-supervised" framing, retitles to "Supervision and
+      recovery", names the OS process supervisor as today's
+      recovery mechanism, and keeps the failure-domain table /
+      belt-and-suspenders timeout / what-restart-recovers-from
+      content unchanged.
+- [x] Architecture mermaid in the design doc updated to show the
+      OS process supervisor (rather than Sentinel) restarting the
+      wrapper and rp.
+- [x] Forward-work note acknowledging that when Sentinel grows
+      generic HTTP service supervision (periodic `/health` probes,
+      configurable restart commands), the wrapper's existing
+      `/health` and graceful-shutdown semantics fit cleanly.
+
+What this phase did **not** do (forward work):
+
+- Extend Sentinel itself with HTTP `/health` polling or per-service
+  restart-command config. That's a larger Sentinel design change
+  beyond this PR's scope; tracked separately.
+- Add `/health` probing logic in any consumer (rp's HTTP client to
+  the wrapper relies on its own outer timeout for each request, not
+  on `/health`).
+
+**Exit criteria met:** operator can stand up `rp-plate-solver` on any
+target OS using the README's recipes; the wrapper's exit semantics
+play correctly with `Restart=on-failure` (systemd) / `KeepAlive`
+(launchd) / `nssm restart` policies.
 
 ### Phase 6 — Nightly cross-platform real-ASTAP smoke (retires ADR-005 OQ 1–4)
 

--- a/docs/services/rp-plate-solver.md
+++ b/docs/services/rp-plate-solver.md
@@ -31,14 +31,16 @@ graph LR
     solver -->|"spawn astap_cli<br/>+ wall-clock deadline"| astap[ASTAP child process]
     astap -->|writes| wcs[".wcs sidecar"]
     solver -->|reads| wcs
-    sentinel[Sentinel] -->|"GET /health"| solver
-    sentinel -.->|configured restart command| solver
-    sentinel -.->|configured restart command| rp
+    supervisor[OS process supervisor<br/>systemd / launchd / NSSM] -.->|restart on exit| solver
+    supervisor -.->|restart on exit| rp
 ```
 
-Three independent processes, three independent failure domains,
-three independent supervisors. See [Sentinel
-Integration](#sentinel-integration) below for the detail.
+Three independent processes, three independent failure domains.
+The operator's OS process supervisor restarts the wrapper and rp
+on exit; the wrapper supervises the ASTAP child via per-request
+deadlines. See [Supervision and recovery](#supervision-and-recovery)
+below for the detail and the path to future Sentinel-driven
+restart.
 
 ### Inputs and Outputs
 
@@ -306,19 +308,26 @@ workflow's job. See `docs/plans/rp-plate-solver.md` §"Real-ASTAP
 coverage: cadence and gating" for the rationale and the `bdd.rs`
 filter snippet.
 
-## Sentinel Integration
+## Supervision and recovery
 
-The service is supervised by Sentinel via the standard
-rp-managed-service supervision flow described in `rp.md`
-§"Sentinel Watchdog Integration".
+The wrapper sits inside a layered supervision design with three
+distinct failure domains. **Today, the wrapper-and-rp domains are
+restarted by the operator's OS-level process supervisor** (systemd /
+launchd / NSSM); see the [README's per-OS recipes](../../services/rp-plate-solver/README.md#process-supervisor-recipes).
+Automated Sentinel-driven restart of rp-managed services is a future
+design item — the current Sentinel
+([`docs/services/sentinel.md`](sentinel.md)) is an Alpaca
+SafetyMonitor poller and notifier, not a generic HTTP service
+supervisor. The "Sentinel Watchdog Integration" section in `rp.md` is
+a forward-looking design.
 
 ### Failure Domains
 
-| Domain | Supervisor | Detection | Action |
-|--------|-----------|-----------|--------|
-| `rp` (gateway) | Sentinel | event-stream disconnect | Operator-configured restart command |
-| `rp-plate-solver` (this service) | Sentinel | `GET /health` non-200 or no response within Sentinel's HTTP timeout | Operator-configured restart command (e.g., `systemctl restart rp-plate-solver`) |
-| `astap_cli` (child) | This service | per-request wall-clock deadline | graceful signal → 2 s grace → force-kill. Unix: `SIGTERM` → `SIGKILL`. Windows: `CTRL_BREAK_EVENT` (with `CREATE_NEW_PROCESS_GROUP` at spawn) → `TerminateProcess`. |
+| Domain | Today's supervisor | Detection | Action |
+|--------|--------------------|-----------|--------|
+| `rp` (gateway) | Operator's process supervisor (systemd / launchd / NSSM) | Process exit (panic, OOM, etc.) | Supervisor restarts per its policy (`Restart=on-failure`, `KeepAlive`, etc.) |
+| `rp-plate-solver` (this service) | Operator's process supervisor | Process exit; or external `/health` probe | Same as above. The wrapper exits non-zero on config-validation failure and on internal panic; the supervisor restarts it. |
+| `astap_cli` (child) | This service | Per-request wall-clock deadline | Graceful signal → 2 s grace → force-kill. Unix: `SIGTERM` → `SIGKILL`. Windows: `CTRL_BREAK_EVENT` (with `CREATE_NEW_PROCESS_GROUP` at spawn) → `TerminateProcess`. |
 
 ### Belt-and-Suspenders Outer Timeout
 
@@ -328,13 +337,22 @@ internal timeout regresses, `rp` does not hang on a `plate_solve`
 call. The wrapper's deadline is the primary control; rp's is the
 backstop.
 
-### What Sentinel Restart Recovers From
+### What restart recovers from
 
 Stateless-across-requests is the property that makes restart safe.
 Restarting the wrapper costs the in-flight request (which gets a
 transient error and may be retried by the orchestrator) and nothing
 else — no session state, no warm caches, no in-memory artifacts the
 operator cares about.
+
+### Forward work: Sentinel extension
+
+When Sentinel grows generic HTTP service supervision — periodic
+`GET /health` probes, configurable restart commands per service —
+this wrapper's `/health` endpoint and graceful-shutdown semantics are
+already shaped to fit. Until then, the operator's process supervisor
+is the sanctioned recovery mechanism, and `/health` is exposed for
+operational tooling (Prometheus blackbox exporter, Nagios, etc.).
 
 ## MVP Scope
 

--- a/services/rp-plate-solver/README.md
+++ b/services/rp-plate-solver/README.md
@@ -10,17 +10,13 @@ for implementation sequencing.
 
 ## Status
 
-This crate is at **Phase 2** of its sequenced plan:
+This crate is at **Phase 4 complete** — HTTP server (`POST /api/v1/solve`,
+`GET /health`), per-request supervision (graceful signal → 2 s grace →
+force-kill), single-flight semaphore, and the full BDD suite are live.
+ASTAP is invoked as an operator-installed subprocess per request; no
+ASTAP binary or index database is bundled.
 
-- [x] Crate skeleton, `AstapRunner` trait, `.wcs` parser, supervision
-      module, `mock_astap` test double.
-- [ ] Phase 3 — BDD scenarios.
-- [ ] Phase 4 — HTTP server + `main.rs`.
-
-The crate produces a library plus the `mock_astap` test binary today.
-The service binary (`main.rs`) lands in Phase 4.
-
-## Operator install (when shipping)
+## Operator install
 
 ASTAP is operator-supplied. The
 [`install-astap`](../../.github/actions/install-astap/action.yml) GitHub
@@ -39,16 +35,143 @@ Configure `rp-plate-solver` to point at the install:
 
 ```json
 {
+  "bind_address": "127.0.0.1",
+  "port": 11131,
   "astap_binary_path": "/opt/astap/astap_cli",
-  "astap_db_directory": "/opt/astap/d05"
+  "astap_db_directory": "/opt/astap/d05",
+  "default_solve_timeout": "30s",
+  "max_solve_timeout": "120s"
 }
 ```
 
-Both fields are required; missing or unreadable values exit non-zero so
-Sentinel surfaces the misconfiguration.
+`astap_binary_path` and `astap_db_directory` are the only required
+fields. Validation runs at startup; missing or unreadable values exit
+the process non-zero so the operator's process supervisor surfaces the
+misconfiguration rather than masking it with a silent retry.
 
-## Sentinel restart command
+## Running
 
-Phase 5 wires this up. Operator's Sentinel config will name a per-platform
-restart command; on Linux/systemd the typical entry is
-`systemctl restart rp-plate-solver`.
+```sh
+rp-plate-solver --config /etc/rp-plate-solver/config.json
+```
+
+The wrapper prints `bound_addr=<host>:<port>` to stdout once it has
+bound its listener (so test harnesses and process supervisors can
+discover the actual port when `port: 0` is used). Logs go to stderr
+via `tracing-subscriber`; set `RUST_LOG=debug` for verbose output.
+
+Graceful shutdown: SIGTERM and SIGINT on Unix, Ctrl-C on Windows.
+
+## Process-supervisor recipes
+
+Phase 5 documents the operator's recovery mechanism: an OS-level
+process supervisor that restarts the wrapper on crash or hang. Today
+this is the canonical answer — automated Sentinel-driven restart of
+rp-managed services is forward work and is **not** wired into the
+current Sentinel design (see [Sentinel integration](#sentinel-integration)
+below).
+
+### Linux / systemd
+
+`/etc/systemd/system/rp-plate-solver.service`:
+
+```ini
+[Unit]
+Description=rp-plate-solver
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/rp-plate-solver --config /etc/rp-plate-solver/config.json
+Restart=on-failure
+RestartSec=2
+User=rp
+Group=rp
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Restart command: `systemctl restart rp-plate-solver`.
+Tail logs:     `journalctl -u rp-plate-solver -f`.
+
+### macOS / launchd
+
+`~/Library/LaunchAgents/com.rusty-photon.rp-plate-solver.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>           <string>com.rusty-photon.rp-plate-solver</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/rp-plate-solver</string>
+    <string>--config</string>
+    <string>/etc/rp-plate-solver/config.json</string>
+  </array>
+  <key>KeepAlive</key>       <true/>
+  <key>StandardOutPath</key> <string>/var/log/rp-plate-solver.out.log</string>
+  <key>StandardErrorPath</key><string>/var/log/rp-plate-solver.err.log</string>
+</dict>
+</plist>
+```
+
+Restart command: `launchctl kickstart -k gui/$(id -u)/com.rusty-photon.rp-plate-solver`.
+
+### Windows / NSSM
+
+[NSSM](https://nssm.cc/) wraps a Win32 binary as a Windows service:
+
+```cmd
+nssm install rp-plate-solver "C:\Program Files\rp-plate-solver\rp-plate-solver.exe"
+nssm set     rp-plate-solver AppParameters "--config C:\ProgramData\rp-plate-solver\config.json"
+nssm set     rp-plate-solver AppRestartDelay 2000
+nssm start   rp-plate-solver
+```
+
+Restart command: `nssm restart rp-plate-solver`.
+
+## Sentinel integration
+
+The wrapper exposes `GET /health` as the standard HTTP health-probe
+pattern. Today, **automated Sentinel-driven restart of rp-managed
+services is not implemented** — Sentinel's existing design
+([`docs/services/sentinel.md`](../../docs/services/sentinel.md)) covers
+ASCOM Alpaca SafetyMonitor polling and Pushover notification, not
+generic HTTP service supervision. The "Sentinel watchdog integration"
+section in `docs/services/rp.md` is a forward-looking design.
+
+Until Sentinel is extended:
+
+- The operator's process supervisor (systemd / launchd / NSSM, recipes
+  above) is the recovery mechanism. It restarts the wrapper on
+  non-zero exit (config-validation failure, panic, etc.).
+- Hangs in the *child* `astap_cli` process are bounded by the
+  wrapper's per-request deadline; the wrapper itself doesn't hang on
+  a wedged solve.
+- `rp`'s HTTP client to the wrapper has its own outer timeout
+  (`plate_solver.timeout_secs` in rp config) — even if the wrapper's
+  internal deadline regresses, rp does not hang on a `plate_solve`
+  call.
+
+When future work extends Sentinel with HTTP `/health` polling and a
+configurable per-service restart command, that mechanism will sit on
+top of the same `/health` endpoint this service already exposes.
+
+## Coordinates and units
+
+- `ra_hint` and `ra_center`: **decimal degrees, 0–360** (matches FITS
+  `CRVAL1`). The wrapper converts `ra_hint` to ASTAP's expected
+  decimal hours (`degrees / 15`) before spawning.
+- `dec_hint` and `dec_center`: **decimal degrees, −90 to +90**. The
+  wrapper converts `dec_hint` to ASTAP's south-pole-distance
+  (`90 + dec`) before spawning.
+- `pixel_scale_arcsec`: arcseconds per pixel.
+- `rotation_deg`: degrees.
+
+Full HTTP contract in [`docs/plans/rp-plate-solver.md`](../../docs/plans/rp-plate-solver.md)
+§"HTTP contract".

--- a/services/rp-plate-solver/README.md
+++ b/services/rp-plate-solver/README.md
@@ -56,20 +56,35 @@ rp-plate-solver --config /etc/rp-plate-solver/config.json
 ```
 
 The wrapper prints `bound_addr=<host>:<port>` to stdout once it has
-bound its listener (so test harnesses and process supervisors can
-discover the actual port when `port: 0` is used). Logs go to stderr
-via `tracing-subscriber`; set `RUST_LOG=debug` for verbose output.
+bound its listener. Test harnesses and wrapper scripts parse this to
+discover the bound port when `port: 0` is configured; production
+deployments should pin a fixed port so reverse proxies, firewall
+rules, and rp's `plate_solver.url` config remain stable. Logs go to
+stderr via `tracing-subscriber`; set `RUST_LOG=debug` for verbose
+output.
 
 Graceful shutdown: SIGTERM and SIGINT on Unix, Ctrl-C on Windows.
 
 ## Process-supervisor recipes
 
 Phase 5 documents the operator's recovery mechanism: an OS-level
-process supervisor that restarts the wrapper on crash or hang. Today
-this is the canonical answer — automated Sentinel-driven restart of
-rp-managed services is forward work and is **not** wired into the
-current Sentinel design (see [Sentinel integration](#sentinel-integration)
+process supervisor that restarts the wrapper on **crash / non-zero
+exit**. Today this is the canonical answer — automated Sentinel-driven
+restart of rp-managed services is forward work and is **not** wired
+into the current Sentinel design (see [Sentinel integration](#sentinel-integration)
 below).
+
+> **Hang recovery is *not* covered by these recipes.** systemd
+> `Restart=on-failure`, launchd `KeepAlive`, and NSSM's auto-restart
+> all fire on process exit, not on a hung-but-still-alive wrapper.
+> A wedged wrapper that's still bound to its port will keep the
+> supervisor happy. Hangs would need an external `/health`-polling
+> watchdog (Prometheus blackbox exporter, Nagios, a small cron-driven
+> probe) that kills the wrapper when `/health` stops returning 200 —
+> tracked as forward work under [Sentinel integration](#sentinel-integration)
+> below. The wrapper does not hang waiting for `astap_cli`: every
+> request is bounded by a wall-clock deadline that escalates to
+> SIGKILL / TerminateProcess after a 2-second grace.
 
 ### Linux / systemd
 
@@ -98,6 +113,11 @@ Tail logs:     `journalctl -u rp-plate-solver -f`.
 
 ### macOS / launchd
 
+This recipe uses a **per-user LaunchAgent**. For a system-wide
+LaunchDaemon (root context, recommended for headless observatory
+machines), put the plist in `/Library/LaunchDaemons` instead and
+swap the log paths to `/var/log/rp-plate-solver.{out,err}.log`.
+
 `~/Library/LaunchAgents/com.rusty-photon.rp-plate-solver.plist`:
 
 ```xml
@@ -114,26 +134,38 @@ Tail logs:     `journalctl -u rp-plate-solver -f`.
     <string>/etc/rp-plate-solver/config.json</string>
   </array>
   <key>KeepAlive</key>       <true/>
-  <key>StandardOutPath</key> <string>/var/log/rp-plate-solver.out.log</string>
-  <key>StandardErrorPath</key><string>/var/log/rp-plate-solver.err.log</string>
+  <key>StandardOutPath</key> <string>/Users/<USER>/Library/Logs/rp-plate-solver.out.log</string>
+  <key>StandardErrorPath</key><string>/Users/<USER>/Library/Logs/rp-plate-solver.err.log</string>
 </dict>
 </plist>
 ```
 
+(Replace `<USER>` with the actual home directory — plist values
+don't expand `~` or `$HOME`.)
+
 Restart command: `launchctl kickstart -k gui/$(id -u)/com.rusty-photon.rp-plate-solver`.
+Tail logs:        `tail -f ~/Library/Logs/rp-plate-solver.err.log`.
 
 ### Windows / NSSM
 
-[NSSM](https://nssm.cc/) wraps a Win32 binary as a Windows service:
+[NSSM](https://nssm.cc/) wraps a Win32 binary as a Windows service.
+By default NSSM doesn't redirect stdout / stderr, so the install
+recipe also sets `AppStdout` / `AppStderr` and enables NSSM's
+built-in log rotation:
 
 ```cmd
 nssm install rp-plate-solver "C:\Program Files\rp-plate-solver\rp-plate-solver.exe"
 nssm set     rp-plate-solver AppParameters "--config C:\ProgramData\rp-plate-solver\config.json"
 nssm set     rp-plate-solver AppRestartDelay 2000
+nssm set     rp-plate-solver AppStdout "C:\ProgramData\rp-plate-solver\stdout.log"
+nssm set     rp-plate-solver AppStderr "C:\ProgramData\rp-plate-solver\stderr.log"
+nssm set     rp-plate-solver AppRotateFiles 1
+nssm set     rp-plate-solver AppRotateBytes 10485760
 nssm start   rp-plate-solver
 ```
 
 Restart command: `nssm restart rp-plate-solver`.
+Tail logs (PowerShell): `Get-Content -Wait C:\ProgramData\rp-plate-solver\stderr.log`.
 
 ## Sentinel integration
 


### PR DESCRIPTION
## Summary

Phase 5 of [`docs/plans/rp-plate-solver.md`](docs/plans/rp-plate-solver.md) — but the framing changes substantially when reality lands. The plan's original Phase 5 ("Sentinel restarts the wrapper on hang/crash via a configured restart command per service") assumed a Sentinel feature that doesn't exist today.

[Sentinel today](docs/services/sentinel.md) is an ASCOM Alpaca SafetyMonitor poller + Pushover notifier — not a generic HTTP service supervisor. The "Sentinel Watchdog Integration" section in `rp.md` is forward-looking design, not built behavior.

The honest v1 answer: **the operator's OS process supervisor is the recovery mechanism**, and future Sentinel work can layer on the `/health` endpoint the wrapper already exposes.

## What this delivers

1. **Per-OS supervisor recipes in README** — systemd unit (Linux), launchd plist (macOS), NSSM commands (Windows). Each entry gives the install snippet plus the operator's restart and log-tail commands.
2. **Design doc retitled** — `Sentinel Integration` → `Supervision and recovery`. Failure-domain table now shows the OS process supervisor as the wrapper-and-rp supervisor; ASTAP-child supervision (this service's per-request deadline) is unchanged. Architecture mermaid updated to match.
3. **Forward-work note** — when Sentinel grows generic HTTP service supervision (periodic `/health` probes + configurable restart commands per service), the wrapper's existing `/health` endpoint and graceful-shutdown semantics fit cleanly.
4. **Plan Phase 5 marked complete** with explicit done / not-done lists separating what shipped from forward work.

## Out of scope (forward work)

- Extending Sentinel with HTTP `/health` polling or per-service restart-command config. Larger Sentinel design change beyond this PR.
- `/health` probing logic in any consumer (rp's HTTP client to the wrapper relies on its own outer timeout for each request, not on `/health`).

## Test plan

- [x] No code changes; no tests affected.
- [x] `cargo rail run --profile commit -q` reports no test targets (docs-only).
- [x] `cargo fmt --check` clean.
- [ ] CI green.
- [ ] Copilot review (request via UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)