### PR TITLE
ci: refresh install-astap SHA pins to ASTAP CLI-2026.05.03

### DIFF
--- a/.github/actions/install-astap/action.yml
+++ b/.github/actions/install-astap/action.yml
@@ -42,7 +42,8 @@ runs:
   using: composite
   steps:
     # Per-OS table. SHA-256 values are pinned against the snapshot
-    # captured 2026-05-02 from upstream SourceForge. See
+    # captured 2026-05-04 from upstream SourceForge (ASTAP CLI
+    # version CLI-2026.05.03). See
     # docs/decisions/005-plate-solver.md §Verification Spike for
     # how/when to refresh these (any upstream release rotates the
     # archive and breaks this check by design).
@@ -55,37 +56,37 @@ runs:
             ARCHIVE="astap_command-line_version_Linux_amd64.zip"
             SUBDIR="linux_installer"
             BIN="astap_cli"
-            SHA256="424e9bcba8ad84b4125d4858f2de07822eff2f6710618f9312e4443de3b1c697"
+            SHA256="9d25e3f92a39863fb7e5762eb46cc3fcd3eb0d6554fda89136606af38d1904a2"
             ;;
           Linux-ARM64)
             ARCHIVE="astap_command-line_version_Linux_aarch64.zip"
             SUBDIR="linux_installer"
             BIN="astap_cli"
-            SHA256="0216f84430b6c2c9b3c0f061476755a6768319be02819447e2e3a7b6a7339267"
+            SHA256="c5391a0561ca71b4dbf0663bd82793dacc9160e78bb0d9961c447b8a074ec76c"
             ;;
           macOS-ARM64)
             ARCHIVE="astap_command-line_version_macOS_M1.zip"
             SUBDIR="macOS%20installer"
             BIN="astap_cli"
-            SHA256="5d8e5083bd6a5dd75a96592f847db20da528bab2e3ad55066bfe3da5cbf66829"
+            SHA256="0e8015112548dac31302bfeea2f607bce0306a7731e92121da001b7a11b8de0f"
             ;;
           macOS-X64)
             ARCHIVE="astap_command-line_version_macOS_x86_64.zip"
             SUBDIR="macOS%20installer"
             BIN="astap_cli"
-            SHA256="b4b1123a470cc324167be0fa375b1f6bd09357719115baa7e7d02198ae379ab4"
+            SHA256="ff95c60988fd1ff100d27f5943ff15bfd13935122549246b5115038f0001601e"
             ;;
           Windows-X64)
             ARCHIVE="astap_command-line_version_win64.zip"
             SUBDIR="windows_installer"
             BIN="astap_cli.exe"
-            SHA256="ac0bb228e46c25809c17c4a48e8e02e59d064067ab728cdd2b3e9b22b2093d91"
+            SHA256="5e0e222668e19ce0b187c91ece1a63389ad2b822b7913a7e7136908fc91e75d2"
             ;;
           Windows-ARM64)
             ARCHIVE="astap_command-line_version_win11_aarch64.zip"
             SUBDIR="windows_installer"
             BIN="astap_cli.exe"
-            SHA256="5ed42b4b7e5221aeca19953561ecc2f53f62ab5f122cd0dc5bdd28f086b86afc"
+            SHA256="4ac1298c07fbe9ededfbac260684fce45ab2c04425f11ac6aa2dd4c28951570d"
             ;;
           *)
             echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"

--- a/.github/actions/install-astap/action.yml
+++ b/.github/actions/install-astap/action.yml
@@ -70,12 +70,6 @@ runs:
             BIN="astap_cli"
             SHA256="0e8015112548dac31302bfeea2f607bce0306a7731e92121da001b7a11b8de0f"
             ;;
-          macOS-X64)
-            ARCHIVE="astap_command-line_version_macOS_x86_64.zip"
-            SUBDIR="macOS%20installer"
-            BIN="astap_cli"
-            SHA256="ff95c60988fd1ff100d27f5943ff15bfd13935122549246b5115038f0001601e"
-            ;;
           Windows-X64)
             ARCHIVE="astap_command-line_version_win64.zip"
             SUBDIR="windows_installer"

--- a/.github/workflows/install-astap.yml
+++ b/.github/workflows/install-astap.yml
@@ -28,8 +28,8 @@ jobs:
         # ubuntu-24.04-arm covers the Linux-ARM64 row of the action's
         # per-OS table — Raspberry Pi 5 is a documented plate-solver
         # target, so its SHA pin needs CI exercise like the others.
-        # Windows-ARM64 and macOS-X64 rows remain pinned-but-unexercised
-        # (not currently supported targets).
+        # The Windows-ARM64 row remains pinned-but-unexercised (not a
+        # currently supported target).
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/install-astap.yml
+++ b/.github/workflows/install-astap.yml
@@ -25,7 +25,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # ubuntu-24.04-arm covers the Linux-ARM64 row of the action's
+        # per-OS table — Raspberry Pi 5 is a documented plate-solver
+        # target, so its SHA pin needs CI exercise like the others.
+        # Windows-ARM64 and macOS-X64 rows remain pinned-but-unexercised
+        # (not currently supported targets).
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
       - name: Install ASTAP

--- a/.github/workflows/install-astap.yml
+++ b/.github/workflows/install-astap.yml
@@ -4,10 +4,10 @@
 # invokes it and asserts the banner string is present.
 #
 # This is the regression target ADR-005 references: each row in this
-# matrix corresponds to one of the ADR's per-platform open questions
-# (macOS Apple Silicon, Windows x64, Linux x64). When a row goes red,
-# operators following the same install recipe by hand would also see
-# the breakage.
+# matrix corresponds to one of the ADR's supported platforms — Linux
+# x64, Linux ARM64 (Raspberry Pi 5), macOS Apple Silicon, and Windows
+# x64. When a row goes red, operators following the same install
+# recipe by hand would also see the breakage.
 permissions:
   contents: read
 on:

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -299,9 +299,11 @@ The verification work has a single artefact: the local
 [`install-astap`](../../.github/actions/install-astap/action.yml)
 composite action plus the
 [`install-astap.yml`](../../.github/workflows/install-astap.yml)
-workflow that exercises it on `ubuntu-latest`, `macos-latest`, and
-`windows-latest`. The action is itself the install recipe — its per-OS
-table names the SourceForge archive each platform downloads from. The
+workflow that exercises it on `ubuntu-latest`, `ubuntu-24.04-arm`,
+`macos-latest`, and `windows-latest` — covering Linux-X64, Linux-ARM64
+(Raspberry Pi 5 target), macOS-ARM64, and Windows-X64. The action is
+itself the install recipe — its per-OS table names the SourceForge
+archive each platform downloads from. The
 smoke workflow forces a fresh upstream download on every run (by
 passing `use-cache: "false"` to the composite action, which skips
 both cache load and save) so upstream regressions surface within a

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -302,15 +302,17 @@ composite action plus the
 workflow that exercises it on `ubuntu-latest`, `macos-latest`, and
 `windows-latest`. The action is itself the install recipe — its per-OS
 table names the SourceForge archive each platform downloads from. The
-smoke workflow forces a fresh upstream download on every run (via
-`cache-key-suffix: github.run_id`) so upstream regressions surface
-within a CI cycle. This mirrors the model `install-omnisim` follows
-for the ASCOM simulator.
+smoke workflow forces a fresh upstream download on every run (by
+passing `use-cache: "false"` to the composite action, which skips
+both cache load and save) so upstream regressions surface within a
+CI cycle. This mirrors the model `install-omnisim` follows for the
+ASCOM simulator.
 
 ### Pinned SHA-256 + refresh procedure
 
 The action's per-OS table pins a SHA-256 for each downloaded archive
-(snapshot captured 2026-05-02) and the optional D05 database. Every
+(snapshot last refreshed 2026-05-04 against ASTAP CLI-2026.05.03)
+and the optional D05 database. Every
 download is verified before extraction; mismatch fails the action
 closed. ASTAP's URLs are unversioned ("latest" filenames), so
 upstream rotates the bytes without bumping the URL — the SHA pin

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -67,9 +67,9 @@ Windows x64, and Windows ARM64.
   hint flags; writes a `.wcs` sidecar that is straightforward to parse.
 - **Cross-platform, including Pi 5 and Apple Silicon.** Verified by
   the [`install-astap`](../../.github/actions/install-astap/action.yml)
-  smoke workflow on Linux x64 + macOS arm64 + Windows x64, plus a
-  manual Linux aarch64 install captured at ADR-time. See
-  [Verification Spike](#verification-spike) for the table of results.
+  smoke workflow on Linux x64, Linux ARM64, macOS arm64, and
+  Windows x64. See [Verification Spike](#verification-spike) for the
+  table of results.
 - **Active.** Releases through 2026-04-26 on the Windows line, 2026-04-28
   on Linux. The dominant default solver in the current amateur stack
   (N.I.N.A., APT, CCDciel).
@@ -312,29 +312,46 @@ ASCOM simulator.
 
 ### Pinned SHA-256 + refresh procedure
 
-The action's per-OS table pins a SHA-256 for each downloaded archive
-(snapshot last refreshed 2026-05-04 against ASTAP CLI-2026.05.03)
-and the optional D05 database. Every
-download is verified before extraction; mismatch fails the action
-closed. ASTAP's URLs are unversioned ("latest" filenames), so
+The action's per-OS table pins a SHA-256 for each downloaded ASTAP
+CLI archive (last refreshed 2026-05-04 against ASTAP CLI-2026.05.03)
+and a separate SHA-256 for the optional D05 star database (still
+pinned against the original 2026-05-02 snapshot — D05 has not
+rotated). Every download is verified before extraction; mismatch
+fails the action closed. ASTAP's URLs are unversioned ("latest" filenames), so
 upstream rotates the bytes without bumping the URL — the SHA pin
 turns that rotation into a deliberate, reviewed event rather than a
 silent supply-chain drift.
 
-**Refresh procedure** (when ASTAP releases an upstream update and the
-verify step starts failing):
+**Refresh procedure for the per-OS ASTAP CLI archives** (when
+ASTAP releases an upstream update and the verify step starts
+failing):
 
 1. Download each archive listed in the action's per-OS table from
-   SourceForge (and `d05_star_database.zip` if the database SHA is
-   what failed).
+   SourceForge.
 2. `sha256sum` each (or `shasum -a 256` on macOS).
 3. Update the corresponding `SHA256=` line in
-   `.github/actions/install-astap/action.yml` and the
-   `astap-d05-database-<8-hex-prefix>` cache-key prefix if applicable.
-4. Run the smoke workflow on the change to confirm the new pin
-   verifies cleanly on all three runner OSes.
+   `.github/actions/install-astap/action.yml`.
+4. Push to a PR branch — the `install-astap` smoke workflow will
+   then verify the new pins on every supported smoke-matrix OS
+   (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`,
+   `windows-latest`). The Windows-ARM64 pin is unsmoked; cross-mirror
+   pulls are the only verification.
 5. Land the PR with a brief note of which ASTAP CLI version the new
    bytes correspond to (read from the binary's `astap_cli` banner).
+
+**Refresh procedure for the D05 star database** (when upstream
+rotates `d05_star_database.zip` and the verify step starts failing
+in `plate-solver-smoke` — `install-astap` does **not** download D05,
+so a D05 refresh has to be smoked through `plate-solver-smoke`,
+which passes `download-database: "true"`):
+
+1. Download `d05_star_database.zip` from SourceForge.
+2. `sha256sum` it (or `shasum -a 256` on macOS).
+3. Update the `EXPECTED=` value in the database verify step **and**
+   the `astap-d05-database-<8-hex-prefix>` cache-key prefix in
+   `.github/actions/install-astap/action.yml`.
+4. Push to a PR branch — `plate-solver-smoke` exercises the
+   downloader on `ubuntu-latest` / `macos-latest` / `windows-latest`.
 
 ### Operator verification, after a BYO install
 
@@ -366,8 +383,8 @@ operators reading the file.
 
 | Platform | ASTAP CLI version | Source | Result |
 |----------|------------------|--------|--------|
-| Linux aarch64 | CLI-2026.02.09 | manual download from SourceForge (2026-05-01) | banner OK |
 | Linux x64 | latest | `install-astap` smoke workflow | banner OK |
+| Linux aarch64 | latest | `install-astap` smoke workflow (`ubuntu-24.04-arm`) | banner OK |
 | macOS arm64 | latest | `install-astap` smoke workflow | banner OK |
 | Windows x64 | CLI-2026.03.05 | `install-astap` smoke workflow | banner OK |
 


### PR DESCRIPTION
## Summary

Three things in this PR (all triggered by an upstream ASTAP rotation that broke CI):

1. **Refresh the per-OS SHA-256 pins** in `.github/actions/install-astap/action.yml` to the new ASTAP `CLI-2026.05.03` archives. Original failure: [run 25299640095](https://github.com/ivonnyssen/rusty-photon/actions/runs/25299640095). Snapshot date in the action's table comment + ADR-005 §Verification Spike both bumped to 2026-05-04.
2. **Expand the `install-astap` smoke matrix** to add `ubuntu-24.04-arm`, so the Linux-ARM64 (Pi 5) SHA pin gets CI exercise on every run instead of only being verified at human-refresh time. Pi 5 is a documented plate-solver target; the row was previously pinned-but-unsmoked.
3. **Drop the `macOS-X64` row from the action.** Not a currently supported plate-solver target (`macos-13` is on its end-of-life path; the Apple Silicon transition is years deep), so removing it shrinks the SHA-refresh maintenance surface to four supported rows. `Windows-ARM64` stays pinned-but-unsmoked since some operators may run on that hardware even though it's out-of-scope for v1.

## Provenance of the new SHAs

- **Linux-X64, macOS-ARM64, Windows-X64**: lifted from the failing CI runs' `actual:` lines (those are the three OSes the original smoke matrix already covered, so a fresh runner had downloaded and hashed them).
- **Linux-ARM64**: downloaded from SourceForge with the same URL the action uses, `sha256sum`'d, then re-downloaded once to confirm stability across pulls. The new `ubuntu-24.04-arm` smoke job in this PR is the first live verification of that SHA — green on this branch, so the locally-computed value matched what the GitHub-hosted ARM runner pulls.
- **Windows-ARM64**: downloaded the same way; pinned but unsmoked because there's no GitHub-hosted Windows-ARM64 runner and the row exists for operator BYO use only.
- Cross-checked the methodology by re-downloading Linux-X64 myself — local SHA matched the CI-reported actual, confirming the download path and `sha256sum` produce the same bytes the runners do.
- Read the ASTAP CLI banner from the Linux-ARM64 archive: `ASTAP astrometric solver version CLI-2026.05.03`. Consistent with all six archives rotating in the same upstream release.

## Test plan

- [x] `install-astap` smoke workflow passes on all four supported legs (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `windows-latest`) — confirmed in the latest CI run.
- [x] `plate-solver-smoke` (D05-enabled) succeeds with the new ASTAP-CLI pins.
- [ ] Wait for the rest of the broader CI workflows (`test`, `coverage`, `bazel`, etc.) to finish before merge.
- [ ] Windows-ARM64 row remains pinned-but-unsmoked; verified by cross-mirror pulls only at refresh time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)