### PR TITLE
build: cut dev debuginfo, archive build-optimization plan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,13 @@ site-root = "target/site"
 site-pkg-dir = "pkg"
 site-addr = "127.0.0.1:11114"
 reload-port = 11115
+
+# Trim debug info to keep `target/` small and link fast. Workspace code keeps
+# line tables so panic backtraces still resolve to file:line; deps get nothing
+# (we don't step into tokio/serde). Override per-build with
+# `RUSTFLAGS="-C debuginfo=2" cargo build` if you need full debug info.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/docs/plans/archive/build-optimization-test-reorganization.md
+++ b/docs/plans/archive/build-optimization-test-reorganization.md
@@ -1,7 +1,47 @@
 # Plan: Reorganize Test Suite to Reduce Build Times
 
+**Status: COMPLETE (archived 2026-05-05).** All four test-reorganization phases
+landed; both linker (mold) and debug-info knobs from "Additional build
+optimizations" are now applied. See **Outcomes** below.
+
 **Date:** 2026-03-28 (updated after TLS merge into main)
 **Baseline:** clean build 2m 46s, 55 test binaries, 1050s total CPU time
+
+## Outcomes (2026-05-05)
+
+- **Phase 1** (unit tests → `src/`): done. All 13 files moved to inline
+  `#[cfg(test)]` modules.
+- **Phase 2** (mock-based tests → `src/`): done. All 7 files moved.
+- **Phase 3** (filemonitor consolidation + qhy-focuser redundant test
+  deletion): done. filemonitor's three integration tests merged into a single
+  `tests/test_integration.rs`.
+- **Phase 4** (phd2-guider integration consolidation): done.
+- Test binary count: **55 → 21**, beating the plan's 32 target (extra
+  reduction from plate-solver / sky-survey work that landed afterward).
+
+Additional build optimizations:
+
+- **mold linker:** applied via `~/.cargo/config.toml` (user-global, personal
+  to dev box) and `user.bazelrc` (gitignored, per-worktree).
+- **Reduced debug info:** committed to workspace `Cargo.toml` —
+  `[profile.dev] debug = "line-tables-only"` plus
+  `[profile.dev.package."*"] debug = false`.
+- **cargo-nextest:** done previously (configured in `.config/nextest.toml`).
+
+Measured impact on this dev box (16-core arm64 Linux, rustc 1.95):
+
+| Scenario              | default ld + full debug | mold + line-tables-only |
+|-----------------------|------------------------:|------------------------:|
+| Clean build           | 43s                     | 28s (-35%)              |
+| Touch + rebuild (rp)  | 4s                      | <1s                     |
+| `target/` size        | ~13G                    | 4.7G (-64%)             |
+
+Note: this box's clean-build baseline is much faster than the original 2m 46s
+plan baseline, so absolute savings are smaller in seconds, but the percentage
+gains hold and the `target/` size win was bigger than the 20–30% projection
+(most of the bloat was dep debug info).
+
+Out-of-scope follow-up: phd2-guider BDD suite remains a separate initiative.
 
 ## Context
 

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -229,15 +229,24 @@ implementation lands, **remove the tag** in the same commit that turns
 the scenarios on for real.
 
 To enable this in a service's `bdd.rs`, swap `.run_and_exit("tests/features")`
-for `.filter_run("tests/features", filter_fn)`:
+for `.filter_run_and_exit("tests/features", filter_fn)`:
 
 ```rust
-.filter_run("tests/features", |feat, _rule, sc| {
+.filter_run_and_exit("tests/features", |feat, _rule, sc| {
     let is_wip = feat.tags.iter().any(|t| t == "wip" || t == "@wip")
         || sc.tags.iter().any(|t| t == "wip" || t == "@wip");
     !is_wip
 })
 ```
+
+**Use `_and_exit` — never plain `filter_run` / `run`.** The bare variants
+return the cucumber summary and let the test binary exit 0 even when
+scenarios fail. Because BDD tests use `harness = false`, `cargo test --test
+bdd` only fails when the binary exits non-zero, so plain `filter_run` makes
+scenario failures silently green in CI. See issue #171 for the precedent
+where 81 failed rp scenarios passed CI for months. The `_and_exit` variants
+have identical signatures plus the side effect of `process::exit(1)` on
+failure — there is no reason to prefer the bare form.
 
 Use `@wip` only for not-yet-implemented behavior. A scenario that fails
 intermittently belongs in an issue, not behind `@wip`. A scenario that
@@ -589,7 +598,7 @@ bdd_infra::bdd_main! {
                 }
             })
         })
-        .filter_run("tests/features", |_, _, _| true)
+        .filter_run_and_exit("tests/features", |_, _, _| true)
         .await;
 }
 ```

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -39,7 +39,6 @@ belong in any single service design doc.
 | [ADR-005](decisions/005-plate-solver.md) | Plate solver: ASTAP via subprocess + verification spike |
 | **Plans** (in-flight initiatives — see [docs/plans/](plans/)) | |
 | [bazel-migration.md](plans/bazel-migration.md) | Bazel build alongside Cargo (shadow mode) |
-| [build-optimization-test-reorganization.md](plans/build-optimization-test-reorganization.md) | Build/test reorganization |
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
 | [image-evaluation-tools.md](plans/image-evaluation-tools.md) | rp image-evaluation MCP tool surface |
 | [plate-solver.md](plans/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing) |


### PR DESCRIPTION
## Summary
- Set workspace `[profile.dev]` to `debug = "line-tables-only"` and `[profile.dev.package."*"]` to `debug = false`. Panic backtraces still resolve to file:line; deps drop debuginfo entirely. Measured locally: `target/` from ~13G to 4.7G, clean build 43s → 28s (16-core arm64, with mold as personal `~/.cargo/config.toml` — not committed).
- Archive the `build-optimization-test-reorganization` plan. All four test-reorg phases landed previously; mold + this debuginfo change cover the plan's "Additional build optimizations" section (cargo-nextest already done). Outcomes summarised inline at the top of the archived doc.
- Drop the plan's row from the in-flight Plans table in `docs/workspace.md`, matching the existing convention for archived plans.
- Fix `docs/skills/testing.md` to require `filter_run_and_exit` in BDD entry points (was documenting the silent-pass `filter_run` pattern that issue #171 tracks).

## Test plan
- [x] `cargo rail run --profile commit -q` — 1377 tests passed, 15 skipped, 0 failed
- [x] `cargo fmt` clean
- [x] Pre-commit hook (clippy `--all-targets --all-features -D warnings` + fmt check) clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)