### PR TITLE
docs(rp-plate-solver): Phase 8 — LGPL §4/§6 review (retires ADR-005 OQ 5)

### DIFF
--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -509,24 +509,29 @@ own guidance on GPL/LGPL boundaries.
 
 **Answer: No.**
 
-LGPL-3.0 §4 ("Combined Works") is the section that converts an
-LGPL work into something the larger program must also license under
-GPL/LGPL terms. It applies when you "convey a Combined Work under
-terms of your choice" — and §0 defines a Combined Work as "a work
-produced by combining or linking an Application with the Library."
-The terms "combining" and "linking" in the LGPL refer to the static
-or dynamic linker boundary; subprocess execution is not linking by
-any commonly-cited interpretation
-([FSF FAQ](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation),
-[FSF "What is mere aggregation"](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation)).
+LGPL-3.0 §4 ("Combined Works") sets *conditions on conveying a
+Combined Work under terms of your choice* — for example, providing
+source for the Library portion and ensuring users can replace the
+LGPL component. It does not auto-relicense the larger program;
+rather, it applies *if and when* you convey a Combined Work, and it
+defines a Combined Work in §0 as "a work produced by combining or
+linking an Application with the Library." The terms "combining" and
+"linking" refer to the static or dynamic linker boundary; subprocess
+execution is not linking under
+[the FSF's own guidance on plugins and subprocesses](https://www.gnu.org/licenses/gpl-faq.html#GPLAndPlugins).
+Two separate reasons §4 doesn't engage at our boundary, then: we
+don't form a Combined Work (no linking), and we don't convey
+anything (the predicate the §4 conditions hang on).
 
 §6 ("Conveying Non-Source Forms") imposes obligations *only when
 conveying* — and conveying is defined in GPL-3.0 §0 (which LGPL-3.0
 §0 inherits) as "any kind of propagation that enables other parties
-to make or receive copies." `rp` and `rp-plate-solver` neither
-make nor receive copies of `astap_cli`; they invoke an
-operator-installed binary by absolute path. The subprocess boundary
-puts §6 outside the runtime path entirely.
+to make or receive copies"
+([FSF on mere aggregation vs. conveyance](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation)).
+`rp` and `rp-plate-solver` neither make nor receive copies of
+`astap_cli`; they invoke an operator-installed binary by its
+configured path. The subprocess boundary puts §6 outside the
+runtime path entirely.
 
 #### Question 2: Does the `install-astap` GH action's per-run fresh download constitute conveyance?
 
@@ -547,9 +552,14 @@ for third-party download under its own distribution channel. The
 that mirrors what a human operator would do by hand from the
 README's "Operator install" section.
 
-The fresh-download-per-run posture (`cache-key-suffix: github.run_id`
-on the smoke workflow) reinforces this: caching is at most a
-performance optimization, not a distribution mechanism.
+The dedicated `install-astap` smoke workflow
+(`.github/workflows/install-astap.yml`) sets `use-cache: "false"` on
+the composite action so each run does a genuinely fresh upstream
+download — there is no cache layer to call into question for that
+workflow at all. Other callers (the production `rp-plate-solver-smoke`
+nightly + path-triggered workflow) leave caching at its default;
+that cache is repo-internal CI infrastructure scoped to the runner
+(see Question 3 below).
 
 #### Question 3: Is the GH-Actions cache layer narrow enough to count as ephemeral build infrastructure?
 

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -400,16 +400,19 @@ below tracks which have been retired.
    2k–4k FITS frames is forward work tracked in Phase 7
    (hint-plumbing verification) — that's where the `@manual` happy-path
    gets exercised by an operator with a real fixture.
-5. **LGPL-3.0 §4 / §6 review under BYO** — confirm that "execute a
-   binary the operator installed" does not engage either clause; that
-   the `install-astap` GitHub action does not constitute conveyance
-   (it triggers a fresh upstream download per run); and that the
-   GH-Actions cache layer for that download is scoped narrowly enough
-   to count as ephemeral build infrastructure rather than mirroring.
-   The §6 "Combined Works" question is also confirmed moot for
-   subprocess execution. This question is the formal closure of the
-   ADR's working assumption — see [License Treatment](#license-treatment).
-   Tracked under Phase 8.
+5. **LGPL-3.0 §4 / §6 review under BYO** — **Retired by Phase 8.**
+   Conclusions: (a) subprocess execution doesn't engage §4
+   (Combined Works) or §6 (Conveying Non-Source Forms) — those
+   apply to linker-boundary combination and to conveyance, both
+   absent here; (b) the `install-astap` GH action is repo-internal
+   CI tooling that downloads from upstream per run, not a
+   distribution channel — no conveyance; (c) GH-Actions cache is
+   ephemeral build infrastructure (per-repo, ≤7-day TTL, no public
+   download surface), not mirroring. Full reasoning, citations, and
+   re-evaluation triggers documented in
+   [License Review](#license-review). Reasoned analysis, not legal
+   advice — operators distributing commercially or in unusual
+   jurisdictions should consult counsel.
 6. **Hint plumbing** — **Retired by Phase 7.** Answer: the ASCOM
    Alpaca Telescope spec does **not** standardize a pointing-
    uncertainty / accuracy property — only `RightAscension` and
@@ -458,9 +461,10 @@ below tracks which have been retired.
 
 ### License Treatment
 
-This section captures the working assumption pending the formal
-LGPL-3.0 review listed as Open Question #5. The posture is "BYO so
-the question reduces to a sanity check," not "conveyance compliant."
+The formal LGPL-3.0 review (Open Question #5) is captured in
+[License Review](#license-review) below. The summary of our posture:
+"BYO so the question reduces to a sanity check," not "conveyance
+compliant."
 
 - ASTAP's binaries are LGPL-3.0. **`rp` does not convey them.**
   Operators install ASTAP separately (from hnsky.org, SourceForge,
@@ -490,6 +494,111 @@ the question reduces to a sanity check," not "conveyance compliant."
 - `solve-field` (Option 2) and any other compatible solver remain
   available via the same configuration knobs; an operator can swap
   implementations without rebuilding `rp`.
+
+### License Review
+
+This section retires Open Question #5 by walking through each of the
+three sub-questions ADR-005 raised about LGPL-3.0 §4 / §6 and the CI
+install path. **This is reasoned analysis, not legal advice.**
+Operators distributing commercially or in jurisdictions with unusual
+copyright doctrines should consult counsel. The reasoning below is
+the standard interpretation under US copyright law and the FSF's
+own guidance on GPL/LGPL boundaries.
+
+#### Question 1: Does subprocess execution engage LGPL §4 or §6?
+
+**Answer: No.**
+
+LGPL-3.0 §4 ("Combined Works") is the section that converts an
+LGPL work into something the larger program must also license under
+GPL/LGPL terms. It applies when you "convey a Combined Work under
+terms of your choice" — and §0 defines a Combined Work as "a work
+produced by combining or linking an Application with the Library."
+The terms "combining" and "linking" in the LGPL refer to the static
+or dynamic linker boundary; subprocess execution is not linking by
+any commonly-cited interpretation
+([FSF FAQ](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation),
+[FSF "What is mere aggregation"](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation)).
+
+§6 ("Conveying Non-Source Forms") imposes obligations *only when
+conveying* — and conveying is defined in GPL-3.0 §0 (which LGPL-3.0
+§0 inherits) as "any kind of propagation that enables other parties
+to make or receive copies." `rp` and `rp-plate-solver` neither
+make nor receive copies of `astap_cli`; they invoke an
+operator-installed binary by absolute path. The subprocess boundary
+puts §6 outside the runtime path entirely.
+
+#### Question 2: Does the `install-astap` GH action's per-run fresh download constitute conveyance?
+
+**Answer: No.**
+
+The action does not republish, mirror, or stage ASTAP for end-user
+consumption. It is repo-internal CI tooling that downloads the
+binary directly from upstream SourceForge (`https://sourceforge.net/...`)
+on each runner, into a runner-local path, for the duration of one
+workflow run. The bytes never leave the runner; nothing is uploaded
+back to GitHub releases or to a downstream artifact channel.
+
+Compare with the explicit "conveyance" example: a project that
+forked or rehosted `astap_cli` binaries on its own GitHub release
+page would be conveying — it would be making the bytes available
+for third-party download under its own distribution channel. The
+`install-astap` action does not do that; it is a download-helper
+that mirrors what a human operator would do by hand from the
+README's "Operator install" section.
+
+The fresh-download-per-run posture (`cache-key-suffix: github.run_id`
+on the smoke workflow) reinforces this: caching is at most a
+performance optimization, not a distribution mechanism.
+
+#### Question 3: Is the GH-Actions cache layer narrow enough to count as ephemeral build infrastructure?
+
+**Answer: Yes, with one note.**
+
+`actions/cache@v5` stores artifacts in a per-repository, per-key
+cache with a default 7-day eviction policy and a 10 GB total cap
+([GitHub docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)).
+Cache entries are scoped to the repository and accessible only to
+workflow runs in that repository (and its forks under the standard
+fork access rules). They are not surfaced as a download endpoint
+the public can hit.
+
+By the test the FSF applies to "mirroring" — does this make the
+work available to third parties under your distribution authority?
+— GH-Actions cache fails the test on every prong: scope is
+repo-internal CI infrastructure, lifetime is bounded, and there is
+no "public download URL" surface. It's the same shape as a CI's
+package-manager cache (npm, pip, cargo) for transitive
+dependencies, which the same analysis treats as ephemeral build
+tooling rather than redistribution.
+
+**The note:** the dedicated `install-astap` smoke workflow
+(`.github/workflows/install-astap.yml`) explicitly disables the
+cache (`use-cache: "false"`) precisely because its job is to catch
+upstream regressions on every run, and a warm cache would mask them.
+Operators forking the repo and running their own builds inherit the
+same cache scope; they're not republishing.
+
+#### Posture summary
+
+- `rp` and `rp-plate-solver` never convey ASTAP. §4 and §6 do not
+  engage at the `rp` boundary.
+- The `install-astap` action is repo-internal CI tooling, not a
+  distribution channel. It does not convey.
+- GH-Actions cache is ephemeral build infrastructure, not mirroring.
+
+The wrapper's HTTP boundary, BYO config posture, and CI tooling
+shape are all consistent with this analysis. ADR-005 OQ #5 is
+**retired** with this conclusion. Future re-evaluation triggers:
+
+- A change in distribution model (e.g., `rp-plate-solver` starts
+  bundling ASTAP — explicitly out of scope per ADR-005's BYO
+  decision).
+- A decision to publish ASTAP archives via GitHub releases on this
+  repo (would convert `install-astap` from "download helper" into
+  "mirror," which would engage §6).
+- A regulatory or jurisdictional change affecting the FSF's
+  guidance on subprocess boundaries.
 
 ### CI / Build
 

--- a/docs/plans/rp-plate-solver.md
+++ b/docs/plans/rp-plate-solver.md
@@ -844,24 +844,35 @@ documented ASCOM-gap answer and the operator-supplied default policy.
 
 ### Phase 8 — LGPL §4/§6 review under BYO (retires ADR-005 OQ 5)
 
-Status: **not started.**
+Status: **complete.**
 
-- [ ] Add a short legal-review note under
-      `docs/decisions/005-plate-solver.md` §"License Treatment"
-      converting the working assumption into a closed item: confirm
-      that subprocess execution of an operator-installed binary
-      engages neither §4 (Conveying Verbatim Copies) nor §6 (Combined
-      Works); confirm that the `install-astap` GH action's per-run
-      fresh download does not constitute conveyance; confirm the
-      GH-Actions cache layer is scoped narrowly enough to count as
-      ephemeral build infrastructure.
-- [ ] If any of those three sub-items returns the opposite finding,
-      open a follow-up issue capturing the remediation (e.g., move the
-      install-astap action's cache scope to per-PR, or drop caching
-      entirely).
+What this phase delivered:
 
-**Exit criteria:** ADR-005 OQ 5 marked retired or a remediation
-issue is open.
+- [x] New §"License Review" subsection in
+      `docs/decisions/005-plate-solver.md` walking through each of
+      the three sub-questions (subprocess vs §4/§6; install-astap as
+      conveyance; GH cache as mirroring) with citations to the
+      LGPL-3.0 text and FSF guidance. Each concludes the BYO posture
+      is consistent with the standard reading of the license.
+- [x] Re-evaluation triggers documented for future-proofing: a
+      change in distribution model (bundling ASTAP), publishing
+      ASTAP archives via this repo's GitHub releases, or a
+      regulatory change affecting subprocess-boundary interpretation.
+- [x] ADR-005 §"Open questions" item 5 marked retired with the
+      conclusion summary and a pointer to the full review section.
+- [x] §"License Treatment" updated to point at the formal review
+      rather than calling it a "working assumption."
+
+What this phase did **not** do:
+
+- Engage outside legal counsel. This is reasoned analysis under the
+  standard reading of LGPL-3.0 and FSF guidance; commercial
+  redistributors or operators in jurisdictions with unusual
+  copyright doctrines should consult counsel for their own posture.
+
+**Exit criteria met:** ADR-005 OQ 5 retired with the documented
+conclusion. None of the three sub-questions returned an opposite
+finding, so no remediation issue is open.
 
 ## Sequencing notes
 


### PR DESCRIPTION
## Summary

Phase 8 of [`docs/plans/rp-plate-solver.md`](docs/plans/rp-plate-solver.md) — the **final phase**. Retires ADR-005 Open Question #5 with a formal License Review section that walks through each of the three sub-questions ADR-005 raised about LGPL-3.0 §4 / §6 and the CI install path.

This is the last open question; with this PR, **all six ADR-005 OQs are retired** and the rp-plate-solver workspace member is plan-complete.

## License Review (new section in ADR-005)

| Sub-question | Conclusion |
|---|---|
| Subprocess execution vs §4/§6? | **No engagement.** §4's "combining or linking" refers to the linker boundary; subprocess is not linking. §6 only applies on conveyance; the wrapper neither makes nor receives copies of `astap_cli`. FSF FAQ on mere aggregation cited inline. |
| `install-astap` GH action as conveyance? | **No.** Per-run upstream download into runner-local storage; bytes never leave the runner; nothing uploaded to GitHub releases or a distribution channel. Repo-internal CI tooling, not a distribution endpoint. |
| GH-Actions cache as mirroring? | **No.** Per-repository, ≤7-day TTL, no public download surface — fails every prong of "available to third parties under your distribution authority". Same shape as a CI's npm/pip/cargo cache. |

**Re-evaluation triggers** documented for future-proofing: change in distribution model (bundling ASTAP), publishing ASTAP archives via this repo's GitHub releases, or a regulatory change affecting subprocess-boundary interpretation.

## Disclaimer

This is reasoned analysis under the standard reading of LGPL-3.0 and FSF guidance, **not legal advice**. Operators distributing commercially or in unusual jurisdictions should consult counsel for their own posture.

## Test plan

- [x] `cargo rail run --profile commit -q` reports no test targets (docs-only)
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] Copilot review (request via UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)