### PR TITLE
docs(design): UI mocks for activity stream paradigm

### DIFF
--- a/docs/plans/ui-design/mocks/1-gallery.html
+++ b/docs/plans/ui-design/mocks/1-gallery.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Gallery (Lightroom-style)</title>
+<style>
+  :root {
+    --bg:#0b0d12; --panel:#11141b; --edge:#1a1f2b;
+    --text:#e6e8ee; --dim:#8a93a6;
+    --hot:#10b981; --warn:#f59e0b; --bad:#ef4444; --accent:#60a5fa;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { height:100%; background:var(--bg); color:var(--text);
+    font-family: ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4; overflow:hidden;
+  }
+  .mono { font-family: ui-monospace,SFMono-Regular,Menlo,monospace }
+  button { font:inherit; color:inherit; background:none; border:0; cursor:pointer }
+
+  /* ── topbar ── */
+  .topbar { height:48px; padding:0 16px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:var(--panel) }
+  .brand { display:flex; align-items:center; gap:8px; font-weight:600; letter-spacing:-.01em }
+  .logo { width:24px; height:24px; border-radius:5px;
+    background:linear-gradient(135deg,#6366f1,#d946ef) }
+  .crumb-sep { color:var(--dim); font-size:13px }
+  .session-name { font-size:13px } .session-name b { color:#fff; font-weight:600 }
+  .spacer { flex:1 }
+  .pill { display:inline-flex; align-items:center; gap:6px; font-size:11px;
+    padding:3px 8px; border-radius:999px;
+    background:rgba(16,185,129,.1); color:#34d399; box-shadow:inset 0 0 0 1px rgba(16,185,129,.3) }
+  .pulse { width:6px; height:6px; border-radius:999px; background:#34d399; animation:pulse 1.6s infinite }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .meta-strip { font-size:13px; color:var(--dim) }
+  .meta-strip b { color:#fff; font-weight:500 }
+  .progress-block { width:240px }
+  .progress-block .row { display:flex; justify-content:space-between; font-size:11px; color:var(--dim); margin-bottom:4px }
+  .progress-block .row b { color:#fff; font-weight:500 }
+  .bar { height:6px; border-radius:999px; background:var(--edge); overflow:hidden }
+  .bar > i { display:block; height:100%; background:#34d399 }
+
+  /* ── main layout ── */
+  main { display:flex; height:calc(100vh - 48px) }
+  .stage { flex:1; display:flex; align-items:center; justify-content:center;
+    padding:24px; position:relative; background:var(--bg) }
+  .stage-tools { position:absolute; top:16px; left:16px; display:flex; gap:6px }
+  .stage-info { position:absolute; top:16px; right:16px; font-size:11px; color:var(--dim);
+    background:rgba(17,20,27,.85); padding:4px 8px; border-radius:4px;
+    border:1px solid var(--edge) }
+  .btn-ghost { padding:5px 10px; font-size:12px; border-radius:4px;
+    background:rgba(17,20,27,.85); border:1px solid var(--edge); color:var(--text) }
+  .btn-ghost:hover { border-color:var(--accent) }
+  .photo { width:100%; height:100%; max-width:1400px; border-radius:6px;
+    overflow:hidden; border:1px solid var(--edge);
+    box-shadow:0 0 60px rgba(0,0,0,.6) }
+  .photo svg { display:block; width:100%; height:100% }
+
+  /* ── right rail ── */
+  .rail { width:320px; border-left:1px solid var(--edge); background:var(--panel);
+    overflow-y:auto }
+  .rail section { padding:16px; border-bottom:1px solid var(--edge) }
+  .rail-label { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); margin-bottom:6px }
+  .frame-title { font-size:17px; font-weight:600 }
+  .frame-sub { font-size:11px; color:var(--dim); margin-top:2px }
+  .meta-grid { display:grid; grid-template-columns:1fr 1fr; gap:6px 12px }
+  .meta-grid dt { color:var(--dim) }
+  .meta-grid dd { font-family:ui-monospace,monospace }
+  .ok { color:#34d399 }
+  .seq-list, .equip-list { list-style:none }
+  .seq-list li { display:flex; justify-content:space-between; padding:3px 0 }
+  .seq-list li.muted { color:var(--dim) }
+  .equip-list li { font-size:12px; color:var(--dim); padding:2px 0; display:flex; align-items:center; gap:6px }
+  .led { width:8px; height:8px; border-radius:999px; flex:none }
+  .led.ok { background:#34d399 } .led.warn { background:#fbbf24 } .led.bad { background:#f87171 }
+
+  /* ── filmstrip ── */
+  details { position:fixed; bottom:0; left:0; right:320px;
+    background:var(--panel); border-top:1px solid var(--edge) }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  .strip-bar { padding:0 16px; height:36px; display:flex; align-items:center;
+    justify-content:space-between; font-size:12px; color:var(--dim) }
+  .strip-bar .left { display:flex; align-items:center; gap:12px }
+  .strip-bar b { color:var(--text); font-weight:500 }
+  .strip-thumbs { padding:12px 16px; display:flex; gap:8px; overflow-x:auto }
+  .thumb { width:160px; height:100px; flex:none; border:1px solid var(--edge);
+    border-radius:6px; overflow:hidden; cursor:pointer; position:relative }
+  .thumb:hover { border-color:var(--accent) }
+  .thumb.active { outline:2px solid var(--accent); outline-offset:1px }
+  .thumb-label { position:absolute; bottom:4px; left:4px;
+    font-family:ui-monospace,monospace; font-size:10px;
+    color:rgba(255,255,255,.8); background:rgba(0,0,0,.4);
+    padding:1px 4px; border-radius:2px }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="brand"><div class="logo"></div><span>rusty&nbsp;photon</span></div>
+  <span class="crumb-sep">/</span>
+  <span class="session-name">Session — <b>M51 — Whirlpool</b></span>
+  <span class="spacer"></span>
+  <span class="pill"><span class="pulse"></span>CAPTURING</span>
+  <span class="meta-strip mono">L · 4&nbsp;/&nbsp;10 · <b>300s</b></span>
+  <div class="progress-block">
+    <div class="row"><span>Sequence</span><b class="mono">26m 14s remaining</b></div>
+    <div class="bar"><i style="width:42%"></i></div>
+  </div>
+  <button class="btn-ghost" style="background:transparent;border:0;color:var(--dim)">⋯</button>
+</header>
+
+<main>
+  <section class="stage">
+    <div class="stage-tools">
+      <button class="btn-ghost">Fit</button>
+      <button class="btn-ghost">100%</button>
+      <button class="btn-ghost">Stretch</button>
+      <button class="btn-ghost">Stars</button>
+    </div>
+    <div class="stage-info mono">Frame 0042 · 21:18:04</div>
+    <div class="photo">
+      <!-- inline starfield SVG -->
+      <svg viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <radialGradient id="neb" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+            <stop offset="60%" stop-color="#1e1b4b" stop-opacity=".15"/>
+            <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+          </radialGradient>
+          <radialGradient id="core" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+            <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+            <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="800" height="600" fill="#03050b"/>
+        <ellipse cx="420" cy="300" rx="380" ry="260" fill="url(#neb)"/>
+        <g transform="translate(420 300) rotate(-22)">
+          <ellipse rx="70" ry="46" fill="url(#core)"/>
+          <path d="M 0 0 Q -160 -60 -260 -10 Q -310 20 -330 80" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q  160  60  260  10 Q  310 -20  330 -80" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q -100 -90 -180 -120" stroke="#fde68a" stroke-opacity=".25" stroke-width="1.5" fill="none"/>
+          <path d="M 0 0 Q  100  90  180  120" stroke="#fde68a" stroke-opacity=".25" stroke-width="1.5" fill="none"/>
+        </g>
+        <ellipse cx="640" cy="220" rx="22" ry="18" fill="#fef3c7" fill-opacity=".7"/>
+        <ellipse cx="640" cy="220" rx="40" ry="32" fill="#fbbf24" fill-opacity=".15"/>
+        <g fill="#fff">
+          <circle cx="50" cy="80" r="1"/><circle cx="120" cy="130" r=".8"/><circle cx="180" cy="60" r=".6"/>
+          <circle cx="240" cy="200" r="1.2"/><circle cx="300" cy="90" r=".7"/><circle cx="360" cy="180" r=".9"/>
+          <circle cx="420" cy="40" r=".6"/><circle cx="480" cy="220" r="1"/><circle cx="540" cy="70" r=".8"/>
+          <circle cx="600" cy="160" r="1.2"/><circle cx="660" cy="100" r=".7"/><circle cx="720" cy="180" r=".9"/>
+          <circle cx="80" cy="250" r=".6"/><circle cx="160" cy="300" r="1"/><circle cx="220" cy="380" r=".8"/>
+          <circle cx="280" cy="260" r=".6"/><circle cx="340" cy="420" r="1.2"/><circle cx="460" cy="340" r=".9"/>
+          <circle cx="520" cy="440" r="1"/><circle cx="580" cy="280" r=".6"/><circle cx="640" cy="460" r=".8"/>
+          <circle cx="700" cy="360" r="1.2"/><circle cx="60" cy="460" r=".9"/><circle cx="140" cy="540" r="1"/>
+          <circle cx="200" cy="480" r=".6"/><circle cx="260" cy="560" r=".8"/><circle cx="320" cy="500" r=".7"/>
+          <circle cx="380" cy="580" r="1.2"/><circle cx="440" cy="520" r=".9"/><circle cx="500" cy="580" r=".6"/>
+          <circle cx="560" cy="540" r="1"/><circle cx="620" cy="500" r=".8"/><circle cx="680" cy="580" r=".7"/>
+          <circle cx="740" cy="540" r=".9"/><circle cx="30" cy="180" r=".6"/><circle cx="90" cy="400" r=".8"/>
+          <circle cx="150" cy="220" r=".7"/><circle cx="210" cy="140" r="1"/><circle cx="270" cy="360" r=".6"/>
+          <circle cx="330" cy="260" r=".9"/><circle cx="390" cy="160" r=".8"/><circle cx="450" cy="420" r=".7"/>
+          <circle cx="510" cy="180" r="1.2"/><circle cx="570" cy="360" r=".6"/><circle cx="630" cy="220" r=".9"/>
+          <circle cx="690" cy="460" r=".8"/><circle cx="750" cy="300" r="1"/><circle cx="770" cy="80" r=".7"/>
+        </g>
+        <g transform="translate(160 460)">
+          <circle r="2.2" fill="#fff"/>
+          <line x1="-14" y1="0" x2="14" y2="0" stroke="#fff" stroke-opacity=".55" stroke-width=".6"/>
+          <line x1="0" y1="-14" x2="0" y2="14" stroke="#fff" stroke-opacity=".55" stroke-width=".6"/>
+        </g>
+      </svg>
+    </div>
+  </section>
+
+  <aside class="rail">
+    <section>
+      <div class="rail-label">Current frame</div>
+      <div class="frame-title">M51 · L · 300s</div>
+      <div class="frame-sub mono">2026-05-03 21:18:04 · Frame 0042</div>
+    </section>
+    <section>
+      <dl class="meta-grid">
+        <dt>Target</dt><dd>M51</dd>
+        <dt>RA / Dec</dt><dd>13:29:53 +47°11′</dd>
+        <dt>Filter</dt><dd>Luminance</dd>
+        <dt>Exposure</dt><dd>300.0 s</dd>
+        <dt>Gain / Offset</dt><dd>100 / 30</dd>
+        <dt>CCD temp</dt><dd class="ok">−10.0 °C</dd>
+        <dt>HFR</dt><dd>1.84″</dd>
+        <dt>Stars</dt><dd>2,941</dd>
+        <dt>Mean ADU</dt><dd>1,247</dd>
+        <dt>Eccentricity</dt><dd>0.41</dd>
+      </dl>
+    </section>
+    <section>
+      <div class="rail-label">Sequence plan</div>
+      <ul class="seq-list">
+        <li><span>L · 300s × 10</span><span class="mono ok">4 / 10</span></li>
+        <li class="muted"><span>R · 180s × 10</span><span class="mono">0 / 10</span></li>
+        <li class="muted"><span>G · 180s × 10</span><span class="mono">0 / 10</span></li>
+        <li class="muted"><span>B · 180s × 10</span><span class="mono">0 / 10</span></li>
+      </ul>
+    </section>
+    <section>
+      <div class="rail-label">Equipment</div>
+      <ul class="equip-list">
+        <li><span class="led ok"></span>Camera — QHY268M · −10°C</li>
+        <li><span class="led ok"></span>Mount — tracking, RMS 0.62″</li>
+        <li><span class="led ok"></span>Focuser — pos 14,820 · 22.4°C</li>
+        <li><span class="led warn"></span>Sky — clouds 18% (rising)</li>
+      </ul>
+    </section>
+  </aside>
+</main>
+
+<details open>
+  <summary class="strip-bar">
+    <div class="left">
+      <b>History</b>
+      <span class="mono">42 frames · this session</span>
+      <button style="color:var(--dim)" onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--dim)'">all sessions →</button>
+    </div>
+    <span>▾ collapse</span>
+  </summary>
+  <div class="strip-thumbs">
+    <div class="thumb active" style="background:linear-gradient(135deg,#1e1b4b,#312e81)"><div class="thumb-label">0042 · L</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0041 · L</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0040 · L</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0039 · L</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0038 · L</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#164e63,#020617)"><div class="thumb-label">0037 · R</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#312e81,#020617)"><div class="thumb-label">0036 · R</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#1e293b,#020617)"><div class="thumb-label">0035 · G</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#1e1b4b,#020617)"><div class="thumb-label">0034 · G</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0033 · B</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0032 · B</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0031 · B</div></div>
+    <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0030 · L</div></div>
+  </div>
+</details>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/10-lcars.html
+++ b/docs/plans/ui-design/mocks/10-lcars.html
@@ -1,0 +1,850 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>RP // LCARS // ACTIVITY</title>
+<style>
+  /* ── LCARS palette ───────────────────────────────────────────────── */
+  :root {
+    --lcars-orange:  #ff9966;   /* salmon-orange (Okudagram primary) */
+    --lcars-amber:   #ff9900;   /* burnt amber */
+    --lcars-peach:   #ffcc99;   /* peach */
+    --lcars-violet:  #cc99cc;   /* violet */
+    --lcars-magenta: #cc6688;   /* dusty magenta */
+    --lcars-blue:    #9999ff;   /* periwinkle blue */
+    --lcars-sky:     #99ccff;   /* light blue */
+    --lcars-yellow:  #ffcc66;   /* honey yellow */
+    --lcars-tan:     #cc9966;   /* tan */
+    --lcars-red:     #ff5544;   /* red alert */
+
+    --bg:    #000;
+    --text:  #ffcc99;
+    --dim:   #886655;
+
+    /* layout */
+    --side-w: 180px;
+    --top-h:  60px;
+    --bot-h:  28px;
+    --corner: 50px;
+    --gap:    4px;
+  }
+
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { background:#000; color:var(--text);
+    font-family:"Helvetica Neue", "Arial Narrow", "Roboto Condensed", Impact, sans-serif;
+    font-stretch:condensed; font-weight:700;
+    font-size:14px; line-height:1.2; min-height:100vh;
+    text-transform:uppercase; letter-spacing:0.04em;
+    -webkit-font-smoothing:antialiased }
+  button, a, label { font:inherit; color:inherit; background:none;
+    border:0; cursor:pointer; text-decoration:none }
+  ol,ul { list-style:none }
+  .case-normal { text-transform:none }
+  .num { font-variant-numeric:tabular-nums; letter-spacing:0.02em }
+
+  /* ── frame: top bar + sidebar + bottom bar (the L-shapes) ───── */
+  .lcars-app { min-height:100vh; padding:var(--gap);
+    display:grid; gap:var(--gap);
+    grid-template-columns:var(--side-w) 1fr;
+    grid-template-rows:var(--top-h) 1fr var(--bot-h) }
+
+  /* TOP BAR — full width, top row */
+  .lcars-top { grid-column:1 / -1; height:var(--top-h);
+    background:var(--lcars-amber);
+    border-radius:var(--corner) var(--corner) 0 0;
+    padding:0 var(--corner) 0 var(--corner);
+    display:grid;
+    grid-template-columns:auto auto 1fr auto auto auto;
+    align-items:center; gap:18px;
+    color:#000 }
+  .lcars-top .logo { font-size:18px; letter-spacing:0.08em }
+  .lcars-top .div { color:rgba(0,0,0,.4) }
+  .lcars-top .title { font-size:24px; letter-spacing:0.12em;
+    justify-self:center; margin-left:40px }
+  .lcars-top .stardate { font-size:13px; color:#000 }
+  .lcars-top .stardate b { font-size:15px; margin-left:6px;
+    font-variant-numeric:tabular-nums }
+  .lcars-top .ref { font-size:12px; color:rgba(0,0,0,.55);
+    border-left:2px solid #000; padding-left:14px; height:24px;
+    line-height:24px }
+  .lcars-top .nv {
+    background:#000; color:var(--lcars-amber);
+    padding:6px 18px; border-radius:99px;
+    font-size:12px; letter-spacing:0.14em;
+    display:flex; align-items:center; gap:8px;
+    border:2px solid #000; cursor:pointer; user-select:none;
+    transition:background .15s, color .15s }
+  .lcars-top .nv:hover { background:#1a1a1a }
+  .lcars-top .nv:has(input:checked) { background:#fff; color:#000 }
+  .lcars-top .nv .icon { font-size:13px }
+  .lcars-top .nv .dot { width:8px; height:8px; border-radius:50%;
+    background:var(--lcars-amber); border:1px solid var(--lcars-amber) }
+  .lcars-top .nv:has(input:checked) .dot { background:#000;
+    border-color:#000; box-shadow:0 0 6px #fff }
+
+  /* SIDEBAR — left column, mid+bottom rows */
+  .lcars-side { grid-row:2 / -1;
+    display:flex; flex-direction:column; gap:var(--gap) }
+
+  /* SIDEBAR pill blocks */
+  .pill {
+    padding:14px 22px 12px;
+    color:#000; font-size:14px; letter-spacing:0.08em;
+    border-radius:0 99px 99px 0;
+    margin-right:var(--corner);
+    cursor:pointer;
+    transition:filter .15s }
+  .pill:hover { filter:brightness(1.15) }
+  .pill.active { padding-right:32px }
+  .pill.active::after { content:"▸"; float:right; margin-top:-1px }
+
+  .pill.amber   { background:var(--lcars-amber) }
+  .pill.peach   { background:var(--lcars-peach) }
+  .pill.salmon  { background:var(--lcars-orange) }
+  .pill.violet  { background:var(--lcars-violet) }
+  .pill.magenta { background:var(--lcars-magenta) }
+  .pill.blue    { background:var(--lcars-blue) }
+  .pill.sky     { background:var(--lcars-sky) }
+  .pill.yellow  { background:var(--lcars-yellow) }
+  .pill.tan     { background:var(--lcars-tan) }
+  .pill.red     { background:var(--lcars-red); color:#fff }
+
+  /* spacer-pill: tiny height, just for color rhythm */
+  .spacer { height:14px; background:var(--lcars-magenta);
+    border-radius:0 99px 99px 0; margin-right:var(--corner) }
+  .spacer.tan    { background:var(--lcars-tan) }
+  .spacer.yellow { background:var(--lcars-yellow) }
+  .spacer.violet { background:var(--lcars-violet) }
+  .spacer.peach  { background:var(--lcars-peach) }
+  .spacer.amber  { background:var(--lcars-amber) }
+  .spacer.blue   { background:var(--lcars-blue) }
+
+  /* sidebar section header — small label at top of a group */
+  .side-section-h { font-size:10px; color:var(--dim);
+    padding:8px 22px 4px; letter-spacing:0.16em }
+
+  /* sidebar status group: tighter rows with LED + label */
+  .side-status { padding:8px 22px 14px var(--corner);
+    background:var(--lcars-magenta);
+    color:#000; border-radius:0 99px 99px 0;
+    display:flex; flex-direction:column; gap:6px;
+    font-size:11px; letter-spacing:0.06em;
+    margin-right:var(--corner) }
+  .side-status li { display:grid; grid-template-columns:auto 1fr auto;
+    gap:8px; align-items:center }
+  .side-status li::before { content:""; width:7px; height:7px; border-radius:50%;
+    background:#000 }
+  .side-status li.warn::before { background:var(--lcars-red) }
+  .side-status li .v { font-variant-numeric:tabular-nums; letter-spacing:0;
+    text-transform:none; font-size:11px }
+
+  /* user / sign-out at bottom */
+  .side-foot { margin-top:auto; display:flex; flex-direction:column; gap:var(--gap) }
+
+  /* ── elbow piece — rounded inside corner of the L ──────────── */
+  /* Sits at the join of top bar bottom and sidebar right.
+     Color matches the top bar / sidebar that meets here. */
+  .elbow-tl { position:absolute;
+    top:calc(var(--gap) + var(--top-h));
+    left:calc(var(--gap) + var(--side-w));
+    width:var(--corner); height:var(--corner);
+    background:var(--lcars-amber);
+    border-bottom-right-radius:var(--corner);
+    pointer-events:none }
+  .elbow-bl { position:absolute;
+    bottom:calc(var(--gap) + var(--bot-h));
+    left:calc(var(--gap) + var(--side-w));
+    width:var(--corner); height:var(--corner);
+    background:var(--lcars-amber);
+    border-top-right-radius:var(--corner);
+    pointer-events:none }
+
+  /* ── BOTTOM BAR — full width, last row ────────────────────────── */
+  .lcars-bot { grid-column:1 / -1; height:var(--bot-h);
+    background:var(--lcars-amber);
+    border-radius:0 0 var(--corner) var(--corner);
+    padding:0 var(--corner);
+    display:flex; align-items:center; gap:18px;
+    color:#000; font-size:11px; letter-spacing:0.12em }
+  .lcars-bot .grow { flex:1 }
+  .lcars-bot .ref { color:rgba(0,0,0,.55); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0.04em }
+
+  /* ── MAIN STAGE (right column, mid row) ─────────────────────── */
+  .lcars-main { background:#000; color:var(--text);
+    overflow:hidden; display:flex; flex-direction:column;
+    gap:var(--gap); padding-left:0 }
+
+  /* ── STRIP — top of main, contains foldable telemetry ─────── */
+  .fold-state { display:none }
+
+  .strip { background:#000; height:34px; padding:0 0 0 0;
+    display:flex; align-items:center; gap:14px;
+    cursor:pointer;
+    border-bottom:1px solid #1a1a1a; transition:background .15s }
+  .strip:hover { background:#0a0a0a }
+
+  .strip-block { background:var(--lcars-orange); color:#000;
+    padding:0 18px 0 14px; height:100%;
+    display:flex; align-items:center; gap:8px;
+    border-radius:0 99px 99px 0;
+    font-size:12px; letter-spacing:0.1em }
+  .strip-pulse { width:8px; height:8px; border-radius:50%; background:#000;
+    animation:blink 1.4s ease-in-out infinite }
+  @keyframes blink { 0%,100% { opacity:1 } 50% { opacity:.35 } }
+  .strip-block .v { letter-spacing:0; text-transform:none;
+    font-variant-numeric:tabular-nums; font-size:13px }
+
+  .strip-stat { display:flex; align-items:center; gap:8px;
+    color:var(--dim); font-size:11px; letter-spacing:0.1em }
+  .strip-stat .lbl-ra  { color:var(--lcars-orange) }
+  .strip-stat .lbl-dec { color:var(--lcars-sky) }
+  .strip-stat .v { color:var(--text); text-transform:none; letter-spacing:0;
+    font-variant-numeric:tabular-nums; font-size:13px }
+  .strip-stat .v.warn { color:var(--lcars-yellow) }
+  .strip-stat .v.live { color:var(--lcars-peach) }
+  .mini { width:60px; height:18px; flex:none }
+
+  .strip-spacer { flex:1 }
+
+  .strip-eta { color:var(--dim); font-size:11px; letter-spacing:0.1em }
+  .strip-eta b { color:var(--text); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0; font-size:13px; margin-left:4px }
+
+  .strip-toggle { background:var(--lcars-violet); color:#000;
+    height:100%; padding:0 18px 0 14px;
+    display:flex; align-items:center; gap:10px;
+    border-radius:99px 0 0 99px;
+    font-size:11px; letter-spacing:0.14em }
+  .strip-toggle .chev {
+    width:7px; height:7px;
+    border-right:2px solid #000; border-bottom:2px solid #000;
+    transform:rotate(45deg) translateY(-2px);
+    transition:transform 320ms cubic-bezier(.4,0,.2,1) }
+  .fold-state:checked ~ .strip .strip-toggle .chev {
+    transform:rotate(-135deg) translateY(2px) }
+  .fold-state:checked ~ .strip .strip-toggle .lbl::before { content:"COLLAPSE" }
+  .fold-state:not(:checked) ~ .strip .strip-toggle .lbl::before { content:"EXPAND" }
+
+  /* ── FOLD PANEL ──────────────────────────────────────────────── */
+  .fold-body {
+    display:grid; grid-template-rows:0fr;
+    transition:grid-template-rows 320ms cubic-bezier(.4,0,.2,1) }
+  .fold-body > .panel {
+    min-height:0; overflow:hidden; opacity:0;
+    transition:opacity 220ms ease }
+  .fold-state:checked ~ .fold-body { grid-template-rows:1fr }
+  .fold-state:checked ~ .fold-body > .panel {
+    opacity:1; transition-delay:60ms }
+
+  .panel { background:#000; padding:var(--gap) 0;
+    display:flex; flex-direction:column; gap:var(--gap) }
+
+  /* panel header strip — small LCARS multi-block bar */
+  .panel-head { display:flex; gap:var(--gap); height:24px; align-items:stretch }
+  .panel-head .blk { padding:0 14px; display:flex; align-items:center;
+    color:#000; font-size:11px; letter-spacing:0.12em }
+  .panel-head .blk.label { background:var(--lcars-violet);
+    border-radius:0 99px 99px 0 }
+  .panel-head .blk.meta  { background:var(--lcars-tan);
+    color:#000; flex:1; justify-content:flex-end;
+    border-radius:99px 0 0 99px;
+    font-variant-numeric:tabular-nums }
+  .panel-head .blk.meta b { letter-spacing:0; text-transform:none;
+    margin:0 4px; font-size:12px }
+
+  .panel-grid { display:grid; grid-template-columns:1fr 280px;
+    gap:var(--gap) }
+
+  /* guider card */
+  .guider { background:#0a0a0a;
+    border-left:6px solid var(--lcars-orange) }
+  .guider-head { display:flex; align-items:center; gap:14px;
+    padding:10px 14px; border-bottom:1px solid #1a1a1a }
+  .guider-head .label { color:var(--lcars-orange); font-size:13px;
+    letter-spacing:0.14em }
+  .guider-head .sub { color:var(--dim); font-size:11px; letter-spacing:0.06em }
+  .gstats { display:flex; gap:14px; margin-left:auto;
+    color:var(--dim); font-size:11px; letter-spacing:0.08em }
+  .gstat { display:flex; align-items:center; gap:6px }
+  .gstat .swatch { width:12px; height:2px }
+  .gstat.ra .swatch { background:var(--lcars-orange) }
+  .gstat.dec .swatch { background:var(--lcars-sky) }
+  .gstat .v { color:var(--text); font-variant-numeric:tabular-nums;
+    letter-spacing:0; text-transform:none; font-size:13px }
+  .gstat.total { padding-left:14px; border-left:1px solid #2a2a2a;
+    color:var(--text) }
+  .gstat.total .v { color:var(--lcars-peach); font-size:14px }
+  .graph { height:220px; padding:8px 12px }
+  .graph svg { display:block; width:100%; height:100% }
+
+  /* trend charts */
+  .charts-row { display:grid; grid-template-columns:repeat(4,1fr);
+    gap:var(--gap) }
+  .chart-card { background:#0a0a0a;
+    border-left:6px solid var(--lcars-violet); padding:0 }
+  .chart-card.alt { border-left-color:var(--lcars-tan) }
+  .chart-card.alt2 { border-left-color:var(--lcars-magenta) }
+  .chart-card.alt3 { border-left-color:var(--lcars-blue) }
+  .chart-h { display:flex; align-items:baseline; gap:8px;
+    padding:8px 14px 4px }
+  .chart-h .k { color:var(--dim); font-size:11px; letter-spacing:0.12em }
+  .chart-h .v { margin-left:auto; color:var(--text);
+    font-variant-numeric:tabular-nums; letter-spacing:0;
+    text-transform:none; font-size:18px }
+  .chart-h .v.warn { color:var(--lcars-yellow) }
+  .chart-h .v.live { color:var(--lcars-peach) }
+  .chart-h .d { color:var(--dim); font-size:10px; letter-spacing:0.06em }
+  .chart-h .d.warn { color:var(--lcars-yellow) }
+  .chart-h .d.live { color:var(--lcars-peach) }
+  .chart-body { padding:0 12px 10px; height:80px }
+  .chart-body svg { display:block; width:100%; height:100% }
+
+  /* side column: stages */
+  .side-card { background:#0a0a0a;
+    border-left:6px solid var(--lcars-blue); padding:14px }
+  .side-card h4 { color:var(--lcars-blue); font-size:12px;
+    letter-spacing:0.14em; margin-bottom:12px;
+    display:flex; align-items:center; justify-content:space-between }
+  .side-card h4 .ref { color:var(--dim); font-size:10px;
+    text-transform:none; letter-spacing:0;
+    font-variant-numeric:tabular-nums }
+  .stages-list { display:flex; flex-direction:column; gap:5px;
+    font-size:12px; letter-spacing:0.04em }
+  .stages-list li { display:grid;
+    grid-template-columns:auto 1fr auto; gap:10px; align-items:center }
+  .stages-list .step { width:14px; height:14px;
+    display:grid; place-items:center; font-size:9px; border-radius:50% }
+  .stages-list .step.done { background:var(--lcars-peach); color:#000 }
+  .stages-list .step.live { background:var(--lcars-amber); color:#000 }
+  .stages-list .step.live::after { content:""; position:absolute;
+    inset:-2px; border-radius:50%; border:1px solid var(--lcars-amber);
+    animation:pulse 1.4s ease-in-out infinite }
+  @keyframes pulse { 0% { transform:scale(1); opacity:1 }
+                     100% { transform:scale(1.6); opacity:0 } }
+  .stages-list .step { position:relative }
+  .stages-list .step.pending { background:transparent;
+    border:1px dashed #2a2a2a }
+  .stages-list li.muted { color:var(--dim) }
+  .stages-list strong { color:var(--text) }
+  .stages-list .right { font-variant-numeric:tabular-nums; color:var(--dim);
+    text-transform:none; letter-spacing:0; font-size:11px }
+
+  /* ── content stream ──────────────────────────────────────────── */
+  .content { padding:var(--gap) 0;
+    display:flex; flex-direction:column; gap:var(--gap);
+    overflow-y:auto; flex:1 }
+
+  /* section header — multi-color bar */
+  .sec-h { display:flex; gap:var(--gap); height:26px; align-items:stretch }
+  .sec-h .blk { padding:0 14px; display:flex; align-items:center;
+    color:#000; font-size:11px; letter-spacing:0.14em }
+  .sec-h .blk.num   { background:var(--lcars-violet);
+    border-radius:0 99px 99px 0 }
+  .sec-h .blk.label { background:var(--lcars-orange) }
+  .sec-h .blk.meta  { background:var(--lcars-tan); flex:1;
+    justify-content:flex-end; border-radius:99px 0 0 99px;
+    font-variant-numeric:tabular-nums }
+  .sec-h .blk.meta b { letter-spacing:0; text-transform:none;
+    margin:0 4px; font-size:12px }
+
+  /* hero */
+  .hero { background:#0a0a0a;
+    display:grid; grid-template-columns:auto 1fr auto;
+    gap:24px; padding:18px 20px;
+    border-left:6px solid var(--lcars-amber) }
+
+  .hero-pct { width:120px;
+    background:var(--lcars-amber); color:#000;
+    border-radius:99px;
+    display:grid; place-items:center; padding:14px;
+    text-align:center }
+  .hero-pct .n { font-size:48px; line-height:1;
+    font-variant-numeric:tabular-nums; letter-spacing:-0.02em }
+  .hero-pct .lbl { font-size:11px; letter-spacing:0.16em; margin-top:2px }
+
+  .hero-body { min-width:0 }
+  .hero-tag { color:var(--lcars-amber); font-size:11px; letter-spacing:0.18em;
+    display:flex; align-items:center; gap:8px }
+  .hero-tag::before { content:""; width:8px; height:8px;
+    background:var(--lcars-amber); animation:blink 1.4s ease-in-out infinite }
+  .hero h1 { font-size:32px; letter-spacing:0.04em; margin:6px 0 4px;
+    color:var(--text) }
+  .hero h1 .dim { color:var(--dim) }
+  .hero .meta { color:var(--dim); font-size:11px; letter-spacing:0.08em }
+  .hero .meta b { color:var(--text); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0; font-size:12px }
+
+  .hero-stages { display:flex; gap:var(--gap); margin-top:14px }
+  .hero-stages li { padding:6px 16px; font-size:11px; letter-spacing:0.14em;
+    background:#1a1a1a; color:var(--dim); border-radius:99px }
+  .hero-stages li.done { background:var(--lcars-peach); color:#000 }
+  .hero-stages li.live { background:var(--lcars-amber); color:#000 }
+
+  .hero-actions { display:flex; flex-direction:column; gap:6px;
+    align-items:flex-end }
+  .btn { padding:8px 18px; font-size:11px; letter-spacing:0.14em;
+    color:#000; background:var(--lcars-tan);
+    border-radius:99px; transition:filter .15s }
+  .btn:hover { filter:brightness(1.15) }
+  .btn.danger { background:var(--lcars-red); color:#fff }
+
+  /* frame card */
+  .frame { background:#0a0a0a;
+    border-left:6px solid var(--lcars-magenta) }
+  .frame-h { padding:10px 14px; display:flex; align-items:center;
+    border-bottom:1px solid #1a1a1a; font-size:11px;
+    letter-spacing:0.08em; color:var(--dim) }
+  .frame-h .name { color:var(--text); font-size:14px; letter-spacing:0.04em }
+  .frame-h .meta { margin-left:14px; font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0 }
+  .frame-h .actions { margin-left:auto; display:flex; gap:14px }
+  .frame-h .actions a:hover { color:var(--text) }
+  .frame-img { background:#000; aspect-ratio:16/9; position:relative }
+  .frame-img svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-ovl { position:absolute; bottom:12px; left:12px;
+    padding:5px 12px; background:#000; color:var(--text-soft, var(--text));
+    font-size:11px; letter-spacing:0.06em;
+    font-variant-numeric:tabular-nums; border:1px solid #2a2a2a }
+
+  /* timeline */
+  .tl { display:flex; flex-direction:column; gap:var(--gap) }
+  .tl-row { background:#0a0a0a; border-left:6px solid var(--lcars-blue) }
+  .tl-row.done { border-left-color:var(--lcars-peach) }
+  .tl-row.warn { border-left-color:var(--lcars-yellow) }
+  .tl-row.bad  { border-left-color:var(--lcars-red) }
+
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .row-chev { transform:rotate(90deg) }
+  .row-chev { display:inline-block; width:7px; height:7px;
+    border-top:2px solid currentColor; border-right:2px solid currentColor;
+    transform:rotate(45deg); transition:transform .15s }
+  .tl-summary { padding:12px 14px; display:grid;
+    grid-template-columns:auto 1fr auto;
+    align-items:center; gap:14px; transition:background .12s }
+  .tl-summary:hover { background:#101010 }
+  .tl-summary .body { min-width:0 }
+  .tl-summary .row1 { display:flex; align-items:baseline; gap:14px }
+  .tl-summary .name { font-size:16px; letter-spacing:0.02em; color:var(--text) }
+  .tl-summary .name .dim { color:var(--dim) }
+  .tl-summary .when { font-size:11px; color:var(--dim); letter-spacing:0.06em }
+  .tl-summary .desc { font-size:11px; color:var(--dim); margin-top:3px;
+    letter-spacing:0.04em; text-transform:none }
+  .tl-pill { padding:5px 14px; font-size:11px; letter-spacing:0.14em;
+    color:#000; border-radius:99px }
+  .tl-pill.ok   { background:var(--lcars-peach) }
+  .tl-pill.warn { background:var(--lcars-yellow) }
+  .tl-pill.bad  { background:var(--lcars-red); color:#fff }
+
+  /* night-vision: red alert mode */
+  body:has(#night-vision:checked) {
+    filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7);
+  }
+</style>
+</head>
+<body>
+
+<div class="lcars-app">
+
+  <!-- TOP BAR -->
+  <div class="lcars-top">
+    <span class="logo">RP</span>
+    <span class="div">/</span>
+    <span class="title">RUSTY PHOTON · ACTIVITY</span>
+    <span class="ref">047 · M-04-2380</span>
+    <span class="stardate">STARDATE <b class="num">47634.44</b></span>
+    <label class="nv" title="Toggle red alert / night-vision">
+      <input type="checkbox" id="night-vision" hidden>
+      <span class="icon">☾</span>
+      <span>NIGHT</span>
+      <span class="dot"></span>
+    </label>
+  </div>
+
+  <!-- SIDEBAR -->
+  <div class="lcars-side">
+    <div class="pill amber active">ACTIVITY</div>
+    <div class="pill peach">EQUIPMENT</div>
+    <div class="pill peach">PLANS</div>
+    <div class="pill peach">LOGS</div>
+    <div class="pill peach">SETTINGS</div>
+    <div class="spacer tan"></div>
+    <div class="side-section-h">SESSION</div>
+    <div class="pill violet">M51</div>
+    <div class="pill violet" style="font-size:11px; padding-top:10px; padding-bottom:10px">NCC&#8209;04&#8209;2380</div>
+    <div class="spacer magenta"></div>
+    <div class="side-section-h">STATUS</div>
+    <ul class="side-status">
+      <li>CAMERA <span class="v">−10.0°</span></li>
+      <li>MOUNT <span class="v">0.62″</span></li>
+      <li>FOCUS <span class="v">14820</span></li>
+      <li>GUIDER <span class="v">SNR 32</span></li>
+      <li class="warn">SKY <span class="v">18% ↑</span></li>
+      <li class="warn">DEW <span class="v">4.8°</span></li>
+    </ul>
+    <div class="side-foot">
+      <div class="pill yellow">IV · IGOR V.N.</div>
+    </div>
+  </div>
+
+  <!-- ELBOWS — rounded inside corners of the L -->
+  <div class="elbow-tl"></div>
+  <div class="elbow-bl"></div>
+
+  <!-- MAIN STAGE -->
+  <div class="lcars-main">
+
+    <!-- LIVE TELEMETRY STRIP + FOLD PANEL -->
+    <input type="checkbox" id="fold-state" class="fold-state" hidden>
+
+    <label for="fold-state" class="strip">
+      <div class="strip-block">
+        <span class="strip-pulse"></span>
+        <span>M51 · L · 300S</span>
+      </div>
+      <div class="strip-stat">
+        <span class="lbl-ra">RA</span>
+        <svg class="mini" viewBox="0 0 200 18" preserveAspectRatio="none">
+          <line x1="0" y1="9" x2="200" y2="9" stroke="#332211" stroke-width=".5"/>
+          <path fill="none" stroke="#ff9966" stroke-width="1.1"
+                d="M0,9 L10,7 L20,11 L30,6 L40,12 L50,8 L60,13 L70,5 L80,8 L90,12 L100,6 L110,14 L120,8 L130,7 L140,13 L150,4 L160,11 L170,8 L180,14 L190,6 L200,9"/>
+        </svg>
+        <span class="v">0.42″</span>
+      </div>
+      <div class="strip-stat">
+        <span class="lbl-dec">DEC</span>
+        <svg class="mini" viewBox="0 0 200 18" preserveAspectRatio="none">
+          <line x1="0" y1="9" x2="200" y2="9" stroke="#332211" stroke-width=".5"/>
+          <path fill="none" stroke="#99ccff" stroke-width="1.1"
+                d="M0,9 L10,8 L20,12 L30,5 L40,11 L50,7 L60,12 L70,9 L80,5 L90,13 L100,7 L110,11 L120,4 L130,12 L140,6 L150,9 L160,14 L170,7 L180,11 L190,6 L200,9"/>
+        </svg>
+        <span class="v">0.51″</span>
+      </div>
+      <div class="strip-stat">HFR <span class="v warn">1.84″</span></div>
+      <div class="strip-stat">CCD <span class="v live">−10.0°</span></div>
+      <div class="strip-stat">SKY <span class="v warn">20.8</span></div>
+      <span class="strip-spacer"></span>
+      <span class="strip-eta">FINISH <b>01:42</b></span>
+      <span class="strip-toggle"><span class="lbl"></span><span class="chev"></span></span>
+    </label>
+
+    <div class="fold-body">
+      <div class="panel">
+        <div class="panel-head">
+          <div class="blk label">// LIVE TELEMETRY</div>
+          <div class="blk meta">STREAMING · UPDATE <b>21:18:47</b> · WINDOW <b>5:00</b> · 047&#8209;Δ</div>
+        </div>
+
+        <div class="panel-grid">
+          <div>
+            <!-- guider -->
+            <section class="guider">
+              <div class="guider-head">
+                <span class="label">GUIDER</span>
+                <span class="sub">RA / DEC ERROR · ARCSEC · 5M</span>
+                <div class="gstats">
+                  <span class="gstat ra"><span class="swatch"></span>RA <span class="v">0.42″</span></span>
+                  <span class="gstat dec"><span class="swatch"></span>DEC <span class="v">0.51″</span></span>
+                  <span class="gstat total">RMS <span class="v">0.66″</span></span>
+                </div>
+              </div>
+              <div class="graph">
+                <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+                  <rect x="0" y="60"  width="600" height="120" fill="#ff9966" fill-opacity=".035"/>
+                  <rect x="0" y="90"  width="600" height="60"  fill="#ff9966" fill-opacity=".05"/>
+                  <line x1="0" y1="120" x2="600" y2="120" stroke="#332211" stroke-width="1"/>
+                  <line x1="0" y1="60"  x2="600" y2="60"  stroke="#221a0e" stroke-width=".5" stroke-dasharray="2,4"/>
+                  <line x1="0" y1="180" x2="600" y2="180" stroke="#221a0e" stroke-width=".5" stroke-dasharray="2,4"/>
+                  <line x1="0" y1="90"  x2="600" y2="90"  stroke="#221a0e" stroke-width=".5" stroke-dasharray="1,5"/>
+                  <line x1="0" y1="150" x2="600" y2="150" stroke="#221a0e" stroke-width=".5" stroke-dasharray="1,5"/>
+                  <text x="6" y="20"  fill="#886655" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif" letter-spacing="0.1em">ARCSEC</text>
+                  <text x="6" y="64"  fill="#886655" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif">+1.0</text>
+                  <text x="6" y="94"  fill="#554433" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif">+0.5</text>
+                  <text x="6" y="124" fill="#886655" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif">  0</text>
+                  <text x="6" y="154" fill="#554433" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif">−0.5</text>
+                  <text x="6" y="184" fill="#886655" font-size="10" font-family="Helvetica Neue, Arial Narrow, sans-serif">−1.0</text>
+                  <text x="100" y="234" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="middle">−4M</text>
+                  <text x="200" y="234" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="middle">−3M</text>
+                  <text x="300" y="234" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="middle">−2M</text>
+                  <text x="400" y="234" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="middle">−1M</text>
+                  <text x="595" y="234" fill="#ffcc99" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="end">NOW</text>
+                  <path fill="none" stroke="#99ccff" stroke-width="1.4" stroke-linejoin="round"
+                        d="M0,120 L10,115 L20,129 L30,102 L40,124 L50,107 L60,129 L70,115 L80,102 L90,134 L100,111 L110,124 L120,98 L130,129 L140,107 L150,115 L160,138 L170,111 L180,124 L190,107 L200,115 L210,129 L220,102 L230,111 L240,124 L250,107 L260,142 L270,115 L280,102 L290,129 L300,107 L310,115 L320,124 L330,98 L340,134 L350,111 L360,102 L370,124 L380,107 L390,111 L400,134 L410,115 L420,102 L430,129 L440,107 L450,115 L460,138 L470,111 L480,107 L490,124 L500,102 L510,111 L520,129 L530,98 L540,124 L550,107 L560,115 L570,134 L580,102 L590,111"/>
+                  <path fill="none" stroke="#ff9966" stroke-width="1.4" stroke-linejoin="round"
+                        d="M0,120 L10,111 L20,124 L30,107 L40,129 L50,115 L60,134 L70,102 L80,115 L90,129 L100,107 L110,138 L120,115 L130,111 L140,134 L150,98 L160,124 L170,111 L180,138 L190,107 L200,115 L210,129 L220,102 L230,134 L240,111 L250,124 L260,107 L270,142 L280,111 L290,115 L300,134 L310,102 L320,129 L330,115 L340,107 L350,129 L360,102 L370,124 L380,111 L390,134 L400,115 L410,98 L420,129 L430,107 L440,124 L450,111 L460,138 L470,115 L480,107 L490,129 L500,102 L510,124 L520,111 L530,107 L540,124 L550,98 L560,134 L570,111 L580,124 L590,102"/>
+                  <line x1="595" y1="0" x2="595" y2="220" stroke="#ffcc66" stroke-width="1" stroke-opacity=".7"/>
+                  <circle cx="595" cy="102" r="2.4" fill="#ff9966"/>
+                  <circle cx="595" cy="111" r="2.4" fill="#99ccff"/>
+                </svg>
+              </div>
+            </section>
+
+            <!-- trend charts -->
+            <div class="charts-row" style="margin-top:var(--gap)">
+              <section class="chart-card">
+                <div class="chart-h">
+                  <span class="k">FOCUS HFR</span>
+                  <span class="d warn">↑ 0.06 / 30M</span>
+                  <span class="v warn">1.84″</span>
+                </div>
+                <div class="chart-body">
+                  <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                    <line x1="0" y1="40" x2="200" y2="40" stroke="#221a0e" stroke-width=".5" stroke-dasharray="2,4"/>
+                    <text x="2" y="11" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">2.4″</text>
+                    <text x="2" y="76" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">1.4″</text>
+                    <path fill="none" stroke="#cc99cc" stroke-width="1.6" stroke-linejoin="round"
+                          d="M0,49 L11,47 L22,45 L33,43 L44,41 L55,39 L66,37 L77,34 L88,30 L99,27 L110,23
+                             M110,23 L121,60 L132,58 L143,56 L154,52 L165,50 L176,46 L187,44 L200,42"/>
+                    <circle cx="200" cy="42" r="2.5" fill="#cc99cc"/>
+                  </svg>
+                </div>
+              </section>
+
+              <section class="chart-card alt">
+                <div class="chart-h">
+                  <span class="k">CCD TEMP</span>
+                  <span class="d live">ON TARGET</span>
+                  <span class="v live">−10.0°</span>
+                </div>
+                <div class="chart-body">
+                  <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                    <text x="2" y="11" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">−9.5</text>
+                    <text x="2" y="76" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">−10.5</text>
+                    <line x1="0" y1="40" x2="200" y2="40" stroke="#221a0e" stroke-width=".5" stroke-dasharray="2,4"/>
+                    <path fill="none" stroke="#cc9966" stroke-width="1.6"
+                          d="M0,40 L11,40 L22,38 L33,40 L44,42 L55,40 L66,40 L77,38 L88,40 L99,40 L110,42 L121,40 L132,40 L143,38 L154,40 L165,42 L176,40 L187,40 L200,40"/>
+                    <circle cx="200" cy="40" r="2.5" fill="#cc9966"/>
+                  </svg>
+                </div>
+              </section>
+
+              <section class="chart-card alt2">
+                <div class="chart-h">
+                  <span class="k">SKY BRIGHTNESS</span>
+                  <span class="d warn">−0.6 / 1H</span>
+                  <span class="v warn">20.8</span>
+                </div>
+                <div class="chart-body">
+                  <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                    <text x="2" y="11" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">21.5</text>
+                    <text x="2" y="76" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">20.5</text>
+                    <path fill="none" stroke="#ffcc66" stroke-width="1.6"
+                          d="M0,14 L11,14 L22,21 L33,21 L44,21 L55,28 L66,28 L77,28 L88,35 L99,35 L110,42 L121,42 L132,49 L143,49 L154,49 L165,57 L176,57 L187,57 L200,57"/>
+                    <circle cx="200" cy="57" r="2.5" fill="#ffcc66"/>
+                  </svg>
+                </div>
+              </section>
+
+              <section class="chart-card alt3">
+                <div class="chart-h">
+                  <span class="k">DEW MARGIN</span>
+                  <span class="d warn">↓ 3.4 / 1H</span>
+                  <span class="v warn">4.8°</span>
+                </div>
+                <div class="chart-body">
+                  <svg viewBox="0 0 200 80" preserveAspectRatio="none">
+                    <text x="2" y="11" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">10°</text>
+                    <text x="2" y="76" fill="#554433" font-size="9" font-family="Helvetica Neue, Arial Narrow, sans-serif">0°</text>
+                    <line x1="0" y1="71" x2="200" y2="71" stroke="#ff5544" stroke-width=".5" stroke-dasharray="2,4"/>
+                    <text x="198" y="69" fill="#aa3322" font-size="8" font-family="Helvetica Neue, Arial Narrow, sans-serif" text-anchor="end">DEW</text>
+                    <path fill="none" stroke="#9999ff" stroke-width="1.6"
+                          d="M0,15 L11,18 L22,19 L33,19 L44,21 L55,21 L66,25 L77,28 L88,32 L99,36 L110,39 L121,42 L132,45 L143,48 L154,52 L165,55 L176,58 L187,58 L200,61"/>
+                    <circle cx="200" cy="61" r="2.5" fill="#9999ff"/>
+                  </svg>
+                </div>
+              </section>
+            </div>
+          </div>
+
+          <!-- side: tonight's plan -->
+          <section class="side-card">
+            <h4>TONIGHT'S PLAN <span class="ref">04 / 10</span></h4>
+            <ol class="stages-list">
+              <li><span class="step done">✓</span> SLEW &amp; SOLVE <span class="right">2:04</span></li>
+              <li><span class="step done">✓</span> AUTO-FOCUS <span class="right">3:11</span></li>
+              <li><span class="step done">✓</span> PHD2 CALIBRATE <span class="right">1:47</span></li>
+              <li><span class="step live"></span> <strong>L · 300S × 10</strong> <span class="right" style="color:var(--text)">4 / 10</span></li>
+              <li class="muted"><span class="step pending"></span> R · 180S × 10 <span class="right">0 / 10</span></li>
+              <li class="muted"><span class="step pending"></span> G · 180S × 10 <span class="right">0 / 10</span></li>
+              <li class="muted"><span class="step pending"></span> B · 180S × 10 <span class="right">0 / 10</span></li>
+              <li class="muted"><span class="step pending"></span> PARK &amp; SHUTDOWN</li>
+            </ol>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- ACTIVITY STREAM CONTENT -->
+    <div class="content">
+
+      <!-- HERO -->
+      <section>
+        <div class="sec-h">
+          <div class="blk num">01</div>
+          <div class="blk label">CAPTURING NOW</div>
+          <div class="blk meta">STARTED <b>21:18</b> · REMAIN <b>26:14</b> · 047 · M&#8209;04&#8209;2380</div>
+        </div>
+        <div class="hero" style="margin-top:var(--gap)">
+          <div class="hero-pct">
+            <div>
+              <div class="n">42</div>
+              <div class="lbl">PERCENT</div>
+            </div>
+          </div>
+          <div class="hero-body">
+            <div class="hero-tag">CAPTURING · LUMINANCE · 300S</div>
+            <h1>M51 <span class="dim">— WHIRLPOOL</span></h1>
+            <div class="meta">FRAME <b>04 / 10</b> THIS FILTER · <b>30 / 40</b> ACROSS L R G B · FINISH <b>01:42</b></div>
+            <ul class="hero-stages">
+              <li class="done">SLEW</li>
+              <li class="done">FOCUS</li>
+              <li class="done">GUIDE</li>
+              <li class="live">L</li>
+              <li>R</li>
+              <li>G</li>
+              <li>B</li>
+              <li>PARK</li>
+            </ul>
+          </div>
+          <div class="hero-actions">
+            <button class="btn">PAUSE</button>
+            <button class="btn danger">ABORT</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- LATEST FRAME -->
+      <section>
+        <div class="sec-h">
+          <div class="blk num">02</div>
+          <div class="blk label">LATEST FRAME</div>
+          <div class="blk meta">FRAME <b>0042</b> · LANDED <b>21:18:04</b> · 047 · Δ</div>
+        </div>
+        <div class="frame" style="margin-top:var(--gap)">
+          <div class="frame-h">
+            <span class="name">M51 · L · 300S</span>
+            <span class="meta">FRAME 0042</span>
+            <div class="actions">
+              <a>OPEN</a>
+              <a>DOWNLOAD</a>
+            </div>
+          </div>
+          <div class="frame-img">
+            <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+              <defs>
+                <radialGradient id="neb10" cx="50%" cy="50%" r="60%">
+                  <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+                  <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+                </radialGradient>
+                <radialGradient id="core10" cx="50%" cy="50%" r="50%">
+                  <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+                  <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+                  <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+                </radialGradient>
+              </defs>
+              <rect width="800" height="450" fill="#03050b"/>
+              <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb10)"/>
+              <g transform="translate(400 225) rotate(-22)">
+                <ellipse rx="60" ry="40" fill="url(#core10)"/>
+                <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+                <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+              </g>
+              <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+              <g fill="#fff">
+                <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+                <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+                <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+                <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+                <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+                <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+                <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+                <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+              </g>
+            </svg>
+            <div class="frame-ovl">HFR 1.84″ · STARS 2941 · ADU 1247 · ECC 0.41</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- PAST SESSIONS -->
+      <section>
+        <div class="sec-h">
+          <div class="blk num">03</div>
+          <div class="blk label">PAST SESSIONS</div>
+          <div class="blk meta">LAST <b>30D</b> · <b>12</b> SESSIONS · 047&#8209;Σ</div>
+        </div>
+        <div class="tl" style="margin-top:var(--gap)">
+          <details class="tl-row done">
+            <summary class="tl-summary">
+              <span class="row-chev"></span>
+              <div class="body">
+                <div class="row1">
+                  <span class="name">M101 <span class="dim">— PINWHEEL</span></span>
+                  <span class="when">LAST NIGHT · 22:14 → 03:48</span>
+                </div>
+                <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+              </div>
+              <span class="tl-pill ok">COMPLETE</span>
+            </summary>
+          </details>
+          <details class="tl-row warn">
+            <summary class="tl-summary">
+              <span class="row-chev"></span>
+              <div class="body">
+                <div class="row1">
+                  <span class="name">NGC 7000 <span class="dim">— NORTH AMERICA</span></span>
+                  <span class="when">3 DAYS AGO · 21:48 → 02:11</span>
+                </div>
+                <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+              </div>
+              <span class="tl-pill warn">ABORTED</span>
+            </summary>
+          </details>
+          <details class="tl-row done">
+            <summary class="tl-summary">
+              <span class="row-chev"></span>
+              <div class="body">
+                <div class="row1">
+                  <span class="name">M31 <span class="dim">— ANDROMEDA</span></span>
+                  <span class="when">A WEEK AGO · 20:31 → 04:02</span>
+                </div>
+                <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+              </div>
+              <span class="tl-pill ok">COMPLETE</span>
+            </summary>
+          </details>
+          <details class="tl-row bad">
+            <summary class="tl-summary">
+              <span class="row-chev"></span>
+              <div class="body">
+                <div class="row1">
+                  <span class="name">IC 1396 <span class="dim">— ELEPHANT'S TRUNK</span></span>
+                  <span class="when">12 DAYS AGO · 22:02 → 23:00</span>
+                </div>
+                <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+              </div>
+              <span class="tl-pill bad">FAILED</span>
+            </summary>
+          </details>
+        </div>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- BOTTOM BAR -->
+  <div class="lcars-bot">
+    <span>SYSTEM NOMINAL</span>
+    <span class="ref">04-22-2380 · 21:18:47</span>
+    <span class="ref">·</span>
+    <span class="ref">RP-NCC-04-2380-Δ-G</span>
+    <span class="grow"></span>
+    <span class="ref">047.7-Λ</span>
+    <span class="ref">SUBPROCESSOR 04 ACTIVE</span>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/2-dashboard.html
+++ b/docs/plans/ui-design/mocks/2-dashboard.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Mission control (Linear-style)</title>
+<style>
+  :root {
+    --bg:#0a0a0b; --panel:#111113; --edge:#202024;
+    --text:#ededef; --dim:#8a8a93;
+    --hot:#22c55e; --warn:#f59e0b; --bad:#ef4444; --accent:#7c3aed;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  body { display:flex; min-height:100vh }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button { font:inherit; color:inherit; background:none; border:0; cursor:pointer }
+  input { font:inherit; color:inherit }
+
+  /* ── nav ── */
+  nav.side { width:56px; border-right:1px solid var(--edge); background:var(--panel);
+    display:flex; flex-direction:column; align-items:center; padding:12px 0; gap:4px; flex:none }
+  .logo { width:32px; height:32px; border-radius:6px;
+    background:linear-gradient(135deg,#6366f1,#d946ef); margin-bottom:8px }
+  .nav-btn { width:36px; height:36px; border-radius:6px; display:grid; place-items:center;
+    color:var(--dim); font-size:16px }
+  .nav-btn.active { background:rgba(255,255,255,.05); color:#fff }
+  .nav-btn:hover { background:rgba(255,255,255,.05) }
+  .grow { flex:1 }
+  .avatar { width:32px; height:32px; border-radius:999px; background:rgba(244,63,94,.2);
+    box-shadow:inset 0 0 0 1px rgba(251,113,133,.4); display:grid; place-items:center; font-size:12px }
+
+  /* ── main column ── */
+  .col { flex:1; min-width:0; display:flex; flex-direction:column }
+
+  header.bar { height:48px; padding:0 20px; border-bottom:1px solid var(--edge);
+    background:var(--panel); display:flex; align-items:center; gap:12px }
+  .crumb { font-size:13px; color:var(--dim) }
+  .crumb b { color:var(--text); font-weight:500 }
+  .pill { font-size:11px; padding:2px 6px; border-radius:4px;
+    background:rgba(34,197,94,.15); color:#4ade80;
+    box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .pill.warn { background:rgba(245,158,11,.15); color:#fbbf24;
+    box-shadow:inset 0 0 0 1px rgba(245,158,11,.3) }
+  .pill.bad { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+  .spacer { flex:1 }
+  .status-strip { font-size:12px; color:var(--dim); display:flex; align-items:center; gap:8px }
+  .led { width:8px; height:8px; border-radius:999px; display:inline-block }
+  .led.ok { background:#4ade80 } .led.warn { background:#fbbf24 }
+  .sep { color:var(--edge) }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+  .btn.danger:hover { background:rgba(239,68,68,.25) }
+
+  main.grid { flex:1; padding:20px; display:grid; grid-template-columns:repeat(12,1fr);
+    gap:20px; overflow-y:auto }
+  .card { border-radius:10px; background:var(--panel);
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .card-head { height:40px; padding:0 16px; display:flex; align-items:center;
+    border-bottom:1px solid var(--edge) }
+  .card-head .label { font-weight:500 } .card-head .sub { color:var(--dim); font-size:12px; margin-left:8px }
+  .card-head .right { margin-left:auto; display:flex; gap:4px; font-size:12px; color:var(--dim) }
+  .card-head .right button { padding:4px 8px } .card-head .right button:hover { color:#fff }
+
+  .image-card { grid-column:span 8; display:flex; flex-direction:column; overflow:hidden }
+  .image-frame { background:#000; flex:1; min-height:420px; position:relative }
+  .image-frame svg { position:absolute; inset:0; width:100%; height:100% }
+  .image-overlay { position:absolute; bottom:12px; left:12px;
+    font-family:ui-monospace,monospace; font-size:11px; color:rgba(255,255,255,.7);
+    background:rgba(0,0,0,.4); padding:4px 8px; border-radius:4px }
+
+  .status-card { grid-column:span 4; padding:20px; display:flex; flex-direction:column; gap:20px }
+  .status-card .head-row { display:flex; align-items:center; justify-content:space-between }
+  .status-card .label-sm { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim) }
+  .status-card h2 { font-size:17px; font-weight:600; margin-top:4px }
+  .status-card .sub { font-size:11px; color:var(--dim); font-family:ui-monospace,monospace }
+  .ring-row { display:flex; align-items:center; gap:20px }
+  .ring { position:relative; width:128px; height:128px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:24px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:10px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+  .stats { font-size:13px; flex:1; display:flex; flex-direction:column; gap:6px }
+  .stats .row { display:flex; justify-content:space-between; gap:16px }
+  .stats .row span:first-child { color:var(--dim) }
+  .stats .row span:last-child { font-family:ui-monospace,monospace }
+  .stats .row .v-warn { color:#fbbf24 }
+
+  .stages { list-style:none; display:flex; flex-direction:column; gap:6px; font-size:13px }
+  .stages li { display:flex; align-items:center; gap:8px }
+  .stages .step { width:18px; height:18px; border-radius:999px; display:grid; place-items:center;
+    font-size:10px; flex:none }
+  .stages .done { background:#22c55e; color:#02180a }
+  .stages .live { background:rgba(34,197,94,.2); box-shadow:inset 0 0 0 1px #4ade80 }
+  .stages .live span { width:6px; height:6px; border-radius:999px; background:#4ade80; animation:pulse 1.6s infinite }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .stages .pending { background:rgba(255,255,255,.05) }
+  .stages li.muted { color:var(--dim) }
+  .stages .right { margin-left:auto; font-family:ui-monospace,monospace; color:var(--dim) }
+
+  .history-card { grid-column:span 12 }
+  .history-head input { background:rgba(0,0,0,.4); border:0; box-shadow:inset 0 0 0 1px var(--edge);
+    border-radius:6px; padding:5px 8px; font-size:12px; width:200px; color:var(--text) }
+  .history-head input::placeholder { color:rgba(138,138,147,.6) }
+  details { border-top:1px solid var(--edge) }
+  details:first-of-type { border-top:0 }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .15s; display:inline-block; color:var(--dim) }
+  .row-summary { padding:0 16px; height:48px; display:flex; align-items:center; gap:12px }
+  .row-summary:hover { background:rgba(255,255,255,.02) }
+  .row-summary .name { font-weight:500 }
+  .row-summary .sub { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace }
+  .row-summary .right { margin-left:auto; display:flex; align-items:center; gap:12px;
+    font-size:12px; color:var(--dim) }
+  .ok-text { color:#4ade80 } .warn-text { color:#fbbf24 } .bad-text { color:#fca5a5 }
+  .thumbs-grid { padding:8px 16px 16px; display:grid; grid-template-columns:repeat(8,1fr); gap:8px }
+  .thumb { aspect-ratio:4/3; border-radius:4px; box-shadow:inset 0 0 0 1px var(--edge);
+    position:relative }
+  .thumb-label { position:absolute; bottom:4px; left:4px;
+    font-family:ui-monospace,monospace; font-size:9px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.4);
+    padding:1px 4px; border-radius:2px }
+</style>
+</head>
+<body>
+
+<nav class="side">
+  <div class="logo"></div>
+  <button class="nav-btn active" title="Sessions">◐</button>
+  <button class="nav-btn" title="Equipment">⚙</button>
+  <button class="nav-btn" title="Plans">▤</button>
+  <button class="nav-btn" title="Logs">≡</button>
+  <button class="nav-btn" title="Settings">…</button>
+  <div class="grow"></div>
+  <div class="avatar">IV</div>
+</nav>
+
+<div class="col">
+
+  <header class="bar">
+    <span class="crumb">Sessions /</span>
+    <span class="crumb"><b>M51 — 2026-05-03</b></span>
+    <span class="pill">In progress</span>
+    <span class="spacer"></span>
+    <span class="status-strip">
+      <span class="led ok"></span> Mount tracking
+      <span class="sep">·</span>
+      <span>Camera −10.0°C</span>
+      <span class="sep">·</span>
+      <span style="color:#fbbf24">Clouds 18%</span>
+    </span>
+    <button class="btn">Pause</button>
+    <button class="btn danger">Abort</button>
+  </header>
+
+  <main class="grid">
+
+    <section class="card image-card">
+      <div class="card-head">
+        <span class="label">Latest frame</span>
+        <span class="sub mono">0042 · L · 300s · 21:18:04</span>
+        <span class="right">
+          <button>Fit</button><button>100%</button><button>Stretch</button><button>⤢</button>
+        </span>
+      </div>
+      <div class="image-frame">
+        <svg viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <radialGradient id="neb2" cx="50%" cy="50%" r="60%">
+              <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+              <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="core2" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+              <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+              <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+            </radialGradient>
+          </defs>
+          <rect width="800" height="600" fill="#03050b"/>
+          <ellipse cx="420" cy="300" rx="380" ry="260" fill="url(#neb2)"/>
+          <g transform="translate(420 300) rotate(-22)">
+            <ellipse rx="70" ry="46" fill="url(#core2)"/>
+            <path d="M 0 0 Q -160 -60 -260 -10 Q -310 20 -330 80" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+            <path d="M 0 0 Q 160 60 260 10 Q 310 -20 330 -80" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          </g>
+          <ellipse cx="640" cy="220" rx="22" ry="18" fill="#fef3c7" fill-opacity=".7"/>
+          <g fill="#fff">
+            <circle cx="50" cy="80" r="1"/><circle cx="120" cy="130" r=".8"/><circle cx="180" cy="60" r=".6"/>
+            <circle cx="240" cy="200" r="1.2"/><circle cx="300" cy="90" r=".7"/><circle cx="360" cy="180" r=".9"/>
+            <circle cx="420" cy="40" r=".6"/><circle cx="480" cy="220" r="1"/><circle cx="540" cy="70" r=".8"/>
+            <circle cx="600" cy="160" r="1.2"/><circle cx="660" cy="100" r=".7"/><circle cx="720" cy="180" r=".9"/>
+            <circle cx="80" cy="250" r=".6"/><circle cx="160" cy="300" r="1"/><circle cx="220" cy="380" r=".8"/>
+            <circle cx="280" cy="260" r=".6"/><circle cx="340" cy="420" r="1.2"/><circle cx="460" cy="340" r=".9"/>
+            <circle cx="520" cy="440" r="1"/><circle cx="580" cy="280" r=".6"/><circle cx="640" cy="460" r=".8"/>
+            <circle cx="700" cy="360" r="1.2"/><circle cx="60" cy="460" r=".9"/><circle cx="140" cy="540" r="1"/>
+            <circle cx="200" cy="480" r=".6"/><circle cx="320" cy="500" r=".7"/><circle cx="500" cy="580" r=".6"/>
+            <circle cx="630" cy="220" r=".9"/><circle cx="770" cy="80" r=".7"/>
+          </g>
+        </svg>
+        <div class="image-overlay">HFR 1.84″ · Stars 2,941 · Ecc 0.41 · ADU 1,247</div>
+      </div>
+    </section>
+
+    <section class="card status-card">
+      <div>
+        <div class="head-row">
+          <span class="label-sm">Now capturing</span>
+          <span class="pill">healthy</span>
+        </div>
+        <h2>M51 · Luminance · 300s</h2>
+        <div class="sub">frame 4 of 10 · started 21:18:04</div>
+      </div>
+
+      <div class="ring-row">
+        <div class="ring">
+          <svg viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="44" fill="none" stroke="#202024" stroke-width="8"/>
+            <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                    stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+          </svg>
+          <div class="center">
+            <div>
+              <div class="pct">42%</div>
+              <div class="cap">complete</div>
+            </div>
+          </div>
+        </div>
+        <div class="stats">
+          <div class="row"><span>Sub elapsed</span><span>02:18 / 05:00</span></div>
+          <div class="row"><span>Sequence ETA</span><span style="color:#fff">26m 14s</span></div>
+          <div class="row"><span>Finish at</span><span>01:42 local</span></div>
+          <div class="row"><span>Meridian flip</span><span class="v-warn">in 1h 48m</span></div>
+        </div>
+      </div>
+
+      <div>
+        <div class="label-sm" style="margin-bottom:8px">Tonight's plan</div>
+        <ol class="stages">
+          <li><span class="step done">✓</span> Slew & plate-solve <span class="right">2m 04s</span></li>
+          <li><span class="step done">✓</span> Auto-focus run <span class="right">3m 11s</span></li>
+          <li><span class="step done">✓</span> PHD2 calibrate <span class="right">1m 47s</span></li>
+          <li><span class="step live"><span></span></span> <strong>L · 300s × 10</strong> <span class="right" style="color:#fff">4 / 10</span></li>
+          <li class="muted"><span class="step pending"></span> R · 180s × 10 <span class="right">0 / 10</span></li>
+          <li class="muted"><span class="step pending"></span> G · 180s × 10 <span class="right">0 / 10</span></li>
+          <li class="muted"><span class="step pending"></span> B · 180s × 10 <span class="right">0 / 10</span></li>
+          <li class="muted"><span class="step pending"></span> Park & shutdown</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="card history-card">
+      <div class="card-head history-head">
+        <span class="label">History</span>
+        <span class="sub mono">last 30 days · 12 sessions · 487 frames</span>
+        <span class="right"><input type="text" placeholder="filter targets…"/></span>
+      </div>
+
+      <details open>
+        <summary class="row-summary">
+          <span class="chev">▸</span>
+          <span class="name">M101 — Pinwheel</span>
+          <span class="sub">2026-05-02 · 22:14 → 03:48</span>
+          <span class="right">
+            <span class="ok-text">62 / 64 frames</span>
+            <span class="mono">5h 34m</span>
+            <span class="pill">complete</span>
+          </span>
+        </summary>
+        <div class="thumbs-grid">
+          <div class="thumb" style="background:linear-gradient(135deg,#1e1b4b,#020617)"><div class="thumb-label">0001</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0002</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0003</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0004</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0005</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#164e63,#020617)"><div class="thumb-label">0006</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#312e81,#020617)"><div class="thumb-label">0007</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e293b,#020617)"><div class="thumb-label">0008</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e1b4b,#020617)"><div class="thumb-label">0009</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0010</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0011</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0012</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0013</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#164e63,#020617)"><div class="thumb-label">0014</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#312e81,#020617)"><div class="thumb-label">0015</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e293b,#020617)"><div class="thumb-label">0016</div></div>
+        </div>
+      </details>
+
+      <details>
+        <summary class="row-summary">
+          <span class="chev">▸</span>
+          <span class="name">NGC 7000 — North America</span>
+          <span class="sub">2026-04-30 · 21:48 → 02:11</span>
+          <span class="right">
+            <span class="warn-text">38 / 50 frames</span>
+            <span class="mono">4h 23m</span>
+            <span class="pill warn">aborted — clouds</span>
+          </span>
+        </summary>
+      </details>
+
+      <details>
+        <summary class="row-summary">
+          <span class="chev">▸</span>
+          <span class="name">M31 — Andromeda</span>
+          <span class="sub">2026-04-26 · 20:31 → 04:02</span>
+          <span class="right">
+            <span class="ok-text">82 / 82 frames</span>
+            <span class="mono">7h 31m</span>
+            <span class="pill">complete</span>
+          </span>
+        </summary>
+      </details>
+
+      <details>
+        <summary class="row-summary">
+          <span class="chev">▸</span>
+          <span class="name">IC 1396 — Elephant's Trunk</span>
+          <span class="sub">2026-04-21 · 22:02 → 03:18</span>
+          <span class="right">
+            <span class="bad-text">12 / 60 frames</span>
+            <span class="mono">0h 58m</span>
+            <span class="pill bad">failed — guide loss</span>
+          </span>
+        </summary>
+      </details>
+    </section>
+
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/3-stream.html
+++ b/docs/plans/ui-design/mocks/3-stream.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Activity (Vercel/Stripe-style)</title>
+<style>
+  :root {
+    --bg:#08080a; --panel:#0f0f12; --edge:#1c1c22;
+    --text:#fafafa; --dim:#9c9ca6;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button, a { font:inherit; color:inherit; background:none; border:0; cursor:pointer; text-decoration:none }
+  .ring-line { box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+
+  /* ── nav ── */
+  nav { height:48px; padding:0 20px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:rgba(15,15,18,.6);
+    backdrop-filter:blur(8px); position:sticky; top:0; z-index:10 }
+  .brand { display:flex; align-items:center; gap:8px; font-weight:600; letter-spacing:-.01em }
+  .logo { width:24px; height:24px; border-radius:5px;
+    background:linear-gradient(135deg,#6366f1,#d946ef) }
+  .nav-tabs { display:flex; align-items:center; gap:4px; margin-left:12px; font-size:13px }
+  .nav-tabs a { padding:5px 10px; border-radius:5px; color:var(--dim) }
+  .nav-tabs a.active { color:#fff; background:rgba(255,255,255,.05) }
+  .nav-tabs a:hover { color:#fff }
+  .grow { flex:1 }
+  .status-strip { font-size:12px; color:var(--dim); display:flex; align-items:center; gap:8px }
+  .led { width:8px; height:8px; border-radius:999px; display:inline-block }
+  .led.ok { background:#4ade80 }
+  .avatar { width:32px; height:32px; border-radius:999px; background:rgba(244,63,94,.2);
+    box-shadow:inset 0 0 0 1px rgba(251,113,133,.4); display:grid; place-items:center; font-size:12px }
+
+  /* ── main ── */
+  main { max-width:768px; margin:0 auto; padding:32px 20px; display:flex; flex-direction:column; gap:24px }
+
+  /* ── hero card ── */
+  .hero { position:relative; border-radius:12px; background:var(--panel);
+    padding:20px; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .hero::before { content:''; position:absolute; top:0; left:0; right:0; height:1px;
+    background:linear-gradient(90deg,transparent,rgba(74,222,128,.6),transparent) }
+  .hero-row { display:flex; align-items:flex-start; gap:20px }
+  .ring { position:relative; width:96px; height:96px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:20px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:10px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+
+  .hero-body { flex:1; min-width:0 }
+  .hero-eyebrow { display:flex; align-items:center; gap:8px }
+  .hero-eyebrow .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#4ade80 }
+  .hero-eyebrow .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .hero h1 { font-size:20px; font-weight:600; line-height:1.2; margin-top:4px }
+  .hero .sub { font-size:13px; color:var(--dim); margin-top:2px }
+  .chips { margin-top:12px; display:flex; flex-wrap:wrap; gap:6px; font-size:11px }
+  .chip { padding:2px 8px; border-radius:4px; background:rgba(34,197,94,.1); color:#4ade80;
+    box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .chip.live { background:rgba(34,197,94,.18); color:#86efac;
+    box-shadow:inset 0 0 0 1px rgba(74,222,128,.4) }
+  .chip.muted { background:rgba(255,255,255,.05); color:var(--dim);
+    box-shadow:inset 0 0 0 1px var(--edge) }
+
+  .hero-buttons { display:flex; flex-direction:column; gap:6px; flex:none }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+  .btn.danger:hover { background:rgba(239,68,68,.25) }
+
+  .env-grid { margin-top:20px; display:grid; grid-template-columns:repeat(4,1fr); gap:12px; font-size:12px }
+  .env-cell { border-radius:6px; padding:10px; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .env-cell .k { color:var(--dim) }
+  .env-cell .v { font-family:ui-monospace,monospace; margin-top:2px }
+  .v.ok { color:#4ade80 } .v.warn { color:#fbbf24 }
+
+  /* ── latest frame card ── */
+  .frame-card { border-radius:12px; background:var(--panel); overflow:hidden;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .frame-head { height:44px; padding:0 20px; display:flex; align-items:center;
+    justify-content:space-between; border-bottom:1px solid var(--edge); font-size:13px }
+  .frame-head .left { display:flex; align-items:center; gap:8px }
+  .frame-head .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .frame-head .right { color:var(--dim); font-size:12px }
+  .frame-head .right button:hover { color:#fff }
+  .frame-image { background:#000; position:relative; aspect-ratio:16/9 }
+  .frame-image svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-image .overlay { position:absolute; bottom:12px; left:12px;
+    font-family:ui-monospace,monospace; font-size:11px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.5);
+    padding:4px 8px; border-radius:4px }
+
+  /* ── timeline ── */
+  .past h2 { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); display:flex; justify-content:space-between; align-items:flex-end;
+    margin-bottom:12px }
+  .past h2 .meta { font-family:ui-monospace,monospace; font-size:11px }
+  .timeline { position:relative; padding-left:28px; display:flex; flex-direction:column; gap:12px }
+  .timeline::before { content:''; position:absolute; left:11px; top:0; bottom:0;
+    width:1px; background:var(--edge) }
+  .tl-item { border-radius:10px; background:var(--panel); position:relative;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .dot { position:absolute; left:-21px; top:14px; width:8px; height:8px;
+    border-radius:999px; background:var(--dim); box-shadow:0 0 0 4px var(--bg) }
+  .dot.live { background:#22c55e; box-shadow:0 0 0 4px var(--bg), 0 0 18px 2px rgba(34,197,94,.6) }
+  .dot.warn { background:#f59e0b }
+  .dot.bad  { background:#ef4444 }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .15s; color:var(--dim); display:inline-block; width:12px }
+
+  .tl-summary { padding:12px 16px; display:flex; align-items:center; gap:12px }
+  .tl-summary .body { flex:1; min-width:0 }
+  .tl-summary .title-row { display:flex; align-items:baseline; gap:8px }
+  .tl-summary .name { font-weight:500 }
+  .tl-summary .when { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace }
+  .tl-summary .desc { font-size:12px; color:var(--dim); margin-top:2px }
+  .tl-pill { font-size:11px; padding:2px 6px; border-radius:4px; flex:none }
+  .tl-pill.ok   { background:rgba(34,197,94,.15);  color:#4ade80; box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .tl-pill.warn { background:rgba(245,158,11,.15); color:#fbbf24; box-shadow:inset 0 0 0 1px rgba(245,158,11,.3) }
+  .tl-pill.bad  { background:rgba(239,68,68,.15);  color:#fca5a5; box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+  .tl-thumbs { padding:0 16px 16px; display:grid; grid-template-columns:repeat(8,1fr); gap:8px }
+  .thumb { aspect-ratio:4/3; border-radius:4px; box-shadow:inset 0 0 0 1px var(--edge);
+    position:relative }
+  .thumb-label { position:absolute; bottom:4px; left:4px;
+    font-family:ui-monospace,monospace; font-size:9px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.4);
+    padding:1px 4px; border-radius:2px }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="brand"><div class="logo"></div><span>rusty&nbsp;photon</span></div>
+  <div class="nav-tabs">
+    <a class="active">Activity</a>
+    <a>Equipment</a>
+    <a>Plans</a>
+    <a>Logs</a>
+    <a>Settings</a>
+  </div>
+  <div class="grow"></div>
+  <div class="status-strip"><span class="led ok"></span>All systems healthy</div>
+  <div class="avatar">IV</div>
+</nav>
+
+<main>
+
+  <!-- hero -->
+  <article class="hero">
+    <div class="hero-row">
+      <div class="ring">
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#1c1c22" stroke-width="8"/>
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                  stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+        </svg>
+        <div class="center">
+          <div>
+            <div class="pct">42%</div>
+            <div class="cap">done</div>
+          </div>
+        </div>
+      </div>
+      <div class="hero-body">
+        <div class="hero-eyebrow">
+          <span class="label">Capturing now</span>
+          <span class="meta">started 21:18 · 26m 14s remaining · finishes 01:42 local</span>
+        </div>
+        <h1>M51 — Whirlpool · Luminance · 300s</h1>
+        <div class="sub">Frame 4 of 10 in this filter · 30 of 40 across L R G B</div>
+        <div class="chips">
+          <span class="chip">✓ slew</span>
+          <span class="chip">✓ focus</span>
+          <span class="chip">✓ guide</span>
+          <span class="chip live">● capturing L</span>
+          <span class="chip muted">R</span>
+          <span class="chip muted">G</span>
+          <span class="chip muted">B</span>
+          <span class="chip muted">park</span>
+        </div>
+      </div>
+      <div class="hero-buttons">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+    <div class="env-grid">
+      <div class="env-cell"><div class="k">Camera</div><div class="v ok">−10.0 °C</div></div>
+      <div class="env-cell"><div class="k">Guide RMS</div><div class="v">0.62″</div></div>
+      <div class="env-cell"><div class="k">Focus HFR</div><div class="v">1.84″</div></div>
+      <div class="env-cell"><div class="k">Sky</div><div class="v warn">18% clouds</div></div>
+    </div>
+  </article>
+
+  <!-- latest frame -->
+  <article class="frame-card">
+    <div class="frame-head">
+      <div class="left">
+        <span class="led ok"></span>
+        <span style="font-weight:500">Latest frame just landed</span>
+        <span class="meta">0042 · L · 300s · 21:18:04</span>
+      </div>
+      <div class="right">
+        <button>open</button> · <button>download</button>
+      </div>
+    </div>
+    <div class="frame-image">
+      <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <radialGradient id="neb3" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+            <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+          </radialGradient>
+          <radialGradient id="core3" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+            <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+            <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="800" height="450" fill="#03050b"/>
+        <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb3)"/>
+        <g transform="translate(400 225) rotate(-22)">
+          <ellipse rx="60" ry="40" fill="url(#core3)"/>
+          <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+        </g>
+        <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+        <g fill="#fff">
+          <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+          <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+          <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+          <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+          <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+          <circle cx="280" cy="200" r=".6"/><circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/>
+          <circle cx="520" cy="340" r="1"/><circle cx="580" cy="220" r=".6"/><circle cx="640" cy="360" r=".8"/>
+          <circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/><circle cx="140" cy="420" r="1"/>
+          <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+        </g>
+      </svg>
+      <div class="overlay">HFR 1.84″ · Stars 2,941 · ADU 1,247 · Ecc 0.41</div>
+    </div>
+  </article>
+
+  <!-- past sessions timeline -->
+  <section class="past">
+    <h2><span>Past sessions</span><span class="meta">last 30 days · 12 sessions</span></h2>
+    <div class="timeline">
+
+      <details open class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">M101 — Pinwheel</span>
+              <span class="when">last night · 22:14 → 03:48</span>
+            </div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+        <div class="tl-thumbs">
+          <div class="thumb" style="background:linear-gradient(135deg,#1e1b4b,#020617)"><div class="thumb-label">0001</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0002</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0003</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0004</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0005</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#164e63,#020617)"><div class="thumb-label">0006</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#312e81,#020617)"><div class="thumb-label">0007</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e293b,#020617)"><div class="thumb-label">0008</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e1b4b,#020617)"><div class="thumb-label">0009</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0f172a,#020617)"><div class="thumb-label">0010</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#111827,#020617)"><div class="thumb-label">0011</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1f2937,#020617)"><div class="thumb-label">0012</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#0c4a6e,#020617)"><div class="thumb-label">0013</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#164e63,#020617)"><div class="thumb-label">0014</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#312e81,#020617)"><div class="thumb-label">0015</div></div>
+          <div class="thumb" style="background:linear-gradient(135deg,#1e293b,#020617)"><div class="thumb-label">0016</div></div>
+        </div>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot warn"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">NGC 7000 — North America</span>
+              <span class="when">3 days ago · 21:48 → 02:11</span>
+            </div>
+            <div class="desc">38 of 50 planned · aborted 02:11 — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted · clouds</span>
+        </summary>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">M31 — Andromeda</span>
+              <span class="when">a week ago · 20:31 → 04:02</span>
+            </div>
+            <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot bad"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">IC 1396 — Elephant's Trunk</span>
+              <span class="when">12 days ago · 22:02 → 23:00</span>
+            </div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed · guide loss</span>
+        </summary>
+      </details>
+
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/4-stream-inline.html
+++ b/docs/plans/ui-design/mocks/4-stream-inline.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Stream + inline live card</title>
+<style>
+  :root {
+    --bg:#08080a; --panel:#0f0f12; --edge:#1c1c22;
+    --text:#fafafa; --dim:#9c9ca6;
+    --ra:#f87171; --dec:#60a5fa;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button, a { font:inherit; color:inherit; background:none; border:0; cursor:pointer; text-decoration:none }
+  .ring-line { box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+
+  nav { height:48px; padding:0 20px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:rgba(15,15,18,.85);
+    backdrop-filter:blur(8px); position:sticky; top:0; z-index:10 }
+  .brand { display:flex; align-items:center; gap:8px; font-weight:600 }
+  .logo { width:24px; height:24px; border-radius:5px;
+    background:linear-gradient(135deg,#6366f1,#d946ef) }
+  .nav-tabs { display:flex; gap:4px; margin-left:12px; font-size:13px }
+  .nav-tabs a { padding:5px 10px; border-radius:5px; color:var(--dim) }
+  .nav-tabs a.active { color:#fff; background:rgba(255,255,255,.05) }
+  .nav-tabs a:hover { color:#fff }
+  .grow { flex:1 }
+  .status-strip { font-size:12px; color:var(--dim); display:flex; align-items:center; gap:8px }
+  .led { width:8px; height:8px; border-radius:999px; display:inline-block }
+  .led.ok { background:#4ade80 }
+  .avatar { width:32px; height:32px; border-radius:999px; background:rgba(244,63,94,.2);
+    box-shadow:inset 0 0 0 1px rgba(251,113,133,.4); display:grid; place-items:center; font-size:12px }
+
+  main { max-width:780px; margin:0 auto; padding:32px 20px; display:flex; flex-direction:column; gap:20px }
+
+  /* hero */
+  .hero { position:relative; border-radius:12px; background:var(--panel);
+    padding:20px; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .hero::before { content:''; position:absolute; top:0; left:0; right:0; height:1px;
+    background:linear-gradient(90deg,transparent,rgba(74,222,128,.6),transparent) }
+  .hero-row { display:flex; align-items:flex-start; gap:20px }
+  .ring { position:relative; width:96px; height:96px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:20px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:10px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+  .hero-body { flex:1; min-width:0 }
+  .hero-eyebrow { display:flex; align-items:center; gap:8px }
+  .hero-eyebrow .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#4ade80 }
+  .hero-eyebrow .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .hero h1 { font-size:20px; font-weight:600; line-height:1.2; margin-top:4px }
+  .hero .sub { font-size:13px; color:var(--dim); margin-top:2px }
+  .chips { margin-top:12px; display:flex; flex-wrap:wrap; gap:6px; font-size:11px }
+  .chip { padding:2px 8px; border-radius:4px; background:rgba(34,197,94,.1); color:#4ade80;
+    box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .chip.live { background:rgba(34,197,94,.18); color:#86efac;
+    box-shadow:inset 0 0 0 1px rgba(74,222,128,.4) }
+  .chip.muted { background:rgba(255,255,255,.05); color:var(--dim);
+    box-shadow:inset 0 0 0 1px var(--edge) }
+  .hero-buttons { display:flex; flex-direction:column; gap:6px; flex:none }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+
+  /* live telemetry card */
+  .live { border-radius:12px; background:var(--panel);
+    box-shadow:inset 0 0 0 1px rgba(74,222,128,.18) }
+  .live-head { padding:14px 20px; display:flex; align-items:center; justify-content:space-between;
+    border-bottom:1px solid var(--edge) }
+  .live-head .l { display:flex; align-items:center; gap:10px; font-size:13px }
+  .live-head .pulse { width:8px; height:8px; border-radius:999px; background:#4ade80;
+    box-shadow:0 0 12px 1px rgba(74,222,128,.6); animation:pulse 1.6s infinite }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .live-head .title { font-weight:500 }
+  .live-head .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .live-head .open { font-size:12px; color:var(--dim);
+    padding:5px 10px; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge) }
+  .live-head .open:hover { color:#fff; background:rgba(255,255,255,.05) }
+
+  .guider { padding:16px 20px }
+  .guider-head { display:flex; align-items:baseline; justify-content:space-between; margin-bottom:8px }
+  .guider-head .gt { font-size:12px; color:var(--dim); text-transform:uppercase; letter-spacing:.06em }
+  .gstats { display:flex; gap:14px; font-size:12px }
+  .gstat { display:flex; align-items:center; gap:5px }
+  .gstat .d { width:7px; height:7px; border-radius:999px }
+  .gstat.ra .d { background:var(--ra) }
+  .gstat.dec .d { background:var(--dec) }
+  .gstat .v { font-family:ui-monospace,monospace }
+  .gstat.total { color:#fff; padding-left:14px; box-shadow:inset 1px 0 0 var(--edge) }
+  .graph { background:#070708; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge);
+    overflow:hidden; height:180px }
+  .graph svg { display:block; width:100%; height:100% }
+  .gfoot { display:flex; justify-content:space-between; margin-top:6px;
+    font-size:11px; color:var(--dim); font-family:ui-monospace,monospace }
+
+  .sparks { padding:0 20px 16px; display:grid; grid-template-columns:repeat(4,1fr); gap:10px }
+  .spark { padding:10px; border-radius:8px; box-shadow:inset 0 0 0 1px var(--edge) }
+  .spark .k { font-size:11px; color:var(--dim); text-transform:uppercase; letter-spacing:.04em }
+  .spark .row { display:flex; align-items:baseline; gap:6px; margin-top:2px }
+  .spark .v { font-size:16px; font-weight:600; font-family:ui-monospace,monospace }
+  .spark .d { font-size:11px; color:var(--dim) }
+  .spark .d.warn { color:#fbbf24 }
+  .spark .d.ok { color:#4ade80 }
+  .spark svg { display:block; width:100%; height:36px; margin-top:4px }
+
+  /* latest frame */
+  .frame-card { border-radius:12px; background:var(--panel); overflow:hidden;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .frame-head { height:44px; padding:0 20px; display:flex; align-items:center;
+    justify-content:space-between; border-bottom:1px solid var(--edge); font-size:13px }
+  .frame-head .left { display:flex; align-items:center; gap:8px }
+  .frame-head .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .frame-head .right { color:var(--dim); font-size:12px }
+  .frame-image { background:#000; position:relative; aspect-ratio:16/9 }
+  .frame-image svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-image .ovl { position:absolute; bottom:12px; left:12px;
+    font-family:ui-monospace,monospace; font-size:11px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.5);
+    padding:4px 8px; border-radius:4px }
+
+  /* past sessions */
+  .past h2 { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); display:flex; justify-content:space-between; align-items:flex-end;
+    margin-bottom:12px }
+  .past h2 .meta { font-family:ui-monospace,monospace; font-size:11px }
+  .timeline { position:relative; padding-left:28px; display:flex; flex-direction:column; gap:12px }
+  .timeline::before { content:''; position:absolute; left:11px; top:0; bottom:0;
+    width:1px; background:var(--edge) }
+  .tl-item { border-radius:10px; background:var(--panel); position:relative;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .dot { position:absolute; left:-21px; top:14px; width:8px; height:8px;
+    border-radius:999px; background:var(--dim); box-shadow:0 0 0 4px var(--bg) }
+  .dot.warn { background:#f59e0b }
+  .dot.bad  { background:#ef4444 }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .15s; color:var(--dim); display:inline-block; width:12px }
+  .tl-summary { padding:12px 16px; display:flex; align-items:center; gap:12px }
+  .tl-summary .body { flex:1; min-width:0 }
+  .tl-summary .title-row { display:flex; align-items:baseline; gap:8px }
+  .tl-summary .name { font-weight:500 }
+  .tl-summary .when { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace }
+  .tl-summary .desc { font-size:12px; color:var(--dim); margin-top:2px }
+  .tl-pill { font-size:11px; padding:2px 6px; border-radius:4px; flex:none }
+  .tl-pill.ok { background:rgba(34,197,94,.15); color:#4ade80; box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .tl-pill.warn { background:rgba(245,158,11,.15); color:#fbbf24; box-shadow:inset 0 0 0 1px rgba(245,158,11,.3) }
+  .tl-pill.bad { background:rgba(239,68,68,.15); color:#fca5a5; box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="brand"><div class="logo"></div><span>rusty&nbsp;photon</span></div>
+  <div class="nav-tabs"><a class="active">Activity</a><a>Equipment</a><a>Plans</a><a>Logs</a><a>Settings</a></div>
+  <div class="grow"></div>
+  <div class="status-strip"><span class="led ok"></span>All systems healthy</div>
+  <div class="avatar">IV</div>
+</nav>
+
+<main>
+
+  <!-- hero -->
+  <article class="hero">
+    <div class="hero-row">
+      <div class="ring">
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#1c1c22" stroke-width="8"/>
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                  stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+        </svg>
+        <div class="center"><div><div class="pct">42%</div><div class="cap">done</div></div></div>
+      </div>
+      <div class="hero-body">
+        <div class="hero-eyebrow">
+          <span class="label">Capturing now</span>
+          <span class="meta">started 21:18 · 26m 14s remaining · finishes 01:42 local</span>
+        </div>
+        <h1>M51 — Whirlpool · Luminance · 300s</h1>
+        <div class="sub">Frame 4 of 10 in this filter · 30 of 40 across L R G B</div>
+        <div class="chips">
+          <span class="chip">✓ slew</span><span class="chip">✓ focus</span><span class="chip">✓ guide</span>
+          <span class="chip live">● capturing L</span>
+          <span class="chip muted">R</span><span class="chip muted">G</span><span class="chip muted">B</span><span class="chip muted">park</span>
+        </div>
+      </div>
+      <div class="hero-buttons">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+  </article>
+
+  <!-- LIVE TELEMETRY CARD -->
+  <article class="live">
+    <div class="live-head">
+      <div class="l">
+        <span class="pulse"></span>
+        <span class="title">Live telemetry</span>
+        <span class="meta">streaming · 21:18:47</span>
+      </div>
+      <button class="open">Open live view ↗</button>
+    </div>
+
+    <div class="guider">
+      <div class="guider-head">
+        <span class="gt">Guider — RA / Dec error</span>
+        <div class="gstats">
+          <span class="gstat ra"><span class="d"></span>RA <span class="v">0.42″</span></span>
+          <span class="gstat dec"><span class="d"></span>Dec <span class="v">0.51″</span></span>
+          <span class="gstat total">Total RMS <span class="v">0.66″</span></span>
+        </div>
+      </div>
+      <div class="graph">
+        <svg viewBox="0 0 600 160" preserveAspectRatio="none">
+          <!-- ±1.0″ band -->
+          <rect x="0" y="50" width="600" height="60" fill="#22c55e" fill-opacity=".05"/>
+          <!-- ±0.5″ band -->
+          <rect x="0" y="65" width="600" height="30" fill="#22c55e" fill-opacity=".06"/>
+          <!-- center line -->
+          <line x1="0" y1="80" x2="600" y2="80" stroke="#27272a" stroke-width="1"/>
+          <!-- ±1.0″ refs -->
+          <line x1="0" y1="50"  x2="600" y2="50"  stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+          <line x1="0" y1="110" x2="600" y2="110" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+          <text x="6" y="14" fill="#52525b" font-size="9" font-family="ui-monospace,monospace">arcsec</text>
+          <text x="6" y="54"  fill="#52525b" font-size="9" font-family="ui-monospace,monospace">+1.0</text>
+          <text x="6" y="84"  fill="#52525b" font-size="9" font-family="ui-monospace,monospace">0</text>
+          <text x="6" y="114" fill="#52525b" font-size="9" font-family="ui-monospace,monospace">−1.0</text>
+          <!-- Dec -->
+          <path fill="none" stroke="#60a5fa" stroke-width="1.1" stroke-linejoin="round"
+                d="M0,80 L10,77 L20,86 L30,68 L40,83 L50,71 L60,86 L70,77 L80,68 L90,89 L100,74 L110,83 L120,65 L130,86 L140,71 L150,77 L160,92 L170,74 L180,83 L190,71 L200,77 L210,86 L220,68 L230,74 L240,83 L250,71 L260,95 L270,77 L280,68 L290,86 L300,71 L310,77 L320,83 L330,65 L340,89 L350,74 L360,68 L370,83 L380,71 L390,74 L400,89 L410,77 L420,68 L430,86 L440,71 L450,77 L460,92 L470,74 L480,71 L490,83 L500,68 L510,74 L520,86 L530,65 L540,83 L550,71 L560,77 L570,89 L580,68 L590,74"/>
+          <!-- RA -->
+          <path fill="none" stroke="#f87171" stroke-width="1.1" stroke-linejoin="round"
+                d="M0,80 L10,74 L20,83 L30,71 L40,86 L50,77 L60,89 L70,68 L80,77 L90,86 L100,71 L110,92 L120,77 L130,74 L140,89 L150,65 L160,83 L170,74 L180,92 L190,71 L200,77 L210,86 L220,68 L230,89 L240,74 L250,83 L260,71 L270,95 L280,74 L290,77 L300,89 L310,68 L320,86 L330,77 L340,71 L350,86 L360,68 L370,83 L380,74 L390,89 L400,77 L410,65 L420,86 L430,71 L440,83 L450,74 L460,92 L470,77 L480,71 L490,86 L500,68 L510,83 L520,74 L530,71 L540,83 L550,65 L560,89 L570,74 L580,83 L590,68"/>
+          <!-- now indicator -->
+          <line x1="595" y1="0" x2="595" y2="160" stroke="#4ade80" stroke-width="1" stroke-opacity=".7"/>
+        </svg>
+      </div>
+      <div class="gfoot">
+        <span>last 5 minutes · 60 samples</span>
+        <span>shaded ±1.0″ · ±0.5″</span>
+      </div>
+    </div>
+
+    <div class="sparks">
+      <div class="spark">
+        <div class="k">Focus HFR</div>
+        <div class="row"><span class="v">1.84″</span><span class="d warn">↑ 0.06 / 30m</span></div>
+        <svg viewBox="0 0 200 50" preserveAspectRatio="none">
+          <line x1="0" y1="25" x2="200" y2="25" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+          <path fill="none" stroke="#a78bfa" stroke-width="1.4"
+                d="M0,33 L11,32 L22,31 L33,30 L44,29 L55,28 L66,27 L77,25 L88,23 L99,21 L110,19 M110,19 L121,36 L132,35 L143,34 L154,32 L165,31 L176,29 L187,28 L200,27"/>
+          <circle cx="200" cy="27" r="2" fill="#a78bfa"/>
+        </svg>
+      </div>
+      <div class="spark">
+        <div class="k">Camera temp</div>
+        <div class="row"><span class="v">−10.0°</span><span class="d ok">on target</span></div>
+        <svg viewBox="0 0 200 50" preserveAspectRatio="none">
+          <path fill="none" stroke="#4ade80" stroke-width="1.4"
+                d="M0,25 L11,25 L22,24 L33,25 L44,26 L55,25 L66,25 L77,24 L88,25 L99,25 L110,26 L121,25 L132,25 L143,24 L154,25 L165,26 L176,25 L187,25 L200,25"/>
+          <circle cx="200" cy="25" r="2" fill="#4ade80"/>
+        </svg>
+      </div>
+      <div class="spark">
+        <div class="k">Sky brightness</div>
+        <div class="row"><span class="v">20.8</span><span class="d warn">−0.6 / 1h</span></div>
+        <svg viewBox="0 0 200 50" preserveAspectRatio="none">
+          <path fill="none" stroke="#fbbf24" stroke-width="1.4"
+                d="M0,9 L11,9 L22,13 L33,13 L44,13 L55,17 L66,17 L77,17 L88,21 L99,21 L110,25 L121,25 L132,29 L143,29 L154,29 L165,33 L176,33 L187,33 L200,33"/>
+          <circle cx="200" cy="33" r="2" fill="#fbbf24"/>
+        </svg>
+      </div>
+      <div class="spark">
+        <div class="k">Dew margin</div>
+        <div class="row"><span class="v">4.8°</span><span class="d warn">↓ 3.4 / 1h</span></div>
+        <svg viewBox="0 0 200 50" preserveAspectRatio="none">
+          <path fill="none" stroke="#fbbf24" stroke-width="1.4"
+                d="M0,12 L11,13 L22,13 L33,13 L44,14 L55,14 L66,15 L77,16 L88,17 L99,18 L110,19 L121,20 L132,21 L143,22 L154,23 L165,24 L176,25 L187,25 L200,26"/>
+          <circle cx="200" cy="26" r="2" fill="#fbbf24"/>
+        </svg>
+      </div>
+    </div>
+  </article>
+
+  <!-- latest frame -->
+  <article class="frame-card">
+    <div class="frame-head">
+      <div class="left">
+        <span class="led ok"></span>
+        <span style="font-weight:500">Latest frame just landed</span>
+        <span class="meta">0042 · L · 300s · 21:18:04</span>
+      </div>
+      <div class="right"><button>open</button> · <button>download</button></div>
+    </div>
+    <div class="frame-image">
+      <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <radialGradient id="neb4" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+            <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+          </radialGradient>
+          <radialGradient id="core4" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+            <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+            <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="800" height="450" fill="#03050b"/>
+        <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb4)"/>
+        <g transform="translate(400 225) rotate(-22)">
+          <ellipse rx="60" ry="40" fill="url(#core4)"/>
+          <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+        </g>
+        <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+        <g fill="#fff">
+          <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+          <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+          <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+          <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+          <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+          <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+          <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+          <circle cx="140" cy="420" r="1"/><circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/>
+          <circle cx="770" cy="60" r=".7"/>
+        </g>
+      </svg>
+      <div class="ovl">HFR 1.84″ · Stars 2,941 · ADU 1,247 · Ecc 0.41</div>
+    </div>
+  </article>
+
+  <!-- past sessions (truncated) -->
+  <section class="past">
+    <h2><span>Past sessions</span><span class="meta">last 30 days · 12 sessions</span></h2>
+    <div class="timeline">
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">M101 — Pinwheel</span>
+              <span class="when">last night · 22:14 → 03:48</span></div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot warn"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">NGC 7000 — North America</span>
+              <span class="when">3 days ago · 21:48 → 02:11</span></div>
+            <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted · clouds</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot bad"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">IC 1396 — Elephant's Trunk</span>
+              <span class="when">12 days ago · 22:02 → 23:00</span></div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed · guide loss</span>
+        </summary>
+      </details>
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/5-stream-sticky.html
+++ b/docs/plans/ui-design/mocks/5-stream-sticky.html
@@ -1,0 +1,313 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Stream + sticky telemetry strip</title>
+<style>
+  :root {
+    --bg:#08080a; --panel:#0f0f12; --edge:#1c1c22;
+    --text:#fafafa; --dim:#9c9ca6;
+    --ra:#f87171; --dec:#60a5fa;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button, a { font:inherit; color:inherit; background:none; border:0; cursor:pointer; text-decoration:none }
+
+  nav { height:48px; padding:0 20px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:rgba(15,15,18,.85);
+    backdrop-filter:blur(8px); position:sticky; top:0; z-index:20 }
+  .brand { display:flex; align-items:center; gap:8px; font-weight:600 }
+  .logo { width:24px; height:24px; border-radius:5px;
+    background:linear-gradient(135deg,#6366f1,#d946ef) }
+  .nav-tabs { display:flex; gap:4px; margin-left:12px; font-size:13px }
+  .nav-tabs a { padding:5px 10px; border-radius:5px; color:var(--dim) }
+  .nav-tabs a.active { color:#fff; background:rgba(255,255,255,.05) }
+  .grow { flex:1 }
+  .avatar { width:32px; height:32px; border-radius:999px; background:rgba(244,63,94,.2);
+    box-shadow:inset 0 0 0 1px rgba(251,113,133,.4); display:grid; place-items:center; font-size:12px }
+
+  /* STICKY LIVE STRIP */
+  .strip { position:sticky; top:48px; z-index:15;
+    background:rgba(15,15,18,.92); backdrop-filter:blur(8px);
+    border-bottom:1px solid var(--edge); height:44px; padding:0 20px;
+    display:flex; align-items:center; gap:18px; font-size:12px;
+    box-shadow:0 1px 0 rgba(74,222,128,.18) }
+  .strip .pulse { width:8px; height:8px; border-radius:999px; background:#4ade80;
+    box-shadow:0 0 12px 1px rgba(74,222,128,.6); animation:pulse 1.6s infinite; flex:none }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .strip .label { font-weight:500; color:#fff }
+  .strip .sep { color:var(--edge); font-size:14px }
+  .strip .stat { display:flex; align-items:center; gap:6px; color:var(--dim) }
+  .strip .stat .v { color:#fff; font-family:ui-monospace,monospace }
+  .strip .stat .v.warn { color:#fbbf24 }
+  .strip .stat .v.ok { color:#4ade80 }
+  .strip .stat .ra { color:var(--ra) }
+  .strip .stat .dec { color:var(--dec) }
+  .strip .mini { width:80px; height:24px }
+  .strip .grow { flex:1 }
+  .strip .open { font-size:12px; color:var(--dim);
+    padding:5px 10px; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge) }
+  .strip .open:hover { color:#fff; background:rgba(255,255,255,.05) }
+
+  main { max-width:780px; margin:0 auto; padding:32px 20px; display:flex; flex-direction:column; gap:20px }
+
+  /* hero */
+  .hero { position:relative; border-radius:12px; background:var(--panel);
+    padding:20px; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .hero::before { content:''; position:absolute; top:0; left:0; right:0; height:1px;
+    background:linear-gradient(90deg,transparent,rgba(74,222,128,.6),transparent) }
+  .hero-row { display:flex; align-items:flex-start; gap:20px }
+  .ring { position:relative; width:96px; height:96px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:20px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:10px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+  .hero-body { flex:1; min-width:0 }
+  .hero-eyebrow { display:flex; align-items:center; gap:8px }
+  .hero-eyebrow .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#4ade80 }
+  .hero-eyebrow .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .hero h1 { font-size:20px; font-weight:600; line-height:1.2; margin-top:4px }
+  .hero .sub { font-size:13px; color:var(--dim); margin-top:2px }
+  .chips { margin-top:12px; display:flex; flex-wrap:wrap; gap:6px; font-size:11px }
+  .chip { padding:2px 8px; border-radius:4px; background:rgba(34,197,94,.1); color:#4ade80;
+    box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .chip.live { background:rgba(34,197,94,.18); color:#86efac;
+    box-shadow:inset 0 0 0 1px rgba(74,222,128,.4) }
+  .chip.muted { background:rgba(255,255,255,.05); color:var(--dim);
+    box-shadow:inset 0 0 0 1px var(--edge) }
+  .hero-buttons { display:flex; flex-direction:column; gap:6px; flex:none }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+
+  /* latest frame */
+  .frame-card { border-radius:12px; background:var(--panel); overflow:hidden;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .frame-head { height:44px; padding:0 20px; display:flex; align-items:center;
+    justify-content:space-between; border-bottom:1px solid var(--edge); font-size:13px }
+  .frame-head .left { display:flex; align-items:center; gap:8px }
+  .frame-head .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .frame-head .right { color:var(--dim); font-size:12px }
+  .frame-image { background:#000; position:relative; aspect-ratio:16/9 }
+  .frame-image svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-image .ovl { position:absolute; bottom:12px; left:12px;
+    font-family:ui-monospace,monospace; font-size:11px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.5);
+    padding:4px 8px; border-radius:4px }
+  .led { width:8px; height:8px; border-radius:999px; display:inline-block }
+  .led.ok { background:#4ade80 }
+
+  /* past sessions */
+  .past h2 { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); display:flex; justify-content:space-between; align-items:flex-end;
+    margin-bottom:12px }
+  .past h2 .meta { font-family:ui-monospace,monospace; font-size:11px }
+  .timeline { position:relative; padding-left:28px; display:flex; flex-direction:column; gap:12px }
+  .timeline::before { content:''; position:absolute; left:11px; top:0; bottom:0;
+    width:1px; background:var(--edge) }
+  .tl-item { border-radius:10px; background:var(--panel); position:relative;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .dot { position:absolute; left:-21px; top:14px; width:8px; height:8px;
+    border-radius:999px; background:var(--dim); box-shadow:0 0 0 4px var(--bg) }
+  .dot.warn { background:#f59e0b } .dot.bad { background:#ef4444 }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .15s; color:var(--dim); display:inline-block; width:12px }
+  .tl-summary { padding:12px 16px; display:flex; align-items:center; gap:12px }
+  .tl-summary .body { flex:1; min-width:0 }
+  .tl-summary .title-row { display:flex; align-items:baseline; gap:8px }
+  .tl-summary .name { font-weight:500 }
+  .tl-summary .when { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace }
+  .tl-summary .desc { font-size:12px; color:var(--dim); margin-top:2px }
+  .tl-pill { font-size:11px; padding:2px 6px; border-radius:4px; flex:none }
+  .tl-pill.ok { background:rgba(34,197,94,.15); color:#4ade80; box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .tl-pill.warn { background:rgba(245,158,11,.15); color:#fbbf24; box-shadow:inset 0 0 0 1px rgba(245,158,11,.3) }
+  .tl-pill.bad { background:rgba(239,68,68,.15); color:#fca5a5; box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+
+  /* spacer to make page tall enough that sticky behavior is obvious */
+  .filler { height:600px; display:flex; align-items:center; justify-content:center;
+    color:var(--dim); font-size:12px; font-style:italic }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="brand"><div class="logo"></div><span>rusty&nbsp;photon</span></div>
+  <div class="nav-tabs"><a class="active">Activity</a><a>Equipment</a><a>Plans</a><a>Logs</a><a>Settings</a></div>
+  <div class="grow"></div>
+  <div class="avatar">IV</div>
+</nav>
+
+<!-- STICKY LIVE STRIP — pinned right under nav -->
+<div class="strip">
+  <span class="pulse"></span>
+  <span class="label">M51 · L · 300s</span>
+  <span class="sep">│</span>
+  <div class="stat">
+    <span class="ra">RA</span>
+    <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+      <line x1="0" y1="12" x2="200" y2="12" stroke="#27272a" stroke-width=".5"/>
+      <path fill="none" stroke="#f87171" stroke-width="1"
+            d="M0,12 L10,10 L20,14 L30,9 L40,15 L50,11 L60,16 L70,8 L80,11 L90,15 L100,9 L110,17 L120,11 L130,10 L140,16 L150,7 L160,14 L170,11 L180,17 L190,9 L200,12"/>
+    </svg>
+    <span class="v">0.42″</span>
+  </div>
+  <div class="stat">
+    <span class="dec">Dec</span>
+    <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+      <line x1="0" y1="12" x2="200" y2="12" stroke="#27272a" stroke-width=".5"/>
+      <path fill="none" stroke="#60a5fa" stroke-width="1"
+            d="M0,12 L10,11 L20,15 L30,8 L40,14 L50,10 L60,15 L70,12 L80,8 L90,16 L100,10 L110,14 L120,7 L130,15 L140,9 L150,12 L160,17 L170,10 L180,14 L190,9 L200,12"/>
+    </svg>
+    <span class="v">0.51″</span>
+  </div>
+  <span class="sep">│</span>
+  <div class="stat">HFR <span class="v warn">1.84″</span></div>
+  <div class="stat">CCD <span class="v ok">−10.0°</span></div>
+  <div class="stat">Sky <span class="v warn">20.8</span></div>
+  <span class="grow"></span>
+  <div class="stat mono">finish 01:42</div>
+  <button class="open">Live view ↗</button>
+</div>
+
+<main>
+
+  <!-- hero -->
+  <article class="hero">
+    <div class="hero-row">
+      <div class="ring">
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#1c1c22" stroke-width="8"/>
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                  stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+        </svg>
+        <div class="center"><div><div class="pct">42%</div><div class="cap">done</div></div></div>
+      </div>
+      <div class="hero-body">
+        <div class="hero-eyebrow">
+          <span class="label">Capturing now</span>
+          <span class="meta">started 21:18 · 26m 14s remaining · finishes 01:42 local</span>
+        </div>
+        <h1>M51 — Whirlpool · Luminance · 300s</h1>
+        <div class="sub">Frame 4 of 10 in this filter · 30 of 40 across L R G B</div>
+        <div class="chips">
+          <span class="chip">✓ slew</span><span class="chip">✓ focus</span><span class="chip">✓ guide</span>
+          <span class="chip live">● capturing L</span>
+          <span class="chip muted">R</span><span class="chip muted">G</span><span class="chip muted">B</span><span class="chip muted">park</span>
+        </div>
+      </div>
+      <div class="hero-buttons">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+  </article>
+
+  <!-- latest frame -->
+  <article class="frame-card">
+    <div class="frame-head">
+      <div class="left">
+        <span class="led ok"></span>
+        <span style="font-weight:500">Latest frame just landed</span>
+        <span class="meta">0042 · L · 300s · 21:18:04</span>
+      </div>
+      <div class="right"><button>open</button> · <button>download</button></div>
+    </div>
+    <div class="frame-image">
+      <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <radialGradient id="neb5" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+            <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+          </radialGradient>
+          <radialGradient id="core5" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+            <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+            <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="800" height="450" fill="#03050b"/>
+        <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb5)"/>
+        <g transform="translate(400 225) rotate(-22)">
+          <ellipse rx="60" ry="40" fill="url(#core5)"/>
+          <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+        </g>
+        <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+        <g fill="#fff">
+          <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+          <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+          <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+          <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+          <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+          <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+          <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+          <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+        </g>
+      </svg>
+      <div class="ovl">HFR 1.84″ · Stars 2,941 · ADU 1,247 · Ecc 0.41</div>
+    </div>
+  </article>
+
+  <!-- past sessions -->
+  <section class="past">
+    <h2><span>Past sessions</span><span class="meta">last 30 days · 12 sessions</span></h2>
+    <div class="timeline">
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">M101 — Pinwheel</span>
+              <span class="when">last night · 22:14 → 03:48</span></div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot warn"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">NGC 7000 — North America</span>
+              <span class="when">3 days ago · 21:48 → 02:11</span></div>
+            <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted · clouds</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">M31 — Andromeda</span>
+              <span class="when">a week ago · 20:31 → 04:02</span></div>
+            <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot bad"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">IC 1396 — Elephant's Trunk</span>
+              <span class="when">12 days ago · 22:02 → 23:00</span></div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed · guide loss</span>
+        </summary>
+      </details>
+    </div>
+    <div class="filler">scroll up and down — telemetry strip stays pinned</div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/6-live.html
+++ b/docs/plans/ui-design/mocks/6-live.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Live view (punch-out)</title>
+<style>
+  :root {
+    --bg:#08080a; --panel:#0f0f12; --edge:#1c1c22;
+    --text:#fafafa; --dim:#9c9ca6;
+    --ra:#f87171; --dec:#60a5fa;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100vh; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  body { display:flex; flex-direction:column; min-height:100vh }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button, a { font:inherit; color:inherit; background:none; border:0; cursor:pointer; text-decoration:none }
+  .ring-line { box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+
+  nav { height:48px; padding:0 20px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:var(--panel); flex:none }
+  .back { color:var(--dim); display:flex; align-items:center; gap:6px; font-size:13px;
+    padding:5px 10px; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge) }
+  .back:hover { color:#fff; background:rgba(255,255,255,.05) }
+  .session { font-size:13px; display:flex; align-items:center; gap:8px }
+  .session .pulse { width:8px; height:8px; border-radius:999px; background:#4ade80;
+    box-shadow:0 0 12px 1px rgba(74,222,128,.6); animation:pulse 1.6s infinite }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .session b { font-weight:600 }
+  .session .meta { color:var(--dim); font-family:ui-monospace,monospace; font-size:12px }
+  .grow { flex:1 }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+
+  main { flex:1; display:grid; grid-template-columns:1fr 320px; gap:16px;
+    padding:16px; min-height:0 }
+
+  .col-main { display:grid; grid-template-rows:1fr auto; gap:16px; min-height:0 }
+  .col-side { display:flex; flex-direction:column; gap:16px; min-height:0 }
+
+  /* card primitives */
+  .card { border-radius:10px; background:var(--panel);
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06); display:flex; flex-direction:column }
+  .card-head { padding:10px 16px; display:flex; align-items:center; gap:10px;
+    border-bottom:1px solid var(--edge); flex:none }
+  .card-head .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim) }
+  .card-head .v { font-family:ui-monospace,monospace; font-size:13px }
+  .card-head .right { margin-left:auto; font-size:11px; color:var(--dim);
+    font-family:ui-monospace,monospace }
+
+  /* big guider graph (hero of this view) */
+  .guider-card { min-height:360px }
+  .guider-head .gstats { display:flex; gap:14px; font-size:12px; margin-left:auto }
+  .gstat { display:flex; align-items:center; gap:5px; color:var(--dim) }
+  .gstat .d { width:7px; height:7px; border-radius:999px }
+  .gstat.ra .d { background:var(--ra) }
+  .gstat.dec .d { background:var(--dec) }
+  .gstat .v { font-family:ui-monospace,monospace; color:#fff; margin-left:2px }
+  .gstat.total { padding-left:12px; box-shadow:inset 1px 0 0 var(--edge); color:#fff }
+  .graph-body { flex:1; padding:12px; min-height:0 }
+  .graph-body svg { display:block; width:100%; height:100% }
+
+  /* charts row */
+  .charts-row { display:grid; grid-template-columns:repeat(3,1fr); gap:16px }
+  .chart-card { padding:0 }
+  .chart-head { padding:10px 14px 4px; display:flex; align-items:baseline; gap:8px }
+  .chart-head .k { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim) }
+  .chart-head .v { font-family:ui-monospace,monospace; font-size:18px; font-weight:600; margin-left:auto }
+  .chart-head .v.warn { color:#fbbf24 } .chart-head .v.ok { color:#4ade80 }
+  .chart-head .d { font-size:11px; color:var(--dim) }
+  .chart-head .d.warn { color:#fbbf24 }
+  .chart-body { padding:0 12px 12px; height:90px }
+  .chart-body svg { display:block; width:100%; height:100% }
+
+  /* status block */
+  .status-block { padding:14px 16px }
+  .status-block .eyebrow { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#4ade80 }
+  .status-block h1 { font-size:17px; font-weight:600; margin-top:4px; line-height:1.25 }
+  .status-block .sub { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace; margin-top:2px }
+  .ring-row { margin-top:14px; display:flex; align-items:center; gap:14px }
+  .ring { position:relative; width:84px; height:84px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:18px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:9px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+  .stats { font-size:12px; flex:1; display:flex; flex-direction:column; gap:5px }
+  .stats .row { display:flex; justify-content:space-between; gap:12px }
+  .stats .row span:first-child { color:var(--dim) }
+  .stats .row span:last-child { font-family:ui-monospace,monospace }
+
+  /* image preview */
+  .preview { padding:0 }
+  .preview .preview-head { padding:10px 14px; display:flex; align-items:center;
+    border-bottom:1px solid var(--edge); font-size:12px }
+  .preview .preview-head .meta { color:var(--dim); font-family:ui-monospace,monospace; font-size:11px; margin-left:auto }
+  .preview .img { background:#000; aspect-ratio:4/3; position:relative }
+  .preview .img svg { position:absolute; inset:0; width:100%; height:100% }
+
+  /* equipment */
+  .equip { padding:14px 16px }
+  .equip h3 { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim); margin-bottom:8px }
+  .equip ul { list-style:none; display:flex; flex-direction:column; gap:6px }
+  .equip li { font-size:12px; display:flex; align-items:center; gap:8px }
+  .led { width:8px; height:8px; border-radius:999px; flex:none }
+  .led.ok { background:#4ade80 } .led.warn { background:#fbbf24 } .led.bad { background:#f87171 }
+  .equip li .v { color:var(--dim); margin-left:auto; font-family:ui-monospace,monospace }
+</style>
+</head>
+<body>
+
+<nav>
+  <a class="back">← Back to activity</a>
+  <span class="session">
+    <span class="pulse"></span>
+    <b>Live view</b>
+    <span class="meta">M51 · session 21:14 → 01:42 · 21:18:47</span>
+  </span>
+  <span class="grow"></span>
+  <button class="btn">Pause</button>
+  <button class="btn danger">Abort</button>
+</nav>
+
+<main>
+
+  <div class="col-main">
+
+    <!-- BIG GUIDER GRAPH -->
+    <section class="card guider-card">
+      <div class="card-head guider-head">
+        <span class="label">Guider</span>
+        <span class="v">RA / Dec error · arcseconds · last 5 minutes</span>
+        <div class="gstats">
+          <span class="gstat ra"><span class="d"></span>RA <span class="v">0.42″</span></span>
+          <span class="gstat dec"><span class="d"></span>Dec <span class="v">0.51″</span></span>
+          <span class="gstat total">Total RMS <span class="v">0.66″</span></span>
+        </div>
+      </div>
+      <div class="graph-body">
+        <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+          <!-- bands -->
+          <rect x="0" y="60" width="600" height="120" fill="#22c55e" fill-opacity=".05"/>
+          <rect x="0" y="90" width="600" height="60"  fill="#22c55e" fill-opacity=".06"/>
+          <!-- center + refs -->
+          <line x1="0" y1="120" x2="600" y2="120" stroke="#27272a" stroke-width="1"/>
+          <line x1="0" y1="60"  x2="600" y2="60"  stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+          <line x1="0" y1="180" x2="600" y2="180" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+          <line x1="0" y1="90"  x2="600" y2="90"  stroke="#27272a" stroke-width=".5" stroke-dasharray="1,4"/>
+          <line x1="0" y1="150" x2="600" y2="150" stroke="#27272a" stroke-width=".5" stroke-dasharray="1,4"/>
+          <text x="6"  y="20"  fill="#52525b" font-size="10" font-family="ui-monospace,monospace">arcsec</text>
+          <text x="6"  y="64"  fill="#52525b" font-size="10" font-family="ui-monospace,monospace">+1.0</text>
+          <text x="6"  y="94"  fill="#3f3f46" font-size="10" font-family="ui-monospace,monospace">+0.5</text>
+          <text x="6"  y="124" fill="#52525b" font-size="10" font-family="ui-monospace,monospace">0</text>
+          <text x="6"  y="154" fill="#3f3f46" font-size="10" font-family="ui-monospace,monospace">−0.5</text>
+          <text x="6"  y="184" fill="#52525b" font-size="10" font-family="ui-monospace,monospace">−1.0</text>
+          <!-- x-axis time markers -->
+          <text x="100" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−4m</text>
+          <text x="200" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−3m</text>
+          <text x="300" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−2m</text>
+          <text x="400" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−1m</text>
+          <text x="595" y="234" fill="#52525b" font-size="9" font-family="ui-monospace,monospace" text-anchor="end">now</text>
+          <!-- Dec (y mapped: orig y ± offset, scale 1.5x). orig y 80 -> 120, delta orig y 65->97.5 etc.
+               Easier: redo paths with scale: each orig y v, new y = (v - 80)*1.5 + 120 = 1.5*v + 0
+               So orig y 80 → 120, 65 → 97.5, 92 → 138 -->
+          <path fill="none" stroke="#60a5fa" stroke-width="1.3" stroke-linejoin="round"
+                d="M0,120 L10,115 L20,129 L30,102 L40,124 L50,107 L60,129 L70,115 L80,102 L90,134 L100,111 L110,124 L120,98 L130,129 L140,107 L150,115 L160,138 L170,111 L180,124 L190,107 L200,115 L210,129 L220,102 L230,111 L240,124 L250,107 L260,142 L270,115 L280,102 L290,129 L300,107 L310,115 L320,124 L330,98 L340,134 L350,111 L360,102 L370,124 L380,107 L390,111 L400,134 L410,115 L420,102 L430,129 L440,107 L450,115 L460,138 L470,111 L480,107 L490,124 L500,102 L510,111 L520,129 L530,98 L540,124 L550,107 L560,115 L570,134 L580,102 L590,111"/>
+          <!-- RA -->
+          <path fill="none" stroke="#f87171" stroke-width="1.3" stroke-linejoin="round"
+                d="M0,120 L10,111 L20,124 L30,107 L40,129 L50,115 L60,134 L70,102 L80,115 L90,129 L100,107 L110,138 L120,115 L130,111 L140,134 L150,98 L160,124 L170,111 L180,138 L190,107 L200,115 L210,129 L220,102 L230,134 L240,111 L250,124 L260,107 L270,142 L280,111 L290,115 L300,134 L310,102 L320,129 L330,115 L340,107 L350,129 L360,102 L370,124 L380,111 L390,134 L400,115 L410,98 L420,129 L430,107 L440,124 L450,111 L460,138 L470,115 L480,107 L490,129 L500,102 L510,124 L520,111 L530,107 L540,124 L550,98 L560,134 L570,111 L580,124 L590,102"/>
+          <!-- now indicator -->
+          <line x1="595" y1="0" x2="595" y2="220" stroke="#4ade80" stroke-width="1" stroke-opacity=".7"/>
+          <circle cx="595" cy="102" r="2.2" fill="#f87171"/>
+          <circle cx="595" cy="111" r="2.2" fill="#60a5fa"/>
+        </svg>
+      </div>
+    </section>
+
+    <!-- THREE SMALLER CHARTS -->
+    <div class="charts-row">
+
+      <section class="card chart-card">
+        <div class="chart-head">
+          <span class="k">Focus HFR</span>
+          <span class="d warn">↑ 0.06 / 30m</span>
+          <span class="v warn">1.84″</span>
+        </div>
+        <div class="chart-body">
+          <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+            <line x1="0" y1="45" x2="200" y2="45" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+            <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">2.4″</text>
+            <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">1.4″</text>
+            <path fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linejoin="round"
+                  d="M0,55 L11,53 L22,51 L33,49 L44,47 L55,45 L66,43 L77,40 L88,36 L99,33 L110,29
+                     M110,29 L121,67 L132,65 L143,63 L154,59 L165,57 L176,53 L187,51 L200,49"/>
+            <circle cx="200" cy="49" r="2.5" fill="#a78bfa"/>
+          </svg>
+        </div>
+      </section>
+
+      <section class="card chart-card">
+        <div class="chart-head">
+          <span class="k">CCD temp</span>
+          <span class="d ok">on target</span>
+          <span class="v ok">−10.0°</span>
+        </div>
+        <div class="chart-body">
+          <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+            <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">−9.5°</text>
+            <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">−10.5°</text>
+            <line x1="0" y1="45" x2="200" y2="45" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+            <path fill="none" stroke="#4ade80" stroke-width="1.5"
+                  d="M0,45 L11,45 L22,43 L33,45 L44,47 L55,45 L66,45 L77,43 L88,45 L99,45 L110,47 L121,45 L132,45 L143,43 L154,45 L165,47 L176,45 L187,45 L200,45"/>
+            <circle cx="200" cy="45" r="2.5" fill="#4ade80"/>
+          </svg>
+        </div>
+      </section>
+
+      <section class="card chart-card">
+        <div class="chart-head">
+          <span class="k">Sky brightness</span>
+          <span class="d warn">−0.6 / 1h</span>
+          <span class="v warn">20.8</span>
+        </div>
+        <div class="chart-body">
+          <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+            <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">21.5</text>
+            <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">20.5</text>
+            <path fill="none" stroke="#fbbf24" stroke-width="1.5"
+                  d="M0,16 L11,16 L22,24 L33,24 L44,24 L55,32 L66,32 L77,32 L88,40 L99,40 L110,48 L121,48 L132,55 L143,55 L154,55 L165,63 L176,63 L187,63 L200,63"/>
+            <circle cx="200" cy="63" r="2.5" fill="#fbbf24"/>
+          </svg>
+        </div>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- side rail -->
+  <div class="col-side">
+
+    <section class="card">
+      <div class="status-block">
+        <div class="eyebrow">Capturing now</div>
+        <h1>M51 · L · 300s</h1>
+        <div class="sub">frame 4 of 10 · started 21:18:04</div>
+        <div class="ring-row">
+          <div class="ring">
+            <svg viewBox="0 0 100 100">
+              <circle cx="50" cy="50" r="44" fill="none" stroke="#1c1c22" stroke-width="8"/>
+              <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                      stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+            </svg>
+            <div class="center"><div><div class="pct">42%</div><div class="cap">done</div></div></div>
+          </div>
+          <div class="stats">
+            <div class="row"><span>Sub elapsed</span><span>02:18 / 05:00</span></div>
+            <div class="row"><span>Sequence ETA</span><span>26m 14s</span></div>
+            <div class="row"><span>Finish at</span><span>01:42</span></div>
+            <div class="row"><span>Meridian flip</span><span style="color:#fbbf24">1h 48m</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card preview">
+      <div class="preview-head">
+        <span style="font-weight:500">Latest frame</span>
+        <span class="meta">0042 · L · 21:18</span>
+      </div>
+      <div class="img">
+        <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <radialGradient id="neb6" cx="50%" cy="50%" r="60%">
+              <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+              <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="core6" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+              <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+              <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+            </radialGradient>
+          </defs>
+          <rect width="400" height="300" fill="#03050b"/>
+          <ellipse cx="200" cy="150" rx="190" ry="130" fill="url(#neb6)"/>
+          <g transform="translate(200 150) rotate(-22)">
+            <ellipse rx="35" ry="23" fill="url(#core6)"/>
+            <path d="M 0 0 Q -80 -30 -130 -10 Q -160 10 -170 40" stroke="#fde68a" stroke-opacity=".35" stroke-width="1.5" fill="none"/>
+            <path d="M 0 0 Q 80 30 130 10 Q 160 -10 170 -40" stroke="#fde68a" stroke-opacity=".35" stroke-width="1.5" fill="none"/>
+          </g>
+          <ellipse cx="320" cy="100" rx="12" ry="9" fill="#fef3c7" fill-opacity=".7"/>
+          <g fill="#fff">
+            <circle cx="30" cy="40" r=".7"/><circle cx="70" cy="80" r=".5"/><circle cx="120" cy="30" r=".4"/>
+            <circle cx="160" cy="110" r=".8"/><circle cx="200" cy="50" r=".5"/><circle cx="240" cy="100" r=".6"/>
+            <circle cx="280" cy="20" r=".4"/><circle cx="320" cy="140" r=".7"/><circle cx="360" cy="50" r=".5"/>
+            <circle cx="40" cy="200" r=".7"/><circle cx="100" cy="240" r=".6"/><circle cx="160" cy="270" r=".5"/>
+            <circle cx="240" cy="220" r=".7"/><circle cx="280" cy="280" r=".5"/><circle cx="340" cy="240" r=".6"/>
+            <circle cx="380" cy="180" r=".5"/><circle cx="60" cy="160" r=".4"/>
+          </g>
+        </svg>
+      </div>
+    </section>
+
+    <section class="card equip">
+      <h3>Equipment</h3>
+      <ul>
+        <li><span class="led ok"></span>Camera <span class="v">−10.0°C</span></li>
+        <li><span class="led ok"></span>Mount <span class="v">RMS 0.62″</span></li>
+        <li><span class="led ok"></span>Focuser <span class="v">14,820 · 22.4°C</span></li>
+        <li><span class="led ok"></span>Guider <span class="v">2.1 px snr 32</span></li>
+        <li><span class="led warn"></span>Sky <span class="v">18% clouds ↑</span></li>
+        <li><span class="led warn"></span>Dew margin <span class="v">4.8°</span></li>
+      </ul>
+    </section>
+
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/7-stream-fold.html
+++ b/docs/plans/ui-design/mocks/7-stream-fold.html
@@ -1,0 +1,584 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — Stream + foldable live panel</title>
+<style>
+  :root {
+    --bg:#08080a; --panel:#0f0f12; --edge:#1c1c22;
+    --text:#fafafa; --dim:#9c9ca6;
+    --ra:#f87171; --dec:#60a5fa;
+  }
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",sans-serif;
+    font-size:14px; line-height:1.4 }
+  .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace }
+  button, a { font:inherit; color:inherit; background:none; border:0; cursor:pointer; text-decoration:none }
+
+  nav { height:48px; padding:0 20px; display:flex; align-items:center; gap:16px;
+    border-bottom:1px solid var(--edge); background:rgba(15,15,18,.85);
+    backdrop-filter:blur(8px); position:sticky; top:0; z-index:30 }
+  .brand { display:flex; align-items:center; gap:8px; font-weight:600 }
+  .logo { width:24px; height:24px; border-radius:5px;
+    background:linear-gradient(135deg,#6366f1,#d946ef) }
+  .nav-tabs { display:flex; gap:4px; margin-left:12px; font-size:13px }
+  .nav-tabs a { padding:5px 10px; border-radius:5px; color:var(--dim) }
+  .nav-tabs a.active { color:#fff; background:rgba(255,255,255,.05) }
+  .grow { flex:1 }
+  .avatar { width:32px; height:32px; border-radius:999px; background:rgba(244,63,94,.2);
+    box-shadow:inset 0 0 0 1px rgba(251,113,133,.4); display:grid; place-items:center; font-size:12px }
+
+  /* ── FOLDABLE LIVE: thin strip when closed, full-width panel when open ── */
+  .fold-state { display:none }
+  .fold-strip { cursor:pointer;
+    position:sticky; top:48px; z-index:20;
+    background:rgba(15,15,18,.95); backdrop-filter:blur(8px);
+    border-bottom:1px solid var(--edge);
+    height:44px; padding:0 20px;
+    display:flex; align-items:center; gap:18px; font-size:12px;
+    box-shadow:0 1px 0 rgba(74,222,128,.18) }
+  .fold-strip:hover { background:rgba(20,20,24,.95) }
+
+  .strip-pulse { width:8px; height:8px; border-radius:999px; background:#4ade80;
+    box-shadow:0 0 12px 1px rgba(74,222,128,.6); animation:pulse 1.6s infinite; flex:none }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  .strip-label { font-weight:500; color:#fff }
+  .sep { color:var(--edge); font-size:14px }
+  .stat { display:flex; align-items:center; gap:6px; color:var(--dim) }
+  .stat .v { color:#fff; font-family:ui-monospace,monospace }
+  .stat .v.warn { color:#fbbf24 } .stat .v.ok { color:#4ade80 }
+  .stat .ra { color:var(--ra) } .stat .dec { color:var(--dec) }
+  .mini { width:80px; height:24px }
+
+  .fold-toggle { font-size:11px; color:var(--dim);
+    padding:5px 10px; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge);
+    display:flex; align-items:center; gap:6px }
+  .fold-toggle .chev { display:inline-block; transition:transform 320ms cubic-bezier(.4,0,.2,1); line-height:1 }
+  .fold-state:checked ~ .fold-strip .fold-toggle .chev { transform:rotate(180deg) }
+  .fold-state:checked ~ .fold-strip .fold-toggle .lbl::before { content:"Collapse" }
+  .fold-state:not(:checked) ~ .fold-strip .fold-toggle .lbl::before { content:"Expand" }
+  .fold-toggle:hover { color:#fff; background:rgba(255,255,255,.05) }
+
+  /* fold animation: CSS Grid 0fr → 1fr trick.
+     works in every browser since late 2023 (Chrome/Firefox/Safari 117+).
+     the .fold-body is a grid container whose single row animates from
+     0fr (collapsed) to 1fr (expanded); the inner .panel needs min-height:0
+     and overflow:hidden so the content clips smoothly during the animation. */
+  .fold-body {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 320ms cubic-bezier(.4, 0, .2, 1);
+  }
+  .fold-body > .panel {
+    min-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: opacity 220ms ease;
+  }
+  .fold-state:checked ~ .fold-body { grid-template-rows: 1fr }
+  .fold-state:checked ~ .fold-body > .panel { opacity: 1; transition-delay: 60ms }
+
+  /* ── FULL-WIDTH PANEL ── */
+  .panel { background:var(--bg); border-bottom:1px solid var(--edge); padding:16px 20px 20px }
+  .panel-head { padding:4px 4px 14px; display:flex; align-items:baseline; gap:10px }
+  .panel-head .title { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); font-weight:500 }
+  .panel-head .meta { color:var(--dim); font-family:ui-monospace,monospace; font-size:12px }
+  .panel-grid { display:grid; grid-template-columns:1fr 280px; gap:16px }
+
+  .card { border-radius:10px; background:var(--panel);
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06); display:flex; flex-direction:column }
+
+  /* big guider graph */
+  .guider-card { padding:0 }
+  .guider-head { padding:12px 16px; display:flex; align-items:center; gap:10px;
+    border-bottom:1px solid var(--edge); flex-wrap:wrap }
+  .guider-head .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim) }
+  .guider-head .sub { font-family:ui-monospace,monospace; font-size:12px; color:var(--dim) }
+  .guider-head .gstats { display:flex; gap:14px; font-size:12px; margin-left:auto }
+  .gstat { display:flex; align-items:center; gap:5px; color:var(--dim) }
+  .gstat .d { width:7px; height:7px; border-radius:999px }
+  .gstat.ra .d { background:var(--ra) }
+  .gstat.dec .d { background:var(--dec) }
+  .gstat .v { font-family:ui-monospace,monospace; color:#fff; margin-left:2px }
+  .gstat.total { padding-left:12px; box-shadow:inset 1px 0 0 var(--edge); color:#fff }
+  .graph-body { padding:12px; height:240px }
+  .graph-body svg { display:block; width:100%; height:100% }
+
+  /* trend charts row */
+  .charts-row { margin-top:16px; display:grid; grid-template-columns:repeat(4,1fr); gap:16px }
+  .chart-card { padding:0 }
+  .chart-head { padding:10px 14px 4px; display:flex; align-items:baseline; gap:8px }
+  .chart-head .k { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim) }
+  .chart-head .v { font-family:ui-monospace,monospace; font-size:18px; font-weight:600; margin-left:auto }
+  .chart-head .v.warn { color:#fbbf24 } .chart-head .v.ok { color:#4ade80 }
+  .chart-head .d { font-size:11px; color:var(--dim) }
+  .chart-head .d.warn { color:#fbbf24 } .chart-head .d.ok { color:#4ade80 }
+  .chart-body { padding:0 12px 12px; height:90px }
+  .chart-body svg { display:block; width:100%; height:100% }
+
+  /* side column: equipment */
+  .equip { padding:14px 16px; flex:1 }
+  .equip h3 { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim); margin-bottom:10px }
+  .equip ul { list-style:none; display:flex; flex-direction:column; gap:8px }
+  .equip li { font-size:12px; display:flex; align-items:center; gap:8px }
+  .led { width:8px; height:8px; border-radius:999px; flex:none; display:inline-block }
+  .led.ok { background:#4ade80 } .led.warn { background:#fbbf24 } .led.bad { background:#f87171 }
+  .equip li .v { color:var(--dim); margin-left:auto; font-family:ui-monospace,monospace }
+  .stages { padding:14px 16px; border-top:1px solid var(--edge) }
+  .stages h3 { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--dim); margin-bottom:10px }
+  .stages ol { list-style:none; display:flex; flex-direction:column; gap:6px; font-size:12px }
+  .stages li { display:flex; align-items:center; gap:8px }
+  .stages .step { width:14px; height:14px; border-radius:999px; display:grid; place-items:center; font-size:8px; flex:none }
+  .stages .done { background:#22c55e; color:#02180a }
+  .stages .live { background:rgba(34,197,94,.2); box-shadow:inset 0 0 0 1px #4ade80 }
+  .stages .live span { width:5px; height:5px; border-radius:999px; background:#4ade80; animation:pulse 1.6s infinite }
+  .stages .pending { background:rgba(255,255,255,.05) }
+  .stages li.muted { color:var(--dim) }
+  .stages .right { margin-left:auto; font-family:ui-monospace,monospace; color:var(--dim); font-size:11px }
+
+  /* main stream content */
+  main { max-width:780px; margin:0 auto; padding:32px 20px; display:flex; flex-direction:column; gap:20px }
+
+  .hero { position:relative; border-radius:12px; background:var(--panel);
+    padding:20px; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .hero::before { content:''; position:absolute; top:0; left:0; right:0; height:1px;
+    background:linear-gradient(90deg,transparent,rgba(74,222,128,.6),transparent) }
+  .hero-row { display:flex; align-items:flex-start; gap:20px }
+  .ring { position:relative; width:96px; height:96px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid; place-items:center; text-align:center }
+  .ring .pct { font-size:20px; font-weight:600; font-family:ui-monospace,monospace }
+  .ring .cap { font-size:10px; text-transform:uppercase; color:var(--dim); letter-spacing:.06em }
+  .hero-body { flex:1; min-width:0 }
+  .hero-eyebrow { display:flex; align-items:center; gap:8px }
+  .hero-eyebrow .label { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:#4ade80 }
+  .hero-eyebrow .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .hero h1 { font-size:20px; font-weight:600; line-height:1.2; margin-top:4px }
+  .hero .sub { font-size:13px; color:var(--dim); margin-top:2px }
+  .chips { margin-top:12px; display:flex; flex-wrap:wrap; gap:6px; font-size:11px }
+  .chip { padding:2px 8px; border-radius:4px; background:rgba(34,197,94,.1); color:#4ade80;
+    box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .chip.live { background:rgba(34,197,94,.18); color:#86efac;
+    box-shadow:inset 0 0 0 1px rgba(74,222,128,.4) }
+  .chip.muted { background:rgba(255,255,255,.05); color:var(--dim);
+    box-shadow:inset 0 0 0 1px var(--edge) }
+  .hero-buttons { display:flex; flex-direction:column; gap:6px; flex:none }
+  .btn { font-size:12px; padding:5px 10px; border-radius:6px;
+    background:rgba(255,255,255,.05); box-shadow:inset 0 0 0 1px var(--edge) }
+  .btn:hover { background:rgba(255,255,255,.1) }
+  .btn.danger { background:rgba(239,68,68,.15); color:#fca5a5;
+    box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+
+  .frame-card { border-radius:12px; background:var(--panel); overflow:hidden;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .frame-head { height:44px; padding:0 20px; display:flex; align-items:center;
+    justify-content:space-between; border-bottom:1px solid var(--edge); font-size:13px }
+  .frame-head .left { display:flex; align-items:center; gap:8px }
+  .frame-head .meta { color:var(--dim); font-size:12px; font-family:ui-monospace,monospace }
+  .frame-head .right { color:var(--dim); font-size:12px }
+  .frame-image { background:#000; position:relative; aspect-ratio:16/9 }
+  .frame-image svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-image .ovl { position:absolute; bottom:12px; left:12px;
+    font-family:ui-monospace,monospace; font-size:11px;
+    color:rgba(255,255,255,.7); background:rgba(0,0,0,.5);
+    padding:4px 8px; border-radius:4px }
+
+  .past h2 { font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    color:var(--dim); display:flex; justify-content:space-between; align-items:flex-end;
+    margin-bottom:12px }
+  .past h2 .meta { font-family:ui-monospace,monospace; font-size:11px }
+  .timeline { position:relative; padding-left:28px; display:flex; flex-direction:column; gap:12px }
+  .timeline::before { content:''; position:absolute; left:11px; top:0; bottom:0;
+    width:1px; background:var(--edge) }
+  .tl-item { border-radius:10px; background:var(--panel); position:relative;
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.06) }
+  .dot { position:absolute; left:-21px; top:14px; width:8px; height:8px;
+    border-radius:999px; background:var(--dim); box-shadow:0 0 0 4px var(--bg) }
+  .dot.warn { background:#f59e0b } .dot.bad { background:#ef4444 }
+  details.tl-item > summary { list-style:none; cursor:pointer }
+  details.tl-item > summary::-webkit-details-marker { display:none }
+  details.tl-item[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .15s; color:var(--dim); display:inline-block; width:12px }
+  .tl-summary { padding:12px 16px; display:flex; align-items:center; gap:12px }
+  .tl-summary .body { flex:1; min-width:0 }
+  .tl-summary .title-row { display:flex; align-items:baseline; gap:8px }
+  .tl-summary .name { font-weight:500 }
+  .tl-summary .when { font-size:12px; color:var(--dim); font-family:ui-monospace,monospace }
+  .tl-summary .desc { font-size:12px; color:var(--dim); margin-top:2px }
+  .tl-pill { font-size:11px; padding:2px 6px; border-radius:4px; flex:none }
+  .tl-pill.ok { background:rgba(34,197,94,.15); color:#4ade80; box-shadow:inset 0 0 0 1px rgba(34,197,94,.3) }
+  .tl-pill.warn { background:rgba(245,158,11,.15); color:#fbbf24; box-shadow:inset 0 0 0 1px rgba(245,158,11,.3) }
+  .tl-pill.bad { background:rgba(239,68,68,.15); color:#fca5a5; box-shadow:inset 0 0 0 1px rgba(239,68,68,.3) }
+  .led-strip { width:8px; height:8px; border-radius:999px; display:inline-block }
+  .led-strip.ok { background:#4ade80 }
+
+  /* ── night-vision toggle ─────────────────────────────────── */
+  .night-toggle { display:flex; align-items:center; gap:8px;
+    padding:5px 10px; border-radius:6px; box-shadow:inset 0 0 0 1px var(--edge);
+    font-size:12px; color:var(--dim); cursor:pointer; user-select:none;
+    transition: color .15s, background .15s }
+  .night-toggle:hover { color:#fff; background:rgba(255,255,255,.05) }
+  .night-toggle .nv-icon { font-size:13px; line-height:1; opacity:.75 }
+  .night-toggle .nv-dot { width:8px; height:8px; border-radius:999px;
+    background:#3a3a3f; box-shadow:inset 0 0 0 1px #4a4a52; transition: background .15s, box-shadow .15s }
+  .night-toggle:has(input:checked) { color:#fff }
+  .night-toggle:has(input:checked) .nv-icon { opacity:1 }
+  .night-toggle:has(input:checked) .nv-dot { background:#fff;
+    box-shadow:0 0 8px 1px rgba(255,255,255,.6) }
+
+  /* ── night-vision mode ───────────────────────────────────── */
+  /* Single page-level filter: grayscale → sepia → rotate hue toward red →
+     saturate → dim. Astrophotos go B&W (no color of their own); all UI
+     accents collapse to red shades. Preserves dark adaptation. */
+  body:has(#night-vision:checked) {
+    filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7);
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="brand"><div class="logo"></div><span>rusty&nbsp;photon</span></div>
+  <div class="nav-tabs"><a class="active">Activity</a><a>Equipment</a><a>Plans</a><a>Logs</a><a>Settings</a></div>
+  <div class="grow"></div>
+  <label class="night-toggle" title="Toggle red night-vision mode">
+    <input type="checkbox" id="night-vision" hidden>
+    <span class="nv-icon">☾</span>
+    <span class="nv-lbl">Night vision</span>
+    <span class="nv-dot"></span>
+  </label>
+  <div class="avatar">IV</div>
+</nav>
+
+<!-- FOLDABLE LIVE — checkbox+label pattern so the CSS Grid 0fr→1fr animation works in every modern browser -->
+<input type="checkbox" id="fold-state" class="fold-state" hidden>
+<label for="fold-state" class="fold-strip">
+    <span class="strip-pulse"></span>
+    <span class="strip-label">M51 · L · 300s</span>
+    <span class="sep">│</span>
+    <div class="stat">
+      <span class="ra">RA</span>
+      <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+        <line x1="0" y1="12" x2="200" y2="12" stroke="#27272a" stroke-width=".5"/>
+        <path fill="none" stroke="#f87171" stroke-width="1"
+              d="M0,12 L10,10 L20,14 L30,9 L40,15 L50,11 L60,16 L70,8 L80,11 L90,15 L100,9 L110,17 L120,11 L130,10 L140,16 L150,7 L160,14 L170,11 L180,17 L190,9 L200,12"/>
+      </svg>
+      <span class="v">0.42″</span>
+    </div>
+    <div class="stat">
+      <span class="dec">Dec</span>
+      <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+        <line x1="0" y1="12" x2="200" y2="12" stroke="#27272a" stroke-width=".5"/>
+        <path fill="none" stroke="#60a5fa" stroke-width="1"
+              d="M0,12 L10,11 L20,15 L30,8 L40,14 L50,10 L60,15 L70,12 L80,8 L90,16 L100,10 L110,14 L120,7 L130,15 L140,9 L150,12 L160,17 L170,10 L180,14 L190,9 L200,12"/>
+      </svg>
+      <span class="v">0.51″</span>
+    </div>
+    <span class="sep">│</span>
+    <div class="stat">HFR <span class="v warn">1.84″</span></div>
+    <div class="stat">CCD <span class="v ok">−10.0°</span></div>
+    <div class="stat">Sky <span class="v warn">20.8</span></div>
+    <span class="grow"></span>
+    <div class="stat mono">finish 01:42</div>
+    <span class="fold-toggle"><span class="lbl"></span><span class="chev">▾</span></span>
+</label>
+
+<div class="fold-body">
+  <div class="panel">
+    <div class="panel-head">
+      <span class="title">Live telemetry</span>
+      <span class="meta">streaming · 21:18:47 · last 5 minutes</span>
+    </div>
+
+    <div class="panel-grid">
+
+      <!-- main column: guider graph + 4 trend charts -->
+      <div>
+        <section class="card guider-card">
+          <div class="guider-head">
+            <span class="label">Guider</span>
+            <span class="sub">RA / Dec error · arcseconds · last 5 minutes</span>
+            <div class="gstats">
+              <span class="gstat ra"><span class="d"></span>RA <span class="v">0.42″</span></span>
+              <span class="gstat dec"><span class="d"></span>Dec <span class="v">0.51″</span></span>
+              <span class="gstat total">Total RMS <span class="v">0.66″</span></span>
+            </div>
+          </div>
+          <div class="graph-body">
+            <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+              <!-- ±1.0″ band -->
+              <rect x="0" y="60" width="600" height="120" fill="#22c55e" fill-opacity=".05"/>
+              <!-- ±0.5″ band -->
+              <rect x="0" y="90" width="600" height="60"  fill="#22c55e" fill-opacity=".06"/>
+              <!-- center + refs -->
+              <line x1="0" y1="120" x2="600" y2="120" stroke="#27272a" stroke-width="1"/>
+              <line x1="0" y1="60"  x2="600" y2="60"  stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+              <line x1="0" y1="180" x2="600" y2="180" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+              <line x1="0" y1="90"  x2="600" y2="90"  stroke="#27272a" stroke-width=".5" stroke-dasharray="1,4"/>
+              <line x1="0" y1="150" x2="600" y2="150" stroke="#27272a" stroke-width=".5" stroke-dasharray="1,4"/>
+              <text x="6" y="20"  fill="#52525b" font-size="10" font-family="ui-monospace,monospace">arcsec</text>
+              <text x="6" y="64"  fill="#52525b" font-size="10" font-family="ui-monospace,monospace">+1.0</text>
+              <text x="6" y="94"  fill="#3f3f46" font-size="10" font-family="ui-monospace,monospace">+0.5</text>
+              <text x="6" y="124" fill="#52525b" font-size="10" font-family="ui-monospace,monospace">0</text>
+              <text x="6" y="154" fill="#3f3f46" font-size="10" font-family="ui-monospace,monospace">−0.5</text>
+              <text x="6" y="184" fill="#52525b" font-size="10" font-family="ui-monospace,monospace">−1.0</text>
+              <!-- x-axis time markers -->
+              <text x="100" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−4m</text>
+              <text x="200" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−3m</text>
+              <text x="300" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−2m</text>
+              <text x="400" y="234" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−1m</text>
+              <text x="595" y="234" fill="#52525b" font-size="9" font-family="ui-monospace,monospace" text-anchor="end">now</text>
+              <!-- Dec -->
+              <path fill="none" stroke="#60a5fa" stroke-width="1.3" stroke-linejoin="round"
+                    d="M0,120 L10,115 L20,129 L30,102 L40,124 L50,107 L60,129 L70,115 L80,102 L90,134 L100,111 L110,124 L120,98 L130,129 L140,107 L150,115 L160,138 L170,111 L180,124 L190,107 L200,115 L210,129 L220,102 L230,111 L240,124 L250,107 L260,142 L270,115 L280,102 L290,129 L300,107 L310,115 L320,124 L330,98 L340,134 L350,111 L360,102 L370,124 L380,107 L390,111 L400,134 L410,115 L420,102 L430,129 L440,107 L450,115 L460,138 L470,111 L480,107 L490,124 L500,102 L510,111 L520,129 L530,98 L540,124 L550,107 L560,115 L570,134 L580,102 L590,111"/>
+              <!-- RA -->
+              <path fill="none" stroke="#f87171" stroke-width="1.3" stroke-linejoin="round"
+                    d="M0,120 L10,111 L20,124 L30,107 L40,129 L50,115 L60,134 L70,102 L80,115 L90,129 L100,107 L110,138 L120,115 L130,111 L140,134 L150,98 L160,124 L170,111 L180,138 L190,107 L200,115 L210,129 L220,102 L230,134 L240,111 L250,124 L260,107 L270,142 L280,111 L290,115 L300,134 L310,102 L320,129 L330,115 L340,107 L350,129 L360,102 L370,124 L380,111 L390,134 L400,115 L410,98 L420,129 L430,107 L440,124 L450,111 L460,138 L470,115 L480,107 L490,129 L500,102 L510,124 L520,111 L530,107 L540,124 L550,98 L560,134 L570,111 L580,124 L590,102"/>
+              <!-- now indicator -->
+              <line x1="595" y1="0" x2="595" y2="220" stroke="#4ade80" stroke-width="1" stroke-opacity=".7"/>
+              <circle cx="595" cy="102" r="2.2" fill="#f87171"/>
+              <circle cx="595" cy="111" r="2.2" fill="#60a5fa"/>
+            </svg>
+          </div>
+        </section>
+
+        <div class="charts-row">
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Focus HFR</span>
+              <span class="d warn">↑ 0.06 / 30m</span>
+              <span class="v warn">1.84″</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+                <line x1="0" y1="45" x2="200" y2="45" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+                <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">2.4″</text>
+                <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">1.4″</text>
+                <path fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linejoin="round"
+                      d="M0,55 L11,53 L22,51 L33,49 L44,47 L55,45 L66,43 L77,40 L88,36 L99,33 L110,29
+                         M110,29 L121,67 L132,65 L143,63 L154,59 L165,57 L176,53 L187,51 L200,49"/>
+                <circle cx="200" cy="49" r="2.5" fill="#a78bfa"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">CCD temp</span>
+              <span class="d ok">on target</span>
+              <span class="v ok">−10.0°</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+                <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">−9.5°</text>
+                <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">−10.5°</text>
+                <line x1="0" y1="45" x2="200" y2="45" stroke="#27272a" stroke-width=".5" stroke-dasharray="2,3"/>
+                <path fill="none" stroke="#4ade80" stroke-width="1.5"
+                      d="M0,45 L11,45 L22,43 L33,45 L44,47 L55,45 L66,45 L77,43 L88,45 L99,45 L110,47 L121,45 L132,45 L143,43 L154,45 L165,47 L176,45 L187,45 L200,45"/>
+                <circle cx="200" cy="45" r="2.5" fill="#4ade80"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Sky brightness</span>
+              <span class="d warn">−0.6 / 1h</span>
+              <span class="v warn">20.8</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+                <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">21.5</text>
+                <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">20.5</text>
+                <path fill="none" stroke="#fbbf24" stroke-width="1.5"
+                      d="M0,16 L11,16 L22,24 L33,24 L44,24 L55,32 L66,32 L77,32 L88,40 L99,40 L110,48 L121,48 L132,55 L143,55 L154,55 L165,63 L176,63 L187,63 L200,63"/>
+                <circle cx="200" cy="63" r="2.5" fill="#fbbf24"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Dew margin</span>
+              <span class="d warn">↓ 3.4 / 1h</span>
+              <span class="v warn">4.8°</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 90" preserveAspectRatio="none">
+                <text x="2" y="14" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">10°</text>
+                <text x="2" y="84" fill="#3f3f46" font-size="9" font-family="ui-monospace,monospace">0°</text>
+                <line x1="0" y1="80" x2="200" y2="80" stroke="#ef4444" stroke-width=".5" stroke-dasharray="2,3"/>
+                <text x="198" y="78" fill="#7f1d1d" font-size="8" font-family="ui-monospace,monospace" text-anchor="end">dew point</text>
+                <path fill="none" stroke="#fbbf24" stroke-width="1.5"
+                      d="M0,18 L11,21 L22,22 L33,22 L44,25 L55,25 L66,29 L77,32 L88,36 L99,40 L110,43 L121,47 L132,50 L143,54 L154,58 L165,61 L176,65 L187,65 L200,68"/>
+                <circle cx="200" cy="68" r="2.5" fill="#fbbf24"/>
+              </svg>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <!-- side column: equipment + stage list -->
+      <div class="card">
+        <div class="equip">
+          <h3>Equipment</h3>
+          <ul>
+            <li><span class="led ok"></span>Camera <span class="v">−10.0°C</span></li>
+            <li><span class="led ok"></span>Mount <span class="v">RMS 0.62″</span></li>
+            <li><span class="led ok"></span>Focuser <span class="v">14,820 · 22.4°C</span></li>
+            <li><span class="led ok"></span>Guider <span class="v">snr 32 · 2.1 px</span></li>
+            <li><span class="led warn"></span>Sky <span class="v">18% clouds ↑</span></li>
+            <li><span class="led warn"></span>Dew margin <span class="v">4.8°</span></li>
+          </ul>
+        </div>
+        <div class="stages">
+          <h3>Tonight's plan</h3>
+          <ol>
+            <li><span class="step done">✓</span> Slew & solve <span class="right">2m 04s</span></li>
+            <li><span class="step done">✓</span> Auto-focus <span class="right">3m 11s</span></li>
+            <li><span class="step done">✓</span> PHD2 calibrate <span class="right">1m 47s</span></li>
+            <li><span class="step live"><span></span></span> <strong>L · 300s × 10</strong> <span class="right" style="color:#fff">4 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> R · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> G · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> B · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> Park & shutdown</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<main>
+
+  <article class="hero">
+    <div class="hero-row">
+      <div class="ring">
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#1c1c22" stroke-width="8"/>
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#22c55e" stroke-width="8"
+                  stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+        </svg>
+        <div class="center"><div><div class="pct">42%</div><div class="cap">done</div></div></div>
+      </div>
+      <div class="hero-body">
+        <div class="hero-eyebrow">
+          <span class="label">Capturing now</span>
+          <span class="meta">started 21:18 · 26m 14s remaining · finishes 01:42 local</span>
+        </div>
+        <h1>M51 — Whirlpool · Luminance · 300s</h1>
+        <div class="sub">Frame 4 of 10 in this filter · 30 of 40 across L R G B</div>
+        <div class="chips">
+          <span class="chip">✓ slew</span><span class="chip">✓ focus</span><span class="chip">✓ guide</span>
+          <span class="chip live">● capturing L</span>
+          <span class="chip muted">R</span><span class="chip muted">G</span><span class="chip muted">B</span><span class="chip muted">park</span>
+        </div>
+      </div>
+      <div class="hero-buttons">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+  </article>
+
+  <article class="frame-card">
+    <div class="frame-head">
+      <div class="left">
+        <span class="led-strip ok"></span>
+        <span style="font-weight:500">Latest frame just landed</span>
+        <span class="meta">0042 · L · 300s · 21:18:04</span>
+      </div>
+      <div class="right"><button>open</button> · <button>download</button></div>
+    </div>
+    <div class="frame-image">
+      <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <radialGradient id="neb7" cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+            <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+          </radialGradient>
+          <radialGradient id="core7" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+            <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+            <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="800" height="450" fill="#03050b"/>
+        <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb7)"/>
+        <g transform="translate(400 225) rotate(-22)">
+          <ellipse rx="60" ry="40" fill="url(#core7)"/>
+          <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+        </g>
+        <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+        <g fill="#fff">
+          <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+          <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+          <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+          <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+          <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+          <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+          <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+          <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+        </g>
+      </svg>
+      <div class="ovl">HFR 1.84″ · Stars 2,941 · ADU 1,247 · Ecc 0.41</div>
+    </div>
+  </article>
+
+  <section class="past">
+    <h2><span>Past sessions</span><span class="meta">last 30 days · 12 sessions</span></h2>
+    <div class="timeline">
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">M101 — Pinwheel</span>
+              <span class="when">last night · 22:14 → 03:48</span></div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot warn"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">NGC 7000 — North America</span>
+              <span class="when">3 days ago · 21:48 → 02:11</span></div>
+            <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted · clouds</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">M31 — Andromeda</span>
+              <span class="when">a week ago · 20:31 → 04:02</span></div>
+            <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot bad"></span><span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row"><span class="name">IC 1396 — Elephant's Trunk</span>
+              <span class="when">12 days ago · 22:02 → 23:00</span></div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed · guide loss</span>
+        </summary>
+      </details>
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/8-plugin-polish.html
+++ b/docs/plans/ui-design/mocks/8-plugin-polish.html
@@ -1,0 +1,890 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>rp — observatory instrument panel</title>
+<style>
+  /* ── design tokens ────────────────────────────────────────────────── */
+  :root {
+    /* warm dark palette — observatory instrument, not blue slate */
+    --bg:           #0b0907;
+    --bg-deep:      #050403;
+    --surface:      #14110d;
+    --surface-2:    #1c1813;
+    --edge:         #2a241c;
+    --edge-soft:    #1f1c16;
+    --edge-strong:  #3d3528;
+
+    --text:         #f4ede0;
+    --text-soft:    #c8bfae;
+    --dim:          #8a8071;
+    --dim-soft:     #5c5447;
+
+    /* accents — one cyan-green for "live", warm amber + coral for warn/bad */
+    --live:         #80e6c4;   /* retro cyan-green */
+    --live-glow:    rgba(128, 230, 196, .55);
+    --warn:         #e8a85c;   /* refined amber */
+    --bad:          #e0775c;   /* warm coral */
+    --armed:        #d68d3a;   /* deeper amber for the top bar */
+
+    --ra:           #ff8a6a;
+    --dec:          #88c0e0;
+    --hfr:          #c89cea;
+
+    /* spacing scale (4px base) */
+    --s-1: 4px; --s-2: 8px; --s-3: 12px; --s-4: 16px;
+    --s-5: 20px; --s-6: 24px; --s-8: 32px; --s-10: 40px;
+
+    /* type scale */
+    --fs-xs: 10.5px;
+    --fs-sm: 12px;
+    --fs-base: 13.5px;
+    --fs-md: 15px;
+    --fs-lg: 17px;
+    --fs-xl: 22px;
+    --fs-2xl: 32px;
+
+    /* fonts — system distinctive */
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino,
+             "URW Palladio L", "Book Antiqua", Georgia, serif;
+    --sans:  ui-sans-serif, -apple-system, "Helvetica Neue",
+             "Segoe UI", Tahoma, sans-serif;
+    --mono:  ui-monospace, "SF Mono", "Cascadia Code", Menlo,
+             Consolas, monospace;
+  }
+
+  /* ── reset ────────────────────────────────────────────────────────── */
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--text);
+    font-family:var(--sans); font-size:var(--fs-base); line-height:1.45;
+    font-feature-settings:"ss01","cv11"; -webkit-font-smoothing:antialiased }
+  button, a, label { font:inherit; color:inherit; background:none;
+    border:0; cursor:pointer; text-decoration:none }
+  input { font:inherit; color:inherit }
+  ol,ul { list-style:none }
+
+  .mono { font-family:var(--mono); font-feature-settings:"tnum","zero" }
+  .serif { font-family:var(--serif); letter-spacing:-0.005em }
+
+  /* ── grain overlay (subtle film grain over the whole page) ─────── */
+  .grain { position:fixed; inset:0; pointer-events:none; z-index:1000;
+    opacity:.5; mix-blend-mode:overlay }
+
+  /* ── armed bar (signals "session live" — top 2px of page) ───────── */
+  .armed-bar { position:sticky; top:0; z-index:40; height:2px;
+    background:linear-gradient(90deg,
+      transparent 0%, var(--armed) 8%, var(--armed) 92%, transparent 100%);
+    box-shadow:0 0 12px 0 rgba(214,141,58,.5) }
+
+  /* ── nav ──────────────────────────────────────────────────────────── */
+  nav { height:54px; padding:0 var(--s-6);
+    display:flex; align-items:center; gap:var(--s-5);
+    background:var(--bg);
+    border-bottom:1px solid var(--edge);
+    position:sticky; top:2px; z-index:30 }
+
+  .brand { display:flex; align-items:baseline; gap:10px }
+  .brand-mark {
+    width:22px; height:22px; border-radius:50%;
+    background:radial-gradient(circle at 35% 30%, #f5e7c8 0%, #d68d3a 30%, #6e3a18 70%, #1c0e06 100%);
+    box-shadow:0 0 0 1px rgba(214,141,58,.3), 0 0 14px rgba(214,141,58,.15);
+    align-self:center;
+  }
+  .brand-name {
+    font-family:var(--serif); font-size:18px; font-weight:600;
+    letter-spacing:-0.015em;
+  }
+  .brand-name em { font-style:italic; color:var(--text-soft); font-weight:400 }
+
+  .nav-tabs { display:flex; gap:2px; margin-left:var(--s-3); font-size:var(--fs-sm) }
+  .nav-tabs a { padding:7px 12px; border-radius:3px; color:var(--dim);
+    transition:color .15s, background .15s }
+  .nav-tabs a:hover { color:var(--text) }
+  .nav-tabs a.active { color:var(--text); background:rgba(255,255,255,.04);
+    box-shadow:inset 0 -1px 0 var(--text) }
+
+  .grow { flex:1 }
+
+  /* night-vision toggle */
+  .night-toggle { display:flex; align-items:center; gap:var(--s-2);
+    padding:6px 12px; font-size:var(--fs-sm); color:var(--dim);
+    border:1px solid var(--edge); border-radius:3px;
+    user-select:none; cursor:pointer; transition:color .15s, border-color .15s }
+  .night-toggle:hover { color:var(--text); border-color:var(--edge-strong) }
+  .night-toggle .nv-icon { font-size:14px; line-height:1; opacity:.75 }
+  .night-toggle .nv-dot { width:7px; height:7px; border-radius:50%;
+    background:#3a3328; box-shadow:inset 0 0 0 1px #4a4234 }
+  .night-toggle:has(input:checked) { color:var(--text); border-color:var(--text) }
+  .night-toggle:has(input:checked) .nv-icon { opacity:1 }
+  .night-toggle:has(input:checked) .nv-dot {
+    background:#fff; box-shadow:0 0 8px 1px rgba(255,255,255,.6) }
+
+  .avatar { width:30px; height:30px; border-radius:50%;
+    background:#3a2818; color:var(--text-soft);
+    display:grid; place-items:center;
+    font-family:var(--serif); font-size:13px; font-weight:600;
+    letter-spacing:0.02em; border:1px solid var(--edge-strong) }
+
+  /* ── live telemetry strip (always visible, sticky) ────────────── */
+  .fold-state { display:none }
+
+  .fold-strip {
+    position:sticky; top:56px; z-index:20;
+    background:var(--bg);
+    border-bottom:1px solid var(--edge);
+    height:46px; padding:0 var(--s-6);
+    display:flex; align-items:center; gap:var(--s-5);
+    font-size:var(--fs-sm); cursor:pointer;
+    transition:background .2s }
+  .fold-strip::after { content:""; position:absolute; left:0; right:0; bottom:-1px;
+    height:1px; background:linear-gradient(90deg,
+      transparent, var(--live-glow) 50%, transparent); opacity:.4 }
+  .fold-strip:hover { background:var(--surface) }
+
+  .strip-pulse { width:8px; height:8px; border-radius:50%;
+    background:var(--live);
+    box-shadow:0 0 0 2px rgba(128,230,196,.18), 0 0 14px var(--live-glow);
+    animation:heartbeat 1.6s ease-in-out infinite; flex:none }
+  @keyframes heartbeat {
+    0%, 100% { transform:scale(1); box-shadow:0 0 0 2px rgba(128,230,196,.18), 0 0 14px var(--live-glow) }
+    50%      { transform:scale(1.15); box-shadow:0 0 0 3px rgba(128,230,196,.25), 0 0 22px var(--live-glow) }
+  }
+
+  .strip-target { font-family:var(--serif); font-size:14px; font-weight:600;
+    letter-spacing:-0.005em; color:var(--text) }
+  .strip-target em { color:var(--dim); font-style:normal;
+    font-family:var(--mono); font-size:var(--fs-sm); margin-left:6px;
+    font-weight:400 }
+
+  .sep { width:1px; height:14px; background:var(--edge-strong); flex:none }
+
+  .stat { display:flex; align-items:center; gap:6px; color:var(--dim);
+    font-size:var(--fs-sm) }
+  .stat .lbl-ra  { color:var(--ra);  font-weight:500; letter-spacing:0.02em }
+  .stat .lbl-dec { color:var(--dec); font-weight:500; letter-spacing:0.02em }
+  .stat .v { color:var(--text); font-family:var(--mono); font-size:12px }
+  .stat .v.warn { color:var(--warn) }
+  .stat .v.live { color:var(--live) }
+
+  .mini { width:78px; height:22px; flex:none }
+
+  .strip-eta { color:var(--dim); font-family:var(--mono); font-size:var(--fs-sm) }
+  .strip-eta b { color:var(--text); font-weight:500 }
+
+  .fold-toggle { display:flex; align-items:center; gap:6px;
+    padding:5px 10px; border:1px solid var(--edge);
+    border-radius:3px; font-size:var(--fs-xs); color:var(--dim);
+    text-transform:uppercase; letter-spacing:0.08em;
+    transition:color .15s, border-color .15s }
+  .fold-toggle:hover { color:var(--text); border-color:var(--edge-strong) }
+  .fold-toggle .chev { display:inline-block;
+    transition:transform 360ms cubic-bezier(.4,0,.2,1); line-height:1 }
+  .fold-state:checked ~ .fold-strip .fold-toggle .chev { transform:rotate(180deg) }
+  .fold-state:checked ~ .fold-strip .fold-toggle .lbl::before { content:"Collapse" }
+  .fold-state:not(:checked) ~ .fold-strip .fold-toggle .lbl::before { content:"Expand" }
+
+  /* ── fold panel (animated full-width drop-down) ──────────────────── */
+  .fold-body {
+    display:grid; grid-template-rows:0fr;
+    transition:grid-template-rows 360ms cubic-bezier(.4,0,.2,1) }
+  .fold-body > .panel {
+    min-height:0; overflow:hidden; opacity:0;
+    transition:opacity 240ms ease }
+  .fold-state:checked ~ .fold-body { grid-template-rows:1fr }
+  .fold-state:checked ~ .fold-body > .panel {
+    opacity:1; transition-delay:80ms }
+
+  .panel { background:var(--bg);
+    border-bottom:1px solid var(--edge);
+    padding:var(--s-5) var(--s-6) var(--s-6) }
+  .panel-head { padding:0 0 var(--s-4); display:flex;
+    align-items:baseline; gap:var(--s-3) }
+  .panel-head .num { font-family:var(--serif); font-size:11px;
+    font-style:italic; color:var(--dim); margin-right:6px }
+  .panel-head .title { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.16em; color:var(--text-soft); font-weight:500 }
+  .panel-head .meta { color:var(--dim); font-family:var(--mono);
+    font-size:var(--fs-sm) }
+  .panel-head .rule { flex:1; height:1px; background:var(--edge);
+    margin-left:var(--s-3); align-self:center }
+
+  .panel-grid { display:grid; grid-template-columns:1fr 296px;
+    gap:var(--s-4) }
+
+  /* ── card primitive (with reticle corners) ──────────────────────── */
+  .card { background:var(--surface);
+    border:1px solid var(--edge);
+    position:relative;
+    display:flex; flex-direction:column }
+  .card::before, .card::after {
+    content:""; position:absolute; width:8px; height:8px;
+    border-color:var(--edge-strong); pointer-events:none }
+  .card::before { top:-1px; left:-1px;
+    border-top:1px solid; border-left:1px solid;
+    border-top-color:var(--text-soft); border-left-color:var(--text-soft);
+    opacity:.35 }
+  .card::after { bottom:-1px; right:-1px;
+    border-bottom:1px solid; border-right:1px solid;
+    border-bottom-color:var(--text-soft); border-right-color:var(--text-soft);
+    opacity:.35 }
+
+  /* ── guider card ─────────────────────────────────────────────────── */
+  .guider-head { padding:var(--s-3) var(--s-4); display:flex;
+    align-items:center; gap:var(--s-3); flex-wrap:wrap;
+    border-bottom:1px solid var(--edge) }
+  .guider-head .label { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.14em; color:var(--text-soft); font-weight:500 }
+  .guider-head .sub { font-family:var(--mono); font-size:var(--fs-sm);
+    color:var(--dim) }
+  .guider-head .gstats { display:flex; gap:var(--s-4); margin-left:auto;
+    font-size:var(--fs-sm); color:var(--dim) }
+  .gstat { display:flex; align-items:baseline; gap:6px }
+  .gstat .swatch { width:14px; height:2px; align-self:center }
+  .gstat.ra .swatch { background:var(--ra) }
+  .gstat.dec .swatch { background:var(--dec) }
+  .gstat .v { font-family:var(--mono); color:var(--text);
+    font-size:13px; font-weight:500 }
+  .gstat.total { padding-left:var(--s-4); border-left:1px solid var(--edge);
+    color:var(--text) }
+  .gstat.total .v { color:var(--live); font-size:14px }
+
+  .graph-body { padding:var(--s-3); height:248px }
+  .graph-body svg { display:block; width:100%; height:100% }
+
+  /* ── trend chart row ─────────────────────────────────────────────── */
+  .charts-row { margin-top:var(--s-4); display:grid;
+    grid-template-columns:repeat(4,1fr); gap:var(--s-4) }
+  .chart-card { padding:0 }
+  .chart-head { padding:var(--s-3) var(--s-4) 4px; display:flex;
+    align-items:baseline; gap:var(--s-2) }
+  .chart-head .k { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.12em; color:var(--text-soft); font-weight:500 }
+  .chart-head .v { font-family:var(--mono); font-size:var(--fs-lg);
+    font-weight:500; margin-left:auto; color:var(--text) }
+  .chart-head .v.warn { color:var(--warn) }
+  .chart-head .v.live { color:var(--live) }
+  .chart-head .d { font-family:var(--mono); font-size:var(--fs-xs);
+    color:var(--dim) }
+  .chart-head .d.warn { color:var(--warn) }
+  .chart-head .d.live { color:var(--live) }
+  .chart-body { padding:0 var(--s-3) var(--s-3); height:88px }
+  .chart-body svg { display:block; width:100%; height:100% }
+
+  /* ── side column: equipment + stages ─────────────────────────────── */
+  .side-card { display:flex; flex-direction:column }
+  .side-section { padding:var(--s-4) }
+  .side-section + .side-section { border-top:1px solid var(--edge) }
+  .side-section h3 { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.14em; color:var(--text-soft); font-weight:500;
+    margin-bottom:var(--s-3); display:flex; align-items:center; gap:8px }
+  .side-section h3::after { content:""; flex:1; height:1px; background:var(--edge) }
+
+  .equip-list { display:flex; flex-direction:column; gap:var(--s-2) }
+  .equip-list li { display:flex; align-items:center; gap:var(--s-2);
+    font-size:var(--fs-sm) }
+  .led { width:8px; height:8px; border-radius:50%; flex:none;
+    box-shadow:inset 0 0 0 1px rgba(0,0,0,.3) }
+  .led.live { background:var(--live); box-shadow:0 0 6px var(--live-glow) }
+  .led.warn { background:var(--warn) }
+  .led.bad  { background:var(--bad) }
+  .equip-list li .v { color:var(--dim); margin-left:auto;
+    font-family:var(--mono); font-size:var(--fs-xs) }
+
+  .stages-list { display:flex; flex-direction:column; gap:8px;
+    font-size:var(--fs-sm) }
+  .stages-list li { display:flex; align-items:center; gap:var(--s-2) }
+  .stages-list .step { width:14px; height:14px; flex:none;
+    display:grid; place-items:center; font-size:8px; border-radius:50% }
+  .stages-list .step.done { background:var(--live); color:#0a0907 }
+  .stages-list .step.live { background:transparent;
+    border:1px solid var(--live); position:relative }
+  .stages-list .step.live::after { content:""; position:absolute;
+    inset:3px; border-radius:50%; background:var(--live);
+    animation:heartbeat 1.6s ease-in-out infinite }
+  .stages-list .step.pending { background:transparent;
+    border:1px dashed var(--edge-strong) }
+  .stages-list li.muted { color:var(--dim) }
+  .stages-list .right { margin-left:auto; font-family:var(--mono);
+    font-size:var(--fs-xs); color:var(--dim) }
+  .stages-list strong { font-weight:500; color:var(--text) }
+
+  /* ── main stream content ─────────────────────────────────────────── */
+  main { max-width:840px; margin:0 auto;
+    padding:var(--s-10) var(--s-6) var(--s-10);
+    display:flex; flex-direction:column; gap:var(--s-6) }
+
+  /* section markers (editorial numbering) */
+  .section-marker { display:flex; align-items:baseline; gap:var(--s-3);
+    margin-bottom:var(--s-3) }
+  .section-marker .num { font-family:var(--serif); font-style:italic;
+    font-size:11px; color:var(--dim); font-weight:400 }
+  .section-marker .label { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.16em; color:var(--text-soft); font-weight:500 }
+  .section-marker .meta { font-family:var(--mono); font-size:var(--fs-xs);
+    color:var(--dim); margin-left:auto }
+  .section-marker .rule { flex:1; height:1px; background:var(--edge);
+    align-self:center }
+
+  /* hero card */
+  .hero { background:var(--surface);
+    border:1px solid var(--edge);
+    padding:var(--s-6); position:relative }
+  .hero::before, .hero::after {
+    content:""; position:absolute; width:10px; height:10px;
+    border-color:var(--text-soft); pointer-events:none; opacity:.35 }
+  .hero::before { top:-1px; left:-1px;
+    border-top:1px solid; border-left:1px solid }
+  .hero::after { bottom:-1px; right:-1px;
+    border-bottom:1px solid; border-right:1px solid }
+
+  .hero-row { display:flex; align-items:flex-start; gap:var(--s-6) }
+
+  .ring { position:relative; width:96px; height:96px; flex:none }
+  .ring svg { width:100%; height:100%; transform:rotate(-90deg) }
+  .ring .center { position:absolute; inset:0; display:grid;
+    place-items:center; text-align:center }
+  .ring .pct { font-family:var(--serif); font-size:24px; font-weight:600;
+    color:var(--text); letter-spacing:-0.02em }
+  .ring .cap { font-size:9px; text-transform:uppercase;
+    color:var(--dim); letter-spacing:0.18em; margin-top:1px }
+
+  .hero-body { flex:1; min-width:0 }
+  .hero-eyebrow { display:flex; align-items:center; gap:var(--s-2) }
+  .hero-eyebrow .label { font-size:var(--fs-xs); text-transform:uppercase;
+    letter-spacing:0.14em; color:var(--live); font-weight:500;
+    display:flex; align-items:center; gap:8px }
+  .hero-eyebrow .label::before { content:""; width:6px; height:6px;
+    border-radius:50%; background:var(--live);
+    box-shadow:0 0 8px var(--live-glow);
+    animation:heartbeat 1.6s ease-in-out infinite }
+  .hero-eyebrow .meta { color:var(--dim); font-family:var(--mono);
+    font-size:var(--fs-sm); margin-left:8px }
+
+  .hero h1 { font-family:var(--serif); font-size:var(--fs-2xl);
+    font-weight:600; line-height:1.1; margin-top:6px;
+    letter-spacing:-0.02em }
+  .hero h1 em { font-style:italic; color:var(--text-soft); font-weight:400 }
+  .hero .sub { font-size:var(--fs-sm); color:var(--dim); margin-top:6px;
+    font-family:var(--mono) }
+
+  .chips { margin-top:var(--s-4); display:flex; flex-wrap:wrap;
+    gap:6px; font-size:var(--fs-xs) }
+  .chip { padding:3px 9px; border-radius:2px; font-family:var(--mono);
+    text-transform:uppercase; letter-spacing:0.08em;
+    color:var(--dim); border:1px solid var(--edge);
+    display:flex; align-items:center; gap:6px }
+  .chip.done { color:var(--text-soft); border-color:var(--edge-strong) }
+  .chip.done::before { content:"✓"; color:var(--live) }
+  .chip.live { color:var(--live); border-color:var(--live);
+    background:rgba(128,230,196,.06) }
+  .chip.live::before { content:""; width:5px; height:5px; border-radius:50%;
+    background:var(--live); box-shadow:0 0 6px var(--live-glow);
+    animation:heartbeat 1.6s ease-in-out infinite }
+
+  .hero-buttons { display:flex; flex-direction:column; gap:6px; flex:none }
+  .btn { font-size:var(--fs-xs); padding:6px 14px; border-radius:2px;
+    border:1px solid var(--edge-strong);
+    color:var(--text-soft);
+    text-transform:uppercase; letter-spacing:0.1em; font-family:var(--mono);
+    transition:color .15s, border-color .15s, background .15s }
+  .btn:hover { color:var(--text); border-color:var(--text) }
+  .btn.danger { color:var(--bad); border-color:rgba(224,119,92,.4) }
+  .btn.danger:hover { color:var(--bad); border-color:var(--bad);
+    background:rgba(224,119,92,.06) }
+
+  /* frame card */
+  .frame-card { background:var(--surface); border:1px solid var(--edge);
+    overflow:hidden; position:relative }
+  .frame-card::before, .frame-card::after {
+    content:""; position:absolute; width:10px; height:10px;
+    border-color:var(--text-soft); pointer-events:none; opacity:.35; z-index:2 }
+  .frame-card::before { top:-1px; left:-1px;
+    border-top:1px solid; border-left:1px solid }
+  .frame-card::after { bottom:-1px; right:-1px;
+    border-bottom:1px solid; border-right:1px solid }
+  .frame-head { height:46px; padding:0 var(--s-5);
+    display:flex; align-items:center; justify-content:space-between;
+    border-bottom:1px solid var(--edge); font-size:var(--fs-sm) }
+  .frame-head .left { display:flex; align-items:center; gap:var(--s-2) }
+  .frame-head .name { font-family:var(--serif); font-size:14px;
+    font-weight:600; letter-spacing:-0.005em }
+  .frame-head .meta { color:var(--dim); font-family:var(--mono);
+    font-size:var(--fs-sm); margin-left:var(--s-2) }
+  .frame-head .right { color:var(--dim); display:flex; gap:var(--s-2);
+    font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:0.1em }
+  .frame-head .right button:hover { color:var(--text) }
+  .frame-image { background:#000; position:relative; aspect-ratio:16/9 }
+  .frame-image svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-image .ovl { position:absolute; bottom:14px; left:14px;
+    font-family:var(--mono); font-size:11px;
+    color:var(--text-soft); background:rgba(11,9,7,.7);
+    padding:5px 10px; border:1px solid var(--edge);
+    backdrop-filter:blur(4px) }
+
+  /* past sessions timeline */
+  .timeline { position:relative; padding-left:32px;
+    display:flex; flex-direction:column; gap:var(--s-3) }
+  .timeline::before { content:""; position:absolute; left:11px; top:6px;
+    bottom:6px; width:1px; background:var(--edge) }
+
+  .tl-item { background:var(--surface); border:1px solid var(--edge);
+    position:relative }
+  .dot { position:absolute; left:-25px; top:14px; width:10px; height:10px;
+    border-radius:50%; background:var(--bg-deep);
+    border:1px solid var(--dim); box-shadow:0 0 0 3px var(--bg) }
+  .dot.done::after { content:""; position:absolute; inset:2px;
+    border-radius:50%; background:var(--text-soft) }
+  .dot.warn { border-color:var(--warn) }
+  .dot.warn::after { content:""; position:absolute; inset:2px;
+    border-radius:50%; background:var(--warn) }
+  .dot.bad { border-color:var(--bad) }
+  .dot.bad::after { content:""; position:absolute; inset:2px;
+    border-radius:50%; background:var(--bad) }
+
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .chev { transform:rotate(90deg) }
+  .chev { transition:transform .2s; color:var(--dim);
+    display:inline-block; width:12px }
+
+  .tl-summary { padding:var(--s-3) var(--s-4); display:flex;
+    align-items:center; gap:var(--s-3); transition:background .15s }
+  .tl-summary:hover { background:var(--surface-2) }
+  .tl-summary .body { flex:1; min-width:0 }
+  .tl-summary .title-row { display:flex; align-items:baseline; gap:var(--s-2) }
+  .tl-summary .name { font-family:var(--serif); font-size:15px;
+    font-weight:600; letter-spacing:-0.005em }
+  .tl-summary .name em { font-style:italic; color:var(--text-soft);
+    font-weight:400 }
+  .tl-summary .when { font-family:var(--mono); font-size:var(--fs-xs);
+    color:var(--dim) }
+  .tl-summary .desc { font-family:var(--mono); font-size:var(--fs-xs);
+    color:var(--dim); margin-top:3px }
+  .tl-pill { font-family:var(--mono); font-size:var(--fs-xs);
+    padding:3px 9px; border-radius:2px; flex:none;
+    text-transform:uppercase; letter-spacing:0.08em }
+  .tl-pill.ok   { color:var(--live);  border:1px solid rgba(128,230,196,.3) }
+  .tl-pill.warn { color:var(--warn);  border:1px solid rgba(232,168,92,.3) }
+  .tl-pill.bad  { color:var(--bad);   border:1px solid rgba(224,119,92,.3) }
+
+  /* night-vision: single page-level filter, monochromatic red */
+  body:has(#night-vision:checked) {
+    filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7);
+  }
+</style>
+</head>
+<body>
+
+<!-- subtle film grain over everything -->
+<svg class="grain" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+  <filter id="noise">
+    <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch"/>
+    <feColorMatrix values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.06 0"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noise)"/>
+</svg>
+
+<!-- 2px amber bar — system armed indicator -->
+<div class="armed-bar"></div>
+
+<nav>
+  <div class="brand">
+    <div class="brand-mark"></div>
+    <span class="brand-name">rusty <em>photon</em></span>
+  </div>
+  <div class="nav-tabs">
+    <a class="active">Activity</a>
+    <a>Equipment</a>
+    <a>Plans</a>
+    <a>Logs</a>
+    <a>Settings</a>
+  </div>
+  <div class="grow"></div>
+  <label class="night-toggle" title="Toggle red night-vision mode">
+    <input type="checkbox" id="night-vision" hidden>
+    <span class="nv-icon">☾</span>
+    <span class="nv-lbl">Night vision</span>
+    <span class="nv-dot"></span>
+  </label>
+  <div class="avatar">IV</div>
+</nav>
+
+<!-- live telemetry strip + foldable panel -->
+<input type="checkbox" id="fold-state" class="fold-state" hidden>
+<label for="fold-state" class="fold-strip">
+  <span class="strip-pulse"></span>
+  <span class="strip-target">M51 <em>· L · 300s</em></span>
+  <span class="sep"></span>
+  <div class="stat">
+    <span class="lbl-ra">RA</span>
+    <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+      <line x1="0" y1="12" x2="200" y2="12" stroke="#3d3528" stroke-width=".5"/>
+      <path fill="none" stroke="#ff8a6a" stroke-width="1"
+            d="M0,12 L10,10 L20,14 L30,9 L40,15 L50,11 L60,16 L70,8 L80,11 L90,15 L100,9 L110,17 L120,11 L130,10 L140,16 L150,7 L160,14 L170,11 L180,17 L190,9 L200,12"/>
+    </svg>
+    <span class="v">0.42″</span>
+  </div>
+  <div class="stat">
+    <span class="lbl-dec">Dec</span>
+    <svg class="mini" viewBox="0 0 200 24" preserveAspectRatio="none">
+      <line x1="0" y1="12" x2="200" y2="12" stroke="#3d3528" stroke-width=".5"/>
+      <path fill="none" stroke="#88c0e0" stroke-width="1"
+            d="M0,12 L10,11 L20,15 L30,8 L40,14 L50,10 L60,15 L70,12 L80,8 L90,16 L100,10 L110,14 L120,7 L130,15 L140,9 L150,12 L160,17 L170,10 L180,14 L190,9 L200,12"/>
+    </svg>
+    <span class="v">0.51″</span>
+  </div>
+  <span class="sep"></span>
+  <div class="stat">HFR <span class="v warn">1.84″</span></div>
+  <div class="stat">CCD <span class="v live">−10.0°</span></div>
+  <div class="stat">Sky <span class="v warn">20.8</span></div>
+  <span class="grow"></span>
+  <span class="strip-eta">finish <b>01:42</b></span>
+  <span class="fold-toggle"><span class="lbl"></span><span class="chev">▾</span></span>
+</label>
+
+<div class="fold-body">
+  <div class="panel">
+    <div class="panel-head">
+      <span class="num">i.</span>
+      <span class="title">Live telemetry</span>
+      <span class="meta">streaming · 21:18:47 · last 5 minutes</span>
+      <span class="rule"></span>
+    </div>
+
+    <div class="panel-grid">
+      <div>
+        <!-- guider graph -->
+        <section class="card guider-card">
+          <div class="guider-head">
+            <span class="label">Guider</span>
+            <span class="sub">RA / Dec error · arcseconds · last 5 minutes</span>
+            <div class="gstats">
+              <span class="gstat ra"><span class="swatch"></span>RA <span class="v">0.42″</span></span>
+              <span class="gstat dec"><span class="swatch"></span>Dec <span class="v">0.51″</span></span>
+              <span class="gstat total">Total RMS <span class="v">0.66″</span></span>
+            </div>
+          </div>
+          <div class="graph-body">
+            <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+              <!-- bands -->
+              <rect x="0" y="60"  width="600" height="120" fill="#80e6c4" fill-opacity=".035"/>
+              <rect x="0" y="90"  width="600" height="60"  fill="#80e6c4" fill-opacity=".045"/>
+              <!-- center + refs -->
+              <line x1="0" y1="120" x2="600" y2="120" stroke="#3d3528" stroke-width="1"/>
+              <line x1="0" y1="60"  x2="600" y2="60"  stroke="#2a241c" stroke-width=".5" stroke-dasharray="2,4"/>
+              <line x1="0" y1="180" x2="600" y2="180" stroke="#2a241c" stroke-width=".5" stroke-dasharray="2,4"/>
+              <line x1="0" y1="90"  x2="600" y2="90"  stroke="#2a241c" stroke-width=".5" stroke-dasharray="1,5"/>
+              <line x1="0" y1="150" x2="600" y2="150" stroke="#2a241c" stroke-width=".5" stroke-dasharray="1,5"/>
+              <!-- y labels -->
+              <text x="6" y="22"  fill="#8a8071" font-size="9.5" font-family="ui-monospace,monospace" letter-spacing="0.05em">arcsec</text>
+              <text x="6" y="64"  fill="#8a8071" font-size="9.5" font-family="ui-monospace,monospace">+1.0</text>
+              <text x="6" y="94"  fill="#5c5447" font-size="9.5" font-family="ui-monospace,monospace">+0.5</text>
+              <text x="6" y="124" fill="#8a8071" font-size="9.5" font-family="ui-monospace,monospace">0</text>
+              <text x="6" y="154" fill="#5c5447" font-size="9.5" font-family="ui-monospace,monospace">−0.5</text>
+              <text x="6" y="184" fill="#8a8071" font-size="9.5" font-family="ui-monospace,monospace">−1.0</text>
+              <!-- x markers -->
+              <text x="100" y="234" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−4m</text>
+              <text x="200" y="234" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−3m</text>
+              <text x="300" y="234" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−2m</text>
+              <text x="400" y="234" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−1m</text>
+              <text x="595" y="234" fill="#80e6c4" font-size="9" font-family="ui-monospace,monospace" text-anchor="end">now</text>
+              <!-- Dec line -->
+              <path fill="none" stroke="#88c0e0" stroke-width="1.3" stroke-linejoin="round"
+                    d="M0,120 L10,115 L20,129 L30,102 L40,124 L50,107 L60,129 L70,115 L80,102 L90,134 L100,111 L110,124 L120,98 L130,129 L140,107 L150,115 L160,138 L170,111 L180,124 L190,107 L200,115 L210,129 L220,102 L230,111 L240,124 L250,107 L260,142 L270,115 L280,102 L290,129 L300,107 L310,115 L320,124 L330,98 L340,134 L350,111 L360,102 L370,124 L380,107 L390,111 L400,134 L410,115 L420,102 L430,129 L440,107 L450,115 L460,138 L470,111 L480,107 L490,124 L500,102 L510,111 L520,129 L530,98 L540,124 L550,107 L560,115 L570,134 L580,102 L590,111"/>
+              <!-- RA line -->
+              <path fill="none" stroke="#ff8a6a" stroke-width="1.3" stroke-linejoin="round"
+                    d="M0,120 L10,111 L20,124 L30,107 L40,129 L50,115 L60,134 L70,102 L80,115 L90,129 L100,107 L110,138 L120,115 L130,111 L140,134 L150,98 L160,124 L170,111 L180,138 L190,107 L200,115 L210,129 L220,102 L230,134 L240,111 L250,124 L260,107 L270,142 L280,111 L290,115 L300,134 L310,102 L320,129 L330,115 L340,107 L350,129 L360,102 L370,124 L380,111 L390,134 L400,115 L410,98 L420,129 L430,107 L440,124 L450,111 L460,138 L470,115 L480,107 L490,129 L500,102 L510,124 L520,111 L530,107 L540,124 L550,98 L560,134 L570,111 L580,124 L590,102"/>
+              <!-- now line + dots -->
+              <line x1="595" y1="0" x2="595" y2="220" stroke="#80e6c4" stroke-width="1" stroke-opacity=".7"/>
+              <circle cx="595" cy="102" r="2.4" fill="#ff8a6a"/>
+              <circle cx="595" cy="111" r="2.4" fill="#88c0e0"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- trend charts -->
+        <div class="charts-row">
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Focus HFR</span>
+              <span class="d warn">↑ 0.06 / 30m</span>
+              <span class="v warn">1.84″</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 88" preserveAspectRatio="none">
+                <line x1="0" y1="44" x2="200" y2="44" stroke="#2a241c" stroke-width=".5" stroke-dasharray="2,4"/>
+                <text x="2" y="13" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">2.4″</text>
+                <text x="2" y="83" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">1.4″</text>
+                <path fill="none" stroke="#c89cea" stroke-width="1.5" stroke-linejoin="round"
+                      d="M0,54 L11,52 L22,50 L33,48 L44,46 L55,44 L66,42 L77,39 L88,35 L99,32 L110,28
+                         M110,28 L121,66 L132,64 L143,62 L154,58 L165,56 L176,52 L187,50 L200,48"/>
+                <circle cx="200" cy="48" r="2.5" fill="#c89cea"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">CCD temp</span>
+              <span class="d live">on target</span>
+              <span class="v live">−10.0°</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 88" preserveAspectRatio="none">
+                <text x="2" y="13" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">−9.5°</text>
+                <text x="2" y="83" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">−10.5°</text>
+                <line x1="0" y1="44" x2="200" y2="44" stroke="#2a241c" stroke-width=".5" stroke-dasharray="2,4"/>
+                <path fill="none" stroke="#80e6c4" stroke-width="1.5"
+                      d="M0,44 L11,44 L22,42 L33,44 L44,46 L55,44 L66,44 L77,42 L88,44 L99,44 L110,46 L121,44 L132,44 L143,42 L154,44 L165,46 L176,44 L187,44 L200,44"/>
+                <circle cx="200" cy="44" r="2.5" fill="#80e6c4"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Sky brightness</span>
+              <span class="d warn">−0.6 / 1h</span>
+              <span class="v warn">20.8</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 88" preserveAspectRatio="none">
+                <text x="2" y="13" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">21.5</text>
+                <text x="2" y="83" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">20.5</text>
+                <path fill="none" stroke="#e8a85c" stroke-width="1.5"
+                      d="M0,15 L11,15 L22,23 L33,23 L44,23 L55,31 L66,31 L77,31 L88,39 L99,39 L110,47 L121,47 L132,54 L143,54 L154,54 L165,62 L176,62 L187,62 L200,62"/>
+                <circle cx="200" cy="62" r="2.5" fill="#e8a85c"/>
+              </svg>
+            </div>
+          </section>
+
+          <section class="card chart-card">
+            <div class="chart-head">
+              <span class="k">Dew margin</span>
+              <span class="d warn">↓ 3.4 / 1h</span>
+              <span class="v warn">4.8°</span>
+            </div>
+            <div class="chart-body">
+              <svg viewBox="0 0 200 88" preserveAspectRatio="none">
+                <text x="2" y="13" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">10°</text>
+                <text x="2" y="83" fill="#5c5447" font-size="9" font-family="ui-monospace,monospace">0°</text>
+                <line x1="0" y1="78" x2="200" y2="78" stroke="#e0775c" stroke-width=".5" stroke-dasharray="2,4"/>
+                <text x="198" y="76" fill="#a04030" font-size="8" font-family="ui-monospace,monospace" text-anchor="end">dew point</text>
+                <path fill="none" stroke="#e8a85c" stroke-width="1.5"
+                      d="M0,17 L11,20 L22,21 L33,21 L44,24 L55,24 L66,28 L77,31 L88,35 L99,39 L110,42 L121,46 L132,49 L143,53 L154,57 L165,60 L176,64 L187,64 L200,67"/>
+                <circle cx="200" cy="67" r="2.5" fill="#e8a85c"/>
+              </svg>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <!-- side: equipment + stages -->
+      <div class="card side-card">
+        <div class="side-section">
+          <h3>Equipment</h3>
+          <ul class="equip-list">
+            <li><span class="led live"></span>Camera <span class="v">−10.0°C</span></li>
+            <li><span class="led live"></span>Mount <span class="v">RMS 0.62″</span></li>
+            <li><span class="led live"></span>Focuser <span class="v">14,820 · 22.4°C</span></li>
+            <li><span class="led live"></span>Guider <span class="v">snr 32 · 2.1 px</span></li>
+            <li><span class="led warn"></span>Sky <span class="v">18% clouds ↑</span></li>
+            <li><span class="led warn"></span>Dew margin <span class="v">4.8°</span></li>
+          </ul>
+        </div>
+        <div class="side-section">
+          <h3>Tonight's plan</h3>
+          <ol class="stages-list">
+            <li><span class="step done">✓</span> Slew &amp; solve <span class="right">2m 04s</span></li>
+            <li><span class="step done">✓</span> Auto-focus <span class="right">3m 11s</span></li>
+            <li><span class="step done">✓</span> PHD2 calibrate <span class="right">1m 47s</span></li>
+            <li><span class="step live"></span> <strong>L · 300s × 10</strong> <span class="right" style="color:var(--text)">4 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> R · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> G · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> B · 180s × 10 <span class="right">0 / 10</span></li>
+            <li class="muted"><span class="step pending"></span> Park &amp; shutdown</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<main>
+
+  <!-- hero -->
+  <article class="hero">
+    <div class="hero-row">
+      <div class="ring">
+        <svg viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#2a241c" stroke-width="6"/>
+          <circle cx="50" cy="50" r="44" fill="none" stroke="#80e6c4" stroke-width="6"
+                  stroke-dasharray="276" stroke-dashoffset="160" stroke-linecap="round"/>
+          <!-- tick marks at quarters -->
+          <g stroke="#3d3528" stroke-width=".8">
+            <line x1="50" y1="3" x2="50" y2="7"/>
+            <line x1="50" y1="93" x2="50" y2="97"/>
+            <line x1="3" y1="50" x2="7" y2="50"/>
+            <line x1="93" y1="50" x2="97" y2="50"/>
+          </g>
+        </svg>
+        <div class="center"><div><div class="pct">42%</div><div class="cap">complete</div></div></div>
+      </div>
+
+      <div class="hero-body">
+        <div class="hero-eyebrow">
+          <span class="label">Capturing now</span>
+          <span class="meta">started 21:18 · 26m 14s remaining · finishes 01:42 local</span>
+        </div>
+        <h1>M51 <em>— Whirlpool</em></h1>
+        <div class="sub">Luminance · 300s · frame 4 of 10 · 30 of 40 across L R G B</div>
+        <div class="chips">
+          <span class="chip done">slew</span>
+          <span class="chip done">focus</span>
+          <span class="chip done">guide</span>
+          <span class="chip live">capturing L</span>
+          <span class="chip">R</span>
+          <span class="chip">G</span>
+          <span class="chip">B</span>
+          <span class="chip">park</span>
+        </div>
+      </div>
+
+      <div class="hero-buttons">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+  </article>
+
+  <!-- latest frame -->
+  <section>
+    <div class="section-marker">
+      <span class="num">ii.</span>
+      <span class="label">Latest frame</span>
+      <span class="rule"></span>
+      <span class="meta">just landed · 21:18:04</span>
+    </div>
+    <article class="frame-card">
+      <div class="frame-head">
+        <div class="left">
+          <span class="name">M51 <em>· L · 300s</em></span>
+          <span class="meta">frame 0042</span>
+        </div>
+        <div class="right">
+          <button>open</button><span style="color:var(--edge-strong)">·</span><button>download</button>
+        </div>
+      </div>
+      <div class="frame-image">
+        <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <radialGradient id="neb8" cx="50%" cy="50%" r="60%">
+              <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+              <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="core8" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+              <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+              <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+            </radialGradient>
+          </defs>
+          <rect width="800" height="450" fill="#03050b"/>
+          <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb8)"/>
+          <g transform="translate(400 225) rotate(-22)">
+            <ellipse rx="60" ry="40" fill="url(#core8)"/>
+            <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+            <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          </g>
+          <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+          <g fill="#fff">
+            <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+            <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+            <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+            <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+            <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+            <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+            <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+            <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+          </g>
+        </svg>
+        <div class="ovl">HFR 1.84″ · stars 2,941 · ADU 1,247 · ecc 0.41</div>
+      </div>
+    </article>
+  </section>
+
+  <!-- past sessions -->
+  <section>
+    <div class="section-marker">
+      <span class="num">iii.</span>
+      <span class="label">Past sessions</span>
+      <span class="rule"></span>
+      <span class="meta">last 30 days · 12 sessions</span>
+    </div>
+
+    <div class="timeline">
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot done"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">M101 <em>— Pinwheel</em></span>
+              <span class="when">last night · 22:14 → 03:48</span>
+            </div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot warn"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">NGC 7000 <em>— North America</em></span>
+              <span class="when">3 days ago · 21:48 → 02:11</span>
+            </div>
+            <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted</span>
+        </summary>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot done"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">M31 <em>— Andromeda</em></span>
+              <span class="when">a week ago · 20:31 → 04:02</span>
+            </div>
+            <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+
+      <details class="tl-item">
+        <summary class="tl-summary">
+          <span class="dot bad"></span>
+          <span class="chev">▸</span>
+          <div class="body">
+            <div class="title-row">
+              <span class="name">IC 1396 <em>— Elephant's Trunk</em></span>
+              <span class="when">12 days ago · 22:02 → 23:00</span>
+            </div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed</span>
+        </summary>
+      </details>
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/9-plugin-fresh.html
+++ b/docs/plans/ui-design/mocks/9-plugin-fresh.html
@@ -1,0 +1,784 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>RP // ACTIVITY</title>
+<style>
+  /* ── tokens ───────────────────────────────────────────────────────── */
+  :root {
+    --bg:        #0a0a0a;
+    --surface:   #0f0f0f;
+    --hover:     #161616;
+    --hairline:  #1f1f1f;
+    --hairline-2:#2a2a2a;
+
+    --fg:        #f5f5f5;
+    --fg-2:      #b8b8b8;
+    --fg-3:      #6e6e6e;
+    --fg-4:      #3a3a3a;
+
+    --phosphor:  #6efa9b;     /* one accent — "live" / on-target */
+    --phosphor-faint: rgba(110,250,155,.12);
+    --warn:      #d8d8d8;     /* warn = brighter, no second hue */
+    --bad:       #fafafa;     /* bad  = brightest + underline animation */
+
+    --ra:        #ff9f80;     /* one warm hue for the RA line */
+    --dec:       #80c8ff;     /* one cool hue for the Dec line */
+
+    /* spacing */
+    --u: 4px;
+
+    /* type scale (all powers of 1.18 from 11) */
+    --t1: 10.5px;
+    --t2: 12px;
+    --t3: 14px;
+    --t4: 17px;
+    --t5: 22px;
+    --t6: 30px;
+
+    /* fonts — mono dominates, sans for one specific role */
+    --mono: ui-monospace, "JetBrains Mono", "Cascadia Code", "SF Mono",
+            Menlo, Consolas, monospace;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", sans-serif;
+  }
+
+  *,*::before,*::after { box-sizing:border-box; margin:0; padding:0 }
+  html,body { min-height:100%; background:var(--bg); color:var(--fg);
+    font-family:var(--mono); font-size:var(--t3); line-height:1.5;
+    font-feature-settings:"zero","ss01","cv01"; -webkit-font-smoothing:antialiased }
+  button, a, label { font:inherit; color:inherit; background:none;
+    border:0; cursor:pointer; text-decoration:none }
+  input { font:inherit; color:inherit }
+  ol,ul { list-style:none }
+
+  ::selection { background:var(--phosphor); color:#000 }
+
+  /* utilities */
+  .uppercase { text-transform:uppercase; letter-spacing:0.12em }
+  .num { font-variant-numeric:tabular-nums }
+  .sans { font-family:var(--sans) }
+  .dim  { color:var(--fg-3) }
+  .dim2 { color:var(--fg-4) }
+  .ok   { color:var(--phosphor) }
+  .warn { color:var(--warn) }
+
+  /* ── nav ──────────────────────────────────────────────────────────── */
+  nav { height:48px; padding:0 var(--t3);
+    display:grid; grid-template-columns:auto auto 1fr auto auto;
+    align-items:center; gap:var(--t3);
+    border-bottom:1px solid var(--hairline);
+    background:var(--bg); position:sticky; top:0; z-index:30 }
+
+  .brand { display:flex; align-items:center; gap:8px;
+    font-size:var(--t3); font-weight:500 }
+  .brand .mark { width:8px; height:8px; background:var(--fg);
+    transform:rotate(45deg) }
+  .brand .name { letter-spacing:0.06em }
+  .brand .div  { color:var(--fg-4) }
+
+  .nav-tabs { display:flex; gap:0; font-size:var(--t1) }
+  .nav-tabs a { padding:6px 12px; color:var(--fg-3); letter-spacing:0.12em;
+    text-transform:uppercase; transition:color .12s, background .12s }
+  .nav-tabs a:hover { color:var(--fg) }
+  .nav-tabs a.active { color:var(--fg); background:var(--hover) }
+
+  .ts { font-size:var(--t1); color:var(--fg-3); letter-spacing:0.08em;
+    text-transform:uppercase; justify-self:end; padding-right:var(--t2) }
+  .ts b { color:var(--fg); font-weight:500 }
+
+  /* night-vision toggle */
+  .nvt { display:flex; align-items:center; gap:8px;
+    padding:5px 10px; font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.12em; text-transform:uppercase;
+    border:1px solid var(--hairline-2); user-select:none; cursor:pointer;
+    transition:color .12s, border-color .12s }
+  .nvt:hover { color:var(--fg); border-color:var(--fg-3) }
+  .nvt .icon { font-size:13px; line-height:1 }
+  .nvt .dot { width:6px; height:6px; background:var(--fg-4);
+    border:1px solid var(--fg-4) }
+  .nvt:has(input:checked) { color:var(--fg); border-color:var(--fg) }
+  .nvt:has(input:checked) .dot { background:#fff; border-color:#fff;
+    box-shadow:0 0 6px #fff }
+
+  .user { width:28px; height:28px; display:grid; place-items:center;
+    background:var(--surface); border:1px solid var(--hairline-2);
+    font-size:var(--t1); letter-spacing:0.06em; color:var(--fg-2) }
+
+  /* ── live strip ───────────────────────────────────────────────────── */
+  .fold-state { display:none }
+
+  .strip {
+    position:sticky; top:48px; z-index:20;
+    background:var(--bg);
+    border-bottom:1px solid var(--hairline);
+    height:42px; padding:0 var(--t3);
+    display:flex; align-items:center; gap:var(--t4);
+    cursor:pointer; transition:background .12s }
+  .strip:hover { background:var(--surface) }
+
+  .strip-pulse { position:relative; width:7px; height:7px;
+    background:var(--phosphor); flex:none }
+  .strip-pulse::before { content:""; position:absolute; inset:-3px;
+    border:1px solid var(--phosphor); animation:pulse 1.6s linear infinite }
+  @keyframes pulse {
+    0%   { opacity:1;   transform:scale(1) }
+    100% { opacity:0;   transform:scale(2.4) }
+  }
+
+  .strip-label { font-size:var(--t1); letter-spacing:0.14em;
+    text-transform:uppercase; color:var(--fg) }
+  .strip-label .dim { color:var(--fg-3); margin-left:6px }
+
+  .strip-divider { color:var(--fg-4); font-size:14px; align-self:center }
+
+  .stat { display:flex; align-items:center; gap:8px;
+    font-size:var(--t1); letter-spacing:0.08em; text-transform:uppercase;
+    color:var(--fg-3) }
+  .stat .lbl-ra  { color:var(--ra) }
+  .stat .lbl-dec { color:var(--dec) }
+  .stat .v { color:var(--fg); text-transform:none; letter-spacing:0;
+    font-size:var(--t2); font-variant-numeric:tabular-nums }
+  .stat .v.warn { color:var(--warn) }
+  .stat .v.ok   { color:var(--phosphor) }
+
+  .mini { width:64px; height:18px; flex:none }
+
+  .strip-spacer { flex:1 }
+
+  .strip-eta { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.08em; text-transform:uppercase }
+  .strip-eta b { color:var(--fg); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0; font-size:var(--t2) }
+
+  .toggle { display:flex; align-items:center; gap:8px;
+    padding:4px 10px; font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.14em; text-transform:uppercase;
+    border:1px solid var(--hairline-2); transition:color .12s, border-color .12s }
+  .toggle:hover { color:var(--fg); border-color:var(--fg-3) }
+  .toggle .chev { width:8px; height:8px;
+    border-right:1px solid currentColor; border-bottom:1px solid currentColor;
+    transform:rotate(45deg) translateY(-1px);
+    transition:transform 320ms cubic-bezier(.4,0,.2,1) }
+  .fold-state:checked ~ .strip .toggle .chev {
+    transform:rotate(-135deg) translateY(1px) }
+  .fold-state:checked ~ .strip .toggle .lbl::before { content:"COLLAPSE" }
+  .fold-state:not(:checked) ~ .strip .toggle .lbl::before { content:"EXPAND" }
+
+  /* ── fold panel ───────────────────────────────────────────────────── */
+  .fold-body {
+    display:grid; grid-template-rows:0fr;
+    transition:grid-template-rows 320ms cubic-bezier(.4,0,.2,1) }
+  .fold-body > .panel {
+    min-height:0; overflow:hidden; opacity:0;
+    transition:opacity 220ms ease }
+  .fold-state:checked ~ .fold-body { grid-template-rows:1fr }
+  .fold-state:checked ~ .fold-body > .panel {
+    opacity:1; transition-delay:60ms }
+
+  .panel { background:var(--bg); border-bottom:1px solid var(--hairline);
+    padding:var(--t4) var(--t3) var(--t4) }
+
+  .panel-head { display:grid;
+    grid-template-columns:auto 1fr auto;
+    align-items:center; gap:var(--t3); padding:0 0 var(--t3) 0 }
+  .panel-head::before { content:"// LIVE"; font-size:var(--t1);
+    color:var(--phosphor); letter-spacing:0.18em;
+    padding-right:var(--t3); border-right:1px solid var(--hairline-2) }
+  .panel-head .meta { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.08em; text-transform:uppercase }
+  .panel-head .meta b { color:var(--fg-2); text-transform:none;
+    font-variant-numeric:tabular-nums; letter-spacing:0 }
+
+  .panel-grid { display:grid; grid-template-columns:1fr 280px; gap:1px;
+    background:var(--hairline) }
+  .panel-grid > * { background:var(--bg); padding:var(--t4) }
+
+  /* guider section */
+  .guider-head { display:flex; align-items:baseline; gap:var(--t3);
+    flex-wrap:wrap; padding-bottom:var(--t3) }
+  .guider-head .label { font-size:var(--t1); letter-spacing:0.18em;
+    text-transform:uppercase; color:var(--fg) }
+  .guider-head .sub { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.04em; text-transform:uppercase }
+  .gstats { display:flex; gap:var(--t4); margin-left:auto;
+    font-size:var(--t1); letter-spacing:0.08em; text-transform:uppercase;
+    color:var(--fg-3) }
+  .gstat { display:flex; align-items:center; gap:6px }
+  .gstat .swatch { width:10px; height:1px }
+  .gstat.ra .swatch { background:var(--ra) }
+  .gstat.dec .swatch { background:var(--dec) }
+  .gstat .v { color:var(--fg); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0; font-size:var(--t2) }
+  .gstat.total { padding-left:var(--t3); border-left:1px solid var(--hairline-2);
+    color:var(--fg) }
+  .gstat.total .v { color:var(--phosphor); font-size:var(--t3) }
+
+  .graph { height:240px; border:1px solid var(--hairline-2) }
+  .graph svg { display:block; width:100%; height:100% }
+
+  /* trend charts */
+  .charts { display:grid; grid-template-columns:repeat(4,1fr);
+    gap:1px; background:var(--hairline);
+    margin-top:var(--t3); border:1px solid var(--hairline) }
+  .charts > .chart { background:var(--bg); padding:var(--t3) }
+  .chart .h { display:flex; align-items:baseline; gap:8px;
+    margin-bottom:6px }
+  .chart .k { font-size:var(--t1); letter-spacing:0.14em;
+    text-transform:uppercase; color:var(--fg-3) }
+  .chart .v { margin-left:auto; font-variant-numeric:tabular-nums;
+    font-size:var(--t4); color:var(--fg) }
+  .chart .v.warn { color:var(--warn) }
+  .chart .v.ok   { color:var(--phosphor) }
+  .chart .d { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.04em; text-transform:uppercase }
+  .chart .d.warn { color:var(--warn) }
+  .chart .d.ok   { color:var(--phosphor) }
+  .chart .body { height:64px }
+  .chart .body svg { display:block; width:100%; height:100% }
+
+  /* side column (equipment + stages) */
+  .side h3 { font-size:var(--t1); letter-spacing:0.16em;
+    text-transform:uppercase; color:var(--fg);
+    padding-bottom:8px; border-bottom:1px solid var(--hairline-2);
+    margin-bottom:var(--t3); display:flex; align-items:center;
+    justify-content:space-between }
+  .side h3::after { content:""; width:6px; height:6px; background:var(--phosphor) }
+  .side h3.idle::after { background:var(--fg-4) }
+  .side .eq { display:flex; flex-direction:column; gap:8px;
+    margin-bottom:var(--t4) }
+  .side .eq li { display:grid; grid-template-columns:auto 1fr auto;
+    gap:8px; align-items:center; font-size:var(--t2) }
+  .side .eq li::before { content:""; width:6px; height:6px;
+    background:var(--phosphor) }
+  .side .eq li.warn::before { background:var(--warn) }
+  .side .eq li.warn { color:var(--warn) }
+  .side .eq li .v { color:var(--fg-3); font-variant-numeric:tabular-nums;
+    font-size:var(--t1) }
+
+  .side .stages { display:flex; flex-direction:column; gap:6px;
+    font-size:var(--t2) }
+  .side .stages li { display:grid; grid-template-columns:auto 1fr auto;
+    gap:10px; align-items:center }
+  .side .stages li::before { content:"·"; color:var(--fg-4); width:14px;
+    text-align:center }
+  .side .stages li.done::before { content:"✓"; color:var(--phosphor) }
+  .side .stages li.live::before { content:"▸"; color:var(--phosphor);
+    animation:pulseDim 1.4s ease-in-out infinite }
+  @keyframes pulseDim { 0%,100% { opacity:1 } 50% { opacity:.4 } }
+  .side .stages li.muted { color:var(--fg-3) }
+  .side .stages strong { color:var(--fg); font-weight:500 }
+  .side .stages .v { font-variant-numeric:tabular-nums; color:var(--fg-3);
+    font-size:var(--t1) }
+
+  /* ── main content ─────────────────────────────────────────────────── */
+  main { max-width:1080px; margin:0 auto;
+    padding:var(--t6) var(--t4) var(--t6);
+    display:flex; flex-direction:column; gap:var(--t6) }
+
+  /* section header */
+  .sec-h { display:grid; grid-template-columns:auto 1fr auto;
+    align-items:center; gap:var(--t3); padding-bottom:var(--t2);
+    border-bottom:1px solid var(--hairline) }
+  .sec-h .num { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.14em }
+  .sec-h .label { font-size:var(--t2); letter-spacing:0.16em;
+    text-transform:uppercase; color:var(--fg) }
+  .sec-h .meta { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.08em; text-transform:uppercase;
+    font-variant-numeric:tabular-nums }
+  .sec-h .meta b { color:var(--fg-2) }
+
+  /* hero */
+  .hero { display:grid; grid-template-columns:120px 1fr auto;
+    gap:var(--t6); padding:var(--t5) 0 0 }
+  .hero-ring { position:relative; width:120px; height:120px;
+    border:1px solid var(--hairline-2);
+    display:grid; place-items:center }
+  .hero-ring::before { content:""; position:absolute; inset:-1px;
+    pointer-events:none;
+    background:
+      linear-gradient(var(--phosphor), var(--phosphor)) 0 0    / 8px 1px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 100% 0 / 8px 1px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 0 0    / 1px 8px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 100% 0 / 1px 8px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 0 100% / 8px 1px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 100% 100% / 8px 1px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 0 100% / 1px 8px no-repeat,
+      linear-gradient(var(--phosphor), var(--phosphor)) 100% 100% / 1px 8px no-repeat }
+  .hero-ring .pct { font-size:var(--t6); color:var(--fg);
+    font-variant-numeric:tabular-nums; line-height:1 }
+  .hero-ring .pctSub { font-size:var(--t1); letter-spacing:0.16em;
+    text-transform:uppercase; color:var(--fg-3); margin-top:6px;
+    text-align:center }
+  .hero-ring .bar { position:absolute; left:-1px; top:auto; bottom:-1px;
+    width:42%; height:2px; background:var(--phosphor) }
+
+  .hero-body { min-width:0 }
+  .hero-tag { font-size:var(--t1); letter-spacing:0.18em;
+    text-transform:uppercase; color:var(--phosphor);
+    display:flex; align-items:center; gap:8px }
+  .hero-tag::before { content:""; width:6px; height:6px;
+    background:var(--phosphor) }
+  .hero h1 { font-family:var(--sans); font-size:var(--t6); font-weight:500;
+    line-height:1.05; letter-spacing:-0.02em; margin:var(--t3) 0 var(--t2);
+    color:var(--fg) }
+  .hero h1 .dim { color:var(--fg-3); font-weight:400 }
+  .hero .meta-row { font-size:var(--t1); letter-spacing:0.08em;
+    text-transform:uppercase; color:var(--fg-3) }
+  .hero .meta-row b { color:var(--fg); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0; font-size:var(--t2) }
+
+  .hero-stages { margin-top:var(--t4); display:flex; gap:0;
+    border:1px solid var(--hairline-2) }
+  .hero-stages li { padding:6px 12px; font-size:var(--t1);
+    letter-spacing:0.14em; text-transform:uppercase; color:var(--fg-3);
+    border-right:1px solid var(--hairline-2); flex:1; text-align:center }
+  .hero-stages li:last-child { border-right:0 }
+  .hero-stages li.done { color:var(--fg-2) }
+  .hero-stages li.live { color:#000; background:var(--phosphor) }
+  .hero-stages li.live::before { content:"●  " }
+
+  .hero-actions { display:flex; flex-direction:column; gap:6px;
+    align-items:flex-end }
+  .btn { padding:6px 14px; font-size:var(--t1);
+    letter-spacing:0.14em; text-transform:uppercase;
+    color:var(--fg-2); border:1px solid var(--hairline-2);
+    transition:color .12s, border-color .12s, background .12s }
+  .btn:hover { color:var(--fg); border-color:var(--fg) }
+  .btn.danger { color:var(--fg-2); border-color:var(--hairline-2) }
+  .btn.danger:hover { color:var(--bg); background:var(--fg);
+    border-color:var(--fg) }
+
+  /* frame card */
+  .frame { border:1px solid var(--hairline) }
+  .frame-h { padding:var(--t2) var(--t3); display:flex; align-items:center;
+    border-bottom:1px solid var(--hairline); font-size:var(--t1);
+    letter-spacing:0.08em; text-transform:uppercase; color:var(--fg-3) }
+  .frame-h .name { color:var(--fg); font-size:var(--t2); letter-spacing:0.04em }
+  .frame-h .meta { margin-left:var(--t3); font-variant-numeric:tabular-nums;
+    text-transform:none; letter-spacing:0 }
+  .frame-h .actions { margin-left:auto; display:flex; gap:var(--t3) }
+  .frame-h .actions a:hover { color:var(--fg) }
+  .frame-img { background:#000; aspect-ratio:16/9; position:relative }
+  .frame-img svg { position:absolute; inset:0; width:100%; height:100% }
+  .frame-ovl { position:absolute; bottom:12px; left:12px;
+    padding:5px 10px; background:#000; border:1px solid var(--hairline-2);
+    font-size:var(--t1); color:var(--fg-3);
+    font-variant-numeric:tabular-nums }
+
+  /* timeline */
+  .tl { display:flex; flex-direction:column; gap:1px;
+    background:var(--hairline); border:1px solid var(--hairline) }
+  .tl-row { background:var(--bg); padding:0 }
+  details > summary { list-style:none; cursor:pointer }
+  details > summary::-webkit-details-marker { display:none }
+  details[open] .row-chev { transform:rotate(90deg) }
+  .row-chev { display:inline-block; width:8px; height:8px;
+    border-top:1px solid currentColor; border-right:1px solid currentColor;
+    transform:rotate(45deg); transition:transform .15s }
+  .tl-summary { padding:var(--t3) var(--t3); display:grid;
+    grid-template-columns:auto auto 1fr auto;
+    align-items:center; gap:var(--t3); transition:background .12s }
+  .tl-summary:hover { background:var(--hover) }
+  .tl-marker { width:10px; height:10px; border:1px solid var(--fg-3);
+    position:relative }
+  .tl-marker.done::before { content:""; position:absolute; inset:2px;
+    background:var(--fg-2) }
+  .tl-marker.warn { border-color:var(--warn) }
+  .tl-marker.warn::before { content:""; position:absolute; inset:2px;
+    background:var(--warn) }
+  .tl-marker.bad { border-color:var(--fg) }
+  .tl-marker.bad::before { content:""; position:absolute; inset:2px;
+    background:var(--fg) }
+  .tl-summary .body { min-width:0 }
+  .tl-summary .row1 { display:flex; align-items:baseline; gap:var(--t3) }
+  .tl-summary .name { font-family:var(--sans); font-size:var(--t3);
+    color:var(--fg); font-weight:500; letter-spacing:-0.005em }
+  .tl-summary .name .dim { color:var(--fg-3); font-weight:400 }
+  .tl-summary .when { font-size:var(--t1); color:var(--fg-3);
+    letter-spacing:0.06em; text-transform:uppercase }
+  .tl-summary .desc { font-size:var(--t1); color:var(--fg-3);
+    margin-top:3px; letter-spacing:0.04em }
+  .tl-pill { padding:3px 10px; font-size:var(--t1);
+    letter-spacing:0.14em; text-transform:uppercase;
+    border:1px solid currentColor }
+  .tl-pill.ok   { color:var(--phosphor) }
+  .tl-pill.warn { color:var(--warn) }
+  .tl-pill.bad  { color:var(--fg) }
+
+  /* night vision */
+  body:has(#night-vision:checked) {
+    filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7);
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="brand">
+    <div class="mark"></div>
+    <span class="name">RP</span>
+    <span class="div">/</span>
+    <span class="dim sans" style="text-transform:uppercase; letter-spacing:0.14em; font-size:var(--t1)">RUSTY PHOTON</span>
+  </div>
+  <div class="nav-tabs">
+    <a class="active">Activity</a>
+    <a>Equipment</a>
+    <a>Plans</a>
+    <a>Logs</a>
+    <a>Settings</a>
+  </div>
+  <div class="ts">2026-05-03 · <b>21:18:47</b></div>
+  <label class="nvt" title="Toggle red night-vision mode">
+    <input type="checkbox" id="night-vision" hidden>
+    <span class="icon">☾</span>
+    <span>NIGHT</span>
+    <span class="dot"></span>
+  </label>
+  <div class="user">IV</div>
+</nav>
+
+<input type="checkbox" id="fold-state" class="fold-state" hidden>
+
+<label for="fold-state" class="strip">
+  <span class="strip-pulse"></span>
+  <span class="strip-label">M51 <span class="dim">L · 300s</span></span>
+  <span class="strip-divider">│</span>
+  <div class="stat">
+    <span class="lbl-ra">RA</span>
+    <svg class="mini" viewBox="0 0 200 18" preserveAspectRatio="none">
+      <line x1="0" y1="9" x2="200" y2="9" stroke="#2a2a2a" stroke-width=".5"/>
+      <path fill="none" stroke="#ff9f80" stroke-width="1"
+            d="M0,9 L10,7 L20,11 L30,6 L40,12 L50,8 L60,13 L70,5 L80,8 L90,12 L100,6 L110,14 L120,8 L130,7 L140,13 L150,4 L160,11 L170,8 L180,14 L190,6 L200,9"/>
+    </svg>
+    <span class="v">0.42″</span>
+  </div>
+  <div class="stat">
+    <span class="lbl-dec">Dec</span>
+    <svg class="mini" viewBox="0 0 200 18" preserveAspectRatio="none">
+      <line x1="0" y1="9" x2="200" y2="9" stroke="#2a2a2a" stroke-width=".5"/>
+      <path fill="none" stroke="#80c8ff" stroke-width="1"
+            d="M0,9 L10,8 L20,12 L30,5 L40,11 L50,7 L60,12 L70,9 L80,5 L90,13 L100,7 L110,11 L120,4 L130,12 L140,6 L150,9 L160,14 L170,7 L180,11 L190,6 L200,9"/>
+    </svg>
+    <span class="v">0.51″</span>
+  </div>
+  <span class="strip-divider">│</span>
+  <div class="stat">HFR <span class="v warn">1.84″</span></div>
+  <div class="stat">CCD <span class="v ok">−10.0°</span></div>
+  <div class="stat">SKY <span class="v warn">20.8</span></div>
+  <span class="strip-spacer"></span>
+  <span class="strip-eta">FINISH <b>01:42</b></span>
+  <span class="toggle"><span class="lbl"></span><span class="chev"></span></span>
+</label>
+
+<div class="fold-body">
+  <div class="panel">
+    <div class="panel-head">
+      <span class="meta">STREAMING · last <b>5m</b> · update <b>21:18:47</b></span>
+      <span></span>
+    </div>
+
+    <div class="panel-grid">
+      <div>
+        <div class="guider-head">
+          <span class="label">GUIDER</span>
+          <span class="sub">RA / Dec error · arcsec · 5m</span>
+          <div class="gstats">
+            <span class="gstat ra"><span class="swatch"></span>RA <span class="v">0.42″</span></span>
+            <span class="gstat dec"><span class="swatch"></span>Dec <span class="v">0.51″</span></span>
+            <span class="gstat total">RMS <span class="v">0.66″</span></span>
+          </div>
+        </div>
+        <div class="graph">
+          <svg viewBox="0 0 600 240" preserveAspectRatio="none">
+            <rect x="0" y="60"  width="600" height="120" fill="#6efa9b" fill-opacity=".03"/>
+            <rect x="0" y="90"  width="600" height="60"  fill="#6efa9b" fill-opacity=".045"/>
+            <line x1="0" y1="120" x2="600" y2="120" stroke="#2a2a2a" stroke-width="1"/>
+            <line x1="0" y1="60"  x2="600" y2="60"  stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="2,4"/>
+            <line x1="0" y1="180" x2="600" y2="180" stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="2,4"/>
+            <line x1="0" y1="90"  x2="600" y2="90"  stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="1,5"/>
+            <line x1="0" y1="150" x2="600" y2="150" stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="1,5"/>
+            <text x="6" y="20"  fill="#6e6e6e" font-size="9" font-family="ui-monospace,monospace" letter-spacing="0.1em">ARCSEC</text>
+            <text x="6" y="64"  fill="#6e6e6e" font-size="9" font-family="ui-monospace,monospace">+1.0</text>
+            <text x="6" y="94"  fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace">+0.5</text>
+            <text x="6" y="124" fill="#6e6e6e" font-size="9" font-family="ui-monospace,monospace">  0</text>
+            <text x="6" y="154" fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace">−0.5</text>
+            <text x="6" y="184" fill="#6e6e6e" font-size="9" font-family="ui-monospace,monospace">−1.0</text>
+            <text x="100" y="234" fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−4M</text>
+            <text x="200" y="234" fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−3M</text>
+            <text x="300" y="234" fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−2M</text>
+            <text x="400" y="234" fill="#3a3a3a" font-size="9" font-family="ui-monospace,monospace" text-anchor="middle">−1M</text>
+            <text x="595" y="234" fill="#6efa9b" font-size="9" font-family="ui-monospace,monospace" text-anchor="end">NOW</text>
+            <path fill="none" stroke="#80c8ff" stroke-width="1.2" stroke-linejoin="round"
+                  d="M0,120 L10,115 L20,129 L30,102 L40,124 L50,107 L60,129 L70,115 L80,102 L90,134 L100,111 L110,124 L120,98 L130,129 L140,107 L150,115 L160,138 L170,111 L180,124 L190,107 L200,115 L210,129 L220,102 L230,111 L240,124 L250,107 L260,142 L270,115 L280,102 L290,129 L300,107 L310,115 L320,124 L330,98 L340,134 L350,111 L360,102 L370,124 L380,107 L390,111 L400,134 L410,115 L420,102 L430,129 L440,107 L450,115 L460,138 L470,111 L480,107 L490,124 L500,102 L510,111 L520,129 L530,98 L540,124 L550,107 L560,115 L570,134 L580,102 L590,111"/>
+            <path fill="none" stroke="#ff9f80" stroke-width="1.2" stroke-linejoin="round"
+                  d="M0,120 L10,111 L20,124 L30,107 L40,129 L50,115 L60,134 L70,102 L80,115 L90,129 L100,107 L110,138 L120,115 L130,111 L140,134 L150,98 L160,124 L170,111 L180,138 L190,107 L200,115 L210,129 L220,102 L230,134 L240,111 L250,124 L260,107 L270,142 L280,111 L290,115 L300,134 L310,102 L320,129 L330,115 L340,107 L350,129 L360,102 L370,124 L380,111 L390,134 L400,115 L410,98 L420,129 L430,107 L440,124 L450,111 L460,138 L470,115 L480,107 L490,129 L500,102 L510,124 L520,111 L530,107 L540,124 L550,98 L560,134 L570,111 L580,124 L590,102"/>
+            <line x1="595" y1="0" x2="595" y2="220" stroke="#6efa9b" stroke-width=".7" stroke-opacity=".7"/>
+            <circle cx="595" cy="102" r="2.2" fill="#ff9f80"/>
+            <circle cx="595" cy="111" r="2.2" fill="#80c8ff"/>
+          </svg>
+        </div>
+
+        <div class="charts">
+          <div class="chart">
+            <div class="h">
+              <span class="k">Focus HFR</span>
+              <span class="d warn">↑ 0.06 / 30M</span>
+              <span class="v warn">1.84″</span>
+            </div>
+            <div class="body">
+              <svg viewBox="0 0 200 64" preserveAspectRatio="none">
+                <line x1="0" y1="32" x2="200" y2="32" stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="2,4"/>
+                <text x="2" y="9" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">2.4″</text>
+                <text x="2" y="61" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">1.4″</text>
+                <path fill="none" stroke="#f5f5f5" stroke-width="1.4" stroke-linejoin="round"
+                      d="M0,40 L11,38 L22,36 L33,34 L44,32 L55,30 L66,28 L77,26 L88,22 L99,19 L110,16
+                         M110,16 L121,48 L132,46 L143,44 L154,40 L165,38 L176,34 L187,32 L200,30"/>
+                <circle cx="200" cy="30" r="2" fill="#f5f5f5"/>
+              </svg>
+            </div>
+          </div>
+          <div class="chart">
+            <div class="h">
+              <span class="k">CCD temp</span>
+              <span class="d ok">ON TARGET</span>
+              <span class="v ok">−10.0°</span>
+            </div>
+            <div class="body">
+              <svg viewBox="0 0 200 64" preserveAspectRatio="none">
+                <text x="2" y="9" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">−9.5</text>
+                <text x="2" y="61" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">−10.5</text>
+                <line x1="0" y1="32" x2="200" y2="32" stroke="#1f1f1f" stroke-width=".5" stroke-dasharray="2,4"/>
+                <path fill="none" stroke="#6efa9b" stroke-width="1.4"
+                      d="M0,32 L11,32 L22,30 L33,32 L44,34 L55,32 L66,32 L77,30 L88,32 L99,32 L110,34 L121,32 L132,32 L143,30 L154,32 L165,34 L176,32 L187,32 L200,32"/>
+                <circle cx="200" cy="32" r="2" fill="#6efa9b"/>
+              </svg>
+            </div>
+          </div>
+          <div class="chart">
+            <div class="h">
+              <span class="k">Sky brightness</span>
+              <span class="d warn">−0.6 / 1H</span>
+              <span class="v warn">20.8</span>
+            </div>
+            <div class="body">
+              <svg viewBox="0 0 200 64" preserveAspectRatio="none">
+                <text x="2" y="9" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">21.5</text>
+                <text x="2" y="61" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">20.5</text>
+                <path fill="none" stroke="#d8d8d8" stroke-width="1.4"
+                      d="M0,11 L11,11 L22,17 L33,17 L44,17 L55,23 L66,23 L77,23 L88,29 L99,29 L110,35 L121,35 L132,40 L143,40 L154,40 L165,46 L176,46 L187,46 L200,46"/>
+                <circle cx="200" cy="46" r="2" fill="#d8d8d8"/>
+              </svg>
+            </div>
+          </div>
+          <div class="chart">
+            <div class="h">
+              <span class="k">Dew margin</span>
+              <span class="d warn">↓ 3.4 / 1H</span>
+              <span class="v warn">4.8°</span>
+            </div>
+            <div class="body">
+              <svg viewBox="0 0 200 64" preserveAspectRatio="none">
+                <text x="2" y="9" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">10°</text>
+                <text x="2" y="61" fill="#3a3a3a" font-size="8" font-family="ui-monospace,monospace">0°</text>
+                <line x1="0" y1="58" x2="200" y2="58" stroke="#fafafa" stroke-width=".5" stroke-dasharray="2,4" stroke-opacity=".4"/>
+                <text x="198" y="56" fill="#6e6e6e" font-size="7" font-family="ui-monospace,monospace" text-anchor="end">DEW</text>
+                <path fill="none" stroke="#d8d8d8" stroke-width="1.4"
+                      d="M0,12 L11,15 L22,15 L33,15 L44,17 L55,17 L66,21 L77,23 L88,26 L99,29 L110,32 L121,35 L132,37 L143,40 L154,43 L165,45 L176,48 L187,48 L200,50"/>
+                <circle cx="200" cy="50" r="2" fill="#d8d8d8"/>
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="side">
+        <h3>Equipment <span></span></h3>
+        <ul class="eq">
+          <li>Camera <span class="v">−10.0°C</span></li>
+          <li>Mount <span class="v">RMS 0.62″</span></li>
+          <li>Focuser <span class="v">14820 · 22.4°</span></li>
+          <li>Guider <span class="v">snr 32 · 2.1px</span></li>
+          <li class="warn">Sky <span class="v">18% ↑</span></li>
+          <li class="warn">Dew margin <span class="v">4.8°</span></li>
+        </ul>
+
+        <h3 class="idle">Plan</h3>
+        <ul class="stages">
+          <li class="done">Slew &amp; solve <span class="v">2:04</span></li>
+          <li class="done">Auto-focus <span class="v">3:11</span></li>
+          <li class="done">PHD2 calibrate <span class="v">1:47</span></li>
+          <li class="live"><strong>L · 300s × 10</strong> <span class="v">4 / 10</span></li>
+          <li class="muted">R · 180s × 10 <span class="v">0 / 10</span></li>
+          <li class="muted">G · 180s × 10 <span class="v">0 / 10</span></li>
+          <li class="muted">B · 180s × 10 <span class="v">0 / 10</span></li>
+          <li class="muted">Park &amp; shutdown</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<main>
+
+  <!-- HERO -->
+  <section>
+    <div class="sec-h">
+      <span class="num">01.</span>
+      <span class="label">Capturing now</span>
+      <span class="meta">started <b>21:18</b> · <b>26m 14s</b> remaining</span>
+    </div>
+
+    <div class="hero">
+      <div class="hero-ring">
+        <div class="pct">42</div>
+        <div class="pctSub">PERCENT</div>
+        <div class="bar"></div>
+      </div>
+      <div class="hero-body">
+        <div class="hero-tag">CAPTURING · LUMINANCE · 300s</div>
+        <h1>M51 <span class="dim">— Whirlpool</span></h1>
+        <div class="meta-row">FRAME <b>04 / 10</b> THIS FILTER  ·  <b>30 / 40</b> ACROSS L R G B  ·  FINISH <b>01:42</b></div>
+        <ul class="hero-stages">
+          <li class="done">Slew</li>
+          <li class="done">Focus</li>
+          <li class="done">Guide</li>
+          <li class="live">L</li>
+          <li>R</li>
+          <li>G</li>
+          <li>B</li>
+          <li>Park</li>
+        </ul>
+      </div>
+      <div class="hero-actions">
+        <button class="btn">Pause</button>
+        <button class="btn danger">Abort</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- LATEST FRAME -->
+  <section>
+    <div class="sec-h">
+      <span class="num">02.</span>
+      <span class="label">Latest frame</span>
+      <span class="meta">just landed · <b>21:18:04</b></span>
+    </div>
+    <div class="frame" style="margin-top:var(--t3)">
+      <div class="frame-h">
+        <span class="name">M51 · L · 300s</span>
+        <span class="meta">FRAME 0042</span>
+        <div class="actions">
+          <a class="dim">OPEN</a>
+          <a class="dim">DOWNLOAD</a>
+        </div>
+      </div>
+      <div class="frame-img">
+        <svg viewBox="0 0 800 450" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <radialGradient id="neb9" cx="50%" cy="50%" r="60%">
+              <stop offset="0%" stop-color="#a78bfa" stop-opacity=".35"/>
+              <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+            </radialGradient>
+            <radialGradient id="core9" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="#fff7ed" stop-opacity=".95"/>
+              <stop offset="35%" stop-color="#fbbf24" stop-opacity=".55"/>
+              <stop offset="100%" stop-color="#7c2d12" stop-opacity="0"/>
+            </radialGradient>
+          </defs>
+          <rect width="800" height="450" fill="#03050b"/>
+          <ellipse cx="400" cy="225" rx="380" ry="200" fill="url(#neb9)"/>
+          <g transform="translate(400 225) rotate(-22)">
+            <ellipse rx="60" ry="40" fill="url(#core9)"/>
+            <path d="M 0 0 Q -150 -50 -240 -10 Q -290 20 -310 70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+            <path d="M 0 0 Q 150 50 240 10 Q 290 -20 310 -70" stroke="#fde68a" stroke-opacity=".35" stroke-width="2" fill="none"/>
+          </g>
+          <ellipse cx="610" cy="160" rx="20" ry="16" fill="#fef3c7" fill-opacity=".7"/>
+          <g fill="#fff">
+            <circle cx="50" cy="60" r="1"/><circle cx="120" cy="100" r=".8"/><circle cx="180" cy="40" r=".6"/>
+            <circle cx="240" cy="160" r="1.2"/><circle cx="300" cy="70" r=".7"/><circle cx="360" cy="140" r=".9"/>
+            <circle cx="420" cy="30" r=".6"/><circle cx="480" cy="180" r="1"/><circle cx="540" cy="50" r=".8"/>
+            <circle cx="600" cy="120" r="1.2"/><circle cx="660" cy="80" r=".7"/><circle cx="720" cy="140" r=".9"/>
+            <circle cx="80" cy="200" r=".6"/><circle cx="160" cy="240" r="1"/><circle cx="220" cy="300" r=".8"/>
+            <circle cx="340" cy="320" r="1.2"/><circle cx="460" cy="260" r=".9"/><circle cx="520" cy="340" r="1"/>
+            <circle cx="640" cy="360" r=".8"/><circle cx="700" cy="280" r="1.2"/><circle cx="60" cy="360" r=".9"/>
+            <circle cx="380" cy="430" r="1.2"/><circle cx="500" cy="430" r=".6"/><circle cx="770" cy="60" r=".7"/>
+          </g>
+        </svg>
+        <div class="frame-ovl">HFR 1.84″ · STARS 2941 · ADU 1247 · ECC 0.41</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PAST SESSIONS -->
+  <section>
+    <div class="sec-h">
+      <span class="num">03.</span>
+      <span class="label">Past sessions</span>
+      <span class="meta">last <b>30 days</b> · <b>12 sessions</b></span>
+    </div>
+
+    <div class="tl" style="margin-top:var(--t3)">
+      <details class="tl-row">
+        <summary class="tl-summary">
+          <span class="row-chev"></span>
+          <span class="tl-marker done"></span>
+          <div class="body">
+            <div class="row1">
+              <span class="name">M101 <span class="dim">— Pinwheel</span></span>
+              <span class="when">last night · 22:14 → 03:48</span>
+            </div>
+            <div class="desc">L 20 · R 14 · G 14 · B 14 · 5h 34m on target · HFR 1.91″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-row">
+        <summary class="tl-summary">
+          <span class="row-chev"></span>
+          <span class="tl-marker warn"></span>
+          <div class="body">
+            <div class="row1">
+              <span class="name">NGC 7000 <span class="dim">— North America</span></span>
+              <span class="when">3 days ago · 21:48 → 02:11</span>
+            </div>
+            <div class="desc">38 of 50 planned · aborted — clouds rose above 60%</div>
+          </div>
+          <span class="tl-pill warn">aborted</span>
+        </summary>
+      </details>
+      <details class="tl-row">
+        <summary class="tl-summary">
+          <span class="row-chev"></span>
+          <span class="tl-marker done"></span>
+          <div class="body">
+            <div class="row1">
+              <span class="name">M31 <span class="dim">— Andromeda</span></span>
+              <span class="when">a week ago · 20:31 → 04:02</span>
+            </div>
+            <div class="desc">L 22 · R 20 · G 20 · B 20 · 7h 31m on target · HFR 1.78″</div>
+          </div>
+          <span class="tl-pill ok">complete</span>
+        </summary>
+      </details>
+      <details class="tl-row">
+        <summary class="tl-summary">
+          <span class="row-chev"></span>
+          <span class="tl-marker bad"></span>
+          <div class="body">
+            <div class="row1">
+              <span class="name">IC 1396 <span class="dim">— Elephant's Trunk</span></span>
+              <span class="when">12 days ago · 22:02 → 23:00</span>
+            </div>
+            <div class="desc">12 of 60 planned · failed — guide loss after meridian flip</div>
+          </div>
+          <span class="tl-pill bad">failed</span>
+        </summary>
+      </details>
+    </div>
+  </section>
+
+</main>
+
+</body>
+</html>

--- a/docs/plans/ui-design/mocks/README.md
+++ b/docs/plans/ui-design/mocks/README.md
@@ -1,0 +1,62 @@
+# Activity stream UI mocks
+
+Static HTML mocks exploring the user-facing UI for rusty-photon. Each file is fully self-contained: vanilla CSS, system fonts, inline SVG, no JavaScript dependencies, no CDN. Open any file directly in a browser.
+
+These are **reference artifacts only** — no production code yet. They exist to lock in the chosen UX paradigm and visual direction before any implementation begins, so future implementation work can be evaluated against a concrete target rather than re-derived from scratch.
+
+## Files
+
+| File | Direction | Familiar pattern |
+|------|-----------|------------------|
+| `1-gallery.html` | Image-first, hero astrophoto with right metadata rail and bottom filmstrip | Lightroom / Apple Photos |
+| `2-dashboard.html` | Multi-panel grid with sidebar nav, dedicated status card, image card, history accordion | Linear / Notion / GitHub Projects |
+| `3-stream.html` | Single-column narrative feed: hero status + latest image + collapsible past sessions | Vercel deploys / Stripe activity |
+| `4-stream-inline.html` | Stream + a big always-on live telemetry card under the hero | — |
+| `5-stream-sticky.html` | Stream + a thin sticky telemetry strip pinned under the nav | — |
+| `6-live.html` | Standalone full-screen telemetry view (superseded by #7) | Trading apps / Grafana |
+| **`7-stream-fold.html`** | **Chosen direction.** Stream + collapsible-by-default sticky telemetry strip that folds open into a full-width inline panel. Includes a CSS-only night-vision toggle. | Stripe activity + collapsible drawers |
+
+## Chosen direction (`7-stream-fold.html`)
+
+A narrative activity stream is the spine of the UI — taking image after image is essentially a story being told over time, and the stream paradigm matches that natively. Live telemetry is layered on top via a sticky strip that's:
+
+- **Collapsed by default**: a 44-px tall pinned bar showing key live numbers (RA / Dec sparklines, HFR, CCD temp, sky brightness) and current operation.
+- **Expandable in place**: clicking the strip folds open a full-width panel containing the full PHD2-style guider graph (with ±1.0″ / ±0.5″ reference bands and time axis), four trend-chart cards (HFR, CCD temp, sky brightness, dew margin), an equipment LED list, and the ordered "tonight's plan" stage list.
+- **Animated**: the panel rolls down using the CSS Grid `0fr → 1fr` trick (cross-browser since 2023) — no JavaScript, no `interpolate-size` requirement.
+
+A single fold-out panel obviates the need for a separate "punch out" full-screen view. `6-live.html` is kept for historical reference but is not reachable from the chosen UI.
+
+## Night-vision mode
+
+Implemented in `7-stream-fold.html`. A pure-CSS toggle (`<input type="checkbox">` + `body:has(:checked)` selector) applies a single page-level `filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7)` that:
+
+- Desaturates astrophotos to true B&W (no residual color).
+- Re-tints the entire UI to red shades, preserving dark adaptation.
+- Dims overall brightness for night use.
+
+**Known limitation**: the filter collapses all hues to red, so green/amber/red severity LEDs become brightness differences instead of color differences. A real implementation should supplement with explicit overrides (or pulse animation) on critical alert states.
+
+## Key design decisions
+
+- **Stream over dashboard.** Capturing is inherently a narrative; the dashboard layout was strong but the stream tells the story better.
+- **Web-first, not desktop.** Targets a remote-access pattern (browser on a laptop, server on the Pi) rather than NINA/SGP-style desktop apps that need a large monitor.
+- **Borrow familiar idioms.** Patterns from web tools users already know (Stripe activity, Vercel deploys, GitHub Actions) so onboarding cost is low — the goal is "users have already learned the interactions elsewhere."
+- **Telemetry is layered, not central.** The stream stays narrative; live telemetry is a transient panel that's mini by default, expandable on demand. Avoids the "constantly-watching cockpit" feel that would compete with reading session history.
+- **Dark mode default + night-vision overlay.** Dark is non-negotiable for astronomy; night-vision is a one-tap layer on top, not a separate theme.
+
+## What's not decided yet
+
+- **Idle state** — what does the page look like when no session is running? The strip and panel are session-only. The stream below should probably show a "Start a session" CTA in place of the hero.
+- **When the strip auto-expands.** Closed-by-default for routine sessions; open-by-default if telemetry crosses a threshold (e.g., HFR climbing, guide RMS spiking) is a candidate.
+- **Severity color encoding under night vision.** See limitation above.
+- **Mobile / phone layout.** Mocks are sized for desktop/tablet. Phone (chair-side glance) is a separate exercise.
+
+## Implementation pointers
+
+When the time comes to implement, the natural Rust stack is:
+
+- Templates: Maud or Askama (server-rendered HTML)
+- Interactivity: HTMX for partial updates instead of polling
+- Styling: pull the inline CSS from `7-stream-fold.html` into a stylesheet; Tailwind + DaisyUI works if a utility approach is preferred
+- Live data: server-sent events or WebSocket for the strip / panel updates
+- Existing baseline: `services/sentinel/src/dashboard.rs` is the current hand-rolled axum dashboard and shows the rendering style already in use

--- a/docs/plans/ui-design/mocks/README.md
+++ b/docs/plans/ui-design/mocks/README.md
@@ -2,19 +2,22 @@
 
 Static HTML mocks exploring the user-facing UI for rusty-photon. Each file is fully self-contained: vanilla CSS, system fonts, inline SVG, no JavaScript dependencies, no CDN. Open any file directly in a browser.
 
-These are **reference artifacts only** — no production code yet. They exist to lock in the chosen UX paradigm and visual direction before any implementation begins, so future implementation work can be evaluated against a concrete target rather than re-derived from scratch.
+These are **reference artifacts only** — no production code yet. They exist to lock in the chosen UX paradigm, visual direction, and implementation approach before any code is written, so future implementation work can be evaluated against a concrete target rather than re-derived from scratch.
 
 ## Files
 
-| File | Direction | Familiar pattern |
-|------|-----------|------------------|
-| `1-gallery.html` | Image-first, hero astrophoto with right metadata rail and bottom filmstrip | Lightroom / Apple Photos |
-| `2-dashboard.html` | Multi-panel grid with sidebar nav, dedicated status card, image card, history accordion | Linear / Notion / GitHub Projects |
-| `3-stream.html` | Single-column narrative feed: hero status + latest image + collapsible past sessions | Vercel deploys / Stripe activity |
-| `4-stream-inline.html` | Stream + a big always-on live telemetry card under the hero | — |
-| `5-stream-sticky.html` | Stream + a thin sticky telemetry strip pinned under the nav | — |
-| `6-live.html` | Standalone full-screen telemetry view (superseded by #7) | Trading apps / Grafana |
-| **`7-stream-fold.html`** | **Chosen direction.** Stream + collapsible-by-default sticky telemetry strip that folds open into a full-width inline panel. Includes a CSS-only night-vision toggle. | Stripe activity + collapsible drawers |
+| File | Status | Direction | Familiar pattern |
+|------|--------|-----------|------------------|
+| `1-gallery.html` | rejected | Image-first, hero astrophoto with right metadata rail and bottom filmstrip | Lightroom / Apple Photos |
+| `2-dashboard.html` | rejected | Multi-panel grid with sidebar nav, dedicated status card, image card, history accordion | Linear / Notion / GitHub Projects |
+| `3-stream.html` | foundational | Single-column narrative feed: hero status + latest image + collapsible past sessions | Vercel deploys / Stripe activity |
+| `4-stream-inline.html` | foundational | Stream + a big always-on live telemetry card under the hero | — |
+| `5-stream-sticky.html` | foundational | Stream + a thin sticky telemetry strip pinned under the nav | — |
+| `6-live.html` | superseded | Standalone full-screen telemetry view (replaced by the inline fold panel in #7) | Trading apps / Grafana |
+| **`7-stream-fold.html`** | **chosen** | Stream + collapsible-by-default sticky telemetry strip that folds open into a full-width inline panel. CSS-only night-vision toggle. | Stripe activity + collapsible drawers |
+| `8-plugin-polish.html` | rejected | Warm-dark "instrument-panel + editorial" polish pass on #7 (serif headlines, reticle corners, grain texture, synchronized heartbeat pulse, amber "armed" bar) | — |
+| `9-plugin-fresh.html` | rejected | Brutalist mono-terminal generated from scratch (strict grayscale, single phosphor-green accent, all-caps mono everywhere) | — |
+| `10-lcars.html` | **easter-egg theme** | Star Trek: The Next Generation LCARS interpretation. Bold colored elbows, condensed all-caps type, pill buttons, stardates, decorative reference codes. | Enterprise-D bridge displays |
 
 ## Chosen direction (`7-stream-fold.html`)
 
@@ -26,37 +29,107 @@ A narrative activity stream is the spine of the UI — taking image after image 
 
 A single fold-out panel obviates the need for a separate "punch out" full-screen view. `6-live.html` is kept for historical reference but is not reachable from the chosen UI.
 
+## LCARS easter-egg theme (`10-lcars.html`)
+
+A full-fidelity Star Trek: The Next Generation interpretation in the iconic LCARS visual language designed by Michael Okuda. Hits every LCARS grammatical element: L-shaped colored frame with rounded inside-corner elbows, pill buttons in the canonical Okudagram palette (amber, peach, violet, magenta, blue, yellow), all-caps condensed type, stardate and decorative reference codes (`M-04-2380`, `047-Δ`, `RP-NCC-04-2380-Δ-G`), multi-block colored section headers, and pill-shaped action buttons.
+
+Preserved as a future *theme*, not the production direction — LCARS is iconic but visually loud and is **not** what users learn from modern web tools, which conflicts with the "borrow familiar idioms" principle. As an opt-in theme accessible via a hidden config flag (or a Konami-code Easter egg), it costs nothing to maintain since the underlying structure and content are identical to `7-stream-fold.html`.
+
+**Bonus**: the night-vision toggle in `10-lcars.html` is thematically perfect — the LCARS amber → red shift is exactly how Enterprise displays transitioned from yellow to red alert.
+
+## Other rejected explorations (`#8`, `#9`)
+
+Both generated using the `frontend-design` plugin to test alternative aesthetic directions; both rejected after review:
+
+- **`8-plugin-polish.html` (warm-dark instrument-panel polish)** — too condensed and visually blocky compared to the chosen direction. The serif headlines, corner reticles, film grain, synchronized heartbeat pulse, and amber "armed" bar added gravitas at the cost of the breathing room that makes `#7` feel calm. Useful as a reference for *what not to do*: don't optimize for instrument-panel feel at the expense of legibility and white space.
+- **`9-plugin-fresh.html` (brutalist mono-terminal)** — beautiful in its own right but reads as a desktop developer tool (closer to k9s or a Bloomberg terminal than to a web app), which conflicts with the "feels like a familiar web tool" goal.
+
+The plugin's value here was mostly in stretching the design space — both rejections sharpened understanding of what *not* to do, even though neither output landed as the chosen direction.
+
 ## Night-vision mode
 
-Implemented in `7-stream-fold.html`. A pure-CSS toggle (`<input type="checkbox">` + `body:has(:checked)` selector) applies a single page-level `filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7)` that:
+Implemented in `7-stream-fold.html` (and inherited by `10-lcars.html`). A pure-CSS toggle using a hidden `<input type="checkbox">` + `body:has(:checked)` selector applies a single page-level filter:
 
+```css
+body:has(#night-vision:checked) {
+  filter: grayscale(1) sepia(1) hue-rotate(-50deg) saturate(7) brightness(0.7);
+}
+```
+
+Effects:
 - Desaturates astrophotos to true B&W (no residual color).
 - Re-tints the entire UI to red shades, preserving dark adaptation.
 - Dims overall brightness for night use.
 
 **Known limitation**: the filter collapses all hues to red, so green/amber/red severity LEDs become brightness differences instead of color differences. A real implementation should supplement with explicit overrides (or pulse animation) on critical alert states.
 
+## Animation technique (CSS Grid `0fr → 1fr`)
+
+The fold panel in `7-stream-fold.html` uses the CSS Grid `0fr → 1fr` trick for the roll-down animation, which works in every modern browser since late 2023 (Chrome / Firefox / Safari 117+) without requiring any JavaScript:
+
+```css
+.fold-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 320ms cubic-bezier(.4, 0, .2, 1);
+}
+.fold-body > .panel {
+  min-height: 0;
+  overflow: hidden;
+}
+.fold-state:checked ~ .fold-body { grid-template-rows: 1fr }
+```
+
+A wrapper div is a CSS Grid container whose single row animates between `0fr` (collapsed, content has zero height) and `1fr` (expanded, content stretches to its natural height). The inner content needs `min-height: 0` and `overflow: hidden` so it clips smoothly during the transition.
+
+A more modern alternative is `::details-content` + `interpolate-size: allow-keywords` (CSS 2024), but support landed later in Firefox and the grid trick is the reliable cross-browser baseline.
+
+The same `<input type="checkbox">` + `<label for>` + sibling-selector pattern is used for the night-vision toggle, keeping every mock JavaScript-free.
+
 ## Key design decisions
 
 - **Stream over dashboard.** Capturing is inherently a narrative; the dashboard layout was strong but the stream tells the story better.
-- **Web-first, not desktop.** Targets a remote-access pattern (browser on a laptop, server on the Pi) rather than NINA/SGP-style desktop apps that need a large monitor.
+- **Web-first, not desktop.** Targets a remote-access pattern (browser on a laptop in the warm room, server on the Pi) rather than NINA/SGP-style desktop apps that need a large monitor.
 - **Borrow familiar idioms.** Patterns from web tools users already know (Stripe activity, Vercel deploys, GitHub Actions) so onboarding cost is low — the goal is "users have already learned the interactions elsewhere."
 - **Telemetry is layered, not central.** The stream stays narrative; live telemetry is a transient panel that's mini by default, expandable on demand. Avoids the "constantly-watching cockpit" feel that would compete with reading session history.
 - **Dark mode default + night-vision overlay.** Dark is non-negotiable for astronomy; night-vision is a one-tap layer on top, not a separate theme.
+- **Foldable over punch-out.** A foldable in-place panel preserves narrative context. Punching out to a separate fullscreen view (`6-live.html`) was tried and rejected for breaking the stream's continuity.
 
 ## What's not decided yet
 
 - **Idle state** — what does the page look like when no session is running? The strip and panel are session-only. The stream below should probably show a "Start a session" CTA in place of the hero.
-- **When the strip auto-expands.** Closed-by-default for routine sessions; open-by-default if telemetry crosses a threshold (e.g., HFR climbing, guide RMS spiking) is a candidate.
+- **When the strip auto-expands.** Closed-by-default for routine sessions; open-by-default if telemetry crosses a threshold (HFR climbing, guide RMS spiking) is a candidate.
 - **Severity color encoding under night vision.** See limitation above.
-- **Mobile / phone layout.** Mocks are sized for desktop/tablet. Phone (chair-side glance) is a separate exercise.
+- **Mobile / phone layout.** Mocks are sized for desktop / tablet. Phone (chair-side glance) is a separate exercise.
 
-## Implementation pointers
+## Implementation plan
 
-When the time comes to implement, the natural Rust stack is:
+Target stack (chosen for minimal tooling, single Rust binary, no npm or Node dependencies):
 
-- Templates: Maud or Askama (server-rendered HTML)
-- Interactivity: HTMX for partial updates instead of polling
-- Styling: pull the inline CSS from `7-stream-fold.html` into a stylesheet; Tailwind + DaisyUI works if a utility approach is preferred
-- Live data: server-sent events or WebSocket for the strip / panel updates
-- Existing baseline: `services/sentinel/src/dashboard.rs` is the current hand-rolled axum dashboard and shows the rendering style already in use
+| Concern | Choice | Rationale |
+|---------|--------|-----------|
+| Templates | [Maud](https://maud.lambda.xyz/) — compile-time HTML inside Rust with type-safety | The `7-stream-fold.html` markup ports near-directly into Maud's `html!` macro |
+| HTTP server | axum | Already in use in `services/sentinel/src/dashboard.rs` |
+| Interactivity | [HTMX](https://htmx.org/) — single ~14KB JS file dropped in via `<script>`, declarative `hx-*` attributes, server returns HTML fragments | No build step, no `node_modules`. Server stays in Rust |
+| Live telemetry updates | Server-Sent Events (SSE) | axum has built-in support; server pushes new HTML fragments for strip values + chart sparklines on a regular interval, HTMX's SSE extension swaps them into target elements by ID |
+| Static assets | Embed via `include_str!()` / `include_bytes!()` (or `rust-embed`) | One executable ships everything (CSS, HTMX bundle, fonts) — fits the Pi 5 deployment story |
+| Foldable panel + night-vision | Stay pure CSS | Already working in mocks; no client-side JS needed |
+| Collapsible history items | Native `<details>` | No JS needed |
+
+### Rejected alternatives
+
+- **Tailwind via npm** — adds a Node toolchain, ruled out by the "no npm" preference.
+- **Tailwind standalone CLI** (Go binary, no Node) — viable but unnecessary; the chosen direction uses ~600 lines of vanilla CSS that's easier to maintain by hand at this scale.
+- **Leptos / Dioxus (Rust → WASM)** — powerful but adds a WASM build step, a frontend framework to learn, and is overkill for what is fundamentally a server-rendered control panel with a few live-updating fields.
+- **Hand-rolled HTML strings in Rust** (the current `services/sentinel/src/dashboard.rs` pattern) — fine for one small page, but `7-stream-fold.html` is large enough that Maud's structure and type-safety pay off.
+
+### Suggested implementation order
+
+When implementation begins:
+
+1. Port `7-stream-fold.html` markup into Maud with placeholder data
+2. Extract the inline `<style>` block into a single CSS file, embed via `include_str!()`
+3. Wire up axum routes and existing event sources to push live fragments via SSE
+4. Verify night-vision and fold-panel still work identically (they should — both are pure CSS)
+5. Decide on idle-state behavior (the open question above) and implement
+6. *(Optional)* implement the LCARS theme as a CSS variant, toggleable via a hidden config flag — nice-to-have, not blocking


### PR DESCRIPTION
## Summary

- Adds 7 self-contained HTML mocks under `docs/plans/ui-design/mocks/` exploring layouts and UX paradigms for the rusty-photon user-facing UI
- Captures the chosen direction and key design decisions in a README
- Reference artifacts only — no production code, no dependencies; intended to lock in the UX direction before implementation begins

## Chosen direction

`7-stream-fold.html` — an activity-stream spine (familiar from Vercel deploys / Stripe activity) with a collapsible-by-default sticky telemetry strip that folds open into a full-width inline panel. The panel contains the PHD2-style guider graph, four trend charts (HFR, CCD temp, sky brightness, dew margin), an equipment LED list, and the ordered "tonight's plan" stage list. A pure-CSS night-vision toggle remaps the entire UI to red shades and grayscales astrophotos for dark-adapted use.

The other six files document the paths considered and rejected (Lightroom-style image-first, Linear-style dashboard, several telemetry treatments, a standalone fullscreen telemetry view that the inline fold panel made unnecessary).

## Test plan

- [ ] Open each `.html` file directly in a browser — every file is fully self-contained (vanilla CSS, system fonts, inline SVG, no JS, no CDN)
- [ ] On `7-stream-fold.html`, verify: strip stays pinned while scrolling, click-to-fold animates smoothly, night-vision toggle in nav remaps the page
- [ ] Read the README to confirm the design rationale and known open questions (idle state, severity color encoding under night vision, mobile layout) match expectations