### PR TITLE
fix(rp): persist image_stats section when document_id supplied (#175)

### DIFF
--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -805,11 +805,14 @@ tools block until the operation completes by polling the device state
 
 #### Image Statistics Tool Details
 
-`compute_image_stats` reads a FITS file by path, flattens the pixel
-data, and computes median, mean, min, and max ADU values. If a
-`document_id` is provided, the stats are written into the exposure
-document as an `"image_stats"` section. This tool does not access the
-camera — it operates on saved image files.
+`compute_image_stats` computes median, mean, min, and max ADU values
+on the captured image. It accepts either a `document_id` (resolved
+through the unified image+document cache, falling back to disk scan
+on miss) or an `image_path` (read from disk via `rp-fits`); when both
+are supplied, `document_id` wins. When called with a `document_id`,
+the stats are written into the exposure document as an `image_stats`
+section. This tool does not access the camera — it operates on saved
+image files.
 
 ### Image Analysis Strategy
 

--- a/services/rp/src/imaging/analysis/stats.rs
+++ b/services/rp/src/imaging/analysis/stats.rs
@@ -13,27 +13,48 @@ pub struct ImageStats {
     pub pixel_count: u64,
 }
 
-/// Compute pixel statistics from a slice of pixel values.
+/// Compute pixel statistics from a mutable slice of pixel values.
+///
+/// Takes `&mut [i32]` so the median's `select_nth_unstable` runs
+/// in-place rather than over an internal clone — for large images
+/// this avoids an extra `n × 4` bytes of peak allocation on top of
+/// the cached pixel buffer. The caller's buffer is left in a
+/// permuted (partially-ordered) state on return; min/max/mean are
+/// read before the first partition so they reflect the original
+/// pixel set regardless of ordering.
 ///
 /// Returns `None` if the pixel slice is empty.
-pub fn compute_stats(pixels: &[i32]) -> Option<ImageStats> {
+pub fn compute_stats(pixels: &mut [i32]) -> Option<ImageStats> {
     if pixels.is_empty() {
         return None;
     }
 
     let pixel_count = pixels.len() as u64;
 
-    let min = *pixels.iter().min().expect("non-empty slice");
-    let max = *pixels.iter().max().expect("non-empty slice");
+    // Fold min/max/mean in a single pass before the partition mutates
+    // the buffer; the values are order-independent so reading them
+    // up front matches the previous (non-mutating) contract.
+    let mut min = i32::MAX;
+    let mut max = i32::MIN;
+    let mut sum = 0.0_f64;
+    for &p in pixels.iter() {
+        if p < min {
+            min = p;
+        }
+        if p > max {
+            max = p;
+        }
+        sum += p.max(0) as f64;
+    }
+    let mean_adu = sum / pixel_count as f64;
 
-    let mut buf = pixels.to_vec();
-    let mid = buf.len() / 2;
-    let median = if buf.len().is_multiple_of(2) {
-        let (_, &mut upper, _) = buf.select_nth_unstable(mid);
-        let (_, &mut lower, _) = buf[..mid].select_nth_unstable(mid - 1);
+    let mid = pixels.len() / 2;
+    let median = if pixels.len().is_multiple_of(2) {
+        let (_, &mut upper, _) = pixels.select_nth_unstable(mid);
+        let (_, &mut lower, _) = pixels[..mid].select_nth_unstable(mid - 1);
         ((lower as i64 + upper as i64) / 2) as i32
     } else {
-        let (_, &mut m, _) = buf.select_nth_unstable(mid);
+        let (_, &mut m, _) = pixels.select_nth_unstable(mid);
         m
     };
 
@@ -44,7 +65,6 @@ pub fn compute_stats(pixels: &[i32]) -> Option<ImageStats> {
     // when they do, callers see a uniform "negatives become zero" rather
     // than a min/max/median of 0 alongside a negative mean.
     let clamp = |v: i32| -> u32 { v.max(0) as u32 };
-    let mean_adu = pixels.iter().map(|&p| p.max(0) as f64).sum::<f64>() / pixel_count as f64;
 
     Some(ImageStats {
         median_adu: clamp(median),
@@ -62,8 +82,8 @@ mod tests {
 
     #[test]
     fn compute_stats_odd_count() {
-        let pixels = vec![10, 20, 30, 40, 50];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![10, 20, 30, 40, 50];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 30);
         assert_eq!(stats.min_adu, 10);
         assert_eq!(stats.max_adu, 50);
@@ -73,8 +93,8 @@ mod tests {
 
     #[test]
     fn compute_stats_even_count() {
-        let pixels = vec![10, 20, 30, 40];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![10, 20, 30, 40];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 25);
         assert_eq!(stats.min_adu, 10);
         assert_eq!(stats.max_adu, 40);
@@ -84,8 +104,8 @@ mod tests {
 
     #[test]
     fn compute_stats_single_pixel() {
-        let pixels = vec![42];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![42];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 42);
         assert_eq!(stats.min_adu, 42);
         assert_eq!(stats.max_adu, 42);
@@ -94,14 +114,14 @@ mod tests {
 
     #[test]
     fn compute_stats_empty() {
-        let pixels: Vec<i32> = vec![];
-        assert!(compute_stats(&pixels).is_none());
+        let mut pixels: Vec<i32> = vec![];
+        assert!(compute_stats(&mut pixels).is_none());
     }
 
     #[test]
     fn compute_stats_all_same() {
-        let pixels = vec![1000; 100];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![1000; 100];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 1000);
         assert_eq!(stats.min_adu, 1000);
         assert_eq!(stats.max_adu, 1000);
@@ -109,8 +129,8 @@ mod tests {
 
     #[test]
     fn compute_stats_unsorted_input() {
-        let pixels = vec![50, 10, 40, 20, 30];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![50, 10, 40, 20, 30];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 30);
         assert_eq!(stats.min_adu, 10);
         assert_eq!(stats.max_adu, 50);
@@ -118,8 +138,8 @@ mod tests {
 
     #[test]
     fn compute_stats_large_values() {
-        let pixels = vec![0, 32768, 65535];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![0, 32768, 65535];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.median_adu, 32768);
         assert_eq!(stats.min_adu, 0);
         assert_eq!(stats.max_adu, 65535);
@@ -131,8 +151,8 @@ mod tests {
         // pixels as zero. Without uniform clamping, mean_adu could be
         // negative while min_adu/max_adu/median_adu sit at 0 (their u32
         // floor), producing internally inconsistent stats.
-        let pixels = vec![-100i32, 0, 50];
-        let stats = compute_stats(&pixels).unwrap();
+        let mut pixels = vec![-100i32, 0, 50];
+        let stats = compute_stats(&mut pixels).unwrap();
         assert_eq!(stats.min_adu, 0);
         assert_eq!(stats.max_adu, 50);
         assert_eq!(stats.median_adu, 0);

--- a/services/rp/src/mcp/built_in/imaging.rs
+++ b/services/rp/src/mcp/built_in/imaging.rs
@@ -12,15 +12,19 @@ use super::super::internals::{
 };
 use super::super::{tool_error, tool_success};
 use crate::imaging;
-use crate::persistence;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ComputeImageStatsParams {
-    pub image_path: String,
-    /// Document ID for persisting image stats as a section in the exposure document.
-    /// When omitted, stats are computed but not persisted.
+    /// Exposure-document id to resolve through the unified image+document
+    /// cache. Wins over `image_path` when both are supplied. When set,
+    /// the computed stats are written into the exposure document as an
+    /// `image_stats` section.
     #[serde(default)]
     pub document_id: Option<String>,
+    /// FITS file on disk (read via `rp-fits`). Used when `document_id`
+    /// is absent or doesn't resolve through the cache.
+    #[serde(default)]
+    pub image_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -162,35 +166,54 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ComputeImageStatsParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let image_path = params.image_path;
+        if params.document_id.is_none() && params.image_path.is_none() {
+            return Ok(tool_error!(
+                "missing required argument: provide either document_id or image_path"
+            ));
+        }
 
-        let path_clone = image_path.clone();
-        let stats = match tokio::task::spawn_blocking(move || {
-            let (pixels, _w, _h) = persistence::read_fits_pixels(&path_clone)?;
-            imaging::compute_stats(&pixels)
-                .ok_or_else(|| crate::error::RpError::Imaging("image has no pixels".into()))
-        })
-        .await
-        {
-            Ok(Ok(s)) => s,
-            Ok(Err(e)) => return Ok(tool_error!("failed to compute stats: {}", e)),
-            Err(e) => return Ok(tool_error!("task error: {}", e)),
+        let stats = if let Some(doc_id) = params.document_id.as_deref() {
+            match self.stats_via_document(doc_id).await {
+                Ok(s) => s,
+                Err(e) => return Ok(tool_error!("failed to compute stats: {}", e)),
+            }
+        } else {
+            let path = params.image_path.as_deref().expect("checked above");
+            match self.stats_via_path(path).await {
+                Ok(s) => s,
+                Err(e) => return Ok(tool_error!("failed to compute stats: {}", e)),
+            }
         };
 
         debug!(
-            image_path = %image_path,
+            document_id = params.document_id.as_deref().unwrap_or(""),
+            image_path = params.image_path.as_deref().unwrap_or(""),
             median = stats.median_adu,
             mean = %stats.mean_adu,
             "computed image stats"
         );
 
-        Ok(tool_success!({
+        let payload = serde_json::json!({
             "median_adu": stats.median_adu,
             "mean_adu": stats.mean_adu,
             "min_adu": stats.min_adu,
             "max_adu": stats.max_adu,
             "pixel_count": stats.pixel_count,
-        }))
+        });
+
+        if let Some(doc_id) = params.document_id.as_deref() {
+            if let Err(e) = self
+                .image_cache
+                .put_section(doc_id, "image_stats", payload.clone())
+                .await
+            {
+                debug!(error = %e, document_id = %doc_id, "failed to persist image_stats section");
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            payload.to_string(),
+        )]))
     }
 
     #[tool(

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -79,6 +79,39 @@ pub(crate) struct ResolvedMeasureStarsParams {
 // ---------------------------------------------------------------------------
 
 impl McpHandler {
+    pub(crate) async fn stats_via_document(
+        &self,
+        doc_id: &str,
+    ) -> crate::error::Result<imaging::ImageStats> {
+        if let Some(cached) = self.image_cache.resolve(doc_id).await {
+            return crate::dispatch_pixels!(&cached.pixels, |arr| stats_outcome(arr));
+        }
+
+        debug!(document_id = %doc_id, "image cache miss, falling back to FITS");
+        let doc = self
+            .image_cache
+            .resolve_document(doc_id)
+            .await
+            .ok_or_else(|| {
+                crate::error::RpError::Imaging(format!("document not found: {}", doc_id))
+            })?;
+        self.stats_via_path(&doc.file_path).await
+    }
+
+    pub(crate) async fn stats_via_path(
+        &self,
+        path: &str,
+    ) -> crate::error::Result<imaging::ImageStats> {
+        let path_owned = path.to_string();
+        tokio::task::spawn_blocking(move || {
+            let (pixels, _w, _h) = persistence::read_fits_pixels(&path_owned)?;
+            imaging::compute_stats(&pixels)
+                .ok_or_else(|| crate::error::RpError::Imaging("image has no pixels".into()))
+        })
+        .await
+        .map_err(|e| crate::error::RpError::Imaging(format!("task join error: {}", e)))?
+    }
+
     pub(crate) async fn measure_via_document(
         &self,
         doc_id: &str,
@@ -793,6 +826,21 @@ impl McpHandler {
 // ---------------------------------------------------------------------------
 // Free helpers
 // ---------------------------------------------------------------------------
+
+pub(crate) fn stats_outcome<T: imaging::Pixel>(
+    view: ndarray::ArrayView2<T>,
+) -> crate::error::Result<imaging::ImageStats> {
+    // `compute_stats` is currently typed on `&[i32]`. Materialize a flat
+    // i32 buffer here so the cached-pixel path stays inside the
+    // `dispatch_pixels!` macro and reuses the same computation as the
+    // FITS-on-disk path. Negative pixels are clamped to 0 inside
+    // `compute_stats`, so the `to_u32() as i32` round-trip is safe for
+    // the realistic camera ranges we care about (u16 cameras + i32
+    // scientific HDR ≤ i32::MAX).
+    let pixels: Vec<i32> = view.iter().map(|p| p.to_u32() as i32).collect();
+    imaging::compute_stats(&pixels)
+        .ok_or_else(|| crate::error::RpError::Imaging("image has no pixels".into()))
+}
 
 pub(crate) fn clip_outcome<T: imaging::Pixel>(
     view: ndarray::ArrayView2<T>,

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -104,8 +104,8 @@ impl McpHandler {
     ) -> crate::error::Result<imaging::ImageStats> {
         let path_owned = path.to_string();
         tokio::task::spawn_blocking(move || {
-            let (pixels, _w, _h) = persistence::read_fits_pixels(&path_owned)?;
-            imaging::compute_stats(&pixels)
+            let (mut pixels, _w, _h) = persistence::read_fits_pixels(&path_owned)?;
+            imaging::compute_stats(&mut pixels)
                 .ok_or_else(|| crate::error::RpError::Imaging("image has no pixels".into()))
         })
         .await
@@ -830,15 +830,16 @@ impl McpHandler {
 pub(crate) fn stats_outcome<T: imaging::Pixel>(
     view: ndarray::ArrayView2<T>,
 ) -> crate::error::Result<imaging::ImageStats> {
-    // `compute_stats` is currently typed on `&[i32]`. Materialize a flat
-    // i32 buffer here so the cached-pixel path stays inside the
-    // `dispatch_pixels!` macro and reuses the same computation as the
-    // FITS-on-disk path. Negative pixels are clamped to 0 inside
-    // `compute_stats`, so the `to_u32() as i32` round-trip is safe for
-    // the realistic camera ranges we care about (u16 cameras + i32
-    // scientific HDR ≤ i32::MAX).
-    let pixels: Vec<i32> = view.iter().map(|p| p.to_u32() as i32).collect();
-    imaging::compute_stats(&pixels)
+    // `compute_stats` is typed on `&mut [i32]` and uses
+    // `select_nth_unstable` in place. Materialize a flat i32 buffer
+    // once here and hand it to the kernel mutably so the cached-pixel
+    // path doesn't pay the second n × 4 bytes that an immutable slice
+    // signature would force (caller copy + kernel-internal clone).
+    // Negative pixels are clamped to 0 inside `compute_stats`, so the
+    // `to_u32() as i32` round-trip is safe for realistic camera
+    // ranges (u16 cameras + i32 scientific HDR ≤ i32::MAX).
+    let mut pixels: Vec<i32> = view.iter().map(|p| p.to_u32() as i32).collect();
+    imaging::compute_stats(&mut pixels)
         .ok_or_else(|| crate::error::RpError::Imaging("image has no pixels".into()))
 }
 

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -1538,11 +1538,133 @@ async fn test_compute_image_stats_bad_fits() {
     });
     let result = handler
         .compute_image_stats(Parameters(ComputeImageStatsParams {
-            image_path: bad_file.to_string_lossy().to_string(),
+            image_path: Some(bad_file.to_string_lossy().to_string()),
             document_id: None,
         }))
         .await;
     assert_tool_error(result, "failed to compute stats");
+}
+
+#[tokio::test]
+async fn test_compute_image_stats_missing_arguments() {
+    // Pins the validation contract surfaced by `rp.md:702` ("document_id
+    // or image_path"): callers must supply at least one. Mirrors the
+    // missing-args branch tested for measure_basic / estimate_background.
+    let handler = test_handler(crate::equipment::EquipmentRegistry {
+        cameras: vec![],
+        filter_wheels: vec![],
+        cover_calibrators: vec![],
+        focusers: vec![],
+        mount: None,
+    });
+    let result = handler
+        .compute_image_stats(Parameters(ComputeImageStatsParams {
+            document_id: None,
+            image_path: None,
+        }))
+        .await;
+    assert_tool_error(result, "image_path");
+}
+
+#[tokio::test]
+async fn test_compute_image_stats_persists_section_via_document_id() {
+    // Pins the load-bearing piece of issue #175: when called with a
+    // `document_id` that resolves through the cache, the computed
+    // stats are written into the exposure document as an
+    // `image_stats` section. Mirrors the section-persistence test
+    // shape used by the other imaging tools (measure_basic ->
+    // image_analysis, estimate_background -> background, etc).
+    let temp = tempfile::tempdir().unwrap();
+    let cache = ImageCache::new(64, 4, temp.path().to_path_buf());
+
+    // Pixels chosen so the resulting stats are unambiguous: pixel_count = 4,
+    // min = 100, max = 400, median = (200 + 300) / 2 = 250, mean = 250.0.
+    let pixel_buf: Vec<u16> = vec![100, 200, 300, 400];
+    let cached_pixels = CachedPixels::from_u16_pixels(pixel_buf, (2, 2)).unwrap();
+
+    let document_id = "doc-image-stats-1".to_string();
+    let uuid8 = "doc-imgs"; // 8-char-stable suffix for the on-disk basename.
+    let file_path = temp
+        .path()
+        .join(format!("{}.fits", uuid8))
+        .to_string_lossy()
+        .into_owned();
+
+    let doc = ExposureDocument {
+        id: document_id.clone(),
+        captured_at: "2026-05-08T00:00:00Z".to_string(),
+        file_path: file_path.clone(),
+        width: 2,
+        height: 2,
+        camera_id: Some("cam".into()),
+        duration: Some(Duration::from_millis(100)),
+        max_adu: Some(65535),
+        optics: None,
+        sections: serde_json::Map::new(),
+    };
+
+    cache.insert(
+        document_id.clone(),
+        crate::persistence::CachedImage::new(
+            cached_pixels,
+            2,
+            2,
+            std::path::PathBuf::from(&file_path),
+            65535,
+            doc,
+        ),
+    );
+
+    let handler = McpHandler::new(
+        Arc::new(crate::equipment::EquipmentRegistry {
+            cameras: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            focusers: vec![],
+            mount: None,
+        }),
+        Arc::new(crate::events::EventBus::from_config(&[])),
+        SessionConfig {
+            data_directory: temp.path().to_string_lossy().to_string(),
+        },
+        cache.clone(),
+        None,
+    );
+
+    let call_result = handler
+        .compute_image_stats(Parameters(ComputeImageStatsParams {
+            document_id: Some(document_id.clone()),
+            image_path: None,
+        }))
+        .await
+        .unwrap();
+    assert!(!call_result.is_error.unwrap_or(false));
+
+    let payload_text = call_result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|tc| tc.text.clone())
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(&payload_text).unwrap();
+    assert_eq!(payload["pixel_count"], 4);
+    assert_eq!(payload["min_adu"], 100);
+    assert_eq!(payload["max_adu"], 400);
+    assert_eq!(payload["median_adu"], 250);
+    assert!((payload["mean_adu"].as_f64().unwrap() - 250.0).abs() < 1e-9);
+
+    let updated = cache
+        .resolve_document(&document_id)
+        .await
+        .expect("document should resolve from cache after compute_image_stats");
+    let section = updated
+        .sections
+        .get("image_stats")
+        .expect("image_stats section must be persisted when document_id is supplied");
+    assert_eq!(section["pixel_count"], 4);
+    assert_eq!(section["min_adu"], 100);
+    assert_eq!(section["max_adu"], 400);
+    assert_eq!(section["median_adu"], 250);
 }
 
 // -----------------------------------------------------------------------

--- a/services/rp/tests/bdd/steps/image_stats_steps.rs
+++ b/services/rp/tests/bdd/steps/image_stats_steps.rs
@@ -2,6 +2,11 @@
 //!
 //! The capture step is defined in tool_steps.rs (shared across features).
 //! It stores last_image_path and last_document_id on the world for chaining.
+//!
+//! Shared steps reused from measure_basic_steps.rs:
+//! (`I fetch the exposure document for the captured document_id`,
+//! `the exposure document should contain a section named ...`, and
+//! `the {string} section should contain {string}`).
 
 use cucumber::{then, when};
 
@@ -16,18 +21,32 @@ async fn mcp_call_compute_stats_with_last_path(world: &mut RpWorld) {
         .last_image_path
         .clone()
         .expect("no captured image path available");
-    let document_id = world.last_document_id.clone();
 
-    call_compute_image_stats(world, &image_path, document_id.as_deref()).await;
+    call_compute_image_stats(world, Some(&image_path), None).await;
+}
+
+#[when("the MCP client calls \"compute_image_stats\" with the captured document_id")]
+async fn mcp_call_compute_stats_with_last_document_id(world: &mut RpWorld) {
+    let document_id = world
+        .last_document_id
+        .clone()
+        .expect("no captured document_id available");
+
+    call_compute_image_stats(world, None, Some(&document_id)).await;
 }
 
 #[when(expr = "the MCP client calls \"compute_image_stats\" with image path {string}")]
 async fn mcp_call_compute_stats_with_path(world: &mut RpWorld, image_path: String) {
-    call_compute_image_stats(world, &image_path, None).await;
+    call_compute_image_stats(world, Some(&image_path), None).await;
 }
 
-#[when("the MCP client calls \"compute_image_stats\" with no image_path")]
-async fn mcp_call_compute_stats_no_path(world: &mut RpWorld) {
+#[when(expr = "the MCP client calls \"compute_image_stats\" with document_id {string}")]
+async fn mcp_call_compute_stats_with_document_id(world: &mut RpWorld, document_id: String) {
+    call_compute_image_stats(world, None, Some(&document_id)).await;
+}
+
+#[when("the MCP client calls \"compute_image_stats\" with no arguments")]
+async fn mcp_call_compute_stats_no_args(world: &mut RpWorld) {
     ensure_mcp_client(world).await;
     let result = world
         .mcp()
@@ -125,11 +144,14 @@ fn stats_contains_field(world: &mut RpWorld, field: String) {
 
 async fn call_compute_image_stats(
     world: &mut RpWorld,
-    image_path: &str,
+    image_path: Option<&str>,
     document_id: Option<&str>,
 ) {
     ensure_mcp_client(world).await;
-    let mut args = serde_json::json!({"image_path": image_path});
+    let mut args = serde_json::json!({});
+    if let Some(path) = image_path {
+        args["image_path"] = serde_json::json!(path);
+    }
     if let Some(doc_id) = document_id {
         args["document_id"] = serde_json::json!(doc_id);
     }

--- a/services/rp/tests/features/image_stats.feature
+++ b/services/rp/tests/features/image_stats.feature
@@ -1,8 +1,10 @@
 @serial
 Feature: Image statistics tool
-  The compute_image_stats MCP tool reads a FITS file from disk and computes
-  pixel statistics: median, mean, min, and max ADU values. If a document_id
-  is provided, it updates the exposure document with an "image_stats" section.
+  The compute_image_stats MCP tool computes pixel statistics -- median, mean,
+  min, and max ADU values -- on a captured image. It accepts either
+  document_id (resolved via the image cache, falling back to FITS on miss)
+  or image_path (read from disk via rp-fits). When called with document_id,
+  results are written into the exposure document as an "image_stats" section.
   This tool does not access the camera -- it operates on saved image files.
 
   Scenario: Returns median and mean ADU after capture
@@ -16,6 +18,30 @@ Feature: Image statistics tool
     And the image stats result should contain "min_adu"
     And the image stats result should contain "max_adu"
     And the image stats result should contain "pixel_count" as a positive integer
+
+  Scenario: Returns contract fields when called with document_id
+    Given a running Alpaca simulator
+    And rp is running with a camera on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "capture" with camera "main-cam" for 1000 ms
+    And the MCP client calls "compute_image_stats" with the captured document_id
+    Then the image stats result should contain "median_adu" as a non-negative integer
+    And the image stats result should contain "mean_adu" as a non-negative number
+    And the image stats result should contain "pixel_count" as a positive integer
+
+  Scenario: Persists image_stats section into the exposure document
+    Given a running Alpaca simulator
+    And rp is running with a camera on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "capture" with camera "main-cam" for 1000 ms
+    And the MCP client calls "compute_image_stats" with the captured document_id
+    And I fetch the exposure document for the captured document_id
+    Then the exposure document should contain a section named "image_stats"
+    And the "image_stats" section should contain "median_adu"
+    And the "image_stats" section should contain "mean_adu"
+    And the "image_stats" section should contain "min_adu"
+    And the "image_stats" section should contain "max_adu"
+    And the "image_stats" section should contain "pixel_count"
 
   Scenario: Tool catalog includes compute_image_stats
     Given a running Alpaca simulator
@@ -31,10 +57,17 @@ Feature: Image statistics tool
     When the MCP client calls "compute_image_stats" with image path "/nonexistent/image.fits"
     Then the tool call should return an error
 
-  Scenario: compute_image_stats with missing image_path returns error
+  Scenario: compute_image_stats with unknown document_id returns error
     Given a running Alpaca simulator
     And rp is running with a camera on the simulator
     And an MCP client connected to rp
-    When the MCP client calls "compute_image_stats" with no image_path
+    When the MCP client calls "compute_image_stats" with document_id "unknown-doc-id"
+    Then the tool call should return an error
+
+  Scenario: compute_image_stats with neither document_id nor image_path returns error
+    Given a running Alpaca simulator
+    And rp is running with a camera on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "compute_image_stats" with no arguments
     Then the tool call should return an error
     And the error message should contain "image_path"


### PR DESCRIPTION
## Summary
- Implements the `document_id` persistence contract for `compute_image_stats` that was documented in `rp.md` but never wired up. When the tool is called with a `document_id`, the computed stats are now written into the exposure document as an `image_stats` section, matching the per-tool persistence pattern that `measure_basic`, `estimate_background`, `detect_stars`, `measure_stars`, and `compute_snr` already use.
- Refines `ComputeImageStatsParams` so it matches the other imaging tools' shape: both `document_id` and `image_path` are optional, `document_id` wins through the unified image+document cache, and the tool body validates that at least one is supplied.
- Tightens the design-doc paragraph at `docs/services/rp.md:806-815` so it accurately describes both input modes.

Closes #175.

## Test plan
- [x] `cargo rail run --profile commit -q` (389 tests passed)
- [x] `cargo test --test bdd -p rp` (238 BDD scenarios passed; image_stats feature now has 7 scenarios covering both input modes, the persistence side effect, the unknown-doc-id error, and the missing-args error)
- [x] `cargo clippy -p rp --all-features --all-targets -- -D warnings` (clean)
- [x] `cargo fmt` (clean)
- [x] New unit test `test_compute_image_stats_persists_section_via_document_id` asserts the cached document carries `sections["image_stats"]` after the call, with the expected median/mean/min/max/pixel_count shape.
- [x] New unit test `test_compute_image_stats_missing_arguments` pins the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)