### PR TITLE
fix(rp): recenter x in fit_parabola for realistic focuser scales

### DIFF
--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -168,18 +168,23 @@ pub fn build_grid(
     grid
 }
 
-/// Result of fitting `hfr = a·x² + b·x + c` with vertex at
-/// `(round(−b/2a), c − b²/(4a))`.
+/// Result of fitting `hfr = a·x'² + b·x' + c` where `x' = x − offset_x`.
+/// The fit is performed in the recentered frame so the normal-equations
+/// determinant doesn't lose precision at real-world focuser positions
+/// (~5_000–50_000 steps); see `fit_parabola` for the rationale. The
+/// vertex sits at `(round(−b/2a) + offset_x, c − b²/(4a))` in the
+/// original frame.
 #[derive(Debug, Clone, Copy)]
 pub struct ParabolaFit {
     pub a: f64,
     pub b: f64,
     pub c: f64,
+    pub offset_x: f64,
 }
 
 impl ParabolaFit {
     pub fn vertex_position(&self) -> i32 {
-        (-self.b / (2.0 * self.a)).round() as i32
+        (-self.b / (2.0 * self.a) + self.offset_x).round() as i32
     }
 
     pub fn vertex_value(&self) -> f64 {
@@ -206,9 +211,21 @@ pub fn fit_parabola(samples: &[(i32, f64, u32)]) -> Result<ParabolaFit, AutoFocu
             needed: 3,
         });
     }
+    // Recenter x by the weighted mean before forming the normal
+    // equations. Without this, `m4 ~ N·p⁴` overflows f64's working
+    // precision (~16 digits) at real-world focuser positions
+    // (p ≳ 5_000 steps): the m4·m2·m0 product hits ~1e30, the actual
+    // determinant of a parabolic fit is much smaller, and roundoff
+    // swamps the cancellation — perfectly fittable V-curves get
+    // rejected as "design matrix is singular". The fit is
+    // translation-invariant in y, so we recover the original-frame
+    // vertex by adding `offset_x` back in `vertex_position`.
+    let total_w: f64 = filtered.iter().map(|(_, _, w)| *w).sum();
+    let offset_x: f64 = filtered.iter().map(|(x, _, w)| w * x).sum::<f64>() / total_w;
+
     // Normal equations Aᵀ W A · [a, b, c]ᵀ = Aᵀ W y, with
-    // A = [x², x, 1] per row, W = diag(weights). Solved via Cramer's
-    // rule on the 3×3 system below.
+    // A = [x'², x', 1] per row (x' = x − offset_x), W = diag(weights).
+    // Solved via Cramer's rule on the 3×3 system below.
     let mut m4 = 0.0;
     let mut m3 = 0.0;
     let mut m2 = 0.0;
@@ -218,16 +235,17 @@ pub fn fit_parabola(samples: &[(i32, f64, u32)]) -> Result<ParabolaFit, AutoFocu
     let mut t1 = 0.0;
     let mut t0 = 0.0;
     for (x, y, w) in &filtered {
-        let x2 = x * x;
-        let x3 = x2 * x;
-        let x4 = x3 * x;
-        m4 += w * x4;
-        m3 += w * x3;
-        m2 += w * x2;
-        m1 += w * x;
+        let xc = x - offset_x;
+        let xc2 = xc * xc;
+        let xc3 = xc2 * xc;
+        let xc4 = xc3 * xc;
+        m4 += w * xc4;
+        m3 += w * xc3;
+        m2 += w * xc2;
+        m1 += w * xc;
         m0 += w;
-        t2 += w * x2 * y;
-        t1 += w * x * y;
+        t2 += w * xc2 * y;
+        t1 += w * xc * y;
         t0 += w * y;
     }
     let det = m4 * (m2 * m0 - m1 * m1) - m3 * (m3 * m0 - m1 * m2) + m2 * (m3 * m1 - m2 * m2);
@@ -254,7 +272,7 @@ pub fn fit_parabola(samples: &[(i32, f64, u32)]) -> Result<ParabolaFit, AutoFocu
             a
         )));
     }
-    Ok(ParabolaFit { a, b, c })
+    Ok(ParabolaFit { a, b, c, offset_x })
 }
 
 /// Drive the V-curve sweep against the supplied focuser/capturer/measurer
@@ -505,25 +523,31 @@ mod tests {
 
     #[test]
     fn fit_parabola_recovers_known_minimum_to_within_one_step() {
-        let samples = make_v_samples(1234, 1.5, 1e-4);
-        let fit = fit_parabola(&samples).unwrap();
-        let vx = fit.vertex_position();
-        assert!(
-            (vx - 1234).abs() <= 1,
-            "expected vertex_position within ±1 of 1234, got {}",
-            vx
-        );
-        let vy = fit.vertex_value();
-        assert!(
-            (vy - 1.5).abs() < 1e-6,
-            "expected vertex_value ≈ 1.5, got {}",
-            vy
-        );
+        // Cover the small-position case plus realistic focuser ranges
+        // (5_000–50_000 steps) where the un-recentered normal equations
+        // would lose precision and reject the fit as singular (#174).
+        for vertex_x in [1234, 11_000, 42_000] {
+            let samples = make_v_samples(vertex_x, 1.5, 1e-4);
+            let fit = fit_parabola(&samples).unwrap();
+            let vx = fit.vertex_position();
+            assert!(
+                (vx - vertex_x).abs() <= 1,
+                "expected vertex_position within ±1 of {vertex_x}, got {vx}"
+            );
+            let vy = fit.vertex_value();
+            assert!(
+                (vy - 1.5).abs() < 1e-6,
+                "expected vertex_value ≈ 1.5 at vertex_x={vertex_x}, got {vy}"
+            );
+        }
     }
 
     #[test]
     fn fit_parabola_rejects_flat_input() {
-        let samples: Vec<_> = (0..10).map(|i| (i * 100, 5.0, 100)).collect();
+        // Realistic focuser-position range — the rejection must
+        // still trigger at the scale where un-recentered moments
+        // would have overflowed f64 precision.
+        let samples: Vec<_> = (0..10).map(|i| (40_000 + i * 100, 5.0, 100)).collect();
         match fit_parabola(&samples) {
             Err(AutoFocusError::MonotonicCurve(_)) => {}
             other => panic!("expected MonotonicCurve, got {:?}", other),
@@ -534,8 +558,8 @@ mod tests {
     fn fit_parabola_rejects_concave_down_curve() {
         let samples: Vec<_> = (0..10)
             .map(|i| {
-                let x = i * 50;
-                let dx = (x - 100) as f64;
+                let x = 40_000 + i * 50;
+                let dx = (x - 40_100) as f64;
                 (x, 5.0 - 1e-4 * dx * dx, 100)
             })
             .collect();

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -172,8 +172,10 @@ pub fn build_grid(
 /// The fit is performed in the recentered frame so the normal-equations
 /// determinant doesn't lose precision at real-world focuser positions
 /// (~5_000–50_000 steps); see `fit_parabola` for the rationale. The
-/// vertex sits at `(round(−b/2a) + offset_x, c − b²/(4a))` in the
-/// original frame.
+/// vertex sits at `(round(−b/2a + offset_x), c − b²/(4a))` in the
+/// original frame — `vertex_position` rounds the recovered original-x
+/// after adding `offset_x` (which is generally non-integer because it's
+/// the weighted mean of the sample positions).
 #[derive(Debug, Clone, Copy)]
 pub struct ParabolaFit {
     pub a: f64,
@@ -192,9 +194,19 @@ impl ParabolaFit {
     }
 }
 
-/// Weighted least-squares fit of a parabola `y = a·x² + b·x + c` to
-/// `(position, hfr, weight)` samples. `weight` is typically the
-/// per-frame `star_count`; samples with `weight == 0` are dropped.
+/// Weighted least-squares fit of a parabola to `(position, hfr, weight)`
+/// samples. `weight` is typically the per-frame `star_count`; samples
+/// with `weight == 0` are dropped.
+///
+/// **Returned coefficients are in the recentered frame.** The fit
+/// solves `y = a·x'² + b·x' + c` where `x' = position − offset_x`;
+/// `offset_x` is the weighted mean of the input positions and is
+/// stored on `ParabolaFit`. Use `vertex_position()` and
+/// `vertex_value()` to recover the original-frame minimum without
+/// re-expanding the polynomial (re-expanding would re-introduce the
+/// precision loss this recentering exists to avoid). Callers that
+/// genuinely need to evaluate `y` at an original-frame `x` must
+/// subtract `offset_x` before substituting.
 ///
 /// Returns `MonotonicCurve` if `a ≤ 0` (the curve has no minimum) or if
 /// the design matrix is too ill-conditioned to invert (essentially

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -3704,17 +3704,14 @@ fn auto_focus_registry(starting_position: i32) -> crate::equipment::EquipmentReg
 
 #[tokio::test]
 async fn auto_focus_happy_path_emits_focus_complete_and_returns_curve() {
-    // starting_position arbitrary — the test only asserts that the
-    // fitted vertex lands near it (the parabola in HFR is symmetric
-    // about d=0 → vertex ≈ starting_position). Kept around 1000 so
-    // the imaging::tools::auto_focus::fit_parabola design matrix
-    // (which uses raw position values directly) stays well-conditioned
-    // for f64. Realistic focusers run at 10k-50k positions, where
-    // fit_parabola hits its precision floor (`monotonic curve: design
-    // matrix is singular …`); fixing that requires the fit to subtract
-    // the mean position before solving the normal equations — tracked
-    // separately from this happy-path coverage test.
-    const STARTING_POSITION: i32 = 1_000;
+    // starting_position pinned at a realistic focuser scale (QHY
+    // M-series, Pegasus FocusCube, Robofocus all operate in the
+    // 5_000–100_000 range). fit_parabola recenters x by the weighted
+    // mean before solving the normal equations, so the design matrix
+    // stays well-conditioned at any plausible focuser scale (#174).
+    // The fitted vertex must land near `starting_position` because
+    // the synthesised parabola in HFR is symmetric about d=0.
+    const STARTING_POSITION: i32 = 11_000;
 
     // Sandbox the FITS writes do_capture performs in a per-test temp
     // dir so successive runs don't pollute /tmp.


### PR DESCRIPTION
## Summary
- `fit_parabola` rejected perfectly fittable V-curves at real-world focuser positions (~5_000–50_000 steps): the un-recentered `m4·m2·m0` product overflowed f64's working precision and the determinant got eaten by roundoff. Subtract the weighted-mean `x` before solving the normal equations and add the offset back in `vertex_position`. `vertex_value` is invariant under x-translation. `ParabolaFit` gains an `offset_x` field; no callers needed updates.
- Bumped `auto_focus_happy_path_emits_focus_complete_and_returns_curve` to `starting_position = 11_000` (the realistic example from `rp.md`) and dropped its workaround comment.
- Extended `fit_parabola_recovers_known_minimum_to_within_one_step` to cover `vertex_x ∈ {1234, 11_000, 42_000}`. Moved the flat-input and concave-down rejection tests into the 40_000 range to spot-check the precision floor.

Closes #174.

## Test plan
- [x] `cargo rail run --profile commit -q` (387 tests pass, including the bumped happy-path test at p=11_000)
- [x] `cargo build -p rp --all-features --all-targets --locked`
- [x] `cargo fmt`
- [x] Pre-commit clippy + fmt-check hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)