### PR TITLE
ci(install-astap): move PR/push smoke to nightly + paths-filtered (#150)

### DIFF
--- a/.github/workflows/install-astap.yml
+++ b/.github/workflows/install-astap.yml
@@ -142,14 +142,27 @@ jobs:
               `notification cadence stays low. Close it once the underlying issue is`,
               `resolved; the next failure will reopen.`,
             ].join("\n");
+            // Search both open AND closed so the body's "the next failure
+            // will reopen" promise is honored. If a maintainer closes the
+            // tracking issue thinking the failure is resolved and the
+            // upstream rotation re-breaks us, we want one continuous
+            // thread per failure mode rather than a fresh issue each time.
             const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: "open",
+              state: "all",
               labels: "install-astap-nightly",
             });
             const match = existing.find(i => i.title === title);
             if (match) {
+              if (match.state === "closed") {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  state: "open",
+                });
+              }
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/install-astap.yml
+++ b/.github/workflows/install-astap.yml
@@ -8,16 +8,43 @@
 # (macOS Apple Silicon, Windows x64, Linux x64). When a row goes red,
 # operators following the same install recipe by hand would also see
 # the breakage.
+#
+# Cadence: nightly cron + workflow_dispatch (manual) + paths-filtered
+# PR/push. The workflow's only failure mode is an upstream SourceForge
+# rotation that invalidates a SHA pin — that happens on the order of
+# weeks-to-months, so paying for the matrix on every PR is mostly a
+# deterministic replay. The paths filter keeps PR-time verification on
+# changes that *can* affect the install (the action itself or this
+# workflow), so a SHA-refresh PR still runs the smoke before merge.
+# The nightly cron catches upstream rotations that arrive between
+# install-touching PRs, and notify-on-failure opens a tracking issue
+# so divergence is visible without trawling scheduled-workflow logs.
+name: install-astap
+
 permissions:
   contents: read
+
 on:
+  schedule:
+    # Daily at 04:30 UTC. Offset from plate-solver-smoke's 03:30 UTC so
+    # the two install-astap consumers don't hit the same SourceForge
+    # endpoint at the same minute.
+    - cron: "30 4 * * *"
+  workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - ".github/actions/install-astap/**"
+      - ".github/workflows/install-astap.yml"
   pull_request:
+    paths:
+      - ".github/actions/install-astap/**"
+      - ".github/workflows/install-astap.yml"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-name: install-astap
+
 jobs:
   smoke:
     name: install-astap / ${{ matrix.os }}
@@ -81,3 +108,59 @@ jobs:
             Write-Error "ASTAP banner not detected in output"
             exit 1
           }
+
+  notify-on-failure:
+    # Open or update a tracking issue when the nightly run fails so an
+    # upstream SHA rotation surfaces without depending on someone reading
+    # scheduled-workflow logs. Skipped on push, pull_request, and
+    # workflow_dispatch so manual debugging runs and refresh-PR
+    # verification don't churn an issue.
+    needs: smoke
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `nightly: install-astap smoke failing (likely upstream SHA rotation)`;
+            const body = [
+              `The nightly install-astap smoke workflow failed.`,
+              ``,
+              `Most likely cause: ASTAP upstream rotated a SourceForge archive`,
+              `without us refreshing the SHA pin in`,
+              `\`.github/actions/install-astap/action.yml\`. See ADR-005`,
+              `§"Pinned SHA-256 + refresh procedure" for the refresh steps.`,
+              ``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `This issue is opened automatically when the workflow fails on schedule.`,
+              `It will be updated (rather than re-opened) on subsequent failures so the`,
+              `notification cadence stays low. Close it once the underlying issue is`,
+              `resolved; the next failure will reopen.`,
+            ].join("\n");
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "install-astap-nightly",
+            });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: run ${context.runId}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["install-astap-nightly", "ci-flake"],
+              });
+            }

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -307,6 +307,27 @@ smoke workflow forces a fresh upstream download on every run (via
 within a CI cycle. This mirrors the model `install-omnisim` follows
 for the ASCOM simulator.
 
+### Trigger surface
+
+The smoke workflow runs on a nightly cron (04:30 UTC, offset from
+`plate-solver-smoke`'s 03:30 UTC), `workflow_dispatch` for manual
+re-runs, and on `push`/`pull_request` filtered to changes that touch
+`.github/actions/install-astap/**` or
+`.github/workflows/install-astap.yml`. The workflow's only failure
+mode is an upstream SourceForge rotation invalidating a SHA pin —
+that happens on the order of weeks-to-months, so paying for the
+full matrix on every PR would be a deterministic replay of the
+merge-base run. The paths filter preserves PR-time verification on
+the only PRs that *can* affect the install (the action itself, this
+workflow, or a SHA-refresh PR), and the nightly cron catches
+upstream rotations that arrive between install-touching PRs.
+
+A `notify-on-failure` job in the same workflow opens (or updates) a
+tracking issue labeled `install-astap-nightly` when a scheduled run
+fails, gated on `if: failure() && github.event_name == 'schedule'`
+so manual debugging runs and refresh-PR verification runs don't
+churn the issue.
+
 ### Pinned SHA-256 + refresh procedure
 
 The action's per-OS table pins a SHA-256 for each downloaded archive


### PR DESCRIPTION
## Summary
- Re-trigger `install-astap.yml` on nightly cron (04:30 UTC, offset from `plate-solver-smoke`'s 03:30), `workflow_dispatch`, and paths-filtered `push`/`pull_request` (the install action and this workflow only). Day-to-day PRs no longer pay for the four-leg matrix; SHA-refresh PRs still verify before merge.
- Add a `notify-on-failure` job that opens/updates an `install-astap-nightly`-labeled tracking issue when a scheduled run fails. Gated on `failure() && github.event_name == 'schedule'` so manual `workflow_dispatch` runs and refresh-PR verification don't churn the issue. Mirrors the `plate-solver-smoke` pattern.
- ADR-005 §Verification Spike gains a "Trigger surface" subsection documenting the new cadence and the notify-on-failure mechanism.

Closes #150

## Test plan
- [ ] PR check: this PR does **not** touch `.github/actions/install-astap/**` or `.github/workflows/install-astap.yml` from the merge-base in a way that should run smoke — wait, it does (the workflow file changed), so the smoke matrix should run on this PR exactly once and pass on all three OSes. Confirm in the Checks tab.
- [ ] Open a follow-up no-op PR (e.g. README typo) and confirm `install-astap` smoke is **skipped** entirely.
- [ ] Trigger the workflow manually via `gh workflow run install-astap.yml` and confirm it runs but does **not** open a tracking issue on failure (since `event_name != 'schedule'`).
- [ ] Wait for or simulate a nightly failure and confirm a tracking issue is created with label `install-astap-nightly`; on a second nightly failure, confirm the existing issue gets a comment instead of a new issue being opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)