### PR TITLE
Phase 6c-prep follow-up: mount park / unpark / get_park_state / abort_slew

### DIFF
--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -730,10 +730,9 @@ Built-in Tools — Hardware) and should not be re-litigated:
 
 **Out of scope (deferred or never):**
 
-- `park` / `unpark` MCP tools. Add when a workflow needs them.
-- `abort_slew` as a standalone MCP tool. Sentinel's safety path
-  already terminates the orchestrator on unsafe transitions; no
-  caller for an MCP `abort_slew` yet.
+- `set_park` MCP tool (sets the current position as the new park
+  position). Power-user feature with no workflow consumer in sight;
+  defer until one surfaces.
 - `tracking_rate` (sidereal / lunar / solar / king). Sidereal is the
   only rate deep-sky workflows need; defer until a planetary or
   comet-tracking workflow surfaces.
@@ -741,6 +740,10 @@ Built-in Tools — Hardware) and should not be re-litigated:
 - `side_of_pier` exposure. The original stub mentioned it on
   `get_mount_position`; deferred until a meridian-flip workflow
   surfaces.
+
+**Follow-up landed:** `park`, `unpark`, `get_park_state`, and
+`abort_slew` MCP tools landed in the next PR after Phase 6c-prep.
+The previous "deferred" entries for these tools have been removed.
 
 **Exit criteria met:** 14 new BDD scenarios green (187/187 total in
 rp's BDD suite, was 173/173 pre-Phase-6c-prep); 33 new lib tests

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -616,6 +616,10 @@ the exact parameter types and return structure.
 | `get_mount_position` | — | ra, dec | Read the mount's current pointing |
 | `get_tracking` | — | tracking, can_set_tracking | Read tracking state and `CanSetTracking` capability; fails loud on read error |
 | `set_tracking` | enabled | — | Enable or disable sidereal tracking |
+| `park` | — | — | Park the mount (blocks until `Slewing == false` and `AtPark == true`, 300 s deadline). Per ASCOM, a successful park clears `Tracking`. Unlike `slew`, does NOT auto-abort on timeout — call `abort_slew` to interrupt a stuck park |
+| `unpark` | — | — | Clear the mount's `AtPark` flag. Returns immediately. Does NOT auto-enable `Tracking`; call `set_tracking` before slewing |
+| `get_park_state` | — | at_park, can_park, can_unpark | Read park state and capabilities; fails loud on `AtPark` read error |
+| `abort_slew` | — | — | Abort an in-progress mount slew or park. Per ASCOM, only valid while `Slewing == true`; the natural Alpaca error propagates otherwise |
 | `set_filter` | filter_wheel_id, filter_name | — | Change filter wheel position |
 | `get_filter` | filter_wheel_id | filter_name, position | Read current filter |
 | `close_cover` | calibrator_id | — | Close the dust cover (blocks until closed) |

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -1101,7 +1101,7 @@ impl McpHandler {
 
         match mount.at_park().await {
             Ok(true) => Ok(()),
-            Ok(false) => Err("mount completed slew but is not at park".to_string()),
+            Ok(false) => Err("park completed but mount is not at park".to_string()),
             Err(e) => Err(format!("failed to verify mount at_park: {}", e)),
         }
     }
@@ -4483,7 +4483,7 @@ mod tests {
         };
         let handler = test_handler(mount_registry(Arc::new(mount), None));
         let result = handler.park(Parameters(ParkParams {})).await;
-        assert_tool_error(result, "completed slew but is not at park");
+        assert_tool_error(result, "park completed but mount is not at park");
     }
 
     /// 300 s deadline expires while `slewing()` keeps returning `true`.
@@ -4564,6 +4564,82 @@ mod tests {
             .get_park_state(Parameters(GetParkStateParams {}))
             .await;
         assert_tool_error(result, "failed to read mount at_park");
+    }
+
+    #[tokio::test]
+    async fn test_get_park_state_fails_when_can_park_read_errors() {
+        let mount = MockTelescope {
+            fail_can_park: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_park_state(Parameters(GetParkStateParams {}))
+            .await;
+        assert_tool_error(result, "failed to read mount can_park");
+    }
+
+    #[tokio::test]
+    async fn test_get_park_state_fails_when_can_unpark_read_errors() {
+        let mount = MockTelescope {
+            fail_can_unpark: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_park_state(Parameters(GetParkStateParams {}))
+            .await;
+        assert_tool_error(result, "failed to read mount can_unpark");
+    }
+
+    /// `park()` succeeds, `slewing()` returns false, but `at_park()`
+    /// itself errors during the post-park verification — distinct from
+    /// `at_park()` returning `Ok(false)` (which is the "completed but
+    /// not at park" arm). Pins the third arm of the post-condition
+    /// check.
+    #[tokio::test]
+    async fn test_park_at_park_read_fails_during_verify() {
+        let mount = MockTelescope {
+            fail_at_park: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "failed to verify mount at_park");
+    }
+
+    /// Polling `slewing()` itself errors during the park wait —
+    /// covers the `PollIdleError::Read` arm in `do_park_blocking`.
+    #[tokio::test]
+    async fn test_park_polling_error_propagates() {
+        let mount = MockTelescope {
+            fail_slewing_poll: true,
+            at_park_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "error polling mount slewing");
+    }
+
+    /// Same coverage for `do_slew_blocking`'s `PollIdleError::Read`
+    /// arm — the helper is shared with park, but the slew callsite
+    /// has its own error-mapping path.
+    #[tokio::test]
+    async fn test_slew_polling_error_propagates() {
+        let mount = MockTelescope {
+            fail_slewing_poll: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .slew(Parameters(SlewParams {
+                ra: Some(0.0),
+                dec: Some(0.0),
+                settle_after: None,
+            }))
+            .await;
+        assert_tool_error(result, "error polling mount slewing");
     }
 
     #[tokio::test]

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -319,6 +319,22 @@ pub struct GetTrackingParams {}
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetMountPositionParams {}
 
+/// Empty parameter struct for `park` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParkParams {}
+
+/// Empty parameter struct for `unpark` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UnparkParams {}
+
+/// Empty parameter struct for `get_park_state` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetParkStateParams {}
+
+/// Empty parameter struct for `abort_slew` — the tool takes no input.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AbortSlewParams {}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AutoFocusToolParams {
     /// Camera device ID. Required (validated in body for deterministic
@@ -1022,19 +1038,16 @@ impl McpHandler {
             .await
             .map_err(|e| format!("failed to slew: {}", e))?;
 
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
-        loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            match mount.slewing().await {
-                Ok(false) => break,
-                Ok(true) if tokio::time::Instant::now() < deadline => continue,
-                Ok(true) => {
-                    // Best-effort abort; ignore the abort's own result and
-                    // surface the timeout error as the primary failure.
-                    let _ = mount.abort_slew().await;
-                    return Err("timeout waiting for mount to settle".to_string());
-                }
-                Err(e) => return Err(format!("error polling mount slewing: {}", e)),
+        match poll_slewing_until_idle(mount.as_ref()).await {
+            Ok(()) => {}
+            Err(PollIdleError::Timeout) => {
+                // Best-effort abort; ignore the abort's own result and
+                // surface the timeout error as the primary failure.
+                let _ = mount.abort_slew().await;
+                return Err("timeout waiting for mount to settle".to_string());
+            }
+            Err(PollIdleError::Read(e)) => {
+                return Err(format!("error polling mount slewing: {}", e));
             }
         }
 
@@ -1052,6 +1065,73 @@ impl McpHandler {
             .await
             .map_err(|e| format!("failed to read mount declination: {}", e))?;
         Ok((actual_ra, actual_dec))
+    }
+
+    /// Resolve the mount, issue `park()`, poll `slewing()` until idle
+    /// (300 s deadline), and verify `at_park()` returns true before
+    /// returning.
+    ///
+    /// Unlike `do_slew_blocking`, this does NOT auto-abort on timeout
+    /// — a partially-completed park is closer to safe than an
+    /// aborted one (the mount is actively trying to reach a known
+    /// safe position; aborting leaves it in an unknown state
+    /// mid-traversal). Callers that want to interrupt a stuck park
+    /// can call the `abort_slew` MCP tool explicitly.
+    ///
+    /// Per ASCOM, a successful `park()` clears `Tracking`. We don't
+    /// touch tracking ourselves; the contract is the driver's.
+    pub(crate) async fn do_park_blocking(&self) -> std::result::Result<(), String> {
+        let (_entry, mount) = self.resolve_mount()?;
+
+        debug!("parking mount");
+        mount
+            .park()
+            .await
+            .map_err(|e| format!("failed to park: {}", e))?;
+
+        match poll_slewing_until_idle(mount.as_ref()).await {
+            Ok(()) => {}
+            Err(PollIdleError::Timeout) => {
+                return Err("timeout waiting for mount to park".to_string());
+            }
+            Err(PollIdleError::Read(e)) => {
+                return Err(format!("error polling mount slewing: {}", e));
+            }
+        }
+
+        match mount.at_park().await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err("mount completed slew but is not at park".to_string()),
+            Err(e) => Err(format!("failed to verify mount at_park: {}", e)),
+        }
+    }
+}
+
+/// Outcome variants for [`poll_slewing_until_idle`].
+enum PollIdleError {
+    /// Deadline expired with `slewing()` still returning `true`.
+    Timeout,
+    /// `slewing()` itself returned an Alpaca error.
+    Read(ascom_alpaca::ASCOMError),
+}
+
+/// Poll `mount.slewing()` every 100 ms until it returns `false`,
+/// bounded by a 300 s deadline. Shared by `do_slew_blocking` and
+/// `do_park_blocking`. Caller decides what to do on
+/// [`PollIdleError::Timeout`] (e.g. best-effort `abort_slew()` for
+/// `slew`; surface the timeout for `park`).
+async fn poll_slewing_until_idle(
+    mount: &(dyn ascom_alpaca::api::Telescope + Send + Sync),
+) -> std::result::Result<(), PollIdleError> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match mount.slewing().await {
+            Ok(false) => return Ok(()),
+            Ok(true) if tokio::time::Instant::now() < deadline => continue,
+            Ok(true) => return Err(PollIdleError::Timeout),
+            Err(e) => return Err(PollIdleError::Read(e)),
+        }
     }
 }
 
@@ -1969,6 +2049,89 @@ impl McpHandler {
         }
     }
 
+    #[tool(
+        description = "Park the mount: invoke ASCOM Park, poll Slewing until idle (300 s deadline), and verify AtPark == true. Per ASCOM, a successful park clears Tracking. Unlike slew, park does NOT auto-abort on timeout — call abort_slew explicitly to interrupt a stuck park."
+    )]
+    async fn park(
+        &self,
+        Parameters(_params): Parameters<ParkParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        match self.do_park_blocking().await {
+            Ok(()) => Ok(tool_success!({})),
+            Err(e) => Ok(tool_error!("{}", e)),
+        }
+    }
+
+    #[tool(
+        description = "Unpark the mount. Returns immediately (no Slewing poll — most drivers just clear the AtPark flag). Does NOT auto-enable Tracking; call set_tracking explicitly before slewing."
+    )]
+    async fn unpark(
+        &self,
+        Parameters(_params): Parameters<UnparkParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        debug!("unparking mount");
+        match mount.unpark().await {
+            Ok(()) => Ok(tool_success!({})),
+            Err(e) => Ok(tool_error!("failed to unpark: {}", e)),
+        }
+    }
+
+    #[tool(
+        description = "Read the mount's park state and capabilities: AtPark, CanPark, CanUnpark. Fails loud on the AtPark read error (the load-bearing field)."
+    )]
+    async fn get_park_state(
+        &self,
+        Parameters(_params): Parameters<GetParkStateParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        let at_park = match mount.at_park().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount at_park: {}", e)),
+        };
+        let can_park = match mount.can_park().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount can_park: {}", e)),
+        };
+        let can_unpark = match mount.can_unpark().await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error!("failed to read mount can_unpark: {}", e)),
+        };
+
+        Ok(tool_success!({
+            "at_park": at_park,
+            "can_park": can_park,
+            "can_unpark": can_unpark,
+        }))
+    }
+
+    #[tool(
+        description = "Abort an in-progress mount slew or park. Per ASCOM, only valid while Slewing == true; the natural Alpaca error propagates otherwise."
+    )]
+    async fn abort_slew(
+        &self,
+        Parameters(_params): Parameters<AbortSlewParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (_entry, mount) = match self.resolve_mount() {
+            Ok(p) => p,
+            Err(e) => return Ok(tool_error!("{}", e)),
+        };
+
+        debug!("aborting mount slew");
+        match mount.abort_slew().await {
+            Ok(()) => Ok(tool_success!({})),
+            Err(e) => Ok(tool_error!("failed to abort slew: {}", e)),
+        }
+    }
+
     // -------------------------------------------------------------------
     // Compound: auto_focus (V-curve)
     // -------------------------------------------------------------------
@@ -2564,10 +2727,19 @@ mod tests {
         fail_tracking: bool,
         fail_can_set_tracking: bool,
         fail_set_tracking: bool,
+        fail_park: bool,
+        fail_unpark: bool,
+        fail_at_park: bool,
+        fail_can_park: bool,
+        fail_can_unpark: bool,
+        fail_abort_slew: bool,
         /// `slewing()` returns `true` forever — drives the timeout path.
         stuck_slewing: bool,
         tracking_value: bool,
         can_set_tracking_value: bool,
+        at_park_value: bool,
+        can_park_value: bool,
+        can_unpark_value: bool,
         ra_value: f64,
         dec_value: f64,
     }
@@ -2583,9 +2755,18 @@ mod tests {
                 fail_tracking: false,
                 fail_can_set_tracking: false,
                 fail_set_tracking: false,
+                fail_park: false,
+                fail_unpark: false,
+                fail_at_park: false,
+                fail_can_park: false,
+                fail_can_unpark: false,
+                fail_abort_slew: false,
                 stuck_slewing: false,
                 tracking_value: true,
                 can_set_tracking_value: true,
+                at_park_value: false,
+                can_park_value: true,
+                can_unpark_value: true,
                 ra_value: 0.0,
                 dec_value: 0.0,
             }
@@ -2601,7 +2782,38 @@ mod tests {
         }
 
         async fn at_park(&self) -> ascom_alpaca::ASCOMResult<bool> {
-            Ok(false)
+            if self.fail_at_park {
+                return Err(ASCOMError::invalid_operation("at_park read failed"));
+            }
+            Ok(self.at_park_value)
+        }
+
+        async fn can_park(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            if self.fail_can_park {
+                return Err(ASCOMError::invalid_operation("can_park read failed"));
+            }
+            Ok(self.can_park_value)
+        }
+
+        async fn can_unpark(&self) -> ascom_alpaca::ASCOMResult<bool> {
+            if self.fail_can_unpark {
+                return Err(ASCOMError::invalid_operation("can_unpark read failed"));
+            }
+            Ok(self.can_unpark_value)
+        }
+
+        async fn park(&self) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_park {
+                return Err(ASCOMError::invalid_operation("park failed"));
+            }
+            Ok(())
+        }
+
+        async fn unpark(&self) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_unpark {
+                return Err(ASCOMError::invalid_operation("unpark failed"));
+            }
+            Ok(())
         }
 
         async fn declination(&self) -> ascom_alpaca::ASCOMResult<f64> {
@@ -2683,6 +2895,9 @@ mod tests {
         }
 
         async fn abort_slew(&self) -> ascom_alpaca::ASCOMResult<()> {
+            if self.fail_abort_slew {
+                return Err(ASCOMError::invalid_operation("abort_slew failed"));
+            }
             Ok(())
         }
 
@@ -4211,5 +4426,175 @@ mod tests {
             .set_tracking(Parameters(SetTrackingParams { enabled: true }))
             .await;
         assert_tool_error(result, "failed to set tracking");
+    }
+
+    // -----------------------------------------------------------------------
+    // Mount park / unpark / get_park_state / abort_slew tests.
+    // Singular mount, no params on any of these tools.
+    // -----------------------------------------------------------------------
+
+    /// Mock's `slewing()` returns false immediately; `at_park()` is
+    /// overridden to true so the post-park verify arm passes.
+    #[tokio::test]
+    async fn test_park_success() {
+        let mount = MockTelescope {
+            at_park_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await.unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_park_no_mount_configured() {
+        let handler = test_handler(empty_registry());
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    #[tokio::test]
+    async fn test_park_mount_not_connected() {
+        let handler = test_handler(disconnected_mount_registry());
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "mount not connected");
+    }
+
+    #[tokio::test]
+    async fn test_park_alpaca_error_propagates() {
+        let mount = MockTelescope {
+            fail_park: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "failed to park");
+    }
+
+    /// Slew completes (slewing() returns false), but at_park() reports
+    /// false — the mount finished its motion but isn't actually parked.
+    /// This is the "rare driver bug" arm that the post-condition guards
+    /// against.
+    #[tokio::test]
+    async fn test_park_completes_but_not_at_park() {
+        let mount = MockTelescope {
+            at_park_value: false,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "completed slew but is not at park");
+    }
+
+    /// 300 s deadline expires while `slewing()` keeps returning `true`.
+    /// Unlike `slew`, `park` does NOT auto-abort — it surfaces the
+    /// timeout and lets the caller decide. `start_paused` lets tokio
+    /// auto-advance virtual time so the test runs in real-time
+    /// milliseconds.
+    #[tokio::test(start_paused = true)]
+    async fn test_park_timeout_does_not_auto_abort() {
+        let mount = MockTelescope {
+            stuck_slewing: true,
+            at_park_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.park(Parameters(ParkParams {})).await;
+        assert_tool_error(result, "timeout waiting for mount to park");
+    }
+
+    #[tokio::test]
+    async fn test_unpark_success() {
+        let mount = MockTelescope {
+            at_park_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.unpark(Parameters(UnparkParams {})).await.unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_unpark_no_mount_configured() {
+        let handler = test_handler(empty_registry());
+        let result = handler.unpark(Parameters(UnparkParams {})).await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    #[tokio::test]
+    async fn test_unpark_alpaca_error() {
+        let mount = MockTelescope {
+            fail_unpark: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.unpark(Parameters(UnparkParams {})).await;
+        assert_tool_error(result, "failed to unpark");
+    }
+
+    #[tokio::test]
+    async fn test_get_park_state_returns_all_fields() {
+        let mount = MockTelescope {
+            at_park_value: true,
+            can_park_value: true,
+            can_unpark_value: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_park_state(Parameters(GetParkStateParams {}))
+            .await
+            .unwrap();
+        let json = ok_text(result);
+        assert_eq!(json["at_park"], true);
+        assert_eq!(json["can_park"], true);
+        assert_eq!(json["can_unpark"], true);
+    }
+
+    /// Per the design decision: fail loud on `at_park` read errors;
+    /// don't try to half-succeed by returning `can_park` alone.
+    #[tokio::test]
+    async fn test_get_park_state_fails_when_at_park_read_errors() {
+        let mount = MockTelescope {
+            fail_at_park: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .get_park_state(Parameters(GetParkStateParams {}))
+            .await;
+        assert_tool_error(result, "failed to read mount at_park");
+    }
+
+    #[tokio::test]
+    async fn test_abort_slew_success() {
+        let mount = MockTelescope::default();
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler
+            .abort_slew(Parameters(AbortSlewParams {}))
+            .await
+            .unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn test_abort_slew_no_mount_configured() {
+        let handler = test_handler(empty_registry());
+        let result = handler.abort_slew(Parameters(AbortSlewParams {})).await;
+        assert_tool_error(result, "no mount configured");
+    }
+
+    /// Models a mount that returns `InvalidOperation` from `abort_slew`
+    /// (e.g. when not currently slewing). The error propagates with
+    /// the friendly prefix.
+    #[tokio::test]
+    async fn test_abort_slew_alpaca_error() {
+        let mount = MockTelescope {
+            fail_abort_slew: true,
+            ..Default::default()
+        };
+        let handler = test_handler(mount_registry(Arc::new(mount), None));
+        let result = handler.abort_slew(Parameters(AbortSlewParams {})).await;
+        assert_tool_error(result, "failed to abort slew");
     }
 }

--- a/services/rp/tests/bdd/steps/mount_steps.rs
+++ b/services/rp/tests/bdd/steps/mount_steps.rs
@@ -169,6 +169,40 @@ async fn mcp_call_set_tracking(world: &mut RpWorld, enabled: String) {
     world.last_tool_result = Some(result);
 }
 
+#[when("the MCP client calls \"park\"")]
+async fn mcp_call_park(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world.mcp().call_tool("park", serde_json::json!({})).await;
+    world.last_tool_result = Some(result);
+}
+
+#[when("the MCP client calls \"unpark\"")]
+async fn mcp_call_unpark(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world.mcp().call_tool("unpark", serde_json::json!({})).await;
+    world.last_tool_result = Some(result);
+}
+
+#[when("the MCP client calls \"get_park_state\"")]
+async fn mcp_call_get_park_state(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("get_park_state", serde_json::json!({}))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+#[when("the MCP client calls \"abort_slew\"")]
+async fn mcp_call_abort_slew(world: &mut RpWorld) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("abort_slew", serde_json::json!({}))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
 // --- Then steps ---
 
 /// OmniSim's slew echo carries sub-arcsecond drift (likely from
@@ -256,6 +290,24 @@ fn get_tracking_can_set_tracking(world: &mut RpWorld, expected: String) {
     assert_eq!(
         actual, expected,
         "expected can_set_tracking={expected}, got {actual}"
+    );
+}
+
+#[then(expr = "the get_park_state result {word} should be {word}")]
+fn get_park_state_field(world: &mut RpWorld, field: String, expected: String) {
+    let result = unwrap_ok(world);
+    let expected: bool = match expected.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected true|false, got {other}"),
+    };
+    let actual = result
+        .get(&field)
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| panic!("expected {field} bool field, got: {result:?}"));
+    assert_eq!(
+        actual, expected,
+        "expected {field}={expected}, got {actual}"
     );
 }
 

--- a/services/rp/tests/features/mount.feature
+++ b/services/rp/tests/features/mount.feature
@@ -159,7 +159,8 @@ Feature: Mount tools
     And rp is running with a mount on the simulator
     And an MCP client connected to rp
     When the MCP client calls "park"
-    And the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    When the MCP client calls "get_park_state"
     Then the tool call should succeed
     And the get_park_state result at_park should be true
 
@@ -176,17 +177,29 @@ Feature: Mount tools
     And rp is running with a mount on the simulator
     And an MCP client connected to rp
     When the MCP client calls "park"
-    And the MCP client calls "unpark"
-    And the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    When the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    And the get_park_state result at_park should be true
+    When the MCP client calls "unpark"
+    Then the tool call should succeed
+    When the MCP client calls "get_park_state"
     Then the tool call should succeed
     And the get_park_state result at_park should be false
 
+  # Unparks first to pin a deterministic at_park == false starting
+  # state — earlier scenarios in this feature park the singleton
+  # OmniSim mount, so the round-trip-from-default assumption can't
+  # hold without an explicit reset.
   Scenario: get_park_state returns at_park, can_park, and can_unpark
     Given a running Alpaca simulator
     And rp is running with a mount on the simulator
     And an MCP client connected to rp
+    When the MCP client calls "unpark"
+    Then the tool call should succeed
     When the MCP client calls "get_park_state"
     Then the tool call should succeed
+    And the get_park_state result at_park should be false
     And the get_park_state result can_park should be true
     And the get_park_state result can_unpark should be true
 

--- a/services/rp/tests/features/mount.feature
+++ b/services/rp/tests/features/mount.feature
@@ -28,6 +28,10 @@ Feature: Mount tools
     And the tool list should include "get_mount_position"
     And the tool list should include "get_tracking"
     And the tool list should include "set_tracking"
+    And the tool list should include "park"
+    And the tool list should include "unpark"
+    And the tool list should include "get_park_state"
+    And the tool list should include "abort_slew"
 
   Scenario: slew drives the mount to absolute equatorial coordinates
     Given a running Alpaca simulator
@@ -149,3 +153,47 @@ Feature: Mount tools
     And the MCP client calls "get_tracking"
     Then the tool call should succeed
     And the get_tracking result tracking should be false
+
+  Scenario: park stows the mount and reports at_park == true
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "park"
+    And the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    And the get_park_state result at_park should be true
+
+  Scenario: park with no mount configured returns an error
+    Given a running Alpaca simulator
+    And rp is running without a mount
+    And an MCP client connected to rp
+    When the MCP client calls "park"
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"
+
+  Scenario: unpark clears the mount's parked flag
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "park"
+    And the MCP client calls "unpark"
+    And the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    And the get_park_state result at_park should be false
+
+  Scenario: get_park_state returns at_park, can_park, and can_unpark
+    Given a running Alpaca simulator
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_park_state"
+    Then the tool call should succeed
+    And the get_park_state result can_park should be true
+    And the get_park_state result can_unpark should be true
+
+  Scenario: abort_slew with no mount configured returns an error
+    Given a running Alpaca simulator
+    And rp is running without a mount
+    And an MCP client connected to rp
+    When the MCP client calls "abort_slew"
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"


### PR DESCRIPTION
## Summary

Adds the four mount-control MCP tools deferred from Phase 6c-prep (PR #133), completing the singular-mount tool surface for `center_on_target` (6c-3) and safety-shutdown workflows.

**Tools (all four take no parameters):**
- **`park`** — invoke ASCOM `Park`, poll `Slewing` until idle (300 s deadline), verify `AtPark == true`. Per ASCOM, a successful park clears `Tracking`. Unlike `slew`, `park` does NOT auto-abort on timeout — a partially-completed park is closer to safe than an aborted one (the mount is actively trying to reach a known safe position; aborting leaves it in an unknown state mid-traversal). Callers wanting to interrupt a stuck park use `abort_slew`.
- **`unpark`** — returns immediately (most drivers just clear `AtPark` — no motion). Does NOT auto-enable `Tracking`; caller calls `set_tracking` explicitly before slewing.
- **`get_park_state`** — `{ at_park, can_park, can_unpark }`. Fails loud on `AtPark` read errors (load-bearing field).
- **`abort_slew`** — aborts an in-progress slew or park. Per ASCOM, only valid while `Slewing == true`; the natural Alpaca error propagates otherwise.

**Implementation notes:**
- Extracted the `Slewing` poll loop from `do_slew_blocking` into a shared `poll_slewing_until_idle` helper (returns a typed `PollIdleError` so `do_slew_blocking` best-effort-aborts on `Timeout` while `do_park_blocking` surfaces the timeout untouched). Eliminates ~10 lines of duplication.
- `MockTelescope` grew `at_park` / `can_park` / `can_unpark` fields plus six `fail_*` injection points. Defaults remain happy-path (capable, not parked).

## Test plan

- [x] `cargo rail run --profile commit -q` — 254/254 affected-package tests pass.
- [x] `cargo test --all-features --test bdd -p rp` — 192/192 BDD scenarios green (was 187, +5 new park scenarios).
- [x] **+14 new mcp.rs unit tests**: 5 park (incl. `start_paused` timeout test that verifies park does NOT auto-abort), 3 unpark, 2 get_park_state, 3 abort_slew, plus the completes-but-not-at-park edge case.
- [x] **+5 new BDD scenarios** on `mount.feature`: park happy path verified via `get_park_state`, park no-mount-configured, unpark round-trip (park → unpark → at_park: false), get_park_state field-presence, abort_slew no-mount-configured. Catalog scenario extended with all four new tools.
- [x] `cargo fmt` clean.
- [x] No new workspace deps; no `bazel mod tidy` needed.

## Files

- `services/rp/src/mcp.rs` — `do_park_blocking` + extracted `poll_slewing_until_idle` helper + 4 tools + `MockTelescope` extensions + 14 unit tests.
- `services/rp/tests/features/mount.feature` — catalog extended; 5 new scenarios.
- `services/rp/tests/bdd/steps/mount_steps.rs` — When/Then steps for the 4 new tools.
- `docs/services/rp.md` — Built-in Tools — Hardware table gains 4 rows.
- `docs/plans/image-evaluation-tools.md` — Phase 6c-prep deferred-list updated (removed `park`/`unpark` and `abort_slew`; added a follow-up-landed note; `set_park` stays deferred).

## Out of scope (still deferred)

- `set_park` (sets the current position as the new park position) — power-user feature with no workflow consumer in sight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)