### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ user.bazelrc
 # Claude Code runtime artifacts.
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` under the existing "Claude Code runtime artifacts" section.
- Local scratch directory created by Claude Code worktree workflows; should never be committed.

## Test plan
- [ ] `git status` no longer shows `.claude/worktrees/` as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)