### PR TITLE
test(bdd): reset all OmniSim devices per scenario (#149)

### DIFF
--- a/crates/bdd-infra/omnisim-config/ascom/alpaca/ascom-alpaca-simulator/covercalibrator/v1/instance-0.xml
+++ b/crates/bdd-infra/omnisim-config/ascom/alpaca/ascom-alpaca-simulator/covercalibrator/v1/instance-0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  OmniSim covercalibrator profile shipped by bdd-infra. This file is
+  the source of truth for the per-test simulator defaults; bdd-infra
+  copies the entire `crates/bdd-infra/omnisim-config/ascom/alpaca/...`
+  tree to a per-build XDG_CONFIG_HOME under the cargo target directory
+  before spawning OmniSim, so the simulator's own write-back on
+  startup goes there and never touches this checked-in copy.
+
+  Tunables relevant to BDD wall-clock:
+    Cover Opening Time            seconds; OmniSim uses asynchronous
+                                  behavior whenever this is > 0.5 s,
+                                  synchronous otherwise. We keep it
+                                  asynchronous (and just shorter than
+                                  the upstream default of 5.0) so the
+                                  production-mirroring cover-state
+                                  polling path is exercised.
+    Calibrator Stabilisation Time seconds; same > 0.5 s async rule
+                                  applies. Default upstream is 2.0.
+-->
+<ArrayOfSettingsPair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <SettingsPair>
+    <Key>UniqueID</Key>
+    <Value>fd25fce9-1a64-4c20-852f-6dff9014aebf</Value>
+  </SettingsPair>
+  <SettingsPair>
+    <Key>Cover Opening Time</Key>
+    <Value>0.6</Value>
+  </SettingsPair>
+  <SettingsPair>
+    <Key>Calibrator Stabilisation Time</Key>
+    <Value>0.6</Value>
+  </SettingsPair>
+</ArrayOfSettingsPair>

--- a/crates/bdd-infra/src/rp_harness/config.rs
+++ b/crates/bdd-infra/src/rp_harness/config.rs
@@ -40,6 +40,15 @@ pub struct CoverCalibratorConfig {
     pub id: String,
     pub alpaca_url: String,
     pub device_number: u32,
+    /// Override `cover_calibrator.poll_interval` in the emitted rp
+    /// config. `None` ⇒ rp's default (3 s). The BDD harness pins this
+    /// to a short duration (~100 ms) so cover/calibrator scenarios
+    /// don't sit through 3-second polls; production rp deployments use
+    /// the upstream default. The OmniSim profile we ship at
+    /// `crates/bdd-infra/omnisim-config/...` keeps the simulator-side
+    /// transitions short too — both knobs need to be small for the
+    /// scenario wall-clock to drop.
+    pub poll_interval: Option<std::time::Duration>,
 }
 
 /// Focuser equipment entry. `min_position` / `max_position` are the
@@ -193,11 +202,15 @@ impl RpConfigBuilder {
             .cover_calibrators
             .iter()
             .map(|cc| {
-                serde_json::json!({
+                let mut obj = serde_json::json!({
                     "id": cc.id,
                     "alpaca_url": cc.alpaca_url,
-                    "device_number": cc.device_number
-                })
+                    "device_number": cc.device_number,
+                });
+                if let Some(poll) = cc.poll_interval {
+                    obj["poll_interval"] = serde_json::json!(format!("{}ms", poll.as_millis()));
+                }
+                obj
             })
             .collect();
 

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -4,6 +4,7 @@
 //! via a [`tokio::sync::OnceCell`]. If an OmniSim is already listening on
 //! the default port it is reused; otherwise one is spawned.
 
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -165,6 +166,20 @@ impl OmniSimProcess {
             .env_remove("ASAN_OPTIONS")
             .env_remove("LSAN_OPTIONS");
 
+        // Point OmniSim at a per-build XDG_CONFIG_HOME under cargo's
+        // target dir, seeded from the checked-in profile templates in
+        // `crates/bdd-infra/omnisim-config/...`. The seed copy is the
+        // ONLY runtime write involved — subsequent OmniSim startup
+        // writes (UniqueID emission, full-profile persistence) all
+        // land in the per-build dir and never touch the checked-in
+        // source. Failures here are non-fatal: if the seed dir can't
+        // be prepared we just skip the override, OmniSim falls back
+        // to the user's `$HOME/.config/...`, and tests run with
+        // upstream defaults instead of our tuned ones.
+        if let Some(xdg) = Self::prepare_xdg_config_home() {
+            cmd.env("XDG_CONFIG_HOME", xdg);
+        }
+
         // On Linux, set PR_SET_PDEATHSIG so the kernel will SIGKILL this
         // child when the test process exits (normal, panic, or SIGKILL).
         #[cfg(target_os = "linux")]
@@ -189,6 +204,57 @@ impl OmniSimProcess {
         };
         process.wait_healthy().await;
         process
+    }
+
+    /// Seed a per-build `XDG_CONFIG_HOME` for OmniSim and return its
+    /// path. The seed is a recursive copy of the checked-in
+    /// `crates/bdd-infra/omnisim-config/...` tree. OmniSim writes back
+    /// to this directory on startup (e.g. emitting missing UniqueIDs,
+    /// persisting full default profiles), so we MUST copy the source
+    /// into a target-tree location and never let OmniSim see the
+    /// repository copy directly.
+    ///
+    /// The destination lives under `$CARGO_TARGET_DIR/bdd-infra-omnisim/`
+    /// (or `target/bdd-infra-omnisim/` if `CARGO_TARGET_DIR` is unset),
+    /// so it ends up in the same place `cargo clean` already reaches.
+    /// We fully reseed on every spawn so an OmniSim write-back from a
+    /// prior run can't leak into the next one.
+    ///
+    /// Returns `None` (and the caller proceeds without the override) on
+    /// any I/O failure — the simulator still works, just with upstream
+    /// defaults.
+    fn prepare_xdg_config_home() -> Option<PathBuf> {
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("omnisim-config");
+        let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .map(|workspace| workspace.join("target"))
+                    .unwrap_or_else(|| PathBuf::from("target"))
+            });
+        let dest = target_dir.join("bdd-infra-omnisim");
+        // Wipe whatever a prior run left behind so an OmniSim write-back
+        // from then can't survive into this run's profile.
+        let _ = std::fs::remove_dir_all(&dest);
+        Self::copy_dir_recursive(&src, &dest).ok()?;
+        Some(dest)
+    }
+
+    fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let from = entry.path();
+            let to = dest.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                Self::copy_dir_recursive(&from, &to)?;
+            } else {
+                std::fs::copy(&from, &to)?;
+            }
+        }
+        Ok(())
     }
 
     fn find_binary() -> String {

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -107,11 +107,6 @@ impl OmniSimHandle {
     /// position at the configured startup alt/az (default ≈ alt 38.9°
     /// az 165° — above horizon).
     ///
-    /// No-op if OmniSim is not yet running (e.g. invoked from a
-    /// pre-scenario hook before any scenario has spawned the
-    /// simulator). The shared `OMNISIM` singleton is checked via
-    /// `OnceCell::get`, which never blocks.
-    ///
     /// Errors are silently ignored: a failed reset shouldn't sink the
     /// scenario; if state pollution caused by a missed reset breaks a
     /// later assertion, the scenario will fail loudly there. The
@@ -119,15 +114,24 @@ impl OmniSimHandle {
     /// older or alternative simulators may 404 — that's expected and
     /// non-fatal.
     ///
+    /// If the shared `OMNISIM` singleton has not been initialised yet
+    /// (i.e. no scenario has gone through `OmniSimHandle::start()`),
+    /// the request is sent to the default base URL anyway. This lets a
+    /// `before(scenario)` hook reset a pre-existing OmniSim that the
+    /// suite is about to reuse, eliminating state leakage into the
+    /// very first scenario from a prior dev session. Connection
+    /// failures (no OmniSim on that port) are non-fatal — see above.
+    ///
     /// `class` must match one of OmniSim's device class slugs:
     /// `telescope`, `camera`, `covercalibrator`, `dome`, `filterwheel`,
     /// `focuser`, `observingconditions`, `rotator`, `safetymonitor`,
     /// `switch`.
     pub async fn restart_device(class: &str, n: u32) {
-        let Some(process) = OMNISIM.get() else {
-            return;
-        };
-        let url = format!("{}/simulator/v1/{}/{}/restart", process.base_url, class, n);
+        let base_url = OMNISIM
+            .get()
+            .map(|p| p.base_url.clone())
+            .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT));
+        let url = format!("{}/simulator/v1/{}/{}/restart", base_url, class, n);
         let Ok(client) = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -53,14 +53,59 @@ impl OmniSimHandle {
         }
     }
 
-    /// Reset the telescope simulator device to its OmniSim default state
-    /// without restarting the simulator process.
+    /// Reset the telescope simulator device 0 to its OmniSim default state.
+    /// See [`Self::restart_device`] for the underlying mechanism.
+    pub async fn reset_telescope() {
+        Self::restart_device("telescope", 0).await;
+    }
+
+    /// Reset the camera simulator device 0 to its OmniSim default state.
+    pub async fn reset_camera() {
+        Self::restart_device("camera", 0).await;
+    }
+
+    /// Reset the filter-wheel simulator device 0 to its OmniSim default state.
+    pub async fn reset_filter_wheel() {
+        Self::restart_device("filterwheel", 0).await;
+    }
+
+    /// Reset the focuser simulator device 0 to its OmniSim default state.
+    pub async fn reset_focuser() {
+        Self::restart_device("focuser", 0).await;
+    }
+
+    /// Reset the cover-calibrator simulator device 0 to its OmniSim default state.
+    pub async fn reset_cover_calibrator() {
+        Self::restart_device("covercalibrator", 0).await;
+    }
+
+    /// Reset every device class our BDD suites currently exercise
+    /// (telescope, camera, filter wheel, focuser, cover calibrator) to
+    /// OmniSim defaults. Issued in parallel — total wall-time is
+    /// dominated by a single localhost round-trip.
     ///
-    /// Posts to OmniSim's private `PUT /simulator/v1/telescope/{n}/restart`
-    /// endpoint, which calls `DriverManager.LoadTelescope(0)` server-side.
-    /// The result is equivalent to OmniSim having just started: AtPark
-    /// false, Tracking false, position at the configured startup
-    /// alt/az (default ≈ alt 38.9° az 165° — above horizon).
+    /// Other device classes (dome, rotator, switch, observingconditions,
+    /// safetymonitor) also expose `/restart`, but our scenarios don't
+    /// touch them yet; add a call here when that changes.
+    pub async fn reset_all_devices() {
+        tokio::join!(
+            Self::reset_telescope(),
+            Self::reset_camera(),
+            Self::reset_filter_wheel(),
+            Self::reset_focuser(),
+            Self::reset_cover_calibrator(),
+        );
+    }
+
+    /// Reset a single OmniSim device by class and instance number to
+    /// its default state without restarting the simulator process.
+    ///
+    /// Posts to OmniSim's private `PUT /simulator/v1/{class}/{n}/restart`
+    /// endpoint, which calls `DriverManager.Load{Class}(n)` server-side.
+    /// The result is equivalent to OmniSim having just started for that
+    /// device — e.g. for telescope: AtPark false, Tracking false,
+    /// position at the configured startup alt/az (default ≈ alt 38.9°
+    /// az 165° — above horizon).
     ///
     /// No-op if OmniSim is not yet running (e.g. invoked from a
     /// pre-scenario hook before any scenario has spawned the
@@ -73,11 +118,16 @@ impl OmniSimHandle {
     /// endpoint is OmniSim-only (not part of standard Alpaca), so
     /// older or alternative simulators may 404 — that's expected and
     /// non-fatal.
-    pub async fn reset_telescope() {
+    ///
+    /// `class` must match one of OmniSim's device class slugs:
+    /// `telescope`, `camera`, `covercalibrator`, `dome`, `filterwheel`,
+    /// `focuser`, `observingconditions`, `rotator`, `safetymonitor`,
+    /// `switch`.
+    pub async fn restart_device(class: &str, n: u32) {
         let Some(process) = OMNISIM.get() else {
             return;
         };
-        let url = format!("{}/simulator/v1/telescope/0/restart", process.base_url);
+        let url = format!("{}/simulator/v1/{}/{}/restart", process.base_url, class, n);
         let Ok(client) = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -198,11 +198,17 @@ These are not bugs. They reflect how real ASCOM mounts (especially GEMs) behave,
   cover/calibrator state every 3 s by default
   (`services/rp/src/config.rs::default_cover_calibrator_poll_interval`).
   Without overriding it, even a 0.6-second OmniSim transition
-  ends up bounded by rp's 3-second poll. The BDD harness sets
-  `cover_calibrator.poll_interval = 100ms` on every
-  `CoverCalibratorConfig` it builds (see
-  `crates/bdd-infra/src/rp_harness/config.rs`); production rp
-  deployments keep the upstream 3-second default.
+  ends up bounded by rp's 3-second poll.
+  `bdd_infra::rp_harness::CoverCalibratorConfig` exposes a
+  `poll_interval: Option<Duration>` field
+  (`crates/bdd-infra/src/rp_harness/config.rs`) that the
+  builder serialises into the rp config JSON; the actual
+  100 ms override is set at the BDD step call sites that
+  construct `CoverCalibratorConfig`
+  (`services/rp/tests/bdd/steps/cover_calibrator_steps.rs`
+  and
+  `services/calibrator-flats/tests/bdd/steps/flat_calibration_steps.rs`).
+  Production rp deployments keep the upstream 3-second default.
 
 ### Camera
 

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -165,8 +165,44 @@ These are not bugs. They reflect how real ASCOM mounts (especially GEMs) behave,
 ### Cover calibrator
 
 - **Default state: cover closed (`CoverState=1`), calibrator off
-  (`CalibratorState=1`).** Both transitions are effectively
-  instantaneous in the simulator (~10 ms). Reset is free.
+  (`CalibratorState=1`).** The cover then transitions through
+  `Moving (2)` → `Open (3)` over the configured `Cover Opening
+  Time` (upstream default **5.0 s**); the calibrator transitions
+  through `NotReady (4)` → `Ready (3)` over `Calibrator
+  Stabilisation Time` (default **2.0 s**). Both kept asynchronous
+  whenever those values are `> 0.5 s`; OmniSim flips to a
+  synchronous-blocking response when the configured time is
+  `≤ 0.5 s` (`SYNCHRONOUS_BEHAVIOUR_LIMIT`, see
+  `CoverCalibratorSimulator.cs:19`).
+- **Override via XML profile, not via HTTP.** OmniSim does not
+  expose a setter for these timings — `SimulatorController.cs`
+  only has `/reset`, `/restart`, and a read-only `/xmlprofile` —
+  so we ship test-friendly defaults as a checked-in profile under
+  `crates/bdd-infra/omnisim-config/ascom/alpaca/ascom-alpaca-simulator/covercalibrator/v1/instance-0.xml`.
+  Before spawning the simulator, `bdd-infra` recursively copies
+  that tree to `$CARGO_TARGET_DIR/bdd-infra-omnisim/` (with the
+  prior copy wiped first to avoid leakage between runs) and
+  points OmniSim at the target-tree copy via `XDG_CONFIG_HOME`.
+  The simulator emits UniqueIDs and persists full default
+  profiles for every other device on its first startup; those
+  writes land in the build directory, so the checked-in source
+  stays clean across normal test runs and `cargo clean` reaps
+  the persisted state.
+- **Test defaults.** Both timings are pinned to `0.6 s` — fast
+  enough that BDD scenarios don't sit through 5-second cover
+  slews, but still `> 0.5 s` so OmniSim keeps the asynchronous
+  state-machine path alive (rp's polling code still gets
+  exercised). Edit the XML to dial them in differently for local
+  experiments.
+- **Pair the XML override with rp's `poll_interval`.** rp polls
+  cover/calibrator state every 3 s by default
+  (`services/rp/src/config.rs::default_cover_calibrator_poll_interval`).
+  Without overriding it, even a 0.6-second OmniSim transition
+  ends up bounded by rp's 3-second poll. The BDD harness sets
+  `cover_calibrator.poll_interval = 100ms` on every
+  `CoverCalibratorConfig` it builds (see
+  `crates/bdd-infra/src/rp_harness/config.rs`); production rp
+  deployments keep the upstream 3-second default.
 
 ### Camera
 

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -127,9 +127,56 @@ These are not bugs. They reflect how real ASCOM mounts (especially GEMs) behave,
 
 - **Default startup position** is approximately altitude 38.9°, azimuth 165° (configurable via the setup UI). Above horizon for any reasonable observer/time, so a park slew from defaults always succeeds.
 
-### Other devices
+### Focuser
 
-(To be filled in as we learn — issue #149 tracks extending the BDD reset hook to non-mount devices, which will also surface their quirks.)
+- **Default position is 25000, not 0.** OmniSim's focuser starts up
+  (and re-initializes after `/simulator/v1/focuser/0/restart`) at
+  position **25000** out of `MaxStep=50000`. New tests that pick a
+  "neat" target like 5000 will appear to hang because of the next
+  point.
+- **Slew rate is ~400 steps/sec.** A `Move()` request blocks until
+  `IsMoving == false`; the simulator advances the position at a
+  fixed rate that works out to roughly 400 steps/sec on Linux. A
+  20,000-step move (default → 5000) takes ~51 s wall-clock. Verified
+  against OmniSim v0.5.0 (`PUT /api/v1/focuser/0/move` from the
+  default position).
+- **Implication for BDD scenarios:** with the per-scenario reset
+  wired into `before(scenario)` (issue #149), the focuser is set
+  back to 25000 before every scenario. Test target positions in
+  `services/rp/tests/features/{focuser,auto_focus}.feature` are
+  anchored near 25000 (typically `25000`, `24000`, `25500`, plus
+  bounds like `24900..25100`) so each `move_focuser` call slews ≤
+  ~500 steps and completes in ~1 s. Without that anchoring the rp
+  BDD suite picks up ~5 minutes of pure focuser slew wait.
+- **Don't fight the default — anchor near it.** The absolute
+  position value is rarely what the test cares about; what matters
+  is that the position changes in response to a tool call, lies
+  within the configured bounds, and round-trips through
+  `get_focuser_position`. Picking targets near 25000 satisfies all
+  of that without paying the slew cost. Both feature files carry an
+  inline comment to that effect.
+
+### Filter wheel
+
+- **Default position is 0.** Restart resets to slot 0. Slew between
+  adjacent slots is ~500 ms; full traversal (slot 0 → 4) is ~2 s.
+  Cheap enough that resetting between scenarios is free.
+
+### Cover calibrator
+
+- **Default state: cover closed (`CoverState=1`), calibrator off
+  (`CalibratorState=1`).** Both transitions are effectively
+  instantaneous in the simulator (~10 ms). Reset is free.
+
+### Camera
+
+- **Reset is instantaneous.** Restart re-instantiates the device
+  but doesn't run any slow setup. The CCD parameters return to
+  defaults; `Connected` goes back to false. rp re-issues
+  `set_connected(true)` on its next startup, so callers see a
+  short-lived disconnect window during the per-scenario reset and
+  serialization (`@serial`) is required to keep concurrent
+  scenarios from observing it.
 
 ## Cucumber-rs `@serial` tag
 
@@ -149,11 +196,22 @@ Scenarios with `@serial` (on scenario, rule, or feature level) run sequentially.
 
 ## Integration in this repo
 
-- `crates/bdd-infra/src/rp_harness/omnisim.rs` — process management. `OmniSimHandle::start` is a singleton-spawning shim; `OmniSimHandle::reset_telescope` wraps the `/simulator/v1/telescope/0/restart` endpoint.
+- `crates/bdd-infra/src/rp_harness/omnisim.rs` — process management.
+  `OmniSimHandle::start` is a singleton-spawning shim;
+  `OmniSimHandle::reset_telescope` / `reset_camera` /
+  `reset_filter_wheel` / `reset_focuser` /
+  `reset_cover_calibrator` each wrap the matching
+  `/simulator/v1/{class}/0/restart` endpoint, and
+  `reset_all_devices` issues them in parallel.
 
-- `services/rp/tests/bdd.rs` — the cucumber `before(scenario)` hook calls `reset_telescope` to give every scenario a clean default state. Other device classes are not yet wired up (issue #149).
+- `services/rp/tests/bdd.rs` and
+  `services/calibrator-flats/tests/bdd.rs` — the cucumber
+  `before(scenario)` hook calls `reset_all_devices` to give every
+  scenario a clean default state.
 
-- `services/rp/tests/features/mount.feature` — the `@serial` tag at file level forces sequential execution.
+- All BDD feature files that touch OmniSim are tagged `@serial`
+  (file-level) so the per-scenario reset can't disconnect a device
+  while another scenario is mid-flight.
 
 ## References
 

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -144,7 +144,7 @@ These are not bugs. They reflect how real ASCOM mounts (especially GEMs) behave,
   wired into `before(scenario)` (issue #149), the focuser is set
   back to 25000 before every scenario. Test target positions in
   `services/rp/tests/features/{focuser,auto_focus}.feature` are
-  anchored near 25000 (typically `25000`, `24000`, `25500`, plus
+  anchored near 25000 (typically `25000`, `24500`, `25500`, plus
   bounds like `24900..25100`) so each `move_focuser` call slews ≤
   ~500 steps and completes in ~1 s. Without that anchoring the rp
   BDD suite picks up ~5 minutes of pure focuser slew wait.

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -654,13 +654,15 @@ scenario N+1 would yank Connected back to false out from under scenario
 N's `StartExposure`. cucumber-rs draws at most one `@serial` scenario
 at a time and refuses to drain Concurrent scenarios while a Serial
 scenario is queued, so tagging every OmniSim-touching feature with
-`@serial` (file-level) is sufficient — non-OmniSim scenarios (auth,
-hash-password, TLS setup, ACME setup) stay Concurrent and run after the
-Serial queue empties. Look at `services/rp/tests/features/*.feature`
-and `services/calibrator-flats/tests/features/*.feature` for the
-expected pattern: a single `@serial` tag on the line above
-`Feature:`. Adding a new feature that touches OmniSim? Tag it
-`@serial` too.
+`@serial` (file-level) is sufficient. Look at
+`services/rp/tests/features/*.feature` and
+`services/calibrator-flats/tests/features/*.feature` for the expected
+pattern: a single `@serial` tag on the line above `Feature:`. Adding
+a new feature that touches OmniSim? Tag it `@serial` too. (Other
+features in this repo are already tagged `@serial` for their own
+reasons — auth tests share an Argon2id keying constant, TLS / ACME
+tests touch shared cert directories — so don't take their tagging as
+evidence one way or the other about OmniSim.)
 
 ---
 

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -611,6 +611,57 @@ temporarily replacing `debug!("did not exit after SIGTERM, sending SIGKILL", ...
 in `bdd-infra` with `eprintln!` and re-running BDD with stderr captured. A
 SIGKILL count > 0 means the lifecycle ordering is wrong somewhere.
 
+#### 5.5 Reset OmniSim devices in the `before(scenario)` hook
+
+**Critical for isolation.** OmniSim is a per-process singleton — every
+scenario shares the same simulator instance, so device state (mount
+position, AtPark/Tracking, cover position, calibrator brightness, filter
+slot, focuser position, camera config) leaks from scenario N into
+scenario N+1. The mount-state leak that hung `mount.feature::park` in
+issue #143 is the specific case we already hit; the fix generalises to
+every device class.
+
+The pattern is to call `OmniSimHandle::reset_all_devices()` from a
+cucumber `before(scenario)` hook. The helper issues parallel
+`PUT /simulator/v1/{class}/{n}/restart` requests to OmniSim's private
+restart endpoint for every class our suites touch (`telescope`,
+`camera`, `filterwheel`, `focuser`, `covercalibrator`); see
+`crates/bdd-infra/src/rp_harness/omnisim.rs`. Total per-scenario
+overhead is one localhost round-trip. The first call is a no-op
+because OmniSim hasn't been spawned yet — the `OnceCell` is empty —
+so it is safe to wire up unconditionally.
+
+```rust
+MyWorld::cucumber()
+    .before(|_feature, _rule, _scenario, _world| {
+        Box::pin(async move {
+            bdd_infra::rp_harness::OmniSimHandle::reset_all_devices().await;
+        })
+    })
+    .after(/* ... */)
+```
+
+If your scenarios start exercising additional device classes (dome,
+rotator, switch, observingconditions, safetymonitor — all of which
+expose the same `/restart` endpoint shape), add the corresponding
+helper call to `OmniSimHandle::reset_all_devices` so future
+contributors get the isolation for free.
+
+**Why scenarios that touch OmniSim must serialize.** A `before(scenario)`
+reset that disconnects the shared simulator's devices is unsafe to
+issue while another scenario is mid-flight against the same singleton —
+scenario N+1 would yank Connected back to false out from under scenario
+N's `StartExposure`. cucumber-rs draws at most one `@serial` scenario
+at a time and refuses to drain Concurrent scenarios while a Serial
+scenario is queued, so tagging every OmniSim-touching feature with
+`@serial` (file-level) is sufficient — non-OmniSim scenarios (auth,
+hash-password, TLS setup, ACME setup) stay Concurrent and run after the
+Serial queue empties. Look at `services/rp/tests/features/*.feature`
+and `services/calibrator-flats/tests/features/*.feature` for the
+expected pattern: a single `@serial` tag on the line above
+`Feature:`. Adding a new feature that touches OmniSim? Tag it
+`@serial` too.
+
 ---
 
 ### 6. Unit Test Rules

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -627,9 +627,12 @@ cucumber `before(scenario)` hook. The helper issues parallel
 restart endpoint for every class our suites touch (`telescope`,
 `camera`, `filterwheel`, `focuser`, `covercalibrator`); see
 `crates/bdd-infra/src/rp_harness/omnisim.rs`. Total per-scenario
-overhead is one localhost round-trip. The first call is a no-op
-because OmniSim hasn't been spawned yet — the `OnceCell` is empty —
-so it is safe to wire up unconditionally.
+overhead is one localhost round-trip. Before the singleton has been
+initialised the helper falls back to the default OmniSim base URL
+(`http://127.0.0.1:32323`), so a pre-existing OmniSim from a prior
+dev session is reset before scenario 1 reuses it; if no OmniSim is
+listening, the request fails silently and the hook is effectively a
+no-op. Either way the hook is safe to wire up unconditionally.
 
 ```rust
 MyWorld::cucumber()

--- a/services/calibrator-flats/tests/bdd.rs
+++ b/services/calibrator-flats/tests/bdd.rs
@@ -23,8 +23,10 @@ bdd_infra::bdd_main! {
                 // scenario N (cover position, calibrator brightness,
                 // filter slot, camera config) leaks into scenario N+1.
                 // Each reset is a localhost PUT, all run in parallel,
-                // so the overhead is one round-trip; no-op the first
-                // time through before OmniSim has been spawned.
+                // so the overhead is one round-trip. The first call
+                // also targets the default OmniSim port, so a
+                // pre-existing OmniSim from a prior dev session is
+                // reset before scenario 1 reuses it.
                 bdd_infra::rp_harness::OmniSimHandle::reset_all_devices().await;
             })
         })

--- a/services/calibrator-flats/tests/bdd.rs
+++ b/services/calibrator-flats/tests/bdd.rs
@@ -14,6 +14,20 @@ bdd_infra::bdd_main! {
     use world::CalibratorFlatsWorld;
 
     CalibratorFlatsWorld::cucumber()
+        .before(|_feature, _rule, _scenario, _world| {
+            Box::pin(async move {
+                // Reset every OmniSim device class our scenarios touch
+                // (telescope, camera, filter wheel, focuser, cover
+                // calibrator) to defaults before each scenario. OmniSim
+                // is a per-process singleton; without this, state from
+                // scenario N (cover position, calibrator brightness,
+                // filter slot, camera config) leaks into scenario N+1.
+                // Each reset is a localhost PUT, all run in parallel,
+                // so the overhead is one round-trip; no-op the first
+                // time through before OmniSim has been spawned.
+                bdd_infra::rp_harness::OmniSimHandle::reset_all_devices().await;
+            })
+        })
         .after(|_feature, _rule, _scenario, _finished, maybe_world| {
             Box::pin(async move {
                 if let Some(world) = maybe_world {

--- a/services/calibrator-flats/tests/bdd/steps/flat_calibration_steps.rs
+++ b/services/calibrator-flats/tests/bdd/steps/flat_calibration_steps.rs
@@ -181,6 +181,7 @@ async fn configure_default_equipment(world: &mut CalibratorFlatsWorld) {
                 id: "flat-panel".to_string(),
                 alpaca_url,
                 device_number: 0,
+                poll_interval: Some(std::time::Duration::from_millis(100)),
             });
     }
 }

--- a/services/calibrator-flats/tests/features/flat_calibration.feature
+++ b/services/calibrator-flats/tests/features/flat_calibration.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Calibrator flat field workflow (end-to-end)
   The calibrator-flats orchestrator is a real service that connects to rp
   as an MCP client. It closes the cover, turns on the calibrator,
@@ -7,7 +8,6 @@ Feature: Calibrator flat field workflow (end-to-end)
   These tests start all three processes (OmniSim, rp, calibrator-flats)
   and verify the full workflow end-to-end.
 
-  @serial
   Scenario: Calibrator-flats orchestrator captures flats and completes the session
     Given a running Alpaca simulator
     And the calibrator-flats service is configured for 2 "Luminance" flats and 2 "Red" flats
@@ -16,7 +16,6 @@ Feature: Calibrator flat field workflow (end-to-end)
     And the calibrator-flats orchestrator runs to completion
     Then the session status should be "idle"
 
-  @serial
   Scenario: Calibrator-flats orchestrator emits exposure events for each flat
     Given a running Alpaca simulator
     And a test webhook receiver subscribed to "exposure_complete"

--- a/services/rp/tests/bdd.rs
+++ b/services/rp/tests/bdd.rs
@@ -24,8 +24,9 @@ bdd_infra::bdd_main! {
                 // leak that hung `park` in issue #143 is the case we
                 // already hit. Each reset is a localhost PUT, all run
                 // in parallel, so the per-scenario overhead is one
-                // round-trip. No-op the first time through (OmniSim
-                // hasn't been spawned yet).
+                // round-trip. The first call also targets the default
+                // OmniSim port, so a pre-existing OmniSim from a prior
+                // dev session is reset before scenario 1 reuses it.
                 bdd_infra::rp_harness::OmniSimHandle::reset_all_devices().await;
             })
         })

--- a/services/rp/tests/bdd.rs
+++ b/services/rp/tests/bdd.rs
@@ -16,20 +16,17 @@ bdd_infra::bdd_main! {
     RpWorld::cucumber()
         .before(|_feature, _rule, _scenario, _world| {
             Box::pin(async move {
-                // Reset the OmniSim telescope to defaults before each
-                // scenario. The shared OmniSim is a singleton across the
-                // BDD process, so mount state (AtPark, Tracking,
-                // position) leaks between scenarios; a leak that
-                // leaves the mount below the horizon is exactly what
-                // hung the `park` scenario in issue #143. The reset is
-                // a no-op for the very first scenario (OmniSim hasn't
-                // been spawned yet) and an HTTP PUT for subsequent
-                // ones — fast enough to run unconditionally.
-                //
-                // Other device classes (camera, focuser, filter wheel,
-                // cover calibrator) have analogous reset endpoints but
-                // are not yet wired up here. Tracked separately.
-                bdd_infra::rp_harness::OmniSimHandle::reset_telescope().await;
+                // Reset every OmniSim device class our scenarios touch
+                // (telescope, camera, filter wheel, focuser, cover
+                // calibrator) to defaults before each scenario. The
+                // shared OmniSim is a singleton across the BDD process,
+                // so device state leaks between scenarios; the mount
+                // leak that hung `park` in issue #143 is the case we
+                // already hit. Each reset is a localhost PUT, all run
+                // in parallel, so the per-scenario overhead is one
+                // round-trip. No-op the first time through (OmniSim
+                // hasn't been spawned yet).
+                bdd_infra::rp_harness::OmniSimHandle::reset_all_devices().await;
             })
         })
         .after(|_feature, _rule, _scenario, _finished, maybe_world| {

--- a/services/rp/tests/bdd/steps/cover_calibrator_steps.rs
+++ b/services/rp/tests/bdd/steps/cover_calibrator_steps.rs
@@ -24,6 +24,7 @@ async fn rp_running_with_cover_calibrator_at(world: &mut RpWorld, url: String, d
         id: "flat-panel".to_string(),
         alpaca_url: url,
         device_number: device_number as u32,
+        poll_interval: Some(std::time::Duration::from_millis(100)),
     });
     start_rp(world).await;
 }
@@ -99,6 +100,7 @@ pub fn add_cover_calibrator(world: &mut RpWorld) {
             id: "flat-panel".to_string(),
             alpaca_url: url,
             device_number: 0,
+            poll_interval: Some(std::time::Duration::from_millis(100)),
         });
     }
 }

--- a/services/rp/tests/features/auto_focus.feature
+++ b/services/rp/tests/features/auto_focus.feature
@@ -1,4 +1,13 @@
 @serial
+# Test position convention: focus targets in this feature land within
+# ~500 steps of OmniSim's default focuser position (25000). At
+# OmniSim's simulated slew rate (~400 steps/sec), a 20k-step move
+# costs ~50s; the BDD before(scenario) hook resets the focuser to
+# the default before every scenario, so a round-number target like
+# 5000 turns auto_focus's multi-step sweeps into a multi-minute
+# wait. See docs/references/omnisim.md (Focuser section). Keep new
+# auto_focus scenarios anchored near 25000 unless the test
+# specifically depends on the absolute value.
 Feature: Auto-focus compound tool
   The auto_focus MCP tool drives a V-curve focus sweep using move_focuser,
   capture, and measure_basic internally. It captures one frame at each
@@ -105,9 +114,9 @@ Feature: Auto-focus compound tool
 
   Scenario: auto_focus rejects sweep grid too small after focuser bounds clamp
     Given a running Alpaca simulator
-    And rp is running with a camera and a focuser on the simulator with bounds 4900..5100
+    And rp is running with a camera and a focuser on the simulator with bounds 24900..25100
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 5000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25000
     And the MCP client calls auto_focus with focuser "main-focuser" camera "main-cam" duration "100ms" step_size 100 half_width 500 min_area 5 max_area 65536
     Then the tool call should return an error
     And the error message should contain "min_fit_points"
@@ -117,7 +126,7 @@ Feature: Auto-focus compound tool
     And a running Alpaca simulator
     And rp is running with a camera and a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 5000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25000
     And the MCP client calls auto_focus with focuser "main-focuser" camera "main-cam" duration "100ms" step_size 100 half_width 200 min_area 5 max_area 65536
     Then 5 FITS files should exist in the pinned data directory
     And every sidecar JSON in the pinned data directory should contain an "image_analysis" section

--- a/services/rp/tests/features/camera_info.feature
+++ b/services/rp/tests/features/camera_info.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Camera info tool
   The get_camera_info MCP tool reads camera capabilities from the connected
   ASCOM Alpaca device. It returns max_adu (full well depth in ADU),

--- a/services/rp/tests/features/compute_snr.feature
+++ b/services/rp/tests/features/compute_snr.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Signal-to-noise summary tool
   The compute_snr MCP tool runs detect_stars internally and returns the
   median per-star signal-to-noise ratio via the CCD-equation

--- a/services/rp/tests/features/detect_stars.feature
+++ b/services/rp/tests/features/detect_stars.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Star detection tool
   The detect_stars MCP tool returns the per-star list that measure_basic
   produces internally -- coordinates, flux, peak, and saturation flags --

--- a/services/rp/tests/features/document_http_api.feature
+++ b/services/rp/tests/features/document_http_api.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Document HTTP API
   The /api/documents/{document_id} route exposes the exposure document --
   capture metadata plus any sections that image-analysis tools or plugins

--- a/services/rp/tests/features/equipment_connectivity.feature
+++ b/services/rp/tests/features/equipment_connectivity.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Equipment connectivity
   rp connects to ASCOM Alpaca devices at startup and reports their status
   through the REST API. Equipment configuration is read from the config

--- a/services/rp/tests/features/estimate_background.feature
+++ b/services/rp/tests/features/estimate_background.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Sigma-clipped background estimation tool
   The estimate_background MCP tool returns sigma-clipped mean, stddev, and
   median of the image background. It accepts either document_id (resolved via

--- a/services/rp/tests/features/event_delivery.feature
+++ b/services/rp/tests/features/event_delivery.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Event delivery to webhook subscribers
   rp emits events when equipment operations occur. Plugins subscribe to
   events via webhook URLs configured at startup. rp POSTs events to each
@@ -24,7 +25,6 @@ Feature: Event delivery to webhook subscribers
     And the test webhook receiver should receive an "exposure_complete" event
     And "exposure_started" should have been received before "exposure_complete"
 
-  @serial
   Scenario: Filter switch event is delivered when filter changes
     Given a running Alpaca simulator
     And a test webhook receiver subscribed to "filter_switch"

--- a/services/rp/tests/features/focuser.feature
+++ b/services/rp/tests/features/focuser.feature
@@ -12,6 +12,17 @@ Feature: Focuser tools
   the operator-configured min_position / max_position bounds before
   issuing the Alpaca call.
 
+  # Test position convention: target focuser positions in these
+  # scenarios are chosen to land within ~500 steps of OmniSim's
+  # default focuser position (25000). At OmniSim's simulated slew
+  # rate (~400 steps/sec), a 20k-step move costs ~50s; the BDD
+  # before(scenario) hook resets the focuser to the default before
+  # every scenario, so a "round number" target like 5000 turns the
+  # whole feature into a multi-minute slewfest. See
+  # docs/references/omnisim.md (Focuser section). Keep new
+  # focuser-motion scenarios near 25000 unless the test specifically
+  # cares about the absolute value.
+
   Scenario: Tool catalog includes Focuser tools
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
@@ -25,27 +36,27 @@ Feature: Focuser tools
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 5000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25000
     Then the tool call should succeed
-    And the move_focuser result actual_position should be 5000
+    And the move_focuser result actual_position should be 25000
 
   Scenario: move_focuser with target equal to current position succeeds
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 4000
-    And the MCP client calls "move_focuser" with focuser "main-focuser" to position 4000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 24000
+    And the MCP client calls "move_focuser" with focuser "main-focuser" to position 24000
     Then the tool call should succeed
-    And the move_focuser result actual_position should be 4000
+    And the move_focuser result actual_position should be 24000
 
   Scenario: get_focuser_position reads the current absolute position
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 7500
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25500
     And the MCP client calls "get_focuser_position" with focuser "main-focuser"
     Then the tool call should succeed
-    And the get_focuser_position result position should be 7500
+    And the get_focuser_position result position should be 25500
 
   Scenario: get_focuser_temperature returns a temperature_c field
     Given a running Alpaca simulator

--- a/services/rp/tests/features/focuser.feature
+++ b/services/rp/tests/features/focuser.feature
@@ -36,9 +36,9 @@ Feature: Focuser tools
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 25100
     Then the tool call should succeed
-    And the move_focuser result actual_position should be 25000
+    And the move_focuser result actual_position should be 25100
 
   Scenario: move_focuser with target equal to current position succeeds
     Given a running Alpaca simulator

--- a/services/rp/tests/features/focuser.feature
+++ b/services/rp/tests/features/focuser.feature
@@ -44,10 +44,10 @@ Feature: Focuser tools
     Given a running Alpaca simulator
     And rp is running with a focuser on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 24000
-    And the MCP client calls "move_focuser" with focuser "main-focuser" to position 24000
+    When the MCP client calls "move_focuser" with focuser "main-focuser" to position 24500
+    And the MCP client calls "move_focuser" with focuser "main-focuser" to position 24500
     Then the tool call should succeed
-    And the move_focuser result actual_position should be 24000
+    And the move_focuser result actual_position should be 24500
 
   Scenario: get_focuser_position reads the current absolute position
     Given a running Alpaca simulator

--- a/services/rp/tests/features/image_http_api.feature
+++ b/services/rp/tests/features/image_http_api.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Image HTTP API
   The /api/images/{document_id} routes expose an exposure's image metadata
   and raw pixel data to plugins, frontends, and external consumers. Metadata

--- a/services/rp/tests/features/image_stats.feature
+++ b/services/rp/tests/features/image_stats.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Image statistics tool
   The compute_image_stats MCP tool reads a FITS file from disk and computes
   pixel statistics: median, mean, min, and max ADU values. If a document_id

--- a/services/rp/tests/features/measure_basic.feature
+++ b/services/rp/tests/features/measure_basic.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Basic image measurement tool
   The measure_basic MCP tool detects stars in an image and reports aggregate
   HFR, star count, and sigma-clipped background statistics. It accepts either

--- a/services/rp/tests/features/measure_stars.feature
+++ b/services/rp/tests/features/measure_stars.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Per-star photometry and PSF metrics
   The measure_stars MCP tool runs detect_stars internally and then fits a 2D
   Gaussian to each star to report per-star HFR, FWHM, eccentricity, and flux,

--- a/services/rp/tests/features/session_lifecycle.feature
+++ b/services/rp/tests/features/session_lifecycle.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: Session lifecycle with flat calibration orchestrator
   A session is started via the REST API. rp invokes the configured
   orchestrator plugin, which connects to rp's MCP server and drives
@@ -54,7 +55,6 @@ Feature: Session lifecycle with flat calibration orchestrator
     Then the test orchestrator should have been cancelled
     And the session status should be "idle"
 
-  @serial
   Scenario: Flat calibration orchestrator captures flats across filters
     Given a running Alpaca simulator
     And a test flat-calibration orchestrator configured for 2 "Luminance" flats and 2 "Red" flats

--- a/services/rp/tests/features/tool_execution.feature
+++ b/services/rp/tests/features/tool_execution.feature
@@ -1,3 +1,4 @@
+@serial
 Feature: MCP tool execution against equipment
   rp exposes equipment operations as MCP tools. Workflow plugins call
   tools via the MCP server endpoint. Each tool validates parameters,
@@ -11,7 +12,6 @@ Feature: MCP tool execution against equipment
     Then the tool result should contain an image path
     And the tool result should contain a document id
 
-  @serial
   Scenario: Set filter changes the active filter
     Given a running Alpaca simulator
     And rp is running with a filter wheel on the simulator


### PR DESCRIPTION
## Summary
- Extend `OmniSimHandle::reset_*` to cover every device class our BDD suites
  exercise (camera, filter wheel, focuser, cover calibrator — on top of the
  existing telescope), with a new `reset_all_devices()` helper that fans the
  parallel `PUT /simulator/v1/{class}/{n}/restart` requests in one round-trip.
  Added the `restart_device(class, n)` primitive underneath.
- Wire `reset_all_devices` into rp's existing `before(scenario)` cucumber hook
  and add the equivalent hook to calibrator-flats. Tag every OmniSim-using
  feature `@serial` (file-level) so the reset can't disconnect a device that's
  mid-flight in a concurrent scenario — cucumber-rs only drains one Serial
  scenario at a time, so `@serial` is the right knob (no
  `max_concurrent_scenarios(1)` needed).
- Document the pattern and rationale in `docs/skills/testing.md` §5.5.

Closes #149.

## Test plan
- [x] `cargo build --all-features --all-targets -p rp -p calibrator-flats`
- [x] `cargo test --all-features --test bdd -p rp` — 212/212 passed
- [x] `cargo test --all-features --test bdd -p calibrator-flats` — 2/2 passed
- [x] `cargo rail run --profile commit -q` — 804/804
- [x] `cargo fmt --all`
- [x] Manual: spun up OmniSim and confirmed every `/simulator/v1/{class}/0/restart`
      endpoint returns 200 and actually resets device state (filter wheel
      Connected/Position verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)