### PR TITLE
fix(phd2-guider): drop miri guard on spawn_mock_phd2_dynamic_port

### DIFF
--- a/services/phd2-guider/tests/test_integration.rs
+++ b/services/phd2-guider/tests/test_integration.rs
@@ -582,7 +582,6 @@ fn start_mock_phd2(port: u16) -> Option<Child> {
 /// failure logs in test output, or `Stdio::null()` to discard them (necessary
 /// when many of these run in parallel — mock_phd2 is verbose enough that an
 /// undrained piped stderr can fill the pipe buffer and deadlock the mock).
-#[cfg(not(miri))]
 fn spawn_mock_phd2_dynamic_port(
     binary: impl AsRef<std::path::Path>,
     mode: &str,


### PR DESCRIPTION
## Summary
- Nightly Miri job for `phd2-guider` started failing on `main` after #165 (consolidation of integration test binaries).
- Failure: `error[E0425]: cannot find function spawn_mock_phd2_dynamic_port` — the helper at `services/phd2-guider/tests/test_integration.rs:586` was gated `#[cfg(not(miri))]`, but `spawn_mock_server_with_mode` (line 1692, used by all the CLI subprocess tests merged from `test_main_integration.rs`) calls it without a matching gate.
- The pre-consolidation equivalent helper in `test_main_integration.rs` was never miri-gated and that suite ran fine under miri. Removing the guard restores that behavior.

Failed run for reference: https://github.com/ivonnyssen/rusty-photon/actions/runs/25360426037 (job `scheduled / ubuntu / miri / phd2-guider`).

## Test plan
- [x] `cargo miri test -p phd2-guider --test test_integration --no-run` — compiles cleanly under miri (the original failure was at compile time)
- [x] `cargo rail run --profile commit -q` — 344/344 pass, 10 skipped
- [x] `cargo fmt --all -- --check` — clean
- [ ] Nightly miri scheduled run on `main` after merge — should turn green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)