### PR TITLE
Phase 6c-prep: mount primitives

### DIFF
--- a/crates/bdd-infra/src/rp_harness/config.rs
+++ b/crates/bdd-infra/src/rp_harness/config.rs
@@ -53,6 +53,18 @@ pub struct FocuserConfig {
     pub max_position: Option<i32>,
 }
 
+/// Singular mount equipment entry. `rp` deployments have at most one
+/// mount — piggyback rigs share one across multiple optical trains —
+/// so the builder field below is `Option<MountConfig>`, not a `Vec`.
+#[derive(Debug, Clone)]
+pub struct MountConfig {
+    pub alpaca_url: String,
+    pub device_number: u32,
+    /// Optional post-`Slewing == false` settle time. `None` ⇒ rp's
+    /// default (zero). Per-call `settle_after` on `slew` overrides.
+    pub settle_after_slew: Option<std::time::Duration>,
+}
+
 /// Accumulates equipment and plugin entries, then emits rp's JSON config.
 #[derive(Debug, Default, Clone)]
 pub struct RpConfigBuilder {
@@ -60,6 +72,8 @@ pub struct RpConfigBuilder {
     pub filter_wheels: Vec<FilterWheelConfig>,
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
     pub focusers: Vec<FocuserConfig>,
+    /// Singular mount — at most one per `rp` deployment.
+    pub mount: Option<MountConfig>,
     pub plugin_configs: Vec<Value>,
     /// Override `session.data_directory`. When `None`, the builder
     /// generates a fresh per-call path. The cross-restart BDD scenarios
@@ -137,6 +151,12 @@ impl RpConfigBuilder {
 
     pub fn add_focuser(&mut self, foc: FocuserConfig) -> &mut Self {
         self.focusers.push(foc);
+        self
+    }
+
+    /// Set the singular mount config (overwrites any prior call).
+    pub fn with_mount(&mut self, mount: MountConfig) -> &mut Self {
+        self.mount = Some(mount);
         self
     }
 
@@ -242,6 +262,20 @@ impl RpConfigBuilder {
                 .to_string()
         });
 
+        let mount_value: Value = match &self.mount {
+            Some(m) => {
+                let mut obj = serde_json::json!({
+                    "alpaca_url": m.alpaca_url,
+                    "device_number": m.device_number,
+                });
+                if let Some(d) = m.settle_after_slew {
+                    obj["settle_after_slew"] = serde_json::json!(format!("{}ms", d.as_millis()));
+                }
+                obj
+            }
+            None => Value::Null,
+        };
+
         let mut config = serde_json::json!({
             "session": {
                 "data_directory": data_directory,
@@ -253,7 +287,7 @@ impl RpConfigBuilder {
             },
             "equipment": {
                 "cameras": cameras,
-                "mount": null,
+                "mount": mount_value,
                 "focusers": focusers,
                 "filter_wheels": filter_wheels,
                 "cover_calibrators": cover_calibrators,
@@ -395,6 +429,39 @@ mod tests {
         assert_eq!(plugins.len(), 2);
         assert_eq!(plugins[0]["name"], "a");
         assert_eq!(plugins[1]["name"], "b");
+    }
+
+    #[test]
+    fn empty_builder_emits_null_mount() {
+        let cfg = RpConfigBuilder::new().build();
+        assert!(cfg["equipment"]["mount"].is_null());
+    }
+
+    #[test]
+    fn with_mount_emits_typed_block() {
+        let mut b = RpConfigBuilder::new();
+        b.with_mount(MountConfig {
+            alpaca_url: "http://127.0.0.1:11122".to_string(),
+            device_number: 0,
+            settle_after_slew: Some(std::time::Duration::from_millis(150)),
+        });
+        let cfg = b.build();
+        let mount = &cfg["equipment"]["mount"];
+        assert_eq!(mount["alpaca_url"], "http://127.0.0.1:11122");
+        assert_eq!(mount["device_number"], 0);
+        assert_eq!(mount["settle_after_slew"], "150ms");
+    }
+
+    #[test]
+    fn with_mount_omits_settle_when_none() {
+        let mut b = RpConfigBuilder::new();
+        b.with_mount(MountConfig {
+            alpaca_url: "http://127.0.0.1:11122".to_string(),
+            device_number: 0,
+            settle_after_slew: None,
+        });
+        let cfg = b.build();
+        assert!(cfg["equipment"]["mount"]["settle_after_slew"].is_null());
     }
 
     #[test]

--- a/crates/bdd-infra/src/rp_harness/mod.rs
+++ b/crates/bdd-infra/src/rp_harness/mod.rs
@@ -31,7 +31,7 @@ mod webhook;
 
 pub use config::{
     build_calibrator_flats_config, CameraConfig, CoverCalibratorConfig, FilterWheelConfig,
-    FocuserConfig, RpConfigBuilder,
+    FocuserConfig, MountConfig, RpConfigBuilder,
 };
 pub use launcher::{start_rp, wait_for_rp_healthy, write_temp_config_file};
 pub use mcp_client::McpTestClient;

--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -554,7 +554,7 @@ re-litigated:
 
 ##### Phase 6c-prep — Mount primitives
 
-Status: **planned (2026-05-02).** Parallels Phase 6a (focuser
+Status: **complete (2026-05-03).** Parallels Phase 6a (focuser
 primitives). Required because `center_on_target` needs `slew` and
 `sync_mount`, neither of which exists in `rp` today.
 
@@ -616,7 +616,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
 
 ###### Work breakdown (in order)
 
-- [ ] **Step 1 — `MountConfig` in `config.rs`.** Fields: `alpaca_url:
+- [x] **Step 1 — `MountConfig` in `config.rs`.** Fields: `alpaca_url:
       String`, `device_number: u32` (`#[serde(default)]`), optional
       `auth: Option<ClientAuthConfig>`, optional
       `settle_after_slew: Option<Duration>` (`humantime_serde`).
@@ -624,7 +624,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       `EquipmentConfig` with `pub mount: Option<MountConfig>`
       (`#[serde(default)]`). Two unit tests — minimal-fields, with
       auth + settle_after_slew.
-- [ ] **Step 2 — `MountEntry` + `connect_mount` in `equipment.rs`.**
+- [x] **Step 2 — `MountEntry` + `connect_mount` in `equipment.rs`.**
       Mirrors `FocuserEntry` / `connect_focuser`. Holds
       `Arc<dyn Telescope>` from ascom-alpaca. Five failure-arm unit
       tests via in-test axum stub (same pattern Phase 6a established
@@ -632,7 +632,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       network error, 5 s `tokio::time::timeout`, no-telescope-in-list,
       `set_connected` Alpaca rejection. Plus one happy-path arm. No
       connect-time probes of `Tracking` / `Slewing` / `AtPark`.
-- [ ] **Step 3 — `EquipmentRegistry` plumbing.** Singular
+- [x] **Step 3 — `EquipmentRegistry` plumbing.** Singular
       `pub mount: Option<MountEntry>` field, populated in
       `EquipmentRegistry::new`. `find_mount(&self) -> Option<&MountEntry>`
       lookup. `EquipmentStatus.mount: Option<DeviceStatus>` (singular,
@@ -640,7 +640,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       end-to-end registry test against the axum stub paralleling
       `connect_focuser_success_returns_connected_entry` +
       `find_focuser`.
-- [ ] **Step 4 — `do_slew_blocking` helper in `mcp.rs`.**
+- [x] **Step 4 — `do_slew_blocking` helper in `mcp.rs`.**
       `pub(crate) async fn do_slew_blocking(&self, ra: f64, dec: f64,
       settle_after: Duration) -> Result<(f64, f64), String>`. Resolves
       the mount, calls `slew_to_coordinates_async`, polls `slewing()`
@@ -650,7 +650,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       deadline expiry before returning the timeout error. Modeled on
       `do_move_focuser_blocking`. Helper `resolve_mount` (no macro)
       handles "no mount configured" + "mount not connected" symmetrically.
-- [ ] **Step 5 — Five MCP tools in `mcp.rs`.**
+- [x] **Step 5 — Five MCP tools in `mcp.rs`.**
       - `slew { ra: f64, dec: f64, settle_after: Option<Duration> }` →
         `{ actual_ra, actual_dec }`. Validates `ra ∈ [0, 24)` hours and
         `dec ∈ [-90, 90]` degrees in the body. `settle_after` resolves
@@ -668,7 +668,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
 
       ~16 unit tests against a `MockTelescope` (paralleling the
       existing `MockFocuser` pattern at `mcp.rs:2160+`).
-- [ ] **Step 6 — `tests/features/mount.feature`** (~15 scenarios,
+- [x] **Step 6 — `tests/features/mount.feature`** (~15 scenarios,
       `@serial` tagged). Catalog (1); `slew` (5: tracking-on happy
       path, tracking-off error, no-mount-configured, mount-not-connected,
       one Outline using `MISSING` sentinel for ra/dec range +
@@ -680,7 +680,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       asserting `settle_after: "100ms"` extends total slew time by
       ~100ms. Slew tolerance: exact equality (revisit at impl time
       if OmniSim diverges).
-- [ ] **Step 7 — `tests/bdd/steps/mount_steps.rs`.** Reuse-first:
+- [x] **Step 7 — `tests/bdd/steps/mount_steps.rs`.** Reuse-first:
       pull `the tool list should include`, `the tool call should
       succeed`, `the tool call should return an error`, `the error
       message should contain` from `tool_steps.rs`. New mount-specific
@@ -693,7 +693,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       steps interpret `MISSING` in the table as "omit that field
       from the JSON-RPC params." No new `RpWorld` fields. Wire into
       `tests/bdd/steps/mod.rs`.
-- [ ] **Step 8 — `bdd_infra::rp_harness::MountConfig` +
+- [x] **Step 8 — `bdd_infra::rp_harness::MountConfig` +
       `RpConfigBuilder::with_mount`.** Test-side struct holds
       `alpaca_url` + `device_number` (no `auth`, matches existing
       test-side device structs). Builder field
@@ -702,7 +702,7 @@ Built-in Tools — Hardware) and should not be re-litigated:
       replacing the current literal `"mount": null` line. No
       `ensure_default_mount` — explicit `.with_mount(...)` reads
       better at every call site that needs a mount.
-- [ ] **Step 9 — `docs/services/rp.md` updates.**
+- [x] **Step 9 — `docs/services/rp.md` updates.**
       - Configuration example: replace the existing
         `mount` block with the singular typed shape including
         optional `settle_after_slew`. Drop the obsolete
@@ -717,13 +717,13 @@ Built-in Tools — Hardware) and should not be re-litigated:
       - One-line prose under the new tools: "`mount.settle_after_slew`
         is applied after `Slewing == false`; per-call `settle_after`
         on `slew` overrides (including `"0s"` to skip)."
-- [ ] **Step 10 — `services/rp/Cargo.toml`.** Append `"telescope"` to
+- [x] **Step 10 — `services/rp/Cargo.toml`.** Append `"telescope"` to
       `ascom-alpaca`'s features list. No new workspace deps; no
       `bazel mod tidy` needed. Per-crate features lists are intent
       expression — workspace builds compile the union due to Cargo
       feature unification, but cargo-hack's feature-powerset CI
       enforces standalone-buildability.
-- [ ] **Step 11 — Plan-doc bookkeeping.** Land alongside the impl:
+- [x] **Step 11 — Plan-doc bookkeeping.** Land alongside the impl:
       flip Phase 6c-prep status to **complete** with the work-breakdown
       checkboxes ticked, exit-criteria block populated with concrete
       counts (BDD scenarios green, lib tests passing).
@@ -742,9 +742,18 @@ Built-in Tools — Hardware) and should not be re-litigated:
   `get_mount_position`; deferred until a meridian-flip workflow
   surfaces.
 
-**Exit criteria:** ~15 new BDD scenarios green; ~24 new lib tests
-across `config` (2), `equipment` (7), `mcp` mount tools (~16);
-`cargo rail run --profile commit -q` clean; `cargo fmt` clean.
+**Exit criteria met:** 14 new BDD scenarios green (187/187 total in
+rp's BDD suite, was 173/173 pre-Phase-6c-prep); 33 new lib tests
+across `config` (3), `equipment` (7 — 5 `connect_mount` failure paths
++ 1 success arm + 1 `EquipmentRegistry` end-to-end via axum stub),
+and `mcp` mount tools (23 against `MockTelescope`); plus 3 new
+`bdd-infra` tests pinning `RpConfigBuilder::with_mount` JSON shape.
+`cargo rail run --profile commit -q` reports 701/701 tests passing
+workspace-wide. `cargo fmt` clean. No new workspace deps; no
+`bazel mod tidy` needed. Slew-echo BDD assertion uses a
+`0.001`-hour / `0.001`-degree tolerance because OmniSim's slew echo
+drifts ~0.4 arcsec from internal coordinate transforms — well under
+any centering workflow's tolerance, well above OmniSim's drift.
 
 ##### Phase 6c-1 — `rp-plate-solver` rp-managed service
 

--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -552,50 +552,199 @@ re-litigated:
   imaging or MCP layer, and "compound tools live under
   `imaging/tools/`" is a clean rule.
 
-##### Phase 6c-prep — Telescope (mount) primitives
+##### Phase 6c-prep — Mount primitives
 
-Status: **not started.** Parallels Phase 6a (focuser primitives).
-Required because `center_on_target` needs `slew` and `sync_mount`,
-neither of which exists in `rp` today.
+Status: **planned (2026-05-02).** Parallels Phase 6a (focuser
+primitives). Required because `center_on_target` needs `slew` and
+`sync_mount`, neither of which exists in `rp` today.
 
-- [ ] `TelescopeConfig` in `config.rs` (`id`, `alpaca_url`,
-      `device_number`, optional `auth: ClientAuthConfig`). Replaces
-      any placeholder telescope slot in the existing config schema.
-- [ ] `TelescopeEntry` in `equipment.rs` mirroring `CameraEntry` /
-      `FocuserEntry`; `connect_telescope` Alpaca client wiring with
-      five-arm failure coverage (`build_alpaca_client` error,
-      `get_devices` network error, 5 s timeout, no-telescope-in-list,
-      `set_connected` Alpaca rejection).
-- [ ] `EquipmentRegistry::find_telescope` plus
-      `EquipmentStatus.telescopes` plumbing.
-- [ ] MCP tools in `mcp.rs`:
-      - `slew` — `telescope_id`, `ra`, `dec`. Blocks via `Slewing`
-        polling (mirrors `move_focuser`'s `is_moving` poll loop) with
-        a deadline appropriate to a mount slew (initial pick: 5 min;
-        revisit during impl).
-      - `sync_mount` — `telescope_id`, `ra`, `dec`. Immediate, no
-        blocking poll.
-      - `get_telescope_position` — returns current `ra` / `dec` /
-        `side_of_pier`. Deferred unless a concrete consumer surfaces
-        before 6c-3 lands.
-- [ ] `services/rp/tests/features/telescope.feature` — catalog,
-      slew/sync/idempotent-slew happy paths, five device-resolution /
-      missing-parameter errors. Mirrors the shape of `focuser.feature`.
-      Target ~10 scenarios.
-- [ ] `services/rp/tests/bdd/steps/telescope_steps.rs` reusing
-      `tool_steps.rs` shared steps; `RpWorld.telescopes` accumulator;
-      new `bdd_infra::rp_harness::TelescopeConfig` + builder.
-- [ ] Direct unit tests for `connect_telescope` failure + success
-      branches via in-test axum stub Alpaca server (same pattern Phase
-      6a established for `connect_focuser`).
-- [ ] `docs/services/rp.md` Configuration example updated with a
-      typed telescope block.
-- [ ] No new workspace deps — only adds the existing `ascom-alpaca`
-      `telescope` feature on the rp crate. No `bazel mod tidy`.
+###### Decisions resolved during planning
 
-**Exit criteria:** new BDD scenarios green, all `connect_telescope`
-failure-path + happy-path unit tests pass, `cargo rail run --profile
-commit -q` clean, `cargo fmt` clean.
+These will be captured in `docs/services/rp.md` (Configuration,
+Built-in Tools — Hardware) and should not be re-litigated:
+
+- **Singular `mount: Option<MountConfig>`, not plural `Vec`.** `rp`
+  is not running farms of mounts. Piggyback rigs share **one** mount
+  with multiple optical trains (multiple cameras, focusers, filter
+  wheels) — those stay plural; the mount stays singular. The
+  one-mount-per-deployment contract is expressed in the type, not
+  enforced as a singleton runtime invariant. `Option` because a
+  camera-only / flats-rig config remains valid.
+- **Naming: "mount" in our code, "telescope" only at the Alpaca
+  boundary.** `MountConfig`, `MountEntry`, `find_mount`, `mount.feature`,
+  `slew`/`sync_mount` MCP tools. The `Arc<dyn Telescope>` field type
+  and the `ascom-alpaca` `"telescope"` feature flag stay (forced by
+  upstream). The two-name asymmetry matches our domain language ("the
+  mount slewed to M31") rather than ASCOM's device-type label.
+- **No `id` field on `MountConfig`.** Singular type, nothing to
+  disambiguate. MCP tools take no `mount_id` / `telescope_id`
+  parameter.
+- **`slew` does not touch `Tracking`.** ASCOM mandates `Tracking ==
+  true` before equatorial `SlewToCoordinatesAsync` (driver raises
+  `InvalidOperationException` otherwise) and guarantees `Tracking ==
+  true` after (per the AbortSlew docs: "equatorial slews by
+  definition always start and finish with Tracking on"). The contract
+  is unambiguous; `slew` propagates the natural Alpaca error if
+  tracking is off rather than auto-enabling. No `ensure_tracking`
+  parameter.
+- **`set_tracking` and `get_tracking` are standalone MCP tools.**
+  Workflows that need to enable tracking before slewing (the common
+  case, after unparking) call `set_tracking` explicitly. `get_tracking`
+  returns `{ tracking, can_set_tracking }`; fails loud when the
+  underlying `Tracking` read errors.
+- **`get_mount_position` is included** (un-deferred from the original
+  stub). Returns `{ ra, dec }`. Needed for BDD verification that
+  `sync_mount` took effect, and useful for any caller that wants to
+  read the current pointing without going through `slew`.
+- **`mount.settle_after_slew` is a config field with optional per-call
+  override.** Mounts have post-slew mechanical settle (gear backlash,
+  ringing) that's a property of the rig, not of any individual
+  workflow. Operator sets `mount.settle_after_slew: "3s"` (or
+  whatever their mount needs); `slew { ra, dec, settle_after?: "1s" }`
+  overrides per call (including `"0s"` to skip). Default `"0s"` (no
+  settle) so the field is purely opt-in.
+- **300 s slew deadline, hardcoded.** Covers a worst-case
+  meridian-flip + park-side traversal at ~1°/s. Move to config later
+  if needed. Best-effort `abort_slew()` on deadline expiry before
+  returning the timeout error (mount runaways are more dangerous than
+  focuser runaways — cables, hard stops, sun-pointing in a flat
+  workflow).
+- **`get_focuser_position` follow-up: issue [#130](https://github.com/ivonnyssen/rusty-photon/issues/130)**
+  tracks revisiting `ensure_default_*` helpers in `bdd-infra` for
+  piggyback (multi-optical-train) BDD scenarios. Out of scope for
+  this PR.
+
+###### Work breakdown (in order)
+
+- [ ] **Step 1 — `MountConfig` in `config.rs`.** Fields: `alpaca_url:
+      String`, `device_number: u32` (`#[serde(default)]`), optional
+      `auth: Option<ClientAuthConfig>`, optional
+      `settle_after_slew: Option<Duration>` (`humantime_serde`).
+      Replace the existing `pub mount: Value` placeholder on
+      `EquipmentConfig` with `pub mount: Option<MountConfig>`
+      (`#[serde(default)]`). Two unit tests — minimal-fields, with
+      auth + settle_after_slew.
+- [ ] **Step 2 — `MountEntry` + `connect_mount` in `equipment.rs`.**
+      Mirrors `FocuserEntry` / `connect_focuser`. Holds
+      `Arc<dyn Telescope>` from ascom-alpaca. Five failure-arm unit
+      tests via in-test axum stub (same pattern Phase 6a established
+      for `connect_focuser`): `build_alpaca_client` error, `get_devices`
+      network error, 5 s `tokio::time::timeout`, no-telescope-in-list,
+      `set_connected` Alpaca rejection. Plus one happy-path arm. No
+      connect-time probes of `Tracking` / `Slewing` / `AtPark`.
+- [ ] **Step 3 — `EquipmentRegistry` plumbing.** Singular
+      `pub mount: Option<MountEntry>` field, populated in
+      `EquipmentRegistry::new`. `find_mount(&self) -> Option<&MountEntry>`
+      lookup. `EquipmentStatus.mount: Option<DeviceStatus>` (singular,
+      JSON-serialized as `null` when no mount is configured). One
+      end-to-end registry test against the axum stub paralleling
+      `connect_focuser_success_returns_connected_entry` +
+      `find_focuser`.
+- [ ] **Step 4 — `do_slew_blocking` helper in `mcp.rs`.**
+      `pub(crate) async fn do_slew_blocking(&self, ra: f64, dec: f64,
+      settle_after: Duration) -> Result<(f64, f64), String>`. Resolves
+      the mount, calls `slew_to_coordinates_async`, polls `slewing()`
+      every 100 ms with a 300 s deadline, sleeps `settle_after` after
+      `Slewing == false`, then reads `(right_ascension(),
+      declination())` and returns. Best-effort `abort_slew()` on
+      deadline expiry before returning the timeout error. Modeled on
+      `do_move_focuser_blocking`. Helper `resolve_mount` (no macro)
+      handles "no mount configured" + "mount not connected" symmetrically.
+- [ ] **Step 5 — Five MCP tools in `mcp.rs`.**
+      - `slew { ra: f64, dec: f64, settle_after: Option<Duration> }` →
+        `{ actual_ra, actual_dec }`. Validates `ra ∈ [0, 24)` hours and
+        `dec ∈ [-90, 90]` degrees in the body. `settle_after` resolves
+        `None → config default`, `Some → override`.
+      - `sync_mount { ra: f64, dec: f64 }` → `{}`. Same validation,
+        calls `sync_to_coordinates`. Immediate, no polling.
+      - `get_mount_position { }` → `{ ra: f64, dec: f64 }`. Reads
+        `right_ascension()` then `declination()`. Fails loud on either
+        read error.
+      - `get_tracking { }` → `{ tracking: bool, can_set_tracking: bool }`.
+        Reads both `tracking()` and `can_set_tracking()`. Fails loud
+        on the `tracking()` read error (no half-success).
+      - `set_tracking { enabled: bool }` → `{}`. Calls `set_tracking`.
+        `CanSetTracking == false` surfaces as the natural Alpaca error.
+
+      ~16 unit tests against a `MockTelescope` (paralleling the
+      existing `MockFocuser` pattern at `mcp.rs:2160+`).
+- [ ] **Step 6 — `tests/features/mount.feature`** (~15 scenarios,
+      `@serial` tagged). Catalog (1); `slew` (5: tracking-on happy
+      path, tracking-off error, no-mount-configured, mount-not-connected,
+      one Outline using `MISSING` sentinel for ra/dec range +
+      missing-field cases); `sync_mount` (3: happy path verified via
+      `get_mount_position`, no-mount/not-connected Outline,
+      ra/dec range Outline); `get_tracking` (1); `set_tracking`
+      (2: enable, disable); `get_mount_position` (2: happy path,
+      no-mount/not-connected); plus one settle-honoring scenario
+      asserting `settle_after: "100ms"` extends total slew time by
+      ~100ms. Slew tolerance: exact equality (revisit at impl time
+      if OmniSim diverges).
+- [ ] **Step 7 — `tests/bdd/steps/mount_steps.rs`.** Reuse-first:
+      pull `the tool list should include`, `the tool call should
+      succeed`, `the tool call should return an error`, `the error
+      message should contain` from `tool_steps.rs`. New mount-specific
+      steps: `Given(rp is running with a mount on the simulator)`,
+      `Given(rp is running without a mount)`,
+      `Given(rp is running with a mount at <url> device <n>)`,
+      `Given(the mount tracking is set to <bool>)`, `When` steps for
+      each MCP tool (slew/sync_mount/get_tracking/set_tracking/get_mount_position),
+      `Then` field-extraction asserts. The slew/sync_mount `When`
+      steps interpret `MISSING` in the table as "omit that field
+      from the JSON-RPC params." No new `RpWorld` fields. Wire into
+      `tests/bdd/steps/mod.rs`.
+- [ ] **Step 8 — `bdd_infra::rp_harness::MountConfig` +
+      `RpConfigBuilder::with_mount`.** Test-side struct holds
+      `alpaca_url` + `device_number` (no `auth`, matches existing
+      test-side device structs). Builder field
+      `mount: Option<MountConfig>`; `with_mount` setter (singular,
+      not `add_*`). `build()` emits `"mount": null | { … }`,
+      replacing the current literal `"mount": null` line. No
+      `ensure_default_mount` — explicit `.with_mount(...)` reads
+      better at every call site that needs a mount.
+- [ ] **Step 9 — `docs/services/rp.md` updates.**
+      - Configuration example: replace the existing
+        `mount` block with the singular typed shape including
+        optional `settle_after_slew`. Drop the obsolete
+        `settle_time_secs` field.
+      - Built-in Tools — Hardware table: add three rows for
+        `get_mount_position`, `get_tracking`, `set_tracking`.
+      - One-line prose under Configuration: "Exactly one mount is
+        the typical deployment — the singular `mount` field reflects
+        that. Piggyback rigs have multiple cameras / focusers /
+        filter wheels on the same mount; multi-mount support is in
+        Future Considerations."
+      - One-line prose under the new tools: "`mount.settle_after_slew`
+        is applied after `Slewing == false`; per-call `settle_after`
+        on `slew` overrides (including `"0s"` to skip)."
+- [ ] **Step 10 — `services/rp/Cargo.toml`.** Append `"telescope"` to
+      `ascom-alpaca`'s features list. No new workspace deps; no
+      `bazel mod tidy` needed. Per-crate features lists are intent
+      expression — workspace builds compile the union due to Cargo
+      feature unification, but cargo-hack's feature-powerset CI
+      enforces standalone-buildability.
+- [ ] **Step 11 — Plan-doc bookkeeping.** Land alongside the impl:
+      flip Phase 6c-prep status to **complete** with the work-breakdown
+      checkboxes ticked, exit-criteria block populated with concrete
+      counts (BDD scenarios green, lib tests passing).
+
+**Out of scope (deferred or never):**
+
+- `park` / `unpark` MCP tools. Add when a workflow needs them.
+- `abort_slew` as a standalone MCP tool. Sentinel's safety path
+  already terminates the orchestrator on unsafe transitions; no
+  caller for an MCP `abort_slew` yet.
+- `tracking_rate` (sidereal / lunar / solar / king). Sidereal is the
+  only rate deep-sky workflows need; defer until a planetary or
+  comet-tracking workflow surfaces.
+- Multi-mount support. Already in `rp.md` Future Considerations.
+- `side_of_pier` exposure. The original stub mentioned it on
+  `get_mount_position`; deferred until a meridian-flip workflow
+  surfaces.
+
+**Exit criteria:** ~15 new BDD scenarios green; ~24 new lib tests
+across `config` (2), `equipment` (7), `mcp` mount tools (~16);
+`cargo rail run --profile commit -q` clean; `cargo fmt` clean.
 
 ##### Phase 6c-1 — `rp-plate-solver` rp-managed service
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -611,8 +611,11 @@ the exact parameter types and return structure.
 | `move_focuser` | focuser_id, position | actual_position | Move focuser to absolute position |
 | `get_focuser_position` | focuser_id | position | Read current focuser position |
 | `get_focuser_temperature` | focuser_id | temperature_c | Read focuser temperature sensor |
-| `slew` | ra, dec | actual_ra, actual_dec | Slew mount to coordinates (blocks until settled) |
+| `slew` | ra, dec, settle_after (optional) | actual_ra, actual_dec | Slew the singular mount to coordinates (blocks until `Slewing == false` plus configured / per-call settle). Tracking must be on; ASCOM error propagates otherwise |
 | `sync_mount` | ra, dec | — | Sync mount position to given coordinates |
+| `get_mount_position` | — | ra, dec | Read the mount's current pointing |
+| `get_tracking` | — | tracking, can_set_tracking | Read tracking state and `CanSetTracking` capability; fails loud on read error |
+| `set_tracking` | enabled | — | Enable or disable sidereal tracking |
 | `set_filter` | filter_wheel_id, filter_name | — | Change filter wheel position |
 | `get_filter` | filter_wheel_id | filter_name, position | Read current filter |
 | `close_cover` | calibrator_id | — | Close the dust cover (blocks until closed) |
@@ -2251,6 +2254,15 @@ ack/completion protocol.
 All configuration is in a single JSON file. Equipment is listed with Alpaca
 connection details. Plugins register their webhook URLs and command endpoints.
 
+The `mount` field is singular: exactly one mount is the typical
+deployment. Piggyback rigs share that one mount across multiple optical
+trains — `cameras`, `focusers`, and `filter_wheels` stay plural for the
+trains; `mount` stays singular. Multi-mount support is in
+[Future Considerations](#future-considerations). `mount.settle_after_slew`
+is applied by `slew` after the mount reports `Slewing == false`; per-call
+`settle_after` on `slew` overrides this value (including `"0s"` to skip
+when the config sets a non-zero default).
+
 ```json
 {
   "session": {
@@ -2288,7 +2300,7 @@ connection details. Plugins register their webhook URLs and command endpoints.
     "mount": {
       "alpaca_url": "http://localhost:11122",
       "device_number": 0,
-      "settle_time_secs": 2
+      "settle_after_slew": "3s"
     },
     "focusers": [
       {

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -34,7 +34,7 @@ ndarray-ndimage = { workspace = true }
 rmpfit = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { workspace = true }
-ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel", "cover_calibrator", "focuser"] }
+ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel", "cover_calibrator", "focuser", "telescope"] }
 rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server", "schemars"] }
 schemars = { workspace = true }
 tempfile = { workspace = true }

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -46,7 +46,7 @@ pub struct EquipmentConfig {
     #[serde(default)]
     pub cameras: Vec<CameraConfig>,
     #[serde(default)]
-    pub mount: Value,
+    pub mount: Option<MountConfig>,
     #[serde(default)]
     pub focusers: Vec<FocuserConfig>,
     #[serde(default)]
@@ -94,6 +94,28 @@ pub struct FocuserConfig {
     /// Operator-supplied upper bound for `move_focuser` validation.
     #[serde(default)]
     pub max_position: Option<i32>,
+    /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::ClientAuthConfig>,
+}
+
+/// `rp` deployments have at most one mount — piggyback rigs share one
+/// mount across multiple optical trains (multiple cameras / focusers /
+/// filter wheels). Multi-mount support is in `rp.md` Future
+/// Considerations. The singular `Option` reflects that contract in the
+/// type; `None` is valid for camera-only / flats-rig configurations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MountConfig {
+    pub alpaca_url: String,
+    #[serde(default)]
+    pub device_number: u32,
+    /// Mechanical settle time applied after the mount reports
+    /// `Slewing == false`, before `slew` returns. Set per-rig (gear
+    /// backlash, mount mass, etc.) — defaults to zero. Per-call
+    /// `settle_after` on `slew` overrides this value (including
+    /// `"0s"` to skip).
+    #[serde(default, with = "humantime_serde")]
+    pub settle_after_slew: Option<Duration>,
     /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
     #[serde(default)]
     pub auth: Option<rp_auth::config::ClientAuthConfig>,
@@ -353,6 +375,80 @@ mod tests {
         let auth = f.auth.as_ref().unwrap();
         assert_eq!(auth.username, "u");
         assert_eq!(auth.password, "p");
+    }
+
+    #[test]
+    fn mount_config_minimal_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "mount": {
+                        "alpaca_url": "http://localhost:11122"
+                    }
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        let m = config.equipment.mount.as_ref().unwrap();
+        assert_eq!(m.alpaca_url, "http://localhost:11122");
+        assert_eq!(m.device_number, 0);
+        assert!(m.settle_after_slew.is_none());
+        assert!(m.auth.is_none());
+    }
+
+    #[test]
+    fn mount_config_with_settle_and_auth() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "mount": {
+                        "alpaca_url": "http://localhost:11122",
+                        "device_number": 1,
+                        "settle_after_slew": "3s",
+                        "auth": {"username": "u", "password": "p"}
+                    }
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        let m = config.equipment.mount.as_ref().unwrap();
+        assert_eq!(m.device_number, 1);
+        assert_eq!(m.settle_after_slew, Some(Duration::from_secs(3)));
+        let auth = m.auth.as_ref().unwrap();
+        assert_eq!(auth.username, "u");
+        assert_eq!(auth.password, "p");
+    }
+
+    #[test]
+    fn mount_config_omitted_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {},
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert!(config.equipment.mount.is_none());
     }
 
     #[test]

--- a/services/rp/src/equipment.rs
+++ b/services/rp/src/equipment.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ascom_alpaca::api::{Camera, CoverCalibrator, FilterWheel, Focuser, TypedDevice};
+use ascom_alpaca::api::{Camera, CoverCalibrator, FilterWheel, Focuser, Telescope, TypedDevice};
 use ascom_alpaca::Client;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
@@ -39,11 +39,21 @@ pub struct FocuserEntry {
     pub device: Option<Arc<dyn Focuser>>,
 }
 
+/// Singular mount entry. Piggyback rigs share one mount across multiple
+/// optical trains, so `EquipmentRegistry.mount` is an `Option`, not a
+/// `Vec`. No `id` field — there is nothing to disambiguate.
+pub struct MountEntry {
+    pub connected: bool,
+    pub config: config::MountConfig,
+    pub device: Option<Arc<dyn Telescope>>,
+}
+
 pub struct EquipmentRegistry {
     pub cameras: Vec<CameraEntry>,
     pub filter_wheels: Vec<FilterWheelEntry>,
     pub cover_calibrators: Vec<CoverCalibratorEntry>,
     pub focusers: Vec<FocuserEntry>,
+    pub mount: Option<MountEntry>,
 }
 
 #[derive(Serialize)]
@@ -52,11 +62,18 @@ pub struct EquipmentStatus {
     pub filter_wheels: Vec<DeviceStatus>,
     pub cover_calibrators: Vec<DeviceStatus>,
     pub focusers: Vec<DeviceStatus>,
+    pub mount: Option<MountStatus>,
 }
 
 #[derive(Serialize)]
 pub struct DeviceStatus {
     pub id: String,
+    pub connected: bool,
+}
+
+/// Singular wire-format counterpart to [`MountEntry`] — no `id`.
+#[derive(Serialize)]
+pub struct MountStatus {
     pub connected: bool,
 }
 
@@ -87,11 +104,17 @@ impl EquipmentRegistry {
             focusers.push(entry);
         }
 
+        let mount = match &equipment_config.mount {
+            Some(mount_config) => Some(connect_mount(mount_config).await),
+            None => None,
+        };
+
         Self {
             cameras,
             filter_wheels,
             cover_calibrators,
             focusers,
+            mount,
         }
     }
 
@@ -129,6 +152,9 @@ impl EquipmentRegistry {
                     connected: f.connected,
                 })
                 .collect(),
+            mount: self.mount.as_ref().map(|m| MountStatus {
+                connected: m.connected,
+            }),
         }
     }
 
@@ -146,6 +172,12 @@ impl EquipmentRegistry {
 
     pub fn find_focuser(&self, id: &str) -> Option<&FocuserEntry> {
         self.focusers.iter().find(|f| f.id == id)
+    }
+
+    /// Returns the singular mount entry, or `None` when no mount is
+    /// configured. Singular: there is no `id` parameter.
+    pub fn find_mount(&self) -> Option<&MountEntry> {
+        self.mount.as_ref()
     }
 }
 
@@ -517,6 +549,89 @@ async fn connect_focuser(config: &config::FocuserConfig) -> FocuserEntry {
     }
 }
 
+async fn connect_mount(config: &config::MountConfig) -> MountEntry {
+    debug!(alpaca_url = %config.alpaca_url, device_number = config.device_number, "connecting to mount");
+
+    let client = match build_alpaca_client(&config.alpaca_url, config.auth.as_ref()) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(error = %e, "failed to create Alpaca client for mount");
+            return MountEntry {
+                connected: false,
+                config: config.clone(),
+                device: None,
+            };
+        }
+    };
+
+    let devices = match tokio::time::timeout(Duration::from_secs(5), client.get_devices()).await {
+        Ok(Ok(devices)) => devices,
+        Ok(Err(e)) => {
+            debug!(error = %e, "failed to get devices from Alpaca server");
+            return MountEntry {
+                connected: false,
+                config: config.clone(),
+                device: None,
+            };
+        }
+        Err(_) => {
+            debug!("timeout connecting to Alpaca server");
+            return MountEntry {
+                connected: false,
+                config: config.clone(),
+                device: None,
+            };
+        }
+    };
+
+    let mut mount_index = 0u32;
+    let mut found_mount: Option<Arc<dyn Telescope>> = None;
+
+    for device in devices {
+        if let TypedDevice::Telescope(t) = device {
+            if mount_index == config.device_number {
+                found_mount = Some(t);
+                break;
+            }
+            mount_index += 1;
+        }
+    }
+
+    let t = match found_mount {
+        Some(t) => t,
+        None => {
+            debug!(
+                device_number = config.device_number,
+                "mount not found on Alpaca server"
+            );
+            return MountEntry {
+                connected: false,
+                config: config.clone(),
+                device: None,
+            };
+        }
+    };
+
+    match t.set_connected(true).await {
+        Ok(()) => {
+            debug!("mount connected successfully");
+            MountEntry {
+                connected: true,
+                config: config.clone(),
+                device: Some(t),
+            }
+        }
+        Err(e) => {
+            debug!(error = %e, "failed to connect mount");
+            MountEntry {
+                connected: false,
+                config: config.clone(),
+                device: None,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -796,7 +911,7 @@ mod tests {
         let stub = spawn_stub(ok_focuser_router()).await;
         let equipment_cfg = config::EquipmentConfig {
             cameras: vec![],
-            mount: serde_json::Value::Null,
+            mount: None,
             focusers: vec![focuser_config_for(&stub.url())],
             filter_wheels: vec![],
             cover_calibrators: vec![],
@@ -815,5 +930,164 @@ mod tests {
         assert_eq!(status.focusers.len(), 1);
         assert_eq!(status.focusers[0].id, "main-focuser");
         assert!(status.focusers[0].connected);
+        assert!(
+            status.mount.is_none(),
+            "mount should be None when unconfigured"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Mount tests — same pattern as focuser tests above. Five failure arms
+    // + one success arm + one EquipmentRegistry end-to-end test.
+    // -----------------------------------------------------------------------
+
+    fn mount_config_for(url: &str) -> config::MountConfig {
+        config::MountConfig {
+            alpaca_url: url.to_string(),
+            device_number: 0,
+            settle_after_slew: None,
+            auth: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_mount_invalid_url_returns_disconnected_entry() {
+        let cfg = mount_config_for("not-a-url");
+        let entry = connect_mount(&cfg).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_mount_unreachable_returns_disconnected_entry() {
+        let cfg = mount_config_for("http://127.0.0.1:1");
+        let entry = connect_mount(&cfg).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_mount_no_telescope_in_devices_returns_disconnected_entry() {
+        let app = Router::new().route(
+            "/management/v1/configureddevices",
+            get(|| async {
+                Json(serde_json::json!({
+                    "Value": [],
+                    "ErrorNumber": 0,
+                    "ErrorMessage": ""
+                }))
+            }),
+        );
+        let stub = spawn_stub(app).await;
+        let entry = connect_mount(&mount_config_for(&stub.url())).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_mount_set_connected_fails_returns_disconnected_entry() {
+        let app = Router::new()
+            .route(
+                "/management/v1/configureddevices",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": [{
+                            "DeviceName": "Telescope 0",
+                            "DeviceType": "Telescope",
+                            "DeviceNumber": 0,
+                            "UniqueID": "test-mount-uid"
+                        }],
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/telescope/0/connected",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 1024,
+                        "ErrorMessage": "simulated set_connected failure"
+                    }))
+                }),
+            );
+        let stub = spawn_stub(app).await;
+        let entry = connect_mount(&mount_config_for(&stub.url())).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connect_mount_timeout_returns_disconnected_entry() {
+        let app = Router::new().route(
+            "/management/v1/configureddevices",
+            get(|| async { std::future::pending::<Json<serde_json::Value>>().await }),
+        );
+        let stub = spawn_stub(app).await;
+        let entry = connect_mount(&mount_config_for(&stub.url())).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    fn ok_mount_router() -> Router {
+        Router::new()
+            .route(
+                "/management/v1/configureddevices",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": [{
+                            "DeviceName": "Telescope 0",
+                            "DeviceType": "Telescope",
+                            "DeviceNumber": 0,
+                            "UniqueID": "test-mount-uid"
+                        }],
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/telescope/0/connected",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+    }
+
+    #[tokio::test]
+    async fn connect_mount_success_returns_connected_entry() {
+        let stub = spawn_stub(ok_mount_router()).await;
+        let entry = connect_mount(&mount_config_for(&stub.url())).await;
+        assert!(entry.connected, "expected entry to be connected");
+        assert!(entry.device.is_some(), "expected entry to hold a device");
+    }
+
+    #[tokio::test]
+    async fn equipment_registry_surfaces_connected_mount_in_status_and_lookup() {
+        let stub = spawn_stub(ok_mount_router()).await;
+        let equipment_cfg = config::EquipmentConfig {
+            cameras: vec![],
+            mount: Some(mount_config_for(&stub.url())),
+            focusers: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            safety_monitors: vec![],
+        };
+        let registry = EquipmentRegistry::new(&equipment_cfg).await;
+
+        let found = registry
+            .find_mount()
+            .expect("find_mount should return the configured mount");
+        assert!(found.connected);
+
+        let status = registry.status();
+        let mount_status = status
+            .mount
+            .as_ref()
+            .expect("EquipmentStatus.mount should be Some when configured");
+        assert!(mount_status.connected);
     }
 }

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -274,6 +274,52 @@ pub struct MoveFocuserParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct SlewParams {
+    /// Target right ascension in decimal hours, in `[0.0, 24.0)`.
+    /// Required (validated in body for deterministic error ordering).
+    #[serde(default)]
+    pub ra: Option<f64>,
+    /// Target declination in decimal degrees, in `[-90.0, 90.0]`.
+    /// Required (validated in body).
+    #[serde(default)]
+    pub dec: Option<f64>,
+    /// Optional per-call override for the post-`Slewing == false`
+    /// settle. `None` uses `mount.settle_after_slew` from config (which
+    /// itself defaults to zero). `Some("0s")` skips settle even when
+    /// the config sets a non-zero default.
+    #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "Option<String>")]
+    pub settle_after: Option<Duration>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SyncMountParams {
+    /// Right ascension in decimal hours, in `[0.0, 24.0)`. Required
+    /// (validated in body).
+    #[serde(default)]
+    pub ra: Option<f64>,
+    /// Declination in decimal degrees, in `[-90.0, 90.0]`. Required
+    /// (validated in body).
+    #[serde(default)]
+    pub dec: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetTrackingParams {
+    /// New tracking state. `true` enables sidereal tracking; `false`
+    /// disables it.
+    pub enabled: bool,
+}
+
+/// Empty parameter struct for `get_tracking` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetTrackingParams {}
+
+/// Empty parameter struct for `get_mount_position` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetMountPositionParams {}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AutoFocusToolParams {
     /// Camera device ID. Required (validated in body for deterministic
     /// error ordering — see `docs/services/rp.md` `auto_focus` Contract).
@@ -922,6 +968,90 @@ impl McpHandler {
         foc.position()
             .await
             .map_err(|e| format!("failed to read focuser position: {}", e))
+    }
+
+    /// Resolve the singular mount, returning the entry + connected device
+    /// or a string error matching the convention `resolve_device!` uses
+    /// for `id`-keyed devices ("no mount configured" / "mount not
+    /// connected"). Singular: no `id` parameter.
+    pub(crate) fn resolve_mount(
+        &self,
+    ) -> std::result::Result<
+        (
+            &crate::equipment::MountEntry,
+            Arc<dyn ascom_alpaca::api::Telescope>,
+        ),
+        String,
+    > {
+        let entry = self
+            .equipment
+            .find_mount()
+            .ok_or_else(|| "no mount configured".to_string())?;
+        let device = entry
+            .device
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "mount not connected".to_string())?;
+        Ok((entry, device))
+    }
+
+    /// Resolve the mount, issue an async slew, poll `slewing()` until
+    /// idle (with a 300 s deadline), sleep `settle_after`, then read
+    /// the post-slew RA/Dec and return them.
+    ///
+    /// Best-effort `abort_slew()` on deadline expiry before returning
+    /// the timeout error — mount runaways have higher blast radius
+    /// than focuser runaways (cables, hard stops, sun in a flat
+    /// workflow).
+    ///
+    /// Mirrors `do_move_focuser_blocking`'s shape; same pass-through
+    /// error mapping. Does NOT touch `Tracking` (per `mount.feature`
+    /// + ASCOM contract — Tracking must already be on for
+    ///   `slew_to_coordinates_async`).
+    pub(crate) async fn do_slew_blocking(
+        &self,
+        ra: f64,
+        dec: f64,
+        settle_after: Duration,
+    ) -> std::result::Result<(f64, f64), String> {
+        let (_entry, mount) = self.resolve_mount()?;
+
+        debug!(ra, dec, "slewing mount");
+        mount
+            .slew_to_coordinates_async(ra, dec)
+            .await
+            .map_err(|e| format!("failed to slew: {}", e))?;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            match mount.slewing().await {
+                Ok(false) => break,
+                Ok(true) if tokio::time::Instant::now() < deadline => continue,
+                Ok(true) => {
+                    // Best-effort abort; ignore the abort's own result and
+                    // surface the timeout error as the primary failure.
+                    let _ = mount.abort_slew().await;
+                    return Err("timeout waiting for mount to settle".to_string());
+                }
+                Err(e) => return Err(format!("error polling mount slewing: {}", e)),
+            }
+        }
+
+        if !settle_after.is_zero() {
+            debug!(?settle_after, "waiting for mount settle");
+            tokio::time::sleep(settle_after).await;
+        }
+
+        let actual_ra = mount
+            .right_ascension()
+            .await
+            .map_err(|e| format!("failed to read mount right_ascension: {}", e))?;
+        let actual_dec = mount
+            .declination()
+            .await
+            .map_err(|e| format!("failed to read mount declination: {}", e))?;
+        Ok((actual_ra, actual_dec))
     }
 }
 
@@ -1670,6 +1800,174 @@ impl McpHandler {
     }
 
     // -------------------------------------------------------------------
+    // Mount tools
+    //
+    // The mount is singular per `rp` deployment (piggyback rigs share
+    // one mount across multiple optical trains). Tools take no
+    // `mount_id` / `telescope_id` parameter — there is nothing to
+    // disambiguate.
+    // -------------------------------------------------------------------
+
+    #[tool(
+        description = "Slew the mount to equatorial coordinates (RA hours, Dec degrees). Blocks until the mount reports Slewing == false plus the configured / per-call settle. Tracking must be on before calling — propagates the Alpaca error otherwise."
+    )]
+    async fn slew(
+        &self,
+        Parameters(params): Parameters<SlewParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Body validation in input order (ra → dec → settle_after) so
+        // the error message points at the first missing or out-of-range
+        // field. Same convention as `auto_focus` / `measure_basic`.
+        let ra = match params.ra {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: ra")),
+        };
+        if !(0.0..24.0).contains(&ra) {
+            return Ok(tool_error!(
+                "ra out of range: {} (must be in [0.0, 24.0))",
+                ra
+            ));
+        }
+        let dec = match params.dec {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: dec")),
+        };
+        if !(-90.0..=90.0).contains(&dec) {
+            return Ok(tool_error!(
+                "dec out of range: {} (must be in [-90.0, 90.0])",
+                dec
+            ));
+        }
+
+        // Resolve the mount once before reading the settle config so
+        // "no mount configured" error wins over a config lookup.
+        let settle_after = match params.settle_after {
+            Some(d) => d,
+            None => match self.equipment.find_mount() {
+                Some(entry) => entry.config.settle_after_slew.unwrap_or_default(),
+                None => Duration::default(),
+            },
+        };
+
+        match self.do_slew_blocking(ra, dec, settle_after).await {
+            Ok((actual_ra, actual_dec)) => Ok(tool_success!({
+                "actual_ra": actual_ra,
+                "actual_dec": actual_dec,
+            })),
+            Err(e) => Ok(tool_error!("{}", e)),
+        }
+    }
+
+    #[tool(
+        description = "Sync the mount's reported position to the given equatorial coordinates (RA hours, Dec degrees). Immediate; no polling."
+    )]
+    async fn sync_mount(
+        &self,
+        Parameters(params): Parameters<SyncMountParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let ra = match params.ra {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: ra")),
+        };
+        if !(0.0..24.0).contains(&ra) {
+            return Ok(tool_error!(
+                "ra out of range: {} (must be in [0.0, 24.0))",
+                ra
+            ));
+        }
+        let dec = match params.dec {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: dec")),
+        };
+        if !(-90.0..=90.0).contains(&dec) {
+            return Ok(tool_error!(
+                "dec out of range: {} (must be in [-90.0, 90.0])",
+                dec
+            ));
+        }
+
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        debug!(ra, dec, "syncing mount");
+        match mount.sync_to_coordinates(ra, dec).await {
+            Ok(()) => Ok(tool_success!({})),
+            Err(e) => Ok(tool_error!("failed to sync mount: {}", e)),
+        }
+    }
+
+    #[tool(description = "Read the mount's current pointing as RA (hours) / Dec (degrees).")]
+    async fn get_mount_position(
+        &self,
+        Parameters(_params): Parameters<GetMountPositionParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        let ra = match mount.right_ascension().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount right_ascension: {}", e)),
+        };
+        let dec = match mount.declination().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount declination: {}", e)),
+        };
+
+        Ok(tool_success!({
+            "ra": ra,
+            "dec": dec,
+        }))
+    }
+
+    #[tool(
+        description = "Read the mount's tracking state and CanSetTracking capability. Fails loud if the Tracking read errors."
+    )]
+    async fn get_tracking(
+        &self,
+        Parameters(_params): Parameters<GetTrackingParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        let tracking = match mount.tracking().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount tracking: {}", e)),
+        };
+        let can_set_tracking = match mount.can_set_tracking().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount can_set_tracking: {}", e)),
+        };
+
+        Ok(tool_success!({
+            "tracking": tracking,
+            "can_set_tracking": can_set_tracking,
+        }))
+    }
+
+    #[tool(description = "Enable or disable the mount's sidereal tracking drive.")]
+    async fn set_tracking(
+        &self,
+        Parameters(params): Parameters<SetTrackingParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        debug!(enabled = params.enabled, "setting mount tracking");
+        match mount.set_tracking(params.enabled).await {
+            Ok(()) => Ok(tool_success!({})),
+            Err(e) => Ok(tool_error!("failed to set tracking: {}", e)),
+        }
+    }
+
+    // -------------------------------------------------------------------
     // Compound: auto_focus (V-curve)
     // -------------------------------------------------------------------
 
@@ -2247,6 +2545,165 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // MockTelescope — single configurable mock for Telescope (mount).
+    //
+    // Defaults are "happy path" (capable, tracking on, returns a fixed
+    // RA/Dec). Set fail_* fields to inject errors per test, or set
+    // tracking_value / can_set_tracking_value / ra_value / dec_value to
+    // shape the read responses.
+    // -----------------------------------------------------------------------
+
+    struct MockTelescope {
+        fail_slew: bool,
+        fail_slewing_poll: bool,
+        fail_sync: bool,
+        fail_right_ascension: bool,
+        fail_declination: bool,
+        fail_tracking: bool,
+        fail_can_set_tracking: bool,
+        fail_set_tracking: bool,
+        /// `slewing()` returns `true` forever — drives the timeout path.
+        stuck_slewing: bool,
+        tracking_value: bool,
+        can_set_tracking_value: bool,
+        ra_value: f64,
+        dec_value: f64,
+    }
+
+    impl Default for MockTelescope {
+        fn default() -> Self {
+            Self {
+                fail_slew: false,
+                fail_slewing_poll: false,
+                fail_sync: false,
+                fail_right_ascension: false,
+                fail_declination: false,
+                fail_tracking: false,
+                fail_can_set_tracking: false,
+                fail_set_tracking: false,
+                stuck_slewing: false,
+                tracking_value: true,
+                can_set_tracking_value: true,
+                ra_value: 0.0,
+                dec_value: 0.0,
+            }
+        }
+    }
+
+    impl_mock_device!(MockTelescope);
+
+    #[async_trait::async_trait]
+    impl ascom_alpaca::api::Telescope for MockTelescope {
+        async fn at_home(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            Ok(false)
+        }
+
+        async fn at_park(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            Ok(false)
+        }
+
+        async fn declination(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            if self.fail_declination {
+                return Err(ASCOMError::invalid_operation("encoder fault"));
+            }
+            Ok(self.dec_value)
+        }
+
+        async fn declination_rate(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            Ok(0.0)
+        }
+
+        async fn equatorial_system(
+            &self,
+        ) -> ascom_alpaca::ASCOMResult<ascom_alpaca::api::telescope::EquatorialCoordinateType>
+        {
+            Ok(ascom_alpaca::api::telescope::EquatorialCoordinateType::J2000)
+        }
+
+        async fn right_ascension(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            if self.fail_right_ascension {
+                return Err(ASCOMError::invalid_operation("encoder fault"));
+            }
+            Ok(self.ra_value)
+        }
+
+        async fn right_ascension_rate(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            Ok(0.0)
+        }
+
+        async fn sidereal_time(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            Ok(0.0)
+        }
+
+        async fn tracking(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            if self.fail_tracking {
+                return Err(ASCOMError::invalid_operation("tracking read failed"));
+            }
+            Ok(self.tracking_value)
+        }
+
+        async fn set_tracking(&self, _: bool) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_set_tracking {
+                return Err(ASCOMError::invalid_operation("CanSetTracking is false"));
+            }
+            Ok(())
+        }
+
+        async fn can_set_tracking(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            if self.fail_can_set_tracking {
+                return Err(ASCOMError::invalid_operation("capability read failed"));
+            }
+            Ok(self.can_set_tracking_value)
+        }
+
+        async fn tracking_rate(
+            &self,
+        ) -> ascom_alpaca::ASCOMResult<ascom_alpaca::api::telescope::DriveRate> {
+            Ok(ascom_alpaca::api::telescope::DriveRate::Sidereal)
+        }
+
+        async fn axis_rates(
+            &self,
+            _axis: ascom_alpaca::api::telescope::TelescopeAxis,
+        ) -> ascom_alpaca::ASCOMResult<Vec<std::ops::RangeInclusive<f64>>> {
+            Ok(vec![])
+        }
+
+        async fn utc_date(&self) -> ascom_alpaca::ASCOMResult<std::time::SystemTime> {
+            Ok(std::time::SystemTime::UNIX_EPOCH)
+        }
+
+        async fn slewing(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            if self.fail_slewing_poll {
+                return Err(ASCOMError::invalid_operation("slewing poll failed"));
+            }
+            Ok(self.stuck_slewing)
+        }
+
+        async fn abort_slew(&self) -> ascom_alpaca::ASCOMResult<()> {
+            Ok(())
+        }
+
+        async fn slew_to_coordinates_async(
+            &self,
+            _ra: f64,
+            _dec: f64,
+        ) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_slew {
+                return Err(ASCOMError::invalid_operation("Tracking is off"));
+            }
+            Ok(())
+        }
+
+        async fn sync_to_coordinates(&self, _ra: f64, _dec: f64) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_sync {
+                return Err(ASCOMError::invalid_operation("sync failed"));
+            }
+            Ok(())
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Helper functions
     // -----------------------------------------------------------------------
 
@@ -2311,6 +2768,7 @@ mod tests {
             filter_wheels: vec![],
             cover_calibrators: vec![],
             focusers: vec![],
+            mount: None,
         }
     }
 
@@ -2334,6 +2792,7 @@ mod tests {
             }],
             cover_calibrators: vec![],
             focusers: vec![],
+            mount: None,
         }
     }
 
@@ -2356,6 +2815,7 @@ mod tests {
                 device: Some(cc),
             }],
             focusers: vec![],
+            mount: None,
         }
     }
 
@@ -2382,6 +2842,58 @@ mod tests {
                 },
                 device: Some(foc),
             }],
+            mount: None,
+        }
+    }
+
+    fn mount_registry(
+        mount: Arc<dyn ascom_alpaca::api::Telescope>,
+        settle_after_slew: Option<Duration>,
+    ) -> crate::equipment::EquipmentRegistry {
+        crate::equipment::EquipmentRegistry {
+            cameras: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            focusers: vec![],
+            mount: Some(crate::equipment::MountEntry {
+                connected: true,
+                config: crate::config::MountConfig {
+                    alpaca_url: "http://localhost:1".to_string(),
+                    device_number: 0,
+                    settle_after_slew,
+                    auth: None,
+                },
+                device: Some(mount),
+            }),
+        }
+    }
+
+    fn empty_registry() -> crate::equipment::EquipmentRegistry {
+        crate::equipment::EquipmentRegistry {
+            cameras: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            focusers: vec![],
+            mount: None,
+        }
+    }
+
+    fn disconnected_mount_registry() -> crate::equipment::EquipmentRegistry {
+        crate::equipment::EquipmentRegistry {
+            cameras: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            focusers: vec![],
+            mount: Some(crate::equipment::MountEntry {
+                connected: false,
+                config: crate::config::MountConfig {
+                    alpaca_url: "http://localhost:1".to_string(),
+                    device_number: 0,
+                    settle_after_slew: None,
+                    auth: None,
+                },
+                device: None,
+            }),
         }
     }
 
@@ -2750,6 +3262,7 @@ mod tests {
                 filter_wheels: vec![],
                 cover_calibrators: vec![],
                 focusers: vec![],
+                mount: None,
             }),
             Arc::new(crate::events::EventBus::from_config(&[])),
             SessionConfig {
@@ -2992,6 +3505,7 @@ mod tests {
             filter_wheels: vec![],
             cover_calibrators: vec![],
             focusers: vec![],
+            mount: None,
         });
         let result = handler
             .compute_image_stats(Parameters(ComputeImageStatsParams {
@@ -3223,6 +3737,7 @@ mod tests {
                 },
                 device: None,
             }],
+            mount: None,
         };
         let handler = test_handler(registry);
         let result = handler
@@ -3271,6 +3786,7 @@ mod tests {
                 },
                 device: None,
             }],
+            mount: None,
         };
         let handler = test_handler(registry);
         let result = handler
@@ -3343,5 +3859,355 @@ mod tests {
             }))
             .await;
         assert_tool_error(result, "failed to read focuser temperature");
+    }
+
+    // -----------------------------------------------------------------------
+    // Mount tool tests — slew / sync_mount / get_mount_position /
+    // get_tracking / set_tracking. Singular mount, no mount_id parameter.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_slew_success() {
+        let mount = MockTelescope {
+            ra_value: 10.6847,
+            dec_value: 41.2689,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(10.6847),
+                dec: Some(41.2689),
+                settle_after: None,
+            }))
+            .await
+            .unwrap();
+        let json = ok_text(result);
+        assert_eq!(json["actual_ra"], 10.6847);
+        assert_eq!(json["actual_dec"], 41.2689);
+    }
+
+    #[tokio::test]
+    async fn test_slew_no_mount_configured() {
+        let handler = test_handler(empty_registry());
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    #[tokio::test]
+    async fn test_slew_mount_not_connected() {
+        let handler = test_handler(disconnected_mount_registry());
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "mount not connected");
+    }
+
+    #[tokio::test]
+    async fn test_slew_missing_ra() {
+        let handler = test_handler(mount_registry(Arc::new(MockTelescope::default()), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: None,
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "missing required parameter: ra");
+    }
+
+    #[tokio::test]
+    async fn test_slew_missing_dec() {
+        let handler = test_handler(mount_registry(Arc::new(MockTelescope::default()), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: None,
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "missing required parameter: dec");
+    }
+
+    #[tokio::test]
+    async fn test_slew_ra_out_of_range() {
+        let handler = test_handler(mount_registry(Arc::new(MockTelescope::default()), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(25.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "ra out of range");
+    }
+
+    #[tokio::test]
+    async fn test_slew_dec_out_of_range() {
+        let handler = test_handler(mount_registry(Arc::new(MockTelescope::default()), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(91.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "dec out of range");
+    }
+
+    /// Models the ASCOM `InvalidOperationException` that fires when
+    /// `Tracking == false` and the caller invokes
+    /// `SlewToCoordinatesAsync` — the natural error path the design
+    /// explicitly chose over a magical `ensure_tracking` parameter.
+    #[tokio::test]
+    async fn test_slew_alpaca_error_propagates() {
+        let mount = MockTelescope {
+            fail_slew: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "failed to slew");
+    }
+
+    /// Drives the timeout escalation path: `slewing()` returns `true`
+    /// indefinitely, the 300 s deadline expires, `abort_slew()` is
+    /// called (best-effort, ignored result), and the tool returns the
+    /// timeout error. `start_paused` lets tokio auto-advance virtual
+    /// time so the test runs in real-time milliseconds.
+    #[tokio::test(start_paused = true)]
+    async fn test_slew_timeout_returns_error_after_abort() {
+        let mount = MockTelescope {
+            stuck_slewing: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "timeout waiting for mount to settle");
+    }
+
+    /// Per-call `settle_after` overrides the config default. Passes
+    /// `Duration::ZERO` to skip an otherwise-non-zero config value;
+    /// behavior of the actual sleep is exercised in BDD where
+    /// wall-clock timing is observable.
+    #[tokio::test]
+    async fn test_slew_per_call_settle_overrides_config() {
+        let mount = MockTelescope::default();
+        let handler = test_handler(mount_registry(
+            Arc::new(mount),
+            Some(Duration::from_secs(60)),
+        ));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: Some(Duration::ZERO),
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_sync_mount_success() {
+        let mount = MockTelescope::default();
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .sync_mount(Parameters(SyncMountParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_sync_mount_no_mount_configured() {
+        let handler = test_handler(empty_registry());
+        let result = handler
+            .sync_mount(Parameters(SyncMountParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+            }))
+            .await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    #[tokio::test]
+    async fn test_sync_mount_alpaca_error() {
+        let mount = MockTelescope {
+            fail_sync: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .sync_mount(Parameters(SyncMountParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+            }))
+            .await;
+        assert_tool_error(result, "failed to sync mount");
+    }
+
+    #[tokio::test]
+    async fn test_sync_mount_ra_out_of_range() {
+        let handler = test_handler(mount_registry(Arc::new(MockTelescope::default()), None));
+        let result = handler
+            .sync_mount(Parameters(SyncMountParams {
+                ra: Some(-1.0),
+                dec: Some(0.0),
+            }))
+            .await;
+        assert_tool_error(result, "ra out of range");
+    }
+
+    #[tokio::test]
+    async fn test_get_mount_position_returns_ra_dec() {
+        let mount = MockTelescope {
+            ra_value: 12.5,
+            dec_value: -23.4,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_mount_position(Parameters(GetMountPositionParams {}))
+            .await
+            .unwrap();
+        let json = ok_text(result);
+        assert_eq!(json["ra"], 12.5);
+        assert_eq!(json["dec"], -23.4);
+    }
+
+    #[tokio::test]
+    async fn test_get_mount_position_no_mount() {
+        let handler = test_handler(empty_registry());
+        let result = handler
+            .get_mount_position(Parameters(GetMountPositionParams {}))
+            .await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    #[tokio::test]
+    async fn test_get_mount_position_ra_read_fails() {
+        let mount = MockTelescope {
+            fail_right_ascension: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_mount_position(Parameters(GetMountPositionParams {}))
+            .await;
+        assert_tool_error(result, "failed to read mount right_ascension");
+    }
+
+    #[tokio::test]
+    async fn test_get_tracking_returns_state_and_capability() {
+        let mount = MockTelescope {
+            tracking_value: true,
+            can_set_tracking_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_tracking(Parameters(GetTrackingParams {}))
+            .await
+            .unwrap();
+        let json = ok_text(result);
+        assert_eq!(json["tracking"], true);
+        assert_eq!(json["can_set_tracking"], true);
+    }
+
+    /// Mount that reports `CanSetTracking == false` — surfaces in the
+    /// tool result rather than failing the call. Workflows can read
+    /// the field and decide whether to continue.
+    #[tokio::test]
+    async fn test_get_tracking_surfaces_can_set_tracking_false() {
+        let mount = MockTelescope {
+            tracking_value: false,
+            can_set_tracking_value: false,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_tracking(Parameters(GetTrackingParams {}))
+            .await
+            .unwrap();
+        let json = ok_text(result);
+        assert_eq!(json["tracking"], false);
+        assert_eq!(json["can_set_tracking"], false);
+    }
+
+    /// Per the design decision: fail loud on `Tracking` read errors;
+    /// don't try to half-succeed by returning `can_set_tracking` alone.
+    #[tokio::test]
+    async fn test_get_tracking_fails_when_tracking_read_errors() {
+        let mount = MockTelescope {
+            fail_tracking: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.get_tracking(Parameters(GetTrackingParams {})).await;
+        assert_tool_error(result, "failed to read mount tracking");
+    }
+
+    #[tokio::test]
+    async fn test_set_tracking_enables() {
+        let mount = MockTelescope::default();
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .set_tracking(Parameters(SetTrackingParams { enabled: true }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_set_tracking_disables() {
+        let mount = MockTelescope::default();
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .set_tracking(Parameters(SetTrackingParams { enabled: false }))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    /// Models a mount that responds to `set_tracking` with an
+    /// `InvalidOperationException` (e.g. `CanSetTracking == false`).
+    /// The error propagates with the friendly prefix.
+    #[tokio::test]
+    async fn test_set_tracking_alpaca_error() {
+        let mount = MockTelescope {
+            fail_set_tracking: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .set_tracking(Parameters(SetTrackingParams { enabled: true }))
+            .await;
+        assert_tool_error(result, "failed to set tracking");
     }
 }

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -1839,8 +1839,10 @@ impl McpHandler {
             ));
         }
 
-        // Resolve the mount once before reading the settle config so
-        // "no mount configured" error wins over a config lookup.
+        // Resolve `settle_after`: explicit per-call value wins; otherwise
+        // pull the mount's configured default (or zero if no mount is
+        // configured — `do_slew_blocking` below calls `resolve_mount`
+        // and surfaces the "no mount configured" error in that case).
         let settle_after = match params.settle_after {
             Some(d) => d,
             None => match self.equipment.find_mount() {

--- a/services/rp/src/routes.rs
+++ b/services/rp/src/routes.rs
@@ -255,6 +255,7 @@ mod tests {
             filter_wheels: vec![],
             cover_calibrators: vec![],
             focusers: vec![],
+            mount: None,
         });
         let session = Arc::new(crate::session::SessionManager::new(event_bus.clone(), &[]));
         let mcp = McpHandler::new(

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -16,6 +16,7 @@ pub mod image_http_api_steps;
 pub mod image_stats_steps;
 pub mod measure_basic_steps;
 pub mod measure_stars_steps;
+pub mod mount_steps;
 pub mod session_steps;
 pub mod tls_steps;
 pub mod tool_steps;

--- a/services/rp/tests/bdd/steps/mount_steps.rs
+++ b/services/rp/tests/bdd/steps/mount_steps.rs
@@ -1,0 +1,265 @@
+//! BDD step definitions for Mount MCP tools.
+//!
+//! Singular mount per rp deployment — there's no `mount_id` parameter
+//! anywhere in this file (or in the `mount.feature` scenarios that
+//! drive these steps).
+
+use std::time::Duration;
+
+use cucumber::{given, then, when};
+use serde_json::Value;
+
+use bdd_infra::rp_harness::{MountConfig, OmniSimHandle};
+
+use crate::steps::tool_steps::{ensure_mcp_client, start_rp};
+use crate::world::RpWorld;
+
+// --- Given steps ---
+
+#[given("rp is running with a mount on the simulator")]
+async fn rp_running_with_mount(world: &mut RpWorld) {
+    if world.omnisim.is_none() {
+        world.omnisim = Some(OmniSimHandle::start().await);
+    }
+    let url = world.omnisim_url();
+    world.mount = Some(MountConfig {
+        alpaca_url: url,
+        device_number: 0,
+        settle_after_slew: None,
+    });
+    start_rp(world).await;
+}
+
+#[given("rp is running without a mount")]
+async fn rp_running_without_mount(world: &mut RpWorld) {
+    if world.omnisim.is_none() {
+        world.omnisim = Some(OmniSimHandle::start().await);
+    }
+    world.mount = None;
+    start_rp(world).await;
+}
+
+#[given(expr = "rp is running with a mount at {string} device {int}")]
+async fn rp_running_with_mount_at(world: &mut RpWorld, url: String, device_number: i32) {
+    let device_number = u32::try_from(device_number)
+        .expect("device_number in mount scenarios must be non-negative");
+    world.mount = Some(MountConfig {
+        alpaca_url: url,
+        device_number,
+        settle_after_slew: None,
+    });
+    start_rp(world).await;
+}
+
+#[given(expr = "rp is running with a mount on the simulator and {int}ms settle")]
+async fn rp_running_with_mount_and_settle(world: &mut RpWorld, settle_ms: i64) {
+    if world.omnisim.is_none() {
+        world.omnisim = Some(OmniSimHandle::start().await);
+    }
+    let url = world.omnisim_url();
+    let settle_ms = u64::try_from(settle_ms).expect("settle_ms must be non-negative");
+    world.mount = Some(MountConfig {
+        alpaca_url: url,
+        device_number: 0,
+        settle_after_slew: Some(Duration::from_millis(settle_ms)),
+    });
+    start_rp(world).await;
+}
+
+#[given(expr = "the mount tracking is set to {word}")]
+async fn mount_tracking_set_to(world: &mut RpWorld, value: String) {
+    let enabled: bool = match value.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected true|false for tracking, got {other}"),
+    };
+    ensure_mcp_client(world).await;
+    let _ = world
+        .mcp()
+        .call_tool("set_tracking", serde_json::json!({ "enabled": enabled }))
+        .await;
+}
+
+// --- When steps ---
+
+/// Slew step that interprets `MISSING` in either ra/dec column as
+/// "omit that field from the JSON-RPC params" — drives the
+/// missing-parameter Outline rows.
+#[when(expr = "the MCP client calls \"slew\" with ra {string} dec {string}")]
+async fn mcp_call_slew(world: &mut RpWorld, ra: String, dec: String) {
+    ensure_mcp_client(world).await;
+    let mut args = serde_json::Map::new();
+    if ra != "MISSING" {
+        let ra_val: f64 = ra
+            .parse()
+            .unwrap_or_else(|_| panic!("expected f64 or MISSING for ra, got {ra}"));
+        args.insert("ra".to_string(), serde_json::json!(ra_val));
+    }
+    if dec != "MISSING" {
+        let dec_val: f64 = dec
+            .parse()
+            .unwrap_or_else(|_| panic!("expected f64 or MISSING for dec, got {dec}"));
+        args.insert("dec".to_string(), serde_json::json!(dec_val));
+    }
+    let result = world.mcp().call_tool("slew", Value::Object(args)).await;
+    world.last_tool_result = Some(result);
+}
+
+#[when(expr = "the MCP client calls \"sync_mount\" with ra {string} dec {string}")]
+async fn mcp_call_sync_mount(world: &mut RpWorld, ra: String, dec: String) {
+    ensure_mcp_client(world).await;
+    let mut args = serde_json::Map::new();
+    if ra != "MISSING" {
+        let ra_val: f64 = ra
+            .parse()
+            .unwrap_or_else(|_| panic!("expected f64 or MISSING for ra, got {ra}"));
+        args.insert("ra".to_string(), serde_json::json!(ra_val));
+    }
+    if dec != "MISSING" {
+        let dec_val: f64 = dec
+            .parse()
+            .unwrap_or_else(|_| panic!("expected f64 or MISSING for dec, got {dec}"));
+        args.insert("dec".to_string(), serde_json::json!(dec_val));
+    }
+    let result = world
+        .mcp()
+        .call_tool("sync_mount", Value::Object(args))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+#[when("the MCP client calls \"get_mount_position\"")]
+async fn mcp_call_get_mount_position(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("get_mount_position", serde_json::json!({}))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+#[when("the MCP client calls \"get_tracking\"")]
+async fn mcp_call_get_tracking(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("get_tracking", serde_json::json!({}))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+#[when(expr = "the MCP client calls \"set_tracking\" with enabled {word}")]
+async fn mcp_call_set_tracking(world: &mut RpWorld, enabled: String) {
+    ensure_mcp_client(world).await;
+    let enabled: bool = match enabled.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected true|false for enabled, got {other}"),
+    };
+    let result = world
+        .mcp()
+        .call_tool("set_tracking", serde_json::json!({ "enabled": enabled }))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+// --- Then steps ---
+
+/// OmniSim's slew echo carries sub-arcsecond drift (likely from
+/// internal topocentric ↔ J2000 transforms), so we assert tolerance,
+/// not exact equality. `0.001` hours ≈ 3.6 arcsec on RA — well under
+/// any centering workflow's tolerance and well above OmniSim's drift.
+const SLEW_ECHO_TOLERANCE: f64 = 0.001;
+
+#[then(expr = "the slew result actual_ra should be {float}")]
+fn slew_actual_ra(world: &mut RpWorld, expected: f64) {
+    let result = unwrap_ok(world);
+    let actual = result
+        .get("actual_ra")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected actual_ra field, got: {result:?}"));
+    assert!(
+        (actual - expected).abs() < SLEW_ECHO_TOLERANCE,
+        "expected actual_ra ≈ {expected} (within {SLEW_ECHO_TOLERANCE}), got {actual}"
+    );
+}
+
+#[then(expr = "the slew result actual_dec should be {float}")]
+fn slew_actual_dec(world: &mut RpWorld, expected: f64) {
+    let result = unwrap_ok(world);
+    let actual = result
+        .get("actual_dec")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected actual_dec field, got: {result:?}"));
+    assert!(
+        (actual - expected).abs() < SLEW_ECHO_TOLERANCE,
+        "expected actual_dec ≈ {expected} (within {SLEW_ECHO_TOLERANCE}), got {actual}"
+    );
+}
+
+#[then(expr = "the get_mount_position result ra should be {float}")]
+fn get_mount_position_ra(world: &mut RpWorld, expected: f64) {
+    let result = unwrap_ok(world);
+    let actual = result
+        .get("ra")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected ra field, got: {result:?}"));
+    assert_eq!(actual, expected, "expected ra {expected}, got {actual}");
+}
+
+#[then(expr = "the get_mount_position result dec should be {float}")]
+fn get_mount_position_dec(world: &mut RpWorld, expected: f64) {
+    let result = unwrap_ok(world);
+    let actual = result
+        .get("dec")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected dec field, got: {result:?}"));
+    assert_eq!(actual, expected, "expected dec {expected}, got {actual}");
+}
+
+#[then(expr = "the get_tracking result tracking should be {word}")]
+fn get_tracking_tracking(world: &mut RpWorld, expected: String) {
+    let result = unwrap_ok(world);
+    let expected: bool = match expected.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected true|false, got {other}"),
+    };
+    let actual = result
+        .get("tracking")
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| panic!("expected tracking bool field, got: {result:?}"));
+    assert_eq!(
+        actual, expected,
+        "expected tracking={expected}, got {actual}"
+    );
+}
+
+#[then(expr = "the get_tracking result can_set_tracking should be {word}")]
+fn get_tracking_can_set_tracking(world: &mut RpWorld, expected: String) {
+    let result = unwrap_ok(world);
+    let expected: bool = match expected.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected true|false, got {other}"),
+    };
+    let actual = result
+        .get("can_set_tracking")
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| panic!("expected can_set_tracking bool field, got: {result:?}"));
+    assert_eq!(
+        actual, expected,
+        "expected can_set_tracking={expected}, got {actual}"
+    );
+}
+
+// --- Helpers ---
+
+fn unwrap_ok(world: &RpWorld) -> &Value {
+    world
+        .last_tool_result
+        .as_ref()
+        .expect("no tool result")
+        .as_ref()
+        .expect("tool call failed")
+}

--- a/services/rp/tests/bdd/steps/mount_steps.rs
+++ b/services/rp/tests/bdd/steps/mount_steps.rs
@@ -74,10 +74,16 @@ async fn mount_tracking_set_to(world: &mut RpWorld, value: String) {
         other => panic!("expected true|false for tracking, got {other}"),
     };
     ensure_mcp_client(world).await;
-    let _ = world
+    // Given step: fail fast on setup problems per testing.md §3.3.
+    // If `set_tracking` fails (e.g., misconfigured mount or
+    // CanSetTracking == false in the simulator), the scenario should
+    // surface that directly rather than failing later with a
+    // less-direct symptom from the When step.
+    world
         .mcp()
         .call_tool("set_tracking", serde_json::json!({ "enabled": enabled }))
-        .await;
+        .await
+        .expect("set_tracking should succeed in scenario setup");
 }
 
 // --- When steps ---

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use bdd_infra::rp_harness::{
     CameraConfig, CoverCalibratorConfig, FilterWheelConfig, FocuserConfig, McpTestClient,
-    OmniSimHandle, OrchestratorInvocation, ReceivedEvent, RpConfigBuilder, TestOrchestrator,
-    WebhookReceiver,
+    MountConfig, OmniSimHandle, OrchestratorInvocation, ReceivedEvent, RpConfigBuilder,
+    TestOrchestrator, WebhookReceiver,
 };
 use bdd_infra::ServiceHandle;
 use cucumber::World;
@@ -51,6 +51,8 @@ pub struct RpWorld {
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
     /// Focuser configs accumulated via Given steps
     pub focusers: Vec<FocuserConfig>,
+    /// Singular mount config — at most one per `rp` deployment.
+    pub mount: Option<MountConfig>,
     /// Plugin configs accumulated via Given steps
     pub plugin_configs: Vec<Value>,
 
@@ -201,6 +203,9 @@ impl RpWorld {
         }
         for foc in &self.focusers {
             builder.add_focuser(foc.clone());
+        }
+        if let Some(mount) = &self.mount {
+            builder.with_mount(mount.clone());
         }
         for plugin in &self.plugin_configs {
             builder.add_plugin(plugin.clone());

--- a/services/rp/tests/features/mount.feature
+++ b/services/rp/tests/features/mount.feature
@@ -1,0 +1,151 @@
+@serial
+Feature: Mount tools
+  rp exposes Telescope (mount) device operations as MCP tools. The
+  mount is singular per rp deployment — piggyback rigs share one
+  mount across multiple optical trains, so the slew / sync_mount /
+  get_mount_position / get_tracking / set_tracking tools take no
+  mount_id parameter.
+
+  slew drives the mount to absolute equatorial coordinates and blocks
+  until Slewing == false plus the configured / per-call settle. ASCOM
+  requires Tracking == true before equatorial slews — slew propagates
+  the natural Alpaca error if tracking is off rather than auto-enabling.
+  Callers manage tracking explicitly via set_tracking / get_tracking.
+
+  sync_mount sets the mount's reported position immediately, no polling.
+  get_mount_position returns the mount's current RA (hours) / Dec
+  (degrees). get_tracking returns both the current tracking state and
+  the CanSetTracking capability; it fails loud if the Tracking read
+  errors (no half-success).
+
+  Scenario: Tool catalog includes Mount tools
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client lists available tools
+    Then the tool list should include "slew"
+    And the tool list should include "sync_mount"
+    And the tool list should include "get_mount_position"
+    And the tool list should include "get_tracking"
+    And the tool list should include "set_tracking"
+
+  Scenario: slew drives the mount to absolute equatorial coordinates
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    And the mount tracking is set to true
+    When the MCP client calls "slew" with ra "10.6847" dec "41.2689"
+    Then the tool call should succeed
+    And the slew result actual_ra should be 10.6847
+    And the slew result actual_dec should be 41.2689
+
+  Scenario: slew with tracking off returns an error
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    And the mount tracking is set to false
+    When the MCP client calls "slew" with ra "10.6847" dec "41.2689"
+    Then the tool call should return an error
+    And the error message should contain "failed to slew"
+
+  Scenario: slew with no mount configured returns an error
+    Given a running Alpaca simulator
+    And rp is running without a mount
+    And an MCP client connected to rp
+    When the MCP client calls "slew" with ra "0.0" dec "0.0"
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"
+
+  Scenario: slew with mount not connected returns an error
+    Given rp is running with a mount at "http://localhost:1" device 0
+    And an MCP client connected to rp
+    When the MCP client calls "slew" with ra "0.0" dec "0.0"
+    Then the tool call should return an error
+    And the error message should contain "mount not connected"
+
+  Scenario Outline: slew rejects out-of-range and missing parameters
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    And the mount tracking is set to true
+    When the MCP client calls "slew" with ra "<ra>" dec "<dec>"
+    Then the tool call should return an error
+    And the error message should contain "<fragment>"
+
+    Examples:
+      | ra      | dec     | fragment                       |
+      | -1.0    | 0.0     | ra out of range                |
+      | 25.0    | 0.0     | ra out of range                |
+      | 0.0     | -91.0   | dec out of range               |
+      | 0.0     | 91.0    | dec out of range               |
+      | MISSING | 0.0     | missing required parameter: ra |
+      | 0.0     | MISSING | missing required parameter: dec|
+
+  Scenario: sync_mount sets the mount's reported position
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "5.0" dec "10.0"
+    Then the tool call should succeed
+
+  Scenario: sync_mount with no mount configured returns an error
+    Given a running Alpaca simulator
+    And rp is running without a mount
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "0.0" dec "0.0"
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"
+
+  Scenario Outline: sync_mount rejects out-of-range parameters
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "<ra>" dec "<dec>"
+    Then the tool call should return an error
+    And the error message should contain "<fragment>"
+
+    Examples:
+      | ra   | dec   | fragment         |
+      | -1.0 | 0.0   | ra out of range  |
+      | 0.0  | 91.0  | dec out of range |
+
+  Scenario: get_mount_position returns the mount's current RA and Dec
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_mount_position"
+    Then the tool call should succeed
+
+  Scenario: get_mount_position with no mount configured returns an error
+    Given a running Alpaca simulator
+    And rp is running without a mount
+    And an MCP client connected to rp
+    When the MCP client calls "get_mount_position"
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"
+
+  Scenario: get_tracking returns tracking state and can_set_tracking
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_tracking"
+    Then the tool call should succeed
+    And the get_tracking result can_set_tracking should be true
+
+  Scenario: set_tracking enables tracking on the mount
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "set_tracking" with enabled true
+    And the MCP client calls "get_tracking"
+    Then the tool call should succeed
+    And the get_tracking result tracking should be true
+
+  Scenario: set_tracking disables tracking on the mount
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "set_tracking" with enabled false
+    And the MCP client calls "get_tracking"
+    Then the tool call should succeed
+    And the get_tracking result tracking should be false


### PR DESCRIPTION
## Summary

Adds the singular Mount equipment primitive to `rp` — config, equipment registry, 5 MCP tools, BDD coverage, and test-harness support — so Phase 6c-3 (`center_on_target`) and Phase 6c-2 (`plate_solve`) can drive the mount via the standard MCP surface.

**Singular by design.** Piggyback rigs share one mount across multiple optical trains; cameras / focusers / filter wheels stay plural. The type encodes that — `mount: Option<MountConfig>`, no `id` field, no `mount_id` parameter on any tool. Multi-mount support stays in `rp.md` Future Considerations. Issue #130 tracks the related `bdd-infra::ensure_default_focuser` follow-up that piggyback BDD scenarios will eventually want.

**Tools follow ASCOM's contract literally.**
- `slew` requires `Tracking == true` and propagates the natural Alpaca error otherwise (no `ensure_tracking` parameter, no automagic).
- Per-call `settle_after` overrides `mount.settle_after_slew` config default (default `0`); operators set per-rig.
- 300 s slew deadline + best-effort `abort_slew()` on expiry (mount runaways are higher blast radius than focuser runaways).
- `get_tracking` fails loud if the `Tracking` read errors (no half-success); `get_mount_position` ditto for either RA or Dec.
- 5 tools: `slew`, `sync_mount`, `get_mount_position`, `get_tracking`, `set_tracking`.

**Sub-plan & decisions resolved** are written into `docs/plans/image-evaluation-tools.md` Phase 6c-prep — landed as the first commit on this branch so the impl has a written contract to land against.

## Test plan

- [x] `cargo rail run --profile commit -q` — 701/701 workspace-wide tests pass.
- [x] `cargo test --all-features --test bdd -p rp` — 187/187 BDD scenarios green (was 173, +14 mount scenarios).
- [x] **+33 new rp lib tests** (3 config + 7 equipment + 23 mcp tool tests against `MockTelescope`).
- [x] **+3 new bdd-infra tests** for `RpConfigBuilder::with_mount` JSON shape.
- [x] OmniSim slew-echo drift (~0.4 arcsec from internal coordinate transforms) handled by asserting against a `0.001`-hour / `0.001`-degree tolerance, not exact equality.
- [x] `cargo fmt` clean.
- [x] No new workspace deps (only added `"telescope"` to ascom-alpaca's existing feature list on services/rp); no `bazel mod tidy` needed.

## Files

- `services/rp/src/config.rs` — `MountConfig` (singular `Option`, replaces `mount: Value`).
- `services/rp/src/equipment.rs` — `MountEntry`, `connect_mount`, `find_mount`, `MountStatus` on `EquipmentStatus`.
- `services/rp/src/mcp.rs` — `do_slew_blocking` + `resolve_mount` helpers + 5 tools + `MockTelescope` + 23 unit tests.
- `services/rp/src/routes.rs` — test fixture wired to new `mount: None` field.
- `services/rp/Cargo.toml` — `"telescope"` feature added to ascom-alpaca.
- `services/rp/tests/features/mount.feature` — 14 BDD scenarios.
- `services/rp/tests/bdd/steps/mount_steps.rs` — step definitions with `MISSING` sentinel for the missing-parameter Outline.
- `services/rp/tests/bdd/{world,steps/mod}.rs` — wire `mount` into `RpWorld` and register `mount_steps`.
- `crates/bdd-infra/src/rp_harness/{config,mod}.rs` — `MountConfig`, `RpConfigBuilder::with_mount`, JSON-shape tests.
- `docs/services/rp.md` — Hardware tools table gains 3 rows (`get_mount_position`, `get_tracking`, `set_tracking`); `slew` row mentions optional `settle_after`; Configuration prose explains singular mount + settle semantics; obsolete `settle_time_secs` dropped.
- `docs/plans/image-evaluation-tools.md` — Phase 6c-prep stub replaced with full sub-plan (decisions resolved + 11-step work breakdown + exit criteria).

## Out of scope (deferred)

- `park` / `unpark`, `abort_slew` as a standalone MCP tool, `tracking_rate`, multi-mount, `side_of_pier` exposure on `get_mount_position`. All called out in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)