### PR TITLE
docs(plans): add workspace i18n strategy plan

### DIFF
--- a/docs/plans/i18n.md
+++ b/docs/plans/i18n.md
@@ -65,8 +65,12 @@ any crate gains a translation dependency.
    languages. The sourcing model has to assume volunteer / machine /
    hybrid input from day one.
 6. **Cost of adding a language is bounded.** Adding `fr_FR` should be a
-   PR that touches translation files only — no Rust changes, no
-   re-compile of every service.
+   PR that touches translation files only — no Rust source changes and
+   no service-by-service refactor. The compile-time-embedded bundle
+   (Goal #4) does mean every binary linking the i18n crate rebuilds when
+   an `.ftl` file changes, but that rebuild is incremental and is the
+   same cost any documentation-only commit pays in CI today. This goal
+   is about translator workflow ergonomics, not avoiding the build.
 
 ## Non-goals
 
@@ -127,6 +131,34 @@ will paste them into. Translated logs fragment the search corpus
 `"Échec de la connexion du moniteur"`). The CLAUDE.md rule 9 posture
 already keeps logs sparse and operator-meaningful; that posture is the
 right ceiling.
+
+### Why "translate user-facing errors" is not a `#[error(...)]` swap
+
+The `thiserror` enums in each service (`RpError`, `SentinelError`,
+`PlateSolverError`, etc.) carry compile-time format strings via
+`#[error("...")]`, and those strings are reused well beyond the CLI:
+plate-solver serialises `self.to_string()` into HTTP error response
+bodies, sentinel logs `error!("{e}")` directly into journalctl, and
+several services thread error variants through the `Display` impl into
+ASCOM Alpaca responses. Translating the `#[error(...)]` attribute in
+place would silently localise three surfaces this plan explicitly keeps
+English: HTTP wire format, log lines, and Alpaca responses.
+
+The translation contract for errors is therefore a **presentation
+layer**, not an attribute swap:
+
+- The internal `thiserror` enum stays English. It is the type used
+  in HTTP bodies, logs, and inter-service wire formats.
+- A separate user-facing renderer — a `LocalizedError` view (trait
+  method or wrapper type) per service — maps each variant to an `.ftl`
+  key and is invoked **only** at the CLI top-level error renderer and
+  the dashboard's user-visible error banner.
+- The mapping table is the unit of translation; an error variant
+  rename is a translation-key rename. (See open question 7.)
+
+This shape is the same posture as `clap` help in Phase 3: localising
+the user-visible presentation does not entail rewriting the underlying
+type system.
 
 ### Why localised numbers / dates need a separate decision per site
 
@@ -501,10 +533,16 @@ error.
 
 **Format:** Fluent (`.ftl`).
 **Rust services:** `i18n-embed` + `fluent-langneg` for locale
-negotiation, `fl!()` macro at call sites, embedded at compile time via
-`include_dir!`. One `i18n/{locale}/{module}.ftl` tree per service. CLI
-errors and user-facing `thiserror` messages adopt `fl!()`; logs and MCP
-tool descriptions stay literal English.
+negotiation, `fl!()` macro at user-facing call sites, embedded at
+compile time via `include_dir!`. One `i18n/{locale}/{module}.ftl` tree
+per service. The internal `thiserror` enums stay English (they're
+serialised into HTTP error bodies and logged via `error!("{e}")`); a
+separate user-facing presentation layer at the CLI top-level renderer
+and the dashboard's error banners maps an error variant to a localised
+`fl!()` message — not a `#[error(...)]` attribute rewrite. `clap` help
+moves from derive doc-comments to runtime `Command` construction so
+help text can be `fl!()`-loaded once the locale is resolved. Logs and
+MCP tool descriptions stay literal English everywhere.
 **Leptos UI:** `leptos-fluent` consuming the same `.ftl` files
 (possibly via a shared `crates/rp-i18n` workspace member that owns the
 loader and re-exports per-module loaders to each service).
@@ -547,11 +585,24 @@ the "decisions resolved during design" pattern.
 
 ### Phase 3 — CLI help + user-facing errors across all services
 
-- Audit each service's `clap` derive surface; convert doc-comments to
-  `i18n-embed`-loaded strings.
-- Convert user-facing `thiserror` `#[error("...")]` messages. Decide
-  per-variant whether the message is operator-visible (translate) or
-  developer-visible (English).
+This phase is a **refactor**, not a string substitution. Both surfaces
+require the call-site shape to change before any `fl!()` lands.
+
+- **CLI help.** `clap` derive bakes `#[arg(help = ...)]` and doc-comments
+  into `Command` metadata at compile time, so an `i18n-embed` loader
+  cannot swap them in place. Each service's CLI moves to runtime
+  `Command` construction — clap's builder API or post-build mutation
+  via `Command::mut_arg` — with help strings sourced from `fl!()` once
+  the locale is resolved at startup. The doc-comments stay in source
+  as the English source-of-truth fed into the `.ftl` bootstrap.
+- **User-facing errors.** Internal `thiserror` enums stay English (see
+  §1 "Why 'translate user-facing errors' is not a `#[error(...)]`
+  swap"). Phase 3 introduces a per-service presentation layer — a
+  `LocalizedError` view that maps each variant to an `.ftl` key — and
+  invokes it **only** at the CLI top-level error renderer and the
+  dashboard's user-visible error banners. HTTP error bodies, log lines,
+  and Alpaca responses continue to render the underlying English
+  `Display` impl unchanged.
 - Update each service's `docs/services/<svc>.md` "Configuration" and
   "Operator runbook" sections to note the `RP_LOCALE` /
   `RUSTY_PHOTON_LOCALE` environment variable.
@@ -605,6 +656,12 @@ the "decisions resolved during design" pattern.
    MCP descriptions stay English because Claude works best in English.
    That assertion deserves periodic re-evaluation as multi-lingual
    tool-use benchmarks evolve.
+7. **Error-variant ↔ `.ftl` key stability.** The error presentation
+   layer maps `thiserror` variants to translation keys. A variant
+   rename is a key rename, and translators need to know. Decide a
+   policy: `#[deprecated]` shim plus key alias for one release, or
+   hard rename with a CHANGELOG note? Phase 3 should pick before the
+   first error variant gets translated.
 
 ## 9 — References
 

--- a/docs/plans/i18n.md
+++ b/docs/plans/i18n.md
@@ -1,0 +1,621 @@
+# Plan: workspace internationalization (i18n)
+
+**Date:** 2026-05-05
+**Branch:** `worktree-i18n-planning`
+**Parent design docs:** [`docs/workspace.md`](../workspace.md), [`docs/services/sentinel.md`](../services/sentinel.md), [`docs/services/rp.md`](../services/rp.md)
+**Closest precedent:** [`docs/plans/rp-planning-tools.md`](rp-planning-tools.md) (cross-service, decision-heavy plan)
+
+> **Status:** strategic options with a recommended path. Phasing is sketched
+> but not yet committed; treat sections 6 and 7 as proposals that need a
+> review pass before they become a binding rollout.
+
+## Background
+
+Rusty Photon is currently English-only. Every user-visible string —
+dashboard HTML, CLI `--help`, `thiserror` messages, `tracing` logs, MCP
+tool descriptions, and the workspace's own documentation — is hand-coded
+in English with no extraction layer. There has been no operator feedback
+demanding translation, but the project's audience is global by nature
+(astronomy is a worldwide hobby with strong communities in DE, ES, FR,
+IT, JP, CN, KR, CZ, PL), and the hand-rolled UI in
+`services/sentinel/src/dashboard.rs` is about to be replaced by the
+Leptos crate `services/sentinel-app/` (currently scaffolded but
+unwired). The Leptos rewrite is the natural moment to introduce an i18n
+layer — retrofitting after both UIs have shipped is more expensive than
+designing the second one with translation in mind.
+
+The workspace is small but heterogeneous:
+
+- 9 services + 7 shared crates, all in one Cargo workspace
+- One web UI today (hand-rolled HTML), one in flight (Leptos / WASM)
+- A Rust MSRV of 1.94.1
+- A polyglot operator audience but a single-vendor maintainer (no in-house
+  translators)
+
+This plan answers three questions:
+
+1. **What gets translated and what stays English-only?** (scope)
+2. **How do we deliver i18n in Rust services and in the Leptos UI?** (tech)
+3. **Where do translations come from, and how is quality controlled?** (sourcing)
+
+It does not commit code yet — Phase 1 of the rollout is the first time
+any crate gains a translation dependency.
+
+## Goals
+
+1. **Operator-visible surfaces are translatable.** A non-English-speaking
+   observer should be able to read the sentinel dashboard, understand
+   CLI errors during setup, and recognise notification text without
+   needing English literacy.
+2. **Developer-facing surfaces stay English.** Logs, MCP tool
+   descriptions (consumed by the LLM, not humans), wire-format protocol
+   strings, and source-code identifiers remain English-only. Translating
+   them adds cost without benefit.
+3. **Single message format across the workspace.** The Rust services and
+   the Leptos UI use the same translation file format. Mixing formats
+   (e.g. Fluent in the UI, gettext in the backend) doubles the
+   translator workflow and tooling.
+4. **Translations live in version control.** Source `.ftl` (or
+   equivalent) files are committed; the CI build embeds them via
+   `include_bytes!` / `include_dir!`. No runtime download, no
+   server-side translation cache. This matches Tenet 1 (robustness) and
+   Tenet 5 (minimal footprint, runs offline at remote dark sites).
+5. **Translations are sourced through a workflow that scales beyond one
+   maintainer.** A single human cannot review translations into ten
+   languages. The sourcing model has to assume volunteer / machine /
+   hybrid input from day one.
+6. **Cost of adding a language is bounded.** Adding `fr_FR` should be a
+   PR that touches translation files only — no Rust changes, no
+   re-compile of every service.
+
+## Non-goals
+
+- **Right-to-left layout.** Arabic, Hebrew, Persian are out of scope for
+  v1. The dashboard layout will not be audited for RTL until there is
+  demand. (Fluent and `leptos-fluent` both support `<html dir>` flipping
+  if we change our minds.)
+- **Localised astronomy units.** Right Ascension stays in
+  `HHhMMmSS.Ss`; declination stays in `±DD°MM'SS"`; magnitudes stay in
+  decimal English. These are scientific notation, not natural language.
+  The decimal separator in astronomy data is **always** `.` regardless
+  of locale.
+- **Translating the Cargo / Rust toolchain output.** Build errors are
+  developer-facing and stay English.
+- **Translating ASCOM Alpaca protocol responses.** The protocol is
+  spec-defined English; clients that connect to our services expect
+  English property names and error strings. (See
+  [docs/references/ascom-alpaca.md](../references/ascom-alpaca.md).)
+- **Translating commit messages, PR descriptions, GitHub issues,
+  CHANGELOG entries.** These are project-internal English.
+
+## 1 — Scope: what gets translated, surface by surface
+
+Concrete inventory of user-visible strings across the workspace, with
+the recommended translation status for each surface. Counts are
+order-of-magnitude estimates from a sweep of `services/` and `crates/`.
+
+| Surface | Approx string count | Audience | Recommended status |
+|---------|--------------------:|----------|--------------------|
+| **Leptos dashboard** (`sentinel-app/`) | 10s today, 50–100 after rewrite | End-observer (non-technical glance) | **Translate** |
+| **CLI help** (`clap` derive across 9 services) | ~100 doc-comments | Operator during install/config | **Translate** (cheap, high-visibility) |
+| **User-facing error messages** (`thiserror` enums + config validation) | 50–100 | Operator during install/debug | **Translate** (selective) |
+| **MCP tool descriptions** (`#[tool(description = ...)]` in `rp/mcp.rs`) | ~30 tools, ~100 strings incl. parameter docs | LLM (Claude); never rendered to humans | **Do NOT translate** |
+| **`info!` / `warn!` / `error!` log messages** | ~50 across services | Operator viewing journalctl | **Do NOT translate** (English log greppability beats locale) |
+| **`debug!` / `trace!` log messages** | ~600 | Developers only (CLAUDE.md rule 9) | **Do NOT translate** |
+| **Pushover notification text** | ~10 hardcoded fragments | End-observer on phone | **Translate** |
+| **ASCOM Alpaca property names + error responses** | spec-defined | Alpaca clients (NINA, SGPro, Voyager) | **Do NOT translate** (wire format) |
+| **Hand-rolled HTML in `sentinel/dashboard.rs`** | ~10 strings | End-observer | **Discard, not translate** — rewrite into `sentinel-app` is already planned |
+| **Service READMEs + `docs/`** | ~35 markdown files, ~50–100k words | Developers + operators | **Stay English** (community translations welcome but not gated) |
+
+### Why MCP tool descriptions are explicitly excluded
+
+The `#[tool(description = "...")]` strings in `services/rp/src/mcp.rs`
+are read by Claude (or whichever LLM is driving the orchestrator), not
+by a human user. The LLM works most accurately in English, the tool
+catalog is part of the system prompt, and translating these would
+introduce a cross-language failure mode where a French description
+disagrees with an English parameter name in the same call. Keep them
+English; if a user-facing description of a tool is needed elsewhere
+(e.g. a future "what can rp do?" UI page), it is a separate string.
+
+### Why logs are explicitly excluded
+
+`info!`/`warn!`/`error!` are read by the operator while debugging — and
+by every search engine, mailing list, and Stack Overflow answer they
+will paste them into. Translated logs fragment the search corpus
+(`"Failed to connect monitor"` finds no hits if the user's log says
+`"Échec de la connexion du moniteur"`). The CLAUDE.md rule 9 posture
+already keeps logs sparse and operator-meaningful; that posture is the
+right ceiling.
+
+### Why localised numbers / dates need a separate decision per site
+
+The Leptos dashboard's wall-clock times (`new Date(...)
+.toLocaleTimeString()` today) are already locale-formatted by the
+browser — that comes free. CPU %, exposure counts, frame indices are
+locale-neutral integers. **Astronomy data** (RA/Dec sexagesimal,
+exposure seconds, focuser steps, well-depth %) stays in fixed
+scientific notation regardless of locale, because operators copy these
+into other ASCOM tools that all expect `.` as decimal separator. The
+i18n layer should only localise the **chrome** (labels, headings,
+errors), not the **data**.
+
+## 2 — Tech stack: Rust backend options
+
+Three families of i18n libraries are viable in the current Rust
+ecosystem (May 2026). Each is a real choice with trade-offs; we are not
+forced to a single answer.
+
+### Option A — Fluent (Project Fluent / Mozilla) via `i18n-embed` + `fluent-rs`
+
+Fluent is Mozilla's translation system, designed specifically for
+natural-sounding translations with proper grammatical features (plural,
+gender, case, declension via "selectors"). The file format is `.ftl`
+(TOML-flavoured, hand-editable). `i18n-embed` is the canonical Rust
+glue: it provides traits + macros that embed `.ftl` files into the
+binary at compile time and select the active locale at runtime via
+`fluent-langneg` (RFC 4647 best-fit matching).
+
+```ftl
+# en/sentinel.ftl
+dashboard-title = Sentinel Dashboard
+monitor-state-safe = Safe
+monitor-error-count = { $count ->
+    [0]    No errors
+    [one]  One error
+   *[other] { $count } errors
+}
+```
+
+```rust
+// in code
+let s = fl!(loader, "monitor-error-count", count = m.consecutive_errors);
+```
+
+**Pros**
+
+- Modern and CLDR-aligned. Plural/gender selectors handle the cases
+  where English's two forms collapse into Polish's three or Arabic's six.
+- `.ftl` is hand-editable by translators, single file per locale per
+  module — no `.po` → `.mo` compile step.
+- `i18n-embed` is the de-facto standard, dual-licensed (MIT/Apache),
+  used by `pop-os`, `cosmic-applet-*`, `helvum`, etc. Active maintenance.
+- `cargo i18n` (the companion `cargo-i18n` sub-command) extracts strings
+  and bootstraps `.ftl` skeletons.
+- Forward-compatible with MessageFormat 2 (Fluent has been the de-facto
+  reference for MF2's design; bridges exist).
+
+**Cons**
+
+- Ecosystem outside Mozilla / GNOME / pop-os is thinner than gettext.
+  Fewer Stack Overflow hits when a translator is stuck.
+- Fluent's selectors take some learning. A translator used to gettext
+  `.po` files needs orientation.
+- `i18n-embed`'s API surface is larger than `rust-i18n`'s — more
+  boilerplate per module to wire up the loader.
+
+### Option B — Gettext via `gettext-rs` or `i18n-embed`'s gettext backend
+
+Gettext is the 30-year-old GNU translation system. `.po` source files,
+`.mo` compiled binary catalogs. Every translation tool on the planet
+reads `.po`. Weblate, Crowdin, Transifex, Poedit, Lokalize, Virtaal —
+all native.
+
+**Pros**
+
+- The largest translator ecosystem, by a wide margin. A volunteer
+  reaching the project will already know `.po`.
+- `xgettext` extracts strings deterministically from source code; tools
+  for `.po` editing exist on every platform.
+- Plural rules supported (CLDR-derived).
+
+**Cons**
+
+- The format is showing its age: no gender / variant selectors beyond
+  plurals, no built-in date/number formatting, separate `.po` source
+  vs. `.mo` binary doubles the build steps.
+- `gettext-rs` links libgettext (C dependency); `i18n-embed`'s gettext
+  backend avoids that but inherits the `.po`/`.mo` two-format awkwardness.
+- Cross-compilation gets fiddly when the C lib is in the picture
+  (Pi 5 builds matter to us).
+- No clean upgrade path to MessageFormat 2 — bridges exist but are not
+  trivial.
+
+### Option C — `rust-i18n` (JSON/YAML, build-time macro)
+
+A simpler, lighter-weight crate that loads a single JSON or YAML file
+of key→message mappings, with `t!()` macro expansion at compile time.
+Used in Cargo, mdBook, several smaller CLIs.
+
+**Pros**
+
+- Tiny dependency, ~zero learning curve, no `.ftl` / `.po` tooling
+  required — translators edit JSON.
+- Compile-time key checking via macro.
+- Works fine for static interfaces with no plural / gender complexity.
+
+**Cons**
+
+- No real plural support (a single-form fallback is the practical
+  default); translators have to either accept that or work around it.
+- No selector grammar for languages that need it (Polish, Russian,
+  Arabic).
+- Translation tools (Weblate, Crowdin) treat JSON well but lose the
+  metadata (translator comments, context strings) that `.ftl` and `.po`
+  carry natively.
+- No clean wasm-friendly Leptos integration story; would mean two
+  formats workspace-wide.
+
+### Option D — ICU4X (the Rust port of ICU) directly
+
+ICU4X is the Rust-native, no-std-friendly port of the ICU library,
+maintained by the Unicode consortium. It supports MessageFormat 2 (now
+stable in CLDR 47) and the full CLDR data set.
+
+**Pros**
+
+- Strongest possible standards posture: CLDR + MF2 directly, no
+  intermediate format.
+- Works in `no_std` and wasm; explicit attention to binary size.
+- Future-proof: MF2 is the format the rest of the industry is
+  converging on.
+
+**Cons**
+
+- The ergonomic layer for application-level i18n is **not** a primary
+  ICU4X concern. Out of the box ICU4X gives you `MessageFormatter`,
+  not a "translate this key" workflow — you build the asset embedding,
+  the loader, and the locale-selection logic yourself.
+- MF2 syntax is the most expressive but also the most verbose for the
+  common case ("hello world").
+- The translator ecosystem for MF2 source files is still maturing in
+  2026 (Weblate has support but it is newer than `.po` / `.ftl`).
+- Heavier than Fluent for our use-case; we don't need its full
+  capability surface.
+
+### Recommendation: Fluent (Option A)
+
+Fluent is the right pick because:
+
+- It matches the data the dashboard actually needs (occasional plurals,
+  no gender, no complex grammar): well above gettext's ceiling, well
+  below ICU4X's runway.
+- `i18n-embed` covers the ergonomics ICU4X leaves to the application.
+- The Leptos side has a first-class Fluent integration (`leptos-fluent`,
+  see Section 3) — picking Fluent here lets the UI and backend share
+  one file format and one toolchain.
+- The MF2 migration path is real: Fluent's design heavily informed MF2
+  and bridge tooling exists.
+
+If we hit a wall with Fluent (e.g. translator pushback against `.ftl`),
+the fallback is gettext — `i18n-embed` lets us swap backends without
+changing call sites, so this is a recoverable bet.
+
+## 3 — Tech stack: Leptos UI options
+
+Two crates own the Leptos i18n space. The choice flows directly from
+Section 2.
+
+### Option A — `leptos-fluent` (Fluent / `.ftl`)
+
+Fluent under the hood, idiomatic Leptos hooks (`tr!`, `move_tr!`),
+`<html lang>` and `<html dir>` synchronisation, language persistence to
+local storage / cookies / URL params, fallback chains.
+
+**Pros**
+
+- **One format workspace-wide** if Section 2 picked Fluent. Translator
+  edits one set of `.ftl` files; the same files feed both the dashboard
+  and the backend strings (with a sensible split into per-component
+  modules).
+- Active development, Leptos 0.7+ support (verify against current
+  workspace `leptos` version before committing).
+
+**Cons**
+
+- Younger than `leptos_i18n`; smaller user base.
+- Macro errors at compile time can be confusing on first use.
+
+### Option B — `leptos_i18n` (custom JSON/YAML, ICU-style plurals)
+
+A different design point: locales are JSON/YAML, parsed and
+type-checked at compile time, with Leptos signals integrated. Strong
+compile-time safety story (every key is checked, every interpolation
+parameter is checked).
+
+**Pros**
+
+- Best-in-class compile-time correctness. Missing keys, typos in
+  interpolation parameters, mismatched plural forms are all build errors.
+- Smaller mental model for developers used to React's `react-intl`.
+
+**Cons**
+
+- **Different format from the backend.** If the backend is Fluent, the
+  UI is JSON, and translators see two file types in PRs. This is the
+  primary reason not to pick it under our recommended stack.
+
+### Recommendation: `leptos-fluent` to match the backend
+
+Pick `leptos-fluent` for the dashboard so the workspace standardises on
+Fluent end-to-end. The compile-time safety in `leptos_i18n` is real,
+but the cost of running two file formats through the translation
+workflow is higher than the cost of catching missing keys with a CI
+check (`cargo i18n verify` exists for exactly this).
+
+## 4 — Sourcing translations
+
+Tech stack picks the format. Sourcing picks the workflow that fills the
+files.
+
+### Option A — Hosted Weblate (FOSS, free for OSS)
+
+Weblate is the open-source translation platform of choice for
+GNU/Linux-aligned projects. The maintainers run a free hosted instance
+(`hosted.weblate.org`) for libre projects. Workflow:
+
+1. PR to add `.ftl` + `i18n.toml` lands.
+2. Weblate's GitHub integration auto-imports new strings.
+3. Translators (volunteers + maintainer + machine-translation
+   suggestions from Weblate's built-in MT proxy to DeepL / GPT-OSS /
+   ModernMT) edit translations in the Weblate web UI.
+4. Weblate opens a PR back to the repo with the updated `.ftl` files.
+5. CI gates the merge.
+
+**Pros**
+
+- Free for libre projects (matches our MIT/Apache posture).
+- Open source itself — no lock-in.
+- Translator UX is good (terminology glossary, screenshots, side-by-side
+  source view, translation memory across the project).
+- Native Fluent + gettext + JSON support.
+- Self-host fallback if Weblate's hosted offering ever changes terms
+  (Weblate is AGPL software).
+
+**Cons**
+
+- The maintainer has to apply for the libre project allowance and
+  manage the Weblate ↔ repo integration (one-time setup, then automatic).
+- Volunteers have to create a Weblate account.
+- Less polished than Crowdin's UX (some translators prefer Crowdin).
+
+### Option B — Crowdin (proprietary, free OSS plan)
+
+Crowdin offers a free tier for open-source projects with no
+revenue model. UX is generally considered the slickest of the three,
+and the AI-assisted suggestions (in 2026) are the strongest of any
+hosted platform.
+
+**Pros**
+
+- Best translator UX, polished UI, mobile app.
+- Excellent AI-assisted translation pipeline (GPT/Claude/DeepL routed
+  per language).
+- Wide industry adoption — many volunteers already have Crowdin accounts.
+
+**Cons**
+
+- Closed-source; we depend on Crowdin's continued goodwill for the OSS
+  tier (Transifex's history shows this is not zero-risk).
+- Vendor lock-in on the platform side, though the source files in our
+  repo remain ours.
+- "Free for OSS" terms can change; Transifex tightened theirs in
+  2018-2019.
+
+### Option C — Transifex (proprietary, free OSS plan with caveats)
+
+Similar shape to Crowdin. Free OSS plan exists but has historically
+been more restrictive (string limits, language limits).
+
+**Pros / Cons**
+
+- Same general profile as Crowdin but with a less attractive OSS tier.
+  Not recommended unless the maintainer specifically prefers Transifex.
+
+### Option D — Maintainer-driven LLM-assisted, no hosting platform
+
+Maintainer runs the LLM (Claude, GPT, DeepL API) over the source `.ftl`,
+commits the output, optionally tags strings as "machine-translated,
+needs review". A community member who speaks the target language opens
+a PR with corrections.
+
+**Pros**
+
+- Zero infrastructure. No third-party signup.
+- Bootstraps day-1 translations in every language Claude/GPT speaks
+  (which is most of them, well).
+- Particularly good fit while the project has no community of
+  translators yet — the platform tier matters most when *there are
+  volunteers to coordinate*.
+
+**Cons**
+
+- Quality is "first draft, not final". A native speaker reviewing
+  random strings will find clunky phrasing, register slips ("you" vs.
+  "thou" in es-ES vs es-MX), incorrect plurals.
+- No translation memory across releases — every version regenerates
+  from scratch unless we cache previous output.
+- Burden of triage falls entirely on the maintainer.
+
+### Option E — Pure volunteer, GitHub PRs
+
+The traditional "anyone who wants German can send a PR" workflow. Works
+fine for small projects with strong communities (e.g. Helix editor).
+
+**Pros / Cons**
+
+- Lowest setup cost, no platform.
+- Slowest, most uneven coverage. Languages get translated only when a
+  volunteer happens to care.
+- Translators without GitHub literacy are excluded.
+
+### Recommendation: D → A (start with LLM-assisted, graduate to Weblate)
+
+While the project has zero translator community, **Option D**
+(maintainer + LLM) is the right starting point. It produces ten
+languages of usable-but-imperfect translation in an afternoon, gets
+the i18n plumbing exercised end-to-end, and creates the artifacts a
+future volunteer can correct.
+
+Once the dashboard ships in v1 and operator feedback identifies
+languages where rough translations are actively confusing, **graduate
+to Option A (hosted Weblate)**. Weblate accepts the existing `.ftl`
+files unchanged and layers translation memory + community workflow on
+top. The graduation cost is low because Fluent is Weblate-native.
+
+Avoid Option B/C unless a maintainer specifically wants the polish —
+they offer a better translator UX, but at the cost of a closed-source
+dependency we don't otherwise have anywhere in the stack.
+
+## 5 — Languages: priority and admission criteria
+
+Adding a language is **cheap** for the build (one more `.ftl` per
+module) and **expensive** for the human review loop. The right
+discipline is "every language has a designated reviewer," even if the
+reviewer is the LLM in v1.
+
+**Tier 1 — Source.** `en` (en-US conventions, decimal `.`, US date
+formatting where the browser doesn't override).
+
+**Tier 2 — Initial seeded set, LLM-bootstrapped.** `de`, `es`, `fr`,
+`it`, `ja`, `zh-CN`. Rationale: the largest amateur-astronomy
+communities outside the English-speaking world, and the locales most
+commonly cited in NINA / SGPro / Voyager translation projects.
+
+**Tier 3 — Add on demand.** `ko`, `pt-BR`, `cs`, `pl`, `ru`, `nl`. Add
+when a real user asks. Tier 3 entries should arrive with a named
+reviewer (the requester), not as a maintainer guess.
+
+**Out of scope for v1.** RTL languages (`ar`, `he`, `fa`) until the
+Leptos layout has been audited for direction-flipping. Logographic
+languages with significant glyph density (Tier 2's `ja` and `zh-CN`
+already test this) cover the typography risk; RTL adds layout risk on
+top.
+
+The build does **not** fail when a language is incomplete. Missing
+keys fall back through the chain `xx-YY → xx → en` per Fluent's
+default. The dashboard renders a partial translation rather than an
+error.
+
+## 6 — Recommended end-to-end stack (one-paragraph summary)
+
+**Format:** Fluent (`.ftl`).
+**Rust services:** `i18n-embed` + `fluent-langneg` for locale
+negotiation, `fl!()` macro at call sites, embedded at compile time via
+`include_dir!`. One `i18n/{locale}/{module}.ftl` tree per service. CLI
+errors and user-facing `thiserror` messages adopt `fl!()`; logs and MCP
+tool descriptions stay literal English.
+**Leptos UI:** `leptos-fluent` consuming the same `.ftl` files
+(possibly via a shared `crates/rp-i18n` workspace member that owns the
+loader and re-exports per-module loaders to each service).
+**Sourcing — bootstrap:** maintainer-driven LLM batch translation into
+the Tier 2 set, committed with a `# machine-translated, needs review`
+comment header in each non-English `.ftl`.
+**Sourcing — graduation:** hosted Weblate when (and only when) we have
+volunteer translators to coordinate. Fluent files port across without
+changes.
+**CI gate:** `cargo i18n verify` (or equivalent) checks every locale
+parses and every `fl!()` key has at least an English source — missing
+non-English values are warnings, not errors.
+**Out of scope until demanded:** RTL languages, localised numbers in
+data, translated logs, translated MCP tool descriptions, translated
+docs/READMEs.
+
+## 7 — Phased rollout (proposed, not committed)
+
+This is a **sketch** to make the recommendation feel concrete. Each
+phase below should become its own plan doc when picked up, following
+the "decisions resolved during design" pattern.
+
+### Phase 1 — Spike + workspace decision (small)
+
+- Stand up `crates/rp-i18n` with `i18n-embed` + Fluent backend.
+- Translate one small surface (`sentinel-app`'s top-level navigation
+  labels, ~10 strings) into `en` + `de`.
+- Wire up `cargo i18n verify` in the pre-push profile (`commit` profile
+  in `.config/rail.toml`).
+- Decision gate: do `.ftl` files survive the maintainer's editor
+  workflow comfortably? If not, fall back to gettext before scaling up.
+
+### Phase 2 — Sentinel dashboard full coverage
+
+- Translate every label in `sentinel-app/src/components/` into the
+  Tier 2 language set via LLM batch.
+- Update `docs/services/sentinel.md` to reference the i18n contract.
+- Add a language picker to the dashboard; default to browser
+  `Accept-Language`, persist override in local storage.
+
+### Phase 3 — CLI help + user-facing errors across all services
+
+- Audit each service's `clap` derive surface; convert doc-comments to
+  `i18n-embed`-loaded strings.
+- Convert user-facing `thiserror` `#[error("...")]` messages. Decide
+  per-variant whether the message is operator-visible (translate) or
+  developer-visible (English).
+- Update each service's `docs/services/<svc>.md` "Configuration" and
+  "Operator runbook" sections to note the `RP_LOCALE` /
+  `RUSTY_PHOTON_LOCALE` environment variable.
+
+### Phase 4 — Pushover / notification text
+
+- Translate the small set of hardcoded fragments in
+  `services/sentinel/src/pushover.rs`. The user-supplied title/body
+  fields stay verbatim (the user already wrote them in their language).
+
+### Phase 5 — Sourcing graduation (conditional)
+
+- If volunteer translators have appeared, register the project on
+  hosted Weblate; configure GitHub integration for auto-PR back.
+- If not, document the maintainer-LLM workflow as the canonical path
+  in `docs/skills/i18n.md` (new skill doc) and revisit at the next
+  release.
+
+### Phase 6 — RTL audit (only if demanded)
+
+- Trigger: a Tier 3 admission for `ar` / `he` / `fa` is requested.
+- Audit Leptos components for `<html dir>` flipping; fix layout asymmetries.
+
+## 8 — Open questions
+
+1. **Where does the `RP_LOCALE` env var live?** Per-service, or
+   workspace-global via `RUSTY_PHOTON_LOCALE`? The dashboard's locale
+   is a per-user concern (browser-driven); the CLI's locale is a
+   per-operator concern (env). These can disagree (operator runs
+   `LANG=de_DE` but dashboard is loaded by a `fr_FR` browser) and the
+   resolution should be documented before Phase 3.
+2. **Fluent file granularity.** One `.ftl` per service, or one per
+   logical surface (`cli.ftl`, `errors.ftl`, `dashboard.ftl`)?
+   Per-surface is friendlier to translators (smaller diffs); per-service
+   is friendlier to developers (locality of reference). Phase 1's
+   decision gate should pick.
+3. **Crate version compat.** Verify `i18n-embed` and `leptos-fluent`
+   support the workspace's current `leptos`, `axum`, and `tokio`
+   versions before Phase 1. Pin in workspace `Cargo.toml` per
+   CLAUDE.md rule 10 (any crate used by ≥2 services).
+4. **Translation comment / context strings.** Fluent supports
+   `# Translator: ...` comments. Establish a convention so machine
+   translators (and human reviewers) know which strings are
+   astronomy-specific terminology vs. ordinary UI prose.
+5. **What happens on Pi 5?** The full ICU4X data is hundreds of KB; the
+   Fluent runtime is much smaller (~100 KB). Verify the wasm-bundle
+   size impact on the dashboard before Phase 2 — if it crosses an
+   alarming threshold, narrow the included locales server-side and
+   serve only the negotiated locale's bundle.
+6. **MCP tool description posture, revisited.** This plan asserts that
+   MCP descriptions stay English because Claude works best in English.
+   That assertion deserves periodic re-evaluation as multi-lingual
+   tool-use benchmarks evolve.
+
+## 9 — References
+
+- [Project Fluent — Fluent vs. gettext](https://github.com/projectfluent/fluent/wiki/Fluent-vs-gettext)
+- [Project Fluent — Fluent and ICU MessageFormat](https://github.com/projectfluent/fluent/wiki/Fluent-and-ICU-MessageFormat)
+- [`i18n-embed` crate](https://crates.io/crates/i18n-embed) +
+  [`cargo-i18n`](https://github.com/kellpossible/cargo-i18n)
+- [`leptos-fluent` crate](https://crates.io/crates/leptos-fluent) +
+  [project page](https://github.com/mondeja/leptos-fluent)
+- [`leptos_i18n` crate](https://crates.io/crates/leptos_i18n) +
+  [book](https://baptistemontan.github.io/leptos_i18n/)
+- [Unicode CLDR 47 — MessageFormat 2.0 stable announcement](http://blog.unicode.org/2025/03/unicode-cldr-47-release-messageformat-2.html)
+- [Hosted Weblate libre-project policy](https://hosted.weblate.org/hosting/)
+- [LogRocket — Rust internationalization, localization, and translation](https://blog.logrocket.com/rust-internationalization-localization-and-translation/)

--- a/docs/plans/i18n.md
+++ b/docs/plans/i18n.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-05
 **Branch:** `worktree-i18n-planning`
-**Parent design docs:** [`docs/workspace.md`](../workspace.md), [`docs/services/sentinel.md`](../services/sentinel.md), [`docs/services/rp.md`](../services/rp.md)
+**Parent design docs:** [`docs/workspace.md`](../workspace.md), [`docs/services/sentinel.md`](../services/sentinel.md), [`docs/services/rp.md`](../services/rp.md), [`docs/plans/ui-design/`](ui-design/) (UX exploration; §3 enumerates an i18n recipe per UX-stack candidate)
 **Closest precedent:** [`docs/plans/rp-planning-tools.md`](rp-planning-tools.md) (cross-service, decision-heavy plan)
 
 > **Status:** strategic options with a recommended path. Phasing is sketched
@@ -17,17 +17,22 @@ tool descriptions, and the workspace's own documentation — is hand-coded
 in English with no extraction layer. There has been no operator feedback
 demanding translation, but the project's audience is global by nature
 (astronomy is a worldwide hobby with strong communities in DE, ES, FR,
-IT, JP, CN, KR, CZ, PL), and the hand-rolled UI in
-`services/sentinel/src/dashboard.rs` is about to be replaced by the
-Leptos crate `services/sentinel-app/` (currently scaffolded but
-unwired). The Leptos rewrite is the natural moment to introduce an i18n
-layer — retrofitting after both UIs have shipped is more expensive than
-designing the second one with translation in mind.
+IT, JP, CN, KR, CZ, PL), and the user-facing UI is being explored in
+[`docs/plans/ui-design/`](ui-design/) with multiple candidate stacks on
+the table (server-rendered Maud + HTMX, Leptos via `leptos-fluent`,
+Leptos via `leptos_i18n`, Dioxus, hand-rolled `format!()` HTML). Whichever
+direction wins, the rewrite of the hand-rolled
+`services/sentinel/src/dashboard.rs` is the natural moment to introduce
+an i18n layer — retrofitting after the new UI has shipped is more
+expensive than designing it with translation in mind. This plan stays
+UI-tech-neutral and gives an i18n recipe per candidate (§3) so the i18n
+design does not gate the UX choice.
 
 The workspace is small but heterogeneous:
 
 - 9 services + 7 shared crates, all in one Cargo workspace
-- One web UI today (hand-rolled HTML), one in flight (Leptos / WASM)
+- One web UI today (hand-rolled HTML); a replacement is under exploration
+  with multiple candidate stacks (see [`docs/plans/ui-design/`](ui-design/))
 - A Rust MSRV of 1.94.1
 - A polyglot operator audience but a single-vendor maintainer (no in-house
   translators)
@@ -35,7 +40,8 @@ The workspace is small but heterogeneous:
 This plan answers three questions:
 
 1. **What gets translated and what stays English-only?** (scope)
-2. **How do we deliver i18n in Rust services and in the Leptos UI?** (tech)
+2. **How do we deliver i18n in Rust services and in the user-facing UI,
+   per UX-stack candidate?** (tech)
 3. **Where do translations come from, and how is quality controlled?** (sourcing)
 
 It does not commit code yet — Phase 1 of the rollout is the first time
@@ -313,9 +319,12 @@ Fluent is the right pick because:
   no gender, no complex grammar): well above gettext's ceiling, well
   below ICU4X's runway.
 - `i18n-embed` covers the ergonomics ICU4X leaves to the application.
-- The Leptos side has a first-class Fluent integration (`leptos-fluent`,
-  see Section 3) — picking Fluent here lets the UI and backend share
-  one file format and one toolchain.
+- Most UI tech candidates under exploration in §3 have first-class
+  Fluent integration available (e.g. `leptos-fluent` for Leptos,
+  direct `Display`-expression interpolation in Maud); picking Fluent
+  here keeps open the option of sharing one file format and one
+  toolchain across the UI and backend, regardless of which UX
+  direction wins.
 - The MF2 migration path is real: Fluent's design heavily informed MF2
   and bridge tooling exists.
 
@@ -323,57 +332,189 @@ If we hit a wall with Fluent (e.g. translator pushback against `.ftl`),
 the fallback is gettext — `i18n-embed` lets us swap backends without
 changing call sites, so this is a recoverable bet.
 
-## 3 — Tech stack: Leptos UI options
+## 3 — Tech stack: UI options (per UX direction under exploration)
 
-Two crates own the Leptos i18n space. The choice flows directly from
-Section 2.
+The user-facing UI is being explored in
+[`docs/plans/ui-design/mocks/`](ui-design/mocks/), with multiple
+candidate stacks on the table. Each candidate has a different i18n
+shape. This section gives an i18n recipe per option so the choice of
+UI tech does not gate the i18n design — pick the row matching whichever
+direction wins.
 
-### Option A — `leptos-fluent` (Fluent / `.ftl`)
+The server-side `.ftl` files and the Fluent / `i18n-embed` recipe in §2
+are unchanged across all options. The differences are: where rendering
+happens, how `fl!()` is invoked at the call site, where `.ftl` lives at
+runtime, and how the user switches locale.
 
-Fluent under the hood, idiomatic Leptos hooks (`tr!`, `move_tr!`),
-`<html lang>` and `<html dir>` synchronisation, language persistence to
-local storage / cookies / URL params, fallback chains.
+### Option A — Server-rendered, typed templates (Maud + axum + HTMX + SSE)
 
-**Pros**
+Architecture: the Rust process owns rendering. Locale is resolved per
+request from `Accept-Language` plus a cookie override, stored in a
+request extension. Maud's `html!` macro emits typed HTML; `fl!()`
+interpolates anywhere a `Display` value is allowed.
 
-- **One format workspace-wide** if Section 2 picked Fluent. Translator
-  edits one set of `.ftl` files; the same files feed both the dashboard
-  and the backend strings (with a sensible split into per-component
-  modules).
-- Active development, Leptos 0.7+ support (verify against current
-  workspace `leptos` version before committing).
+```rust
+let loader = state.i18n.for_request(&req);
+html! {
+    h1 { (fl!(loader, "dashboard-title")) }
+    p { (fl!(loader, "monitor-error-count", count = m.consecutive_errors)) }
+}
+```
 
-**Cons**
+- **Locale switch:** HTMX form posts to `/locale`, server sets a cookie
+  and returns a re-rendered `<body>` via `hx-swap="outerHTML"`. No
+  client-side state.
+- **SSE fragments:** each fragment is a Maud `html!` block rendered
+  with the request's stored locale. The server pushes already-localised
+  HTML; HTMX swaps it into the target by id.
+- **Asset embedding:** `i18n-embed`'s `RustEmbed` derive bakes `.ftl`
+  files into the binary. Nothing ships to the browser beyond rendered
+  HTML.
+- **Pros:** simplest model. Backend and UI share one loader, one `.ftl`
+  tree, one set of locale-negotiation logic. No WASM bundle. Pi 5 cost
+  is trivial. Direct-link-with-locale is free (URL or cookie carries
+  it). RTL support via `<html dir="rtl">` set server-side — no reactive
+  plumbing.
+- **Cons:** locale switch costs a round-trip + page swap. Live-cell
+  locale changes (a setting toggle that re-renders without reloading)
+  need an explicit HTMX swap. Live telemetry strings already round-trip
+  via SSE so this is moot for the activity-stream mock; a fully-client
+  locale toggle is more work than in a reactive framework.
 
-- Younger than `leptos_i18n`; smaller user base.
-- Macro errors at compile time can be confusing on first use.
+### Option B — Hand-rolled HTML strings (current `dashboard.rs` pattern)
 
-### Option B — `leptos_i18n` (custom JSON/YAML, ICU-style plurals)
+Architecture: Rust `format!()` builds HTML strings. `fl!()` interpolates
+anywhere `format!`-style interpolation accepts a `Display`.
 
-A different design point: locales are JSON/YAML, parsed and
-type-checked at compile time, with Leptos signals integrated. Strong
-compile-time safety story (every key is checked, every interpolation
-parameter is checked).
+- Identical i18n shape to Option A — same loader, same `.ftl` files.
+  Just no template safety.
+- **Pros:** zero new dependency on top of Option A. Keeps the option
+  open if the UI scope stays small (one short page).
+- **Cons:** doesn't scale to the activity-stream mocks. The ui-design
+  README notes Maud is preferred at that scale. If Option B does win,
+  the i18n call-site count is small enough that the lack of template
+  safety is not a problem.
 
-**Pros**
+### Option C — Leptos (Rust → WASM) via `leptos-fluent`
 
-- Best-in-class compile-time correctness. Missing keys, typos in
-  interpolation parameters, mismatched plural forms are all build errors.
-- Smaller mental model for developers used to React's `react-intl`.
+Architecture: Rust compiled to WASM, runs in the browser (with optional
+SSR pre-render — see Option F). `leptos-fluent` wraps the same Fluent
+runtime as the backend in Leptos-idiomatic context + macros.
 
-**Cons**
+```rust
+view! { <h1>{move_tr!("dashboard-title")}</h1> }
+```
 
-- **Different format from the backend.** If the backend is Fluent, the
-  UI is JSON, and translators see two file types in PRs. This is the
-  primary reason not to pick it under our recommended stack.
+- **Locale switch:** reactive — `expect_i18n().language.set(Language::De)`
+  re-renders all `tr!()` calls instantly. Persistence to localStorage /
+  cookie / URL is built in.
+- **`<html lang>` / `<html dir>`:** synchronised reactively to the
+  active language by the crate.
+- **Asset shipping:** `.ftl` files embedded into the WASM bundle at
+  compile time. `leptos-fluent` supports per-locale lazy-loading so
+  clients don't pay for languages they don't pick.
+- **Pros:** snappy locale switching, good UX for users who flip between
+  languages. Same `.ftl` files as the backend (translator workflow is
+  single-format). RTL story is reactive and clean.
+- **Cons:** WASM bundle pays per included locale (~20–60 KB each before
+  tree-shaking; verify before Phase 2). SSR needs an extra config step
+  to render the user's locale on the first byte (Option F). The crate
+  is younger than `leptos_i18n`; verify against the workspace's pinned
+  `leptos` version before commit.
 
-### Recommendation: `leptos-fluent` to match the backend
+### Option D — Leptos via `leptos_i18n` (custom JSON/YAML)
 
-Pick `leptos-fluent` for the dashboard so the workspace standardises on
-Fluent end-to-end. The compile-time safety in `leptos_i18n` is real,
-but the cost of running two file formats through the translation
-workflow is higher than the cost of catching missing keys with a CI
-check (`cargo i18n verify` exists for exactly this).
+Architecture: same Leptos shape as Option C, but the source format is
+JSON or YAML, parsed and type-checked at compile time.
+
+```rust
+view! { <h1>{t!(i18n, dashboard_title)}</h1> }
+```
+
+- **Pros:** strongest compile-time safety in the Leptos space — missing
+  keys, wrong interpolation parameters, mismatched plural forms are all
+  build errors.
+- **Cons:** **format diverges from the backend.** If §2 picked Fluent,
+  this option means translators see two file types (`.ftl` from the
+  backend, JSON/YAML from the UI). Doubles the Weblate component count
+  and the translator-orientation cost. `cargo i18n verify` plus a CI
+  check on the Fluent side recovers most of the compile-time-safety
+  benefit Option D claims.
+
+### Option E — Dioxus (Rust → WASM) via `dioxus-i18n` or similar
+
+Architecture: similar in shape to Leptos. The i18n ecosystem around
+Dioxus is smaller; `dioxus-i18n` exists and is maintained but with
+fewer users than the Leptos options. Format support is JSON-based out
+of the box; Fluent integration would be DIY.
+
+- **Pros:** consistent React-like model for developers coming from that
+  background.
+- **Cons:** less mature i18n story than Leptos. If Dioxus wins on UI
+  grounds, expect to either accept a JSON-based format (diverges from
+  backend) or layer Fluent in by hand.
+
+### Option F — Leptos SSR with hydration (server-rendered first byte)
+
+Architecture: Leptos with the `ssr` feature, axum integrating Leptos
+route handlers, locale resolved server-side and embedded into the
+initial HTML, then hydrated by client WASM.
+
+- This is the option that minimises Option C's "first-byte locale"
+  problem (the user sees the right language before the WASM bundle
+  loads) but adds the most build complexity (Cargo `ssr` / `hydrate`
+  features, `cargo leptos`, dual builds).
+- Mentioned for completeness; not recommended unless server-first SEO
+  or first-paint locale is a hard requirement.
+
+### Cross-option summary
+
+| Option | Where rendering lives | Where `.ftl` lives at runtime | Locale switch | Same format as backend? | Call-site shape |
+|--------|-----------------------|------------------------------|---------------|--------------------------|------------------|
+| A — Maud + HTMX + SSE        | Server          | Server only       | Round-trip + page swap     | Yes        | `fl!()` in `html!`       |
+| B — Hand-rolled `format!()`  | Server          | Server only       | Round-trip                 | Yes        | `fl!()` in `format!`     |
+| C — Leptos / `leptos-fluent` | Browser (WASM)  | WASM bundle       | Reactive, instant          | Yes        | `tr!` / `move_tr!`       |
+| D — Leptos / `leptos_i18n`   | Browser (WASM)  | WASM bundle       | Reactive, instant          | **No** (JSON/YAML) | `t!`             |
+| E — Dioxus + `dioxus-i18n`   | Browser (WASM)  | WASM bundle       | Reactive                   | **Likely no**      | Component-driven |
+| F — Leptos SSR + hydrate     | Server, then browser | Both         | Reactive after hydrate     | Yes        | `tr!` / `move_tr!`       |
+
+### Cross-option workspace shape
+
+A shared `crates/rp-i18n` workspace member owns the `i18n-embed` loader
+and the `.ftl` directory in **every** option. It is consumed differently:
+
+- **Server-rendered (A, B):** axum services depend on it directly; one
+  loader instance per request, scoped to that request's locale.
+- **WASM-rendered (C, D, E):** the WASM crate also depends on it, with
+  the same `.ftl` content embedded into the bundle at compile time.
+  Locale negotiation moves to `leptos-fluent` / the WASM client; the
+  loader is the same crate.
+- **Hybrid (F):** both — the SSR pre-render uses the server-side
+  loader; hydration switches to the WASM-side loader on the same
+  bundle.
+
+The point of the shared crate is that the **call-site macro** is the
+only per-option difference (`fl!()` for backend / Maud, `tr!` /
+`move_tr!` for Leptos, `t!` for `leptos_i18n`, `dioxus-i18n`'s macros
+for Dioxus). The `.ftl` files, the loader, the language tier, and the
+sourcing workflow are identical.
+
+### What this section does NOT recommend
+
+UI tech is being decided in a separate exploration
+([`docs/plans/ui-design/`](ui-design/)). This plan therefore avoids
+declaring a winner among A–F. The only constraint i18n places on that
+decision is **one file format across the workspace** (Goal #3): under
+§2's Fluent recommendation, options D and E require either accepting a
+second format or doing the Fluent integration by hand. Options A, B, C,
+F all preserve the single-format property.
+
+If the UX exploration converges on a server-rendered direction (A or
+B), i18n is the simplest of the candidates: backend and UI share the
+same loader and the same `.ftl` tree end-to-end. If it converges on
+Leptos with `leptos-fluent` (C or F), the workspace stays single-format
+but pays the WASM-bundle cost. The other options require explicit
+acceptance of the trade-offs flagged above.
 
 ## 4 — Sourcing translations
 
@@ -519,10 +660,11 @@ when a real user asks. Tier 3 entries should arrive with a named
 reviewer (the requester), not as a maintainer guess.
 
 **Out of scope for v1.** RTL languages (`ar`, `he`, `fa`) until the
-Leptos layout has been audited for direction-flipping. Logographic
+chosen UI's layout has been audited for direction-flipping. Logographic
 languages with significant glyph density (Tier 2's `ja` and `zh-CN`
 already test this) cover the typography risk; RTL adds layout risk on
-top.
+top, and the layout audit shape depends on which UX direction in §3
+wins.
 
 The build does **not** fail when a language is incomplete. Missing
 keys fall back through the chain `xx-YY → xx → en` per Fluent's
@@ -543,9 +685,14 @@ and the dashboard's error banners maps an error variant to a localised
 moves from derive doc-comments to runtime `Command` construction so
 help text can be `fl!()`-loaded once the locale is resolved. Logs and
 MCP tool descriptions stay literal English everywhere.
-**Leptos UI:** `leptos-fluent` consuming the same `.ftl` files
-(possibly via a shared `crates/rp-i18n` workspace member that owns the
-loader and re-exports per-module loaders to each service).
+**UI:** depends on which UX direction wins (see §3, Options A–F). All
+options consume the same `.ftl` files via a shared `crates/rp-i18n`
+workspace member that owns the loader. The only per-option difference
+is the call-site macro: `fl!()` inside Maud `html!` (A) or `format!`
+(B) for server-rendered candidates; `tr!` / `move_tr!` for Leptos via
+`leptos-fluent` (C, F); `t!` for `leptos_i18n` (D, diverges from
+Fluent); component-driven for Dioxus (E, likely diverges from Fluent).
+A, B, C, F preserve the single-format property; D and E do not.
 **Sourcing — bootstrap:** maintainer-driven LLM batch translation into
 the Tier 2 set, committed with a `# machine-translated, needs review`
 comment header in each non-English `.ftl`.
@@ -575,13 +722,27 @@ the "decisions resolved during design" pattern.
 - Decision gate: do `.ftl` files survive the maintainer's editor
   workflow comfortably? If not, fall back to gettext before scaling up.
 
-### Phase 2 — Sentinel dashboard full coverage
+### Phase 2 — User-facing UI full coverage
 
-- Translate every label in `sentinel-app/src/components/` into the
-  Tier 2 language set via LLM batch.
-- Update `docs/services/sentinel.md` to reference the i18n contract.
-- Add a language picker to the dashboard; default to browser
-  `Accept-Language`, persist override in local storage.
+Trigger: the UX exploration in
+[`docs/plans/ui-design/`](ui-design/) converges on a chosen direction.
+Phases 1, 3, 4 are unblocked before this happens.
+
+- Translate every label in the chosen UI into the Tier 2 language set
+  via LLM batch. The `.ftl` content is identical across §3 Options
+  A–F; only the call-site shape (Maud `html!`, Leptos `view!`, etc.)
+  differs.
+- Update `docs/services/sentinel.md` to reference the i18n contract,
+  and update the chosen UI's design doc to note the locale-switcher
+  shape.
+- Add a locale switcher matched to the UX direction:
+  - **Server-rendered candidates (A — Maud + HTMX, B — `format!()`):**
+    HTMX form posts to a `/locale` endpoint; cookie set, page or body
+    re-rendered via `hx-swap="outerHTML"`.
+  - **WASM candidates (C — `leptos-fluent`, D — `leptos_i18n`, E —
+    Dioxus, F — Leptos SSR):** language picker bound to the framework's
+    reactive locale signal; persisted to localStorage / cookie / URL.
+  - In both cases, default to browser `Accept-Language` on first load.
 
 ### Phase 3 — CLI help + user-facing errors across all services
 
@@ -647,11 +808,14 @@ require the call-site shape to change before any `fl!()` lands.
    `# Translator: ...` comments. Establish a convention so machine
    translators (and human reviewers) know which strings are
    astronomy-specific terminology vs. ordinary UI prose.
-5. **What happens on Pi 5?** The full ICU4X data is hundreds of KB; the
-   Fluent runtime is much smaller (~100 KB). Verify the wasm-bundle
-   size impact on the dashboard before Phase 2 — if it crosses an
-   alarming threshold, narrow the included locales server-side and
-   serve only the negotiated locale's bundle.
+5. **What happens on Pi 5?** Server-rendered UI candidates (§3 Options
+   A, B) pay only ~100 KB of Fluent runtime in the binary — trivial.
+   WASM candidates (C, D, E, F) ship the runtime + per-locale `.ftl`
+   data to the browser; verify the bundle-size impact before Phase 2
+   (each locale typically adds 20–60 KB before tree-shaking) and
+   lazy-load per-locale if needed. ICU4X's full CLDR data is hundreds
+   of KB — not a concern under Fluent (§2 Option A), but a hard wall
+   for §2 Option D (ICU4X direct).
 6. **MCP tool description posture, revisited.** This plan asserts that
    MCP descriptions stay English because Claude works best in English.
    That assertion deserves periodic re-evaluation as multi-lingual
@@ -662,6 +826,14 @@ require the call-site shape to change before any `fl!()` lands.
    policy: `#[deprecated]` shim plus key alias for one release, or
    hard rename with a CHANGELOG note? Phase 3 should pick before the
    first error variant gets translated.
+8. **Which UX direction wins, and when.** §3 sketches an i18n recipe
+   per candidate (A–F), but a few details bind to the eventual choice:
+   the locale-switcher UX shape, the WASM bundle audit (only relevant
+   under C, D, E, F), and the RTL layout audit (the audit cost differs
+   sharply between server-rendered and reactive frameworks). Phase 2
+   should not start before the UX exploration in
+   [`docs/plans/ui-design/`](ui-design/) converges; Phases 1, 3, 4 are
+   unblocked.
 
 ## 9 — References
 
@@ -673,6 +845,11 @@ require the call-site shape to change before any `fl!()` lands.
   [project page](https://github.com/mondeja/leptos-fluent)
 - [`leptos_i18n` crate](https://crates.io/crates/leptos_i18n) +
   [book](https://baptistemontan.github.io/leptos_i18n/)
+- [`dioxus-i18n` crate](https://crates.io/crates/dioxus-i18n)
+- [Maud — compile-time HTML in Rust](https://maud.lambda.xyz/)
+- [HTMX — declarative interactivity over HTML](https://htmx.org/)
+- [`docs/plans/ui-design/mocks/README.md`](ui-design/mocks/README.md)
+  — UX exploration, candidate stacks, animation techniques
 - [Unicode CLDR 47 — MessageFormat 2.0 stable announcement](http://blog.unicode.org/2025/03/unicode-cldr-47-release-messageformat-2.html)
 - [Hosted Weblate libre-project policy](https://hosted.weblate.org/hosting/)
 - [LogRocket — Rust internationalization, localization, and translation](https://blog.logrocket.com/rust-internationalization-localization-and-translation/)

--- a/docs/plans/i18n.md
+++ b/docs/plans/i18n.md
@@ -715,8 +715,13 @@ the "decisions resolved during design" pattern.
 ### Phase 1 — Spike + workspace decision (small)
 
 - Stand up `crates/rp-i18n` with `i18n-embed` + Fluent backend.
-- Translate one small surface (`sentinel-app`'s top-level navigation
-  labels, ~10 strings) into `en` + `de`.
+- Translate one small surface that already ships today, so the spike
+  does not depend on the §3 outcome: the static labels in
+  `services/sentinel/src/dashboard.rs` (page heading, monitor-state
+  badges Safe / Unsafe / Unknown, "Never" / "Pending" placeholders,
+  table column headers) — ~8 strings — into `en` + `de`. Whichever
+  §3 option ultimately wins inherits the same label set, so the
+  translation work is durable.
 - Wire up `cargo i18n verify` in the pre-push profile (`commit` profile
   in `.config/rail.toml`).
 - Decision gate: do `.ftl` files survive the maintainer's editor

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -41,6 +41,7 @@ belong in any single service design doc.
 | [bazel-migration.md](plans/bazel-migration.md) | Bazel build alongside Cargo (shadow mode) |
 | [build-optimization-test-reorganization.md](plans/build-optimization-test-reorganization.md) | Build/test reorganization |
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
+| [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
 | [image-evaluation-tools.md](plans/image-evaluation-tools.md) | rp image-evaluation MCP tool surface |
 | [plate-solver.md](plans/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing) |
 | [rp-planning-tools.md](plans/rp-planning-tools.md) | rp planning & ephemeris tools: site config, `rp-ephemeris` + `rp-catalog` crates, primitive + convenience MCP tools |


### PR DESCRIPTION
## Summary

- New `docs/plans/i18n.md` (621 lines): strategic options doc for internationalization across the rusty-photon workspace.
- Indexed in `docs/workspace.md` Plans table.
- No code changes.

The plan covers four forks, with pros/cons at each:

1. **Scope** — translate the Leptos dashboard, CLI help, user-facing errors, and Pushover notification text. **Don't** translate logs (greppability beats locale), MCP tool descriptions (LLM consumes English), ASCOM Alpaca wire format, or docs/READMEs.
2. **Rust tech** — Fluent / `i18n-embed` / `gettext` / `rust-i18n` / ICU4X compared. Recommendation: **Fluent via `i18n-embed`**, with gettext as the fallback if translators push back on `.ftl`.
3. **Leptos tech** — `leptos-fluent` vs `leptos_i18n`. Recommendation: **`leptos-fluent`** so the UI and backend share one file format.
4. **Sourcing** — hosted Weblate / Crowdin / Transifex / maintainer+LLM / pure volunteer PRs. Recommendation: **start maintainer+LLM**, graduate to **Weblate** when volunteers materialise.

Also includes a language-tier proposal (`en` source; Tier 2 LLM-bootstrap `de es fr it ja zh-CN`; Tier 3 on demand with named reviewer; RTL deferred), a six-phase rollout sketch, and six open questions for review.

## Test plan

- [x] Pre-commit hook passed (`cargo clippy --all-targets --all-features -- -D warnings` + `cargo fmt --check`).
- [ ] Maintainer review of the recommendation in §6 and the open questions in §8 before any phase is picked up.
- [ ] No phase committed yet — Phase 1 will land as a separate PR with the spike that introduces `crates/rp-i18n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)