### PR TITLE
build(bazel): split rp-plate-solver into prod and _with_mock variants (#157)

### DIFF
--- a/crates/rp-plate-solver/BUILD.bazel
+++ b/crates/rp-plate-solver/BUILD.bazel
@@ -21,8 +21,10 @@ rust_library(
 )
 
 # Test-only variant exposing `MockPlateSolveClient` to downstream
-# rust_test targets. Depend on this from `rust_test` only — never
-# from `rust_library` or `rust_binary`.
+# rust_test targets. `testonly = True` blocks production
+# rust_library / rust_binary targets from depending on it at
+# Bazel-build time, so the convention isn't only enforced by code
+# review.
 rust_library(
     name = "rp-plate-solver_with_mock",
     srcs = glob(["src/**/*.rs"]),
@@ -31,6 +33,7 @@ rust_library(
     crate_name = "rp_plate_solver",
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
+    testonly = True,
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True),
 )

--- a/crates/rp-plate-solver/BUILD.bazel
+++ b/crates/rp-plate-solver/BUILD.bazel
@@ -3,8 +3,28 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 exports_files(["Cargo.toml"], visibility = ["//visibility:public"])
 
+# Production-clean library: no `mock` feature, no mockall in the
+# linked binary. Use this from rust_library / rust_binary targets.
+# Cargo gets the same shape via `[dev-dependencies] rp-plate-solver
+# = { features = ["mock"] }`; Bazel needs an explicit second target
+# because crate_features is a compile-time attribute of the library
+# output (see docs/plans/bazel-migration.md "Mockall mock variants").
 rust_library(
     name = "rp-plate-solver",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = aliases(),
+    crate_name = "rp_plate_solver",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True),
+)
+
+# Test-only variant exposing `MockPlateSolveClient` to downstream
+# rust_test targets. Depend on this from `rust_test` only — never
+# from `rust_library` or `rust_binary`.
+rust_library(
+    name = "rp-plate-solver_with_mock",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
     crate_features = ["mock"],
@@ -22,8 +42,7 @@ rust_test(
         proc_macro_dev = True,
     ),
     size = "small",
-    crate = ":rp-plate-solver",
-    crate_features = ["mock"],
+    crate = ":rp-plate-solver_with_mock",
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -163,6 +163,54 @@ Captured after Phase 1 pilot; these tests pass under Cargo but fail under Bazel'
 
 Not a migration blocker — 227 of 244 tests across these four targets pass; the failures are confined to code that tests cargo-integration machinery which is inherently Cargo-specific.
 
+### Mockall mock variants (cross-crate)
+
+Some workspace crates expose mockall-generated types so downstream
+test code in *other* crates can mock them. Cargo handles this with a
+`mock` feature gated on `dep:mockall` plus a dev-dependency
+re-declaration:
+
+```toml
+[features]
+mock = ["dep:mockall"]
+
+[dev-dependencies]
+some-crate = { workspace = true, features = ["mock"] }
+```
+
+Cargo unifies the dep declarations so test compilations see the mock
+symbol while production binaries link a feature-free version. Bazel
+has no equivalent — `crate_features` is a compile-time attribute of
+the library output. The pattern:
+
+1. Production-clean `rust_library` named `<crate>` with **no**
+   `crate_features`.
+2. Test-only `rust_library` variant named `<crate>_with_mock` with
+   `crate_features = ["mock"]`. Same `crate_name` as the production
+   target — they are never linked into the same binary.
+3. Downstream `rust_library` / `rust_binary` targets depend on the
+   production variant. (Not both: two crates with the same
+   `crate_name` in one closure produces an `E0464 multiple
+   candidates` link conflict.)
+4. Downstream consumers whose unit tests reuse the library's sources
+   via `rust_test(crate = ":<lib>")` need a **twin** `rust_library`
+   target (`<lib>_with_mock`) that swaps in the `_with_mock` variant
+   of the mock-providing dep. rules_rust merges the parent crate's
+   deps with the rust_test's deps, so swapping deps only on the
+   `rust_test` is not sufficient — the parent must already be on
+   the test-only dep. The twin shares all attributes with the
+   production library except for the swapped dep.
+5. The mock-providing crate's own `rust_test` points at
+   `crate = ":<crate>_with_mock"` so `cfg(test)` and
+   `feature = "mock"` agree.
+
+Today only `crates/rp-plate-solver` exposes mocks across crate
+boundaries (`MockPlateSolveClient` for `services/rp:rp_unit_test`).
+`crates/rp-tls` uses `#[cfg_attr(test, mockall::automock)]` —
+single-crate scope, no cross-crate consumer, no `_with_mock` variant
+needed. New crates that expose mockall mocks for downstream tests
+follow the variant pattern.
+
 ### BDD conventions under Bazel (post Phase 3)
 
 Each service's `tests/bdd.rs` is now a Bazel `rust_test` with:

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -186,20 +186,24 @@ the library output. The pattern:
 1. Production-clean `rust_library` named `<crate>` with **no**
    `crate_features`.
 2. Test-only `rust_library` variant named `<crate>_with_mock` with
-   `crate_features = ["mock"]`. Same `crate_name` as the production
-   target — they are never linked into the same binary.
+   `crate_features = ["mock"]` and `testonly = True`. Same
+   `crate_name` as the production target — they are never linked
+   into the same binary. `testonly = True` makes Bazel reject any
+   production `rust_library` / `rust_binary` that tries to depend
+   on the variant, so the convention is enforced at build time.
 3. Downstream `rust_library` / `rust_binary` targets depend on the
    production variant. (Not both: two crates with the same
    `crate_name` in one closure produces an `E0464 multiple
    candidates` link conflict.)
 4. Downstream consumers whose unit tests reuse the library's sources
    via `rust_test(crate = ":<lib>")` need a **twin** `rust_library`
-   target (`<lib>_with_mock`) that swaps in the `_with_mock` variant
-   of the mock-providing dep. rules_rust merges the parent crate's
-   deps with the rust_test's deps, so swapping deps only on the
-   `rust_test` is not sufficient — the parent must already be on
-   the test-only dep. The twin shares all attributes with the
-   production library except for the swapped dep.
+   target (`<lib>_with_mock`, also `testonly = True`) that swaps in
+   the `_with_mock` variant of the mock-providing dep. rules_rust
+   merges the parent crate's deps with the rust_test's deps, so
+   swapping deps only on the `rust_test` is not sufficient — the
+   parent must already be on the test-only dep. The twin shares all
+   attributes with the production library except for the swapped
+   dep and the `testonly` flag.
 5. The mock-providing crate's own `rust_test` points at
    `crate = ":<crate>_with_mock"` so `cfg(test)` and
    `feature = "mock"` agree.

--- a/services/rp/BUILD.bazel
+++ b/services/rp/BUILD.bazel
@@ -8,9 +8,15 @@ _INTRA_WORKSPACE_DEPS = [
     "//crates/rp-catalog:rp-catalog",
     "//crates/rp-ephemeris:rp-ephemeris",
     "//crates/rp-fits:rp-fits",
-    "//crates/rp-plate-solver:rp-plate-solver",
     "//crates/rp-tls:rp-tls",
 ]
+
+# rp-plate-solver ships two Bazel variants — production-clean for
+# library/binary targets and `_with_mock` for tests that need
+# MockPlateSolveClient. See docs/plans/bazel-migration.md
+# ("Mockall mock variants") for the pattern.
+_RP_PLATE_SOLVER = "//crates/rp-plate-solver:rp-plate-solver"
+_RP_PLATE_SOLVER_WITH_MOCK = "//crates/rp-plate-solver:rp-plate-solver_with_mock"
 
 rust_library(
     name = "rp_lib",
@@ -20,7 +26,24 @@ rust_library(
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
-    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+    deps = _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER] + all_crate_deps(normal = True),
+)
+
+# Test-only twin of `rp_lib` linking the `_with_mock` plate-solver
+# variant so unit tests in mcp.rs can use MockPlateSolveClient.
+# Same crate_name as `rp_lib` — they are never linked into the same
+# binary. rules_rust merges `crate=`'s parent deps with the test's
+# own, so the test must reach the with-mock plate-solver through
+# this twin (not by overriding deps on the rust_test directly,
+# which produces an `E0464 multiple candidates` link conflict).
+rust_library(
+    name = "rp_lib_with_mock",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
+    aliases = aliases(),
+    crate_name = "rp",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    deps = _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER_WITH_MOCK] + all_crate_deps(normal = True),
 )
 
 rust_binary(
@@ -30,7 +53,7 @@ rust_binary(
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
-    deps = [":rp_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+    deps = [":rp_lib"] + _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER] + all_crate_deps(normal = True),
 )
 
 rust_test(
@@ -40,12 +63,12 @@ rust_test(
         proc_macro_dev = True,
     ),
     size = "small",
-    crate = ":rp_lib",
+    crate = ":rp_lib_with_mock",
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,
     ),
-    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(
+    deps = _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER_WITH_MOCK] + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),
@@ -84,7 +107,7 @@ rust_test(
     rustc_env = {"CARGO_PKG_NAME": "rp"},
     tags = ["bdd"],
     use_libtest_harness = False,
-    deps = [":rp_lib", "//crates/bdd-infra:bdd-infra_rp_harness"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+    deps = [":rp_lib", "//crates/bdd-infra:bdd-infra_rp_harness"] + _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER] + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),

--- a/services/rp/BUILD.bazel
+++ b/services/rp/BUILD.bazel
@@ -36,6 +36,8 @@ rust_library(
 # own, so the test must reach the with-mock plate-solver through
 # this twin (not by overriding deps on the rust_test directly,
 # which produces an `E0464 multiple candidates` link conflict).
+# `testonly = True` is also required here because the twin depends
+# on the testonly `:rp-plate-solver_with_mock`.
 rust_library(
     name = "rp_lib_with_mock",
     srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
@@ -43,6 +45,7 @@ rust_library(
     crate_name = "rp",
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
+    testonly = True,
     deps = _INTRA_WORKSPACE_DEPS + [_RP_PLATE_SOLVER_WITH_MOCK] + all_crate_deps(normal = True),
 )
 


### PR DESCRIPTION
## Summary

- Closes #157.
- `crates/rp-plate-solver/BUILD.bazel` now exposes two `rust_library` targets: a production-clean `rp-plate-solver` (no `crate_features`) and a test-only `rp-plate-solver_with_mock` (`crate_features = ["mock"]`).
- `services/rp/BUILD.bazel` switches consumers accordingly: `rp_lib`, the `rp` binary, and the `bdd` test target depend on the production variant; a new sibling `rp_lib_with_mock` carries the `_with_mock` plate-solver and is the `crate=` parent for `rp_unit_test`. The twin library is needed because rules_rust merges the `crate=` parent's `deps` with the `rust_test`'s `deps`, so swapping the dep only on the test produced an `E0464 multiple candidates` link conflict.
- Pattern documented under "Mockall mock variants" in `docs/plans/bazel-migration.md`. `rp-tls` keeps its mocks single-crate via `cfg_attr(test, ...)` and needs no variant today.

## Test plan

- [x] `bazel build //crates/rp-plate-solver:rp-plate-solver //crates/rp-plate-solver:rp-plate-solver_with_mock` — both variants build.
- [x] `bazel test //crates/rp-plate-solver:rp-plate-solver_unit_test //services/rp:rp_unit_test` — both pass.
- [x] `bazel build //services/rp:rp //services/rp:bdd //services/rp:rp_lib //services/rp:rp_lib_with_mock` — clean build.
- [x] `nm bazel-bin/services/rp/rp | grep -ci mockall` returns `0` (previously transitively linked).
- [x] `cargo rail run --profile commit -q` — 394/394 tests pass.
- [x] `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)