### PR TITLE
feat(rp): persist optics block in exposure document sidecar (#153)

### DIFF
--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -152,7 +152,18 @@ The document accumulates data as it flows through the system.
   "file_path": "/data/lights/M31/M31_L_300s_001.fits",
   "session_id": "session-2026-03-01",
   "sequence_number": 42,
-  "max_adu": 65535
+  "max_adu": 65535,
+  "optics": {
+    "focal_length_mm": 1000.0,
+    "pixel_size_x_um": 3.76,
+    "pixel_size_y_um": 3.76,
+    "sensor_width_px": 9576,
+    "sensor_height_px": 6388,
+    "pixel_scale_x_arcsec_per_pixel": 0.7756,
+    "pixel_scale_y_arcsec_per_pixel": 0.7756,
+    "fov_width_deg": 2.0630,
+    "fov_height_deg": 1.3762
+  }
 }
 ```
 
@@ -164,6 +175,45 @@ uses it to choose the `CachedPixels::U16` vs `I32` variant without
 needing the originating camera to be connected. `null` (omitted on
 serialize) when the read failed at capture time; in that case the
 cache insert is skipped and the entry serves from disk on demand.
+
+`optics` carries the camera + optical-train geometry that consumers
+need to interpret the frame without re-deriving it from a plate
+solve. Built at capture time from three sources:
+
+1. `focal_length_mm` is operator-supplied via `equipment.cameras[].focal_length_mm`.
+   It captures the optical train (telescope, reducers, extenders) which has no
+   ASCOM Alpaca property — even the optional `Telescope.FocalLength` ignores
+   anything screwed in front of the camera.
+2. `pixel_size_x_um` / `pixel_size_y_um` come from `cam.pixel_size_x()` /
+   `cam.pixel_size_y()` (Alpaca `PixelSizeX` / `PixelSizeY`, microns).
+3. `sensor_width_px` / `sensor_height_px` come from `cam.camera_x_size()` /
+   `cam.camera_y_size()` (Alpaca `CameraXSize` / `CameraYSize`).
+
+Pixel scale and FOV are derived (`fov_width_deg` corresponds to
+`sensor_width_px`; height likewise):
+
+```
+pixel_scale_arcsec_per_pixel = 206.265 × pixel_size_um / focal_length_mm
+fov_deg                       = pixel_scale_arcsec_per_pixel × sensor_size_px / 3600
+```
+
+The block is omitted (serializes as absent, not `null`) when any of
+its inputs is unavailable: `focal_length_mm` was not configured for
+this camera, the camera's `pixel_size_*` read failed, or the camera's
+`camera_*_size` read failed. Each missing input is logged at `debug!`.
+Capture continues — `optics` is auxiliary metadata, not gating.
+
+Per-frame variation (binning swaps, focal reducers screwed in
+mid-session) is out of scope. The persisted block reflects the
+operator-declared static optical train and the camera's reported
+sensor geometry at capture time. This is sufficient for `plate_solve`
+hint sourcing and for consumers like annotation and mosaic planning.
+
+When the Phase 6c-2 `plate_solve` built-in tool lands (see
+`docs/plans/image-evaluation-tools.md`), its `document_id` mode uses
+`optics.fov_height_deg` as the default `fov_hint_deg` — `fov_height_deg`
+matches ASTAP's `-fov` semantics ("image height in degrees"). Callers
+keep the option to override with an explicit `fov_hint_deg` parameter.
 
 ### Plugin Sections (contributed via API)
 
@@ -2540,6 +2590,7 @@ when the config sets a non-zero default).
         "cooler_target_c": -10,
         "gain": 100,
         "offset": 50,
+        "focal_length_mm": 1000.0,
         "auth": {
           "username": "observatory",
           "password": "secret"
@@ -2553,7 +2604,8 @@ when the config sets a non-zero default).
         "device_number": 0,
         "cooler_target_c": -10,
         "gain": 200,
-        "offset": 30
+        "offset": 30,
+        "focal_length_mm": 200.0
       }
     ],
     "mount": {

--- a/services/rp/src/config.rs
+++ b/services/rp/src/config.rs
@@ -113,6 +113,17 @@ pub struct CameraConfig {
     pub gain: Option<i32>,
     #[serde(default)]
     pub offset: Option<i32>,
+    /// Effective focal length of the optical train feeding this camera,
+    /// in millimetres. Used at capture time to derive pixel scale and FOV
+    /// for the exposure document's `optics` block. The value lives in
+    /// config because the optical train (telescope + reducer/extender) has
+    /// no ASCOM Alpaca property — even the optional
+    /// `Telescope.FocalLength` does not reflect anything screwed in front
+    /// of the camera. Omitted → no `optics` block on captures from this
+    /// camera. See `docs/services/rp.md` §"Core Fields" for the derivation
+    /// and failure modes.
+    #[serde(default)]
+    pub focal_length_mm: Option<f64>,
     /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
     #[serde(default)]
     pub auth: Option<rp_auth::config::ClientAuthConfig>,
@@ -261,7 +272,29 @@ pub fn load_config(path: &Path) -> Result<Config> {
     if let Some(site) = config.site.as_ref() {
         site.validate()?;
     }
+    for cam in &config.equipment.cameras {
+        cam.validate()?;
+    }
     Ok(config)
+}
+
+impl CameraConfig {
+    /// Range-validate the camera, returning a [`RpError::Config`] with a
+    /// message naming the offending field on failure. Today the only
+    /// validated field is `focal_length_mm` — must be strictly positive
+    /// when supplied — but the impl exists so future fields land in one
+    /// canonical place.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(f) = self.focal_length_mm {
+            if !(f > 0.0 && f.is_finite()) {
+                return Err(RpError::Config(format!(
+                    "equipment.cameras['{}'].focal_length_mm must be a positive finite number; got {}",
+                    self.id, f
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -613,5 +646,90 @@ mod tests {
 
         let err = load_config(&path).unwrap_err();
         assert!(err.to_string().contains("failed to parse config file"));
+    }
+
+    #[test]
+    fn camera_config_focal_length_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "cameras": [
+                        {
+                            "id": "main-cam",
+                            "alpaca_url": "http://localhost:11120",
+                            "focal_length_mm": 540.0
+                        }
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        let cam = &config.equipment.cameras[0];
+        assert_eq!(cam.focal_length_mm, Some(540.0));
+    }
+
+    #[test]
+    fn camera_config_focal_length_defaults_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "cameras": [
+                        {
+                            "id": "main-cam",
+                            "alpaca_url": "http://localhost:11120"
+                        }
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert!(
+            config.equipment.cameras[0].focal_length_mm.is_none(),
+            "omitted focal_length_mm must deserialize to None"
+        );
+    }
+
+    #[test]
+    fn camera_config_rejects_non_positive_focal_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "cameras": [
+                        {
+                            "id": "main-cam",
+                            "alpaca_url": "http://localhost:11120",
+                            "focal_length_mm": -100.0
+                        }
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("focal_length_mm") && msg.contains("main-cam"),
+            "expected focal_length diagnostic naming the camera, got: {msg}"
+        );
     }
 }

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -1065,7 +1065,31 @@ impl McpHandler {
                     sensor_height_px,
                 ) {
                     (Some(px), Some(py), Some(sw), Some(sh)) => {
-                        persistence::Optics::from_camera_geometry(focal_length_mm, px, py, sw, sh)
+                        let derived = persistence::Optics::from_camera_geometry(
+                            focal_length_mm,
+                            px,
+                            py,
+                            sw,
+                            sh,
+                        );
+                        if derived.is_none() {
+                            // All Alpaca reads succeeded but the derivation
+                            // declined — typically a non-positive or
+                            // wild-magnitude reading that would have
+                            // overflowed the derived pixel scale / FOV.
+                            // Surface enough to diagnose bad camera state
+                            // or a misconfigured focal length.
+                            debug!(
+                                camera_id,
+                                focal_length_mm,
+                                pixel_size_x_um = px,
+                                pixel_size_y_um = py,
+                                sensor_width_px = sw,
+                                sensor_height_px = sh,
+                                "optics derivation declined; omitting block"
+                            );
+                        }
+                        derived
                     }
                     _ => None,
                 }
@@ -4174,9 +4198,10 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&text).unwrap();
         let image_path = json["image_path"].as_str().unwrap().to_string();
         let sidecar = persistence::sidecar_path(&image_path);
-        // Keep `temp` alive until after the read by leaking into a path we
-        // already extracted; it drops at the end of the function regardless.
         let doc = persistence::read_sidecar_sync(&sidecar).unwrap();
+        // Explicit drop pins the TempDir lifetime past the sidecar read
+        // — without it the borrow checker is happy but the temp dir could
+        // be cleaned up at any drop point the optimizer chose.
         drop(temp);
         doc
     }

--- a/services/rp/src/mcp.rs
+++ b/services/rp/src/mcp.rs
@@ -956,6 +956,10 @@ impl McpHandler {
             .as_ref()
             .cloned()
             .ok_or_else(|| format!("camera not connected: {}", camera_id))?;
+        // Snapshot the configured focal length now — `cam_entry` is a
+        // borrow off `self.equipment` and we want the f64 (Copy) without
+        // hanging on to that borrow across the `await`s below.
+        let focal_length_mm = cam_entry.config.focal_length_mm;
 
         let document_id = Uuid::new_v4().to_string();
         // The 8-char UUID suffix is the on-disk reverse-lookup key used by
@@ -1018,6 +1022,63 @@ impl McpHandler {
             }
         };
 
+        // Optical geometry for the sidecar's `optics` block. Combines the
+        // operator-supplied focal length with raw Alpaca pixel-size and
+        // sensor-dimension reads. Any missing piece (focal length not
+        // configured, camera read failed) drops the whole block — see
+        // `docs/services/rp.md` §"Core Fields". Failures are isolated to
+        // this auxiliary metadata; capture itself proceeds.
+        let optics = match focal_length_mm {
+            Some(focal_length_mm) => {
+                let pixel_size_x_um = match cam.pixel_size_x().await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        debug!(error = %e, "pixel_size_x unavailable for this capture");
+                        None
+                    }
+                };
+                let pixel_size_y_um = match cam.pixel_size_y().await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        debug!(error = %e, "pixel_size_y unavailable for this capture");
+                        None
+                    }
+                };
+                let sensor_width_px = match cam.camera_x_size().await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        debug!(error = %e, "camera_x_size unavailable for this capture");
+                        None
+                    }
+                };
+                let sensor_height_px = match cam.camera_y_size().await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        debug!(error = %e, "camera_y_size unavailable for this capture");
+                        None
+                    }
+                };
+                match (
+                    pixel_size_x_um,
+                    pixel_size_y_um,
+                    sensor_width_px,
+                    sensor_height_px,
+                ) {
+                    (Some(px), Some(py), Some(sw), Some(sh)) => {
+                        persistence::Optics::from_camera_geometry(focal_length_mm, px, py, sw, sh)
+                    }
+                    _ => None,
+                }
+            }
+            None => {
+                debug!(
+                    camera_id,
+                    "focal_length_mm not configured; omitting optics block"
+                );
+                None
+            }
+        };
+
         // Dispatch on max_adu, collecting pixels directly into the
         // narrowest type each path needs and reusing the same buffer
         // for the cache insert.
@@ -1054,6 +1115,7 @@ impl McpHandler {
             camera_id: Some(camera_id.to_string()),
             duration: Some(duration),
             max_adu: captured_max_adu,
+            optics,
             sections: serde_json::Map::new(),
         };
         self.persist_capture_artifact(doc, cached_pixels, captured_max_adu)
@@ -2995,6 +3057,7 @@ mod tests {
         fail_image_array: bool,
         fail_max_adu: bool,
         fail_camera_size: bool,
+        fail_pixel_size: bool,
         fail_exposure_range: bool,
         /// `0` ⇒ default 65535. Any other value is returned verbatim — set
         /// to `> u16::MAX` to exercise the I32 cache-insert path.
@@ -3080,10 +3143,16 @@ mod tests {
         }
 
         async fn pixel_size_x(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            if self.fail_pixel_size {
+                return Err(ASCOMError::invalid_operation("pixel size unavailable"));
+            }
             Ok(3.76)
         }
 
         async fn pixel_size_y(&self) -> ascom_alpaca::ASCOMResult<f64> {
+            if self.fail_pixel_size {
+                return Err(ASCOMError::invalid_operation("pixel size unavailable"));
+            }
             Ok(3.76)
         }
 
@@ -3573,6 +3642,13 @@ mod tests {
     fn camera_registry(
         cam: Arc<dyn ascom_alpaca::api::Camera>,
     ) -> crate::equipment::EquipmentRegistry {
+        camera_registry_with_focal_length(cam, None)
+    }
+
+    fn camera_registry_with_focal_length(
+        cam: Arc<dyn ascom_alpaca::api::Camera>,
+        focal_length_mm: Option<f64>,
+    ) -> crate::equipment::EquipmentRegistry {
         crate::equipment::EquipmentRegistry {
             cameras: vec![crate::equipment::CameraEntry {
                 id: "cam".to_string(),
@@ -3586,6 +3662,7 @@ mod tests {
                     cooler_target_c: None,
                     gain: None,
                     offset: None,
+                    focal_length_mm,
                     auth: None,
                 },
                 device: Some(cam),
@@ -4064,6 +4141,113 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // capture — optics block in sidecar
+    // -----------------------------------------------------------------------
+
+    async fn capture_and_read_sidecar(
+        registry: crate::equipment::EquipmentRegistry,
+    ) -> ExposureDocument {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(64, 4, std::path::PathBuf::from("/nonexistent"));
+        let handler = McpHandler::new(
+            Arc::new(registry),
+            Arc::new(crate::events::EventBus::from_config(&[])),
+            SessionConfig {
+                data_directory: temp.path().to_string_lossy().to_string(),
+            },
+            cache,
+            None,
+        );
+        let result = handler
+            .capture(Parameters(CaptureParams {
+                camera_id: "cam".into(),
+                duration: Duration::from_millis(100),
+            }))
+            .await
+            .unwrap();
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|tc| tc.text.clone())
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let image_path = json["image_path"].as_str().unwrap().to_string();
+        let sidecar = persistence::sidecar_path(&image_path);
+        // Keep `temp` alive until after the read by leaking into a path we
+        // already extracted; it drops at the end of the function regardless.
+        let doc = persistence::read_sidecar_sync(&sidecar).unwrap();
+        drop(temp);
+        doc
+    }
+
+    #[tokio::test]
+    async fn test_capture_persists_optics_when_focal_length_configured() {
+        // Mock returns 3.76 µm pixels and 1024×1024 sensor; with a 1000 mm
+        // focal length the derivation gives:
+        //   pixel_scale = 206.265 × 3.76 / 1000 ≈ 0.7755564 arcsec/px
+        //   fov         = 0.7755564 × 1024 / 3600 ≈ 0.220603 deg
+        let cam = MockCamera::default();
+        let registry = camera_registry_with_focal_length(Arc::new(cam), Some(1000.0));
+        let doc = capture_and_read_sidecar(registry).await;
+        let optics = doc.optics.expect("optics block should be present");
+        assert_eq!(optics.focal_length_mm, 1000.0);
+        assert_eq!(optics.pixel_size_x_um, 3.76);
+        assert_eq!(optics.pixel_size_y_um, 3.76);
+        assert_eq!(optics.sensor_width_px, 1024);
+        assert_eq!(optics.sensor_height_px, 1024);
+        assert!(
+            (optics.pixel_scale_x_arcsec_per_pixel - 0.7755564).abs() < 1e-6,
+            "pixel_scale_x = {}",
+            optics.pixel_scale_x_arcsec_per_pixel
+        );
+        assert!(
+            (optics.fov_height_deg - 0.220603).abs() < 1e-4,
+            "fov_height_deg = {}",
+            optics.fov_height_deg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_capture_omits_optics_when_focal_length_missing() {
+        let cam = MockCamera::default();
+        let registry = camera_registry_with_focal_length(Arc::new(cam), None);
+        let doc = capture_and_read_sidecar(registry).await;
+        assert!(
+            doc.optics.is_none(),
+            "optics must be omitted when focal_length_mm is not configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_capture_omits_optics_when_pixel_size_unavailable() {
+        let cam = MockCamera {
+            fail_pixel_size: true,
+            ..Default::default()
+        };
+        let registry = camera_registry_with_focal_length(Arc::new(cam), Some(1000.0));
+        let doc = capture_and_read_sidecar(registry).await;
+        assert!(
+            doc.optics.is_none(),
+            "optics must be omitted when pixel size read fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_capture_omits_optics_when_sensor_size_unavailable() {
+        let cam = MockCamera {
+            fail_camera_size: true,
+            ..Default::default()
+        };
+        let registry = camera_registry_with_focal_length(Arc::new(cam), Some(1000.0));
+        let doc = capture_and_read_sidecar(registry).await;
+        assert!(
+            doc.optics.is_none(),
+            "optics must be omitted when sensor size read fails"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // persist_capture_artifact — sidecar failure skips cache
     // -----------------------------------------------------------------------
 
@@ -4109,6 +4293,7 @@ mod tests {
             camera_id: Some("cam".into()),
             duration: Some(Duration::from_millis(100)),
             max_adu: Some(65535),
+            optics: None,
             sections: serde_json::Map::new(),
         };
         let cached = CachedPixels::from_i32_pixels(vec![1, 2, 3, 4], (2, 2), 65535);

--- a/services/rp/src/persistence/cache.rs
+++ b/services/rp/src/persistence/cache.rs
@@ -530,6 +530,7 @@ mod tests {
             camera_id: None,
             duration: None,
             max_adu: None,
+            optics: None,
             sections: Map::new(),
         }
     }

--- a/services/rp/src/persistence/document.rs
+++ b/services/rp/src/persistence/document.rs
@@ -56,8 +56,82 @@ pub struct ExposureDocument {
     /// Document Cache section of `docs/services/rp.md`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_adu: Option<u32>,
+    /// Optical-train geometry resolved at capture time. Carries both the raw
+    /// Alpaca camera readings (`pixel_size_*_um`, `sensor_*_px`) and the
+    /// derived pixel scale and FOV that consumers like `plate_solve` and
+    /// annotation tools want without re-deriving from the FITS header.
+    /// Omitted when any input was missing — see `docs/services/rp.md`
+    /// §"Core Fields".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub optics: Option<Optics>,
     #[serde(default)]
     pub sections: Map<String, Value>,
+}
+
+/// Optical-train geometry persisted on the exposure document at capture
+/// time. See [`ExposureDocument::optics`] and `docs/services/rp.md`
+/// §"Core Fields" for the derivation, the failure modes, and the
+/// `plate_solve` consumer contract.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Optics {
+    /// Operator-supplied effective focal length of the optical train,
+    /// in millimetres (verbatim from `equipment.cameras[].focal_length_mm`).
+    pub focal_length_mm: f64,
+    /// Raw Alpaca `PixelSizeX` reading at capture time, in microns.
+    pub pixel_size_x_um: f64,
+    /// Raw Alpaca `PixelSizeY` reading at capture time, in microns.
+    pub pixel_size_y_um: f64,
+    /// Raw Alpaca `CameraXSize` reading at capture time, in pixels.
+    pub sensor_width_px: u32,
+    /// Raw Alpaca `CameraYSize` reading at capture time, in pixels.
+    pub sensor_height_px: u32,
+    /// Derived: `206.265 × pixel_size_x_um / focal_length_mm`.
+    pub pixel_scale_x_arcsec_per_pixel: f64,
+    /// Derived: `206.265 × pixel_size_y_um / focal_length_mm`.
+    pub pixel_scale_y_arcsec_per_pixel: f64,
+    /// Derived: `pixel_scale_x_arcsec_per_pixel × sensor_width_px / 3600`.
+    pub fov_width_deg: f64,
+    /// Derived: `pixel_scale_y_arcsec_per_pixel × sensor_height_px / 3600`.
+    /// Matches ASTAP's `-fov` semantics ("image height in degrees"); used
+    /// as the `plate_solve` `fov_hint_deg` default in `document_id` mode.
+    pub fov_height_deg: f64,
+}
+
+impl Optics {
+    /// Compute pixel scale + FOV from the operator-supplied focal length
+    /// and the camera-reported pixel size + sensor dimensions. Returns
+    /// `None` when any input is non-finite or non-positive — callers log
+    /// at `debug!` and persist the document without an `optics` block.
+    pub fn from_camera_geometry(
+        focal_length_mm: f64,
+        pixel_size_x_um: f64,
+        pixel_size_y_um: f64,
+        sensor_width_px: u32,
+        sensor_height_px: u32,
+    ) -> Option<Self> {
+        let positive = |v: f64| v.is_finite() && v > 0.0;
+        if !positive(focal_length_mm)
+            || !positive(pixel_size_x_um)
+            || !positive(pixel_size_y_um)
+            || sensor_width_px == 0
+            || sensor_height_px == 0
+        {
+            return None;
+        }
+        let pixel_scale_x = 206.265 * pixel_size_x_um / focal_length_mm;
+        let pixel_scale_y = 206.265 * pixel_size_y_um / focal_length_mm;
+        Some(Self {
+            focal_length_mm,
+            pixel_size_x_um,
+            pixel_size_y_um,
+            sensor_width_px,
+            sensor_height_px,
+            pixel_scale_x_arcsec_per_pixel: pixel_scale_x,
+            pixel_scale_y_arcsec_per_pixel: pixel_scale_y,
+            fov_width_deg: pixel_scale_x * f64::from(sensor_width_px) / 3600.0,
+            fov_height_deg: pixel_scale_y * f64::from(sensor_height_px) / 3600.0,
+        })
+    }
 }
 
 /// Sidecar JSON path for a given FITS file path (`/foo/<uuid8>.fits` →
@@ -157,6 +231,7 @@ mod tests {
             camera_id: Some("cam".to_string()),
             duration: Some(Duration::from_secs(1)),
             max_adu: Some(65535),
+            optics: None,
             sections: Map::new(),
         }
     }
@@ -310,5 +385,73 @@ mod tests {
             "max_adu should be omitted when None, got: {}",
             body
         );
+    }
+
+    #[test]
+    fn serialization_skips_none_optics() {
+        let mut doc = doc_with_path("doc-1", "/tmp/x.fits");
+        doc.optics = None;
+        let body = serde_json::to_string(&doc).unwrap();
+        assert!(
+            !body.contains("optics"),
+            "optics should be omitted when None, got: {}",
+            body
+        );
+    }
+
+    #[test]
+    fn optics_round_trips_through_json() {
+        let mut doc = doc_with_path("doc-1", "/tmp/x.fits");
+        let optics = Optics::from_camera_geometry(1000.0, 3.76, 3.76, 9576, 6388).unwrap();
+        doc.optics = Some(optics.clone());
+        let body = serde_json::to_string(&doc).unwrap();
+        let parsed: ExposureDocument = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed.optics, Some(optics));
+    }
+
+    #[test]
+    fn optics_derives_pixel_scale_and_fov() {
+        // 1000 mm focal length, 3.76 µm pixels, IMX455-class sensor.
+        // Pixel scale = 206.265 × 3.76 / 1000  ≈ 0.7755564 arcsec/px
+        // Width FOV   = 0.7755564 × 9576 / 3600 ≈ 2.062980 deg
+        // Height FOV  = 0.7755564 × 6388 / 3600 ≈ 1.376181 deg
+        let optics = Optics::from_camera_geometry(1000.0, 3.76, 3.76, 9576, 6388).unwrap();
+        assert!(
+            (optics.pixel_scale_x_arcsec_per_pixel - 0.7755564).abs() < 1e-6,
+            "pixel_scale_x_arcsec_per_pixel = {}",
+            optics.pixel_scale_x_arcsec_per_pixel
+        );
+        assert!(
+            (optics.fov_width_deg - 2.062980).abs() < 1e-5,
+            "fov_width_deg = {}",
+            optics.fov_width_deg
+        );
+        assert!(
+            (optics.fov_height_deg - 1.376181).abs() < 1e-5,
+            "fov_height_deg = {}",
+            optics.fov_height_deg
+        );
+    }
+
+    #[test]
+    fn optics_supports_anisotropic_pixels() {
+        let optics = Optics::from_camera_geometry(1000.0, 4.0, 5.0, 100, 100).unwrap();
+        assert!(
+            optics.pixel_scale_x_arcsec_per_pixel < optics.pixel_scale_y_arcsec_per_pixel,
+            "wider pixels in y must produce a larger y pixel scale"
+        );
+        assert!(optics.fov_width_deg < optics.fov_height_deg);
+    }
+
+    #[test]
+    fn optics_rejects_non_positive_inputs() {
+        assert!(Optics::from_camera_geometry(0.0, 3.76, 3.76, 1024, 1024).is_none());
+        assert!(Optics::from_camera_geometry(-1.0, 3.76, 3.76, 1024, 1024).is_none());
+        assert!(Optics::from_camera_geometry(1000.0, 0.0, 3.76, 1024, 1024).is_none());
+        assert!(Optics::from_camera_geometry(1000.0, 3.76, -3.76, 1024, 1024).is_none());
+        assert!(Optics::from_camera_geometry(1000.0, 3.76, 3.76, 0, 1024).is_none());
+        assert!(Optics::from_camera_geometry(1000.0, 3.76, 3.76, 1024, 0).is_none());
+        assert!(Optics::from_camera_geometry(f64::NAN, 3.76, 3.76, 1024, 1024).is_none());
+        assert!(Optics::from_camera_geometry(f64::INFINITY, 3.76, 3.76, 1024, 1024).is_none());
     }
 }

--- a/services/rp/src/persistence/document.rs
+++ b/services/rp/src/persistence/document.rs
@@ -100,8 +100,16 @@ pub struct Optics {
 impl Optics {
     /// Compute pixel scale + FOV from the operator-supplied focal length
     /// and the camera-reported pixel size + sensor dimensions. Returns
-    /// `None` when any input is non-finite or non-positive — callers log
-    /// at `debug!` and persist the document without an `optics` block.
+    /// `None` when any input — or any derived value — is non-finite or
+    /// non-positive. Callers log at `debug!` and persist the document
+    /// without an `optics` block.
+    ///
+    /// Derived values are validated because `serde_json` rejects
+    /// non-finite floats: a sub-normal `focal_length_mm` could push the
+    /// pixel scale to `inf`, which would then fail the *entire* sidecar
+    /// write — breaking capture's persistence contract for an auxiliary
+    /// metadata block. Defense in depth keeps the failure scoped to the
+    /// `optics` field.
     pub fn from_camera_geometry(
         focal_length_mm: f64,
         pixel_size_x_um: f64,
@@ -120,6 +128,15 @@ impl Optics {
         }
         let pixel_scale_x = 206.265 * pixel_size_x_um / focal_length_mm;
         let pixel_scale_y = 206.265 * pixel_size_y_um / focal_length_mm;
+        let fov_width_deg = pixel_scale_x * f64::from(sensor_width_px) / 3600.0;
+        let fov_height_deg = pixel_scale_y * f64::from(sensor_height_px) / 3600.0;
+        if !positive(pixel_scale_x)
+            || !positive(pixel_scale_y)
+            || !positive(fov_width_deg)
+            || !positive(fov_height_deg)
+        {
+            return None;
+        }
         Some(Self {
             focal_length_mm,
             pixel_size_x_um,
@@ -128,8 +145,8 @@ impl Optics {
             sensor_height_px,
             pixel_scale_x_arcsec_per_pixel: pixel_scale_x,
             pixel_scale_y_arcsec_per_pixel: pixel_scale_y,
-            fov_width_deg: pixel_scale_x * f64::from(sensor_width_px) / 3600.0,
-            fov_height_deg: pixel_scale_y * f64::from(sensor_height_px) / 3600.0,
+            fov_width_deg,
+            fov_height_deg,
         })
     }
 }
@@ -389,12 +406,17 @@ mod tests {
 
     #[test]
     fn serialization_skips_none_optics() {
+        // Parse the JSON and check the top-level key is absent — `contains`
+        // would false-pass if a future field name happened to embed
+        // "optics" as a substring.
         let mut doc = doc_with_path("doc-1", "/tmp/x.fits");
         doc.optics = None;
         let body = serde_json::to_string(&doc).unwrap();
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        let obj = parsed.as_object().expect("top-level should be an object");
         assert!(
-            !body.contains("optics"),
-            "optics should be omitted when None, got: {}",
+            !obj.contains_key("optics"),
+            "optics key should be omitted when None, got: {}",
             body
         );
     }
@@ -453,5 +475,33 @@ mod tests {
         assert!(Optics::from_camera_geometry(1000.0, 3.76, 3.76, 1024, 0).is_none());
         assert!(Optics::from_camera_geometry(f64::NAN, 3.76, 3.76, 1024, 1024).is_none());
         assert!(Optics::from_camera_geometry(f64::INFINITY, 3.76, 3.76, 1024, 1024).is_none());
+    }
+
+    #[test]
+    fn optics_rejects_when_derived_overflows_to_infinity() {
+        // A sub-normal focal length passes the input filter (it's finite
+        // and > 0) but pushes the derived pixel scale and FOV to `inf`.
+        // `serde_json` rejects non-finite floats, so persisting this in
+        // the sidecar would fail the entire exposure-document write —
+        // breaking capture's persistence contract for an auxiliary block.
+        // The constructor must guard against it and return `None`.
+        let optics = Optics::from_camera_geometry(f64::MIN_POSITIVE, 3.76, 3.76, 1024, 1024);
+        assert!(
+            optics.is_none(),
+            "derivation must reject inputs that overflow to infinity, got: {:?}",
+            optics
+        );
+    }
+
+    #[test]
+    fn optics_with_overflow_inputs_does_not_break_sidecar_serialization() {
+        // Smoke test: even when a hypothetical buggy mock returned wild
+        // values, building the document and serializing must succeed —
+        // because `from_camera_geometry` returns `None` and the doc's
+        // `optics` field is `skip_serializing_if = Option::is_none`.
+        let mut doc = doc_with_path("doc-1", "/tmp/x.fits");
+        doc.optics = Optics::from_camera_geometry(f64::MIN_POSITIVE, 1.0, 1.0, 1, 1);
+        assert!(doc.optics.is_none());
+        serde_json::to_string(&doc).expect("doc must serialize when optics derivation declined");
     }
 }

--- a/services/rp/src/persistence/mod.rs
+++ b/services/rp/src/persistence/mod.rs
@@ -18,6 +18,6 @@ pub mod fits;
 
 pub use cache::{CachedImage, CachedPixels, ImageCache};
 pub use document::{
-    read_sidecar_sync, sidecar_path, write_sidecar, write_sidecar_at, ExposureDocument,
+    read_sidecar_sync, sidecar_path, write_sidecar, write_sidecar_at, ExposureDocument, Optics,
 };
 pub use fits::{read_fits_doc_id, read_fits_pixels, write_fits_i32, write_fits_u16};

--- a/services/rp/src/routes.rs
+++ b/services/rp/src/routes.rs
@@ -309,6 +309,7 @@ mod tests {
             camera_id: None,
             duration: None,
             max_adu: None,
+            optics: None,
             sections: serde_json::Map::new(),
         }
     }
@@ -437,6 +438,7 @@ mod tests {
             camera_id: None,
             duration: None,
             max_adu: None,
+            optics: None,
             sections: serde_json::Map::new(),
         };
         std::fs::write(


### PR DESCRIPTION
## Summary

- Add `optics` block to the exposure document containing the optical-train geometry resolved at capture time: raw Alpaca readings (`pixel_size_x_um`, `pixel_size_y_um`, `sensor_width_px`, `sensor_height_px`), the operator-supplied `focal_length_mm`, and the derived `pixel_scale_x/y_arcsec_per_pixel` and `fov_width/height_deg`.
- Add optional `focal_length_mm` to `CameraConfig` — focal length is operator-declared because it depends on the optical train (telescope + reducer/extender), which has no ASCOM Alpaca property.
- The block is omitted from the sidecar (`skip_serializing_if = Option::is_none`) when any input is unavailable; capture itself never fails on optics. Each missing input is logged at `debug!`.
- Sets up the `plate_solve` `fov_hint_deg` source: when Phase 6c-2 lands, `document_id` mode will default to `optics.fov_height_deg` (which matches ASTAP's `-fov` "image height in degrees" semantics).

Closes #153.

## Design choices

The two open questions in #153:

1. **Source of truth for FOV.** Operator supplies only `focal_length_mm`. Pixel size and sensor dimensions come from ASCOM Alpaca (`PixelSizeX/Y`, `CameraXSize/Y`). Focal length is the only piece ASCOM cannot supply, so we don't duplicate camera-reported geometry in config.
2. **Document field shape.** Richer `optics` block (vs. flat `fov_deg`). It carries the raw readings alongside the derived values so consumers can audit or recompute, and it matches what later tools (annotation, mosaic planning) need without another schema change.

## Test plan

- [x] `cargo rail run --profile commit -q` — 352/352 tests passing
- [x] `cargo fmt -- --check` clean
- [x] New unit tests:
  - `Optics::from_camera_geometry` derivation, anisotropic pixels, rejection of non-positive / non-finite inputs
  - JSON round-trip with and without optics
  - `serialization_skips_none_optics`
  - `CameraConfig` `focal_length_mm` round-trip + non-positive rejection
  - Capture flow: optics persisted when configured, omitted when focal length missing, omitted when pixel size or sensor size reads fail
- [ ] BDD scenarios unaffected (bdd-infra `CameraConfig` does not emit `focal_length_mm`; `optics` simply absent on captured documents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)