### PR TITLE
docs(star-adventurer-gti): add Phase 1 design doc + protocol reference

### DIFF
--- a/docs/references/skywatcher-motor-controller-command-set.md
+++ b/docs/references/skywatcher-motor-controller-command-set.md
@@ -1,0 +1,415 @@
+# Sky-Watcher Motor Controller Command Set
+
+> **Authoritative source:** [skywatcher_motor_controller_command_set.pdf](https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf)
+> (Sky-Watcher application notes, no version number on the file). The
+> file below is a clean markdown rendering of the same content for
+> in-tree reference; if it disagrees with the upstream PDF, the PDF wins.
+> All material here is © Sky-Watcher and reproduced for engineering
+> reference under fair-use; the canonical URL is the public-facing copy.
+
+This is the wire-protocol specification used by:
+
+- The [`star-adventurer-gti`](../services/star-adventurer-gti.md) ASCOM
+  Telescope driver (USB at 115200 baud, or UDP/11880 over WiFi).
+- The `skywatcher-motor-protocol` crate (codec; transport-agnostic).
+
+The same protocol is shared by Sky-Watcher mounts including (per the EQMOD
+project's published compatibility list) EQ4, EQ5, HEQ5, NEQ6, EQ6-R Pro,
+EQ8, EQ8-R, EQ8-Rh, EQM-35 Pro, AZ-EQ5GT, AZ-EQ6GT, AZ-GTi, Star
+Adventurer GTi, HDX110, and Orion-rebadged variants (Sirius Pro AZ/EQ-G,
+Atlas Pro AZ/EQ-G).
+
+---
+
+## 1. Motor Speed Control
+
+The motor controller has a hardware timer **T1** that generates stepping
+pulses for stepper motors (or reference positions for servomotors). T1's
+input clock frequency plus its preset value determine slew speed.
+
+When T1 generates an interrupt, the controller might:
+
+- Drive the motor **1 step** (1 micro-step or 1 encoder tick) for low-speed
+  slewing.
+- Drive the motor **up to 32 steps** for high-speed slewing. (Firmware
+  v2.x only — firmware v3.x and above always advance 1 step per
+  interrupt.)
+
+## 2. Two Motion Modes
+
+**GOTO mode.** The master device tells the motor controller the desired
+destination, then sends a "Start" command. The controller moves the motor
+to that destination. The master can poll status, position, and cancel the
+slew during the GOTO.
+
+**Speed (Tracking) mode.** The master computes a T1 preset value for the
+desired speed and sends it to the controller, then sends "Start". The
+controller drives the motor at that constant speed. The master can poll
+status, position, and stop the slew.
+
+The mode for the next "Start" is selected by a separate command. The motor
+should be at full-stop status before changing motion mode.
+
+When a motor stops automatically (i.e. arrives at GOTO target), the
+controller returns to Speed mode by default.
+
+A typical slewing session:
+
+1. Confirm motor is at full stop. If not, stop it.
+2. Set motion mode.
+3. Set parameters (destination or T1 preset).
+4. Send "Start".
+5. For GOTO: poll status until motor stops (= arrived).
+   For Speed: send "Stop" to end the session.
+
+## 3. Master-Side Calculations
+
+A Sky-Watcher motor controller does not perform complex calculations.
+The master device does, using values it queries from the controller.
+
+### Encoder counts ↔ angle
+
+The controller counts encoder ticks. The master inquires **CPR** (Counts
+Per Revolution) from the controller and converts angle ↔ counts.
+**CPR may differ between the two axes of a mount.**
+
+### T1 preset for tracking-mode speed
+
+The master inquires **TMR_Freq** (T1 input clock frequency).
+
+```
+Speed_CountsPerSec = Speed_DegPerSec × CPR / 360
+T1_Preset          = TMR_Freq / Speed_CountsPerSec
+                   = TMR_Freq × 360 / (Speed_DegPerSec × CPR)
+```
+
+### T1 preset for high-speed slewing
+
+When required slew speed is high (e.g. > 128× sidereal), T1's preset can
+become unworkably small. The controller offers a high-speed mode that
+moves **N micro-steps per T1 interrupt** instead of 1, where **N** is a
+fixed mount-specific value (typically 16, 32, or 64) inquired from the
+controller.
+
+```
+T1_Preset_HighSpeed = N × TMR_Freq × 360 / (Speed_DegPerSec × CPR)
+```
+
+When entering Speed mode the master must tell the controller whether it
+intends low-speed or high-speed slewing. In GOTO mode the controller
+selects automatically.
+
+## 4. Command Format
+
+### Frame structure
+
+```
+Command:    : <cmd> <axis> <payload?> \r
+Response:   = <payload?>             \r        (success)
+Response:   ! <2-hex-errcode>        \r        (error)
+```
+
+- Every command starts with `:` (`0x3A`) and ends with carriage return
+  `\r` (`0x0D`).
+- If a second `:` is received before `\r`, the controller discards the
+  partial frame and starts receiving a new one. (Useful for resync.)
+- The controller processes the command and replies after it has read the
+  complete frame.
+- A normal response starts with `=`. An error response starts with `!`
+  followed by 2 hex digits of error code.
+- All bytes are ASCII.
+
+### Command parts
+
+- **1 byte** leading `:`
+- **1 byte** command word (see command set table)
+- **1 byte** channel word: `'1'` = RA/Az axis, `'2'` = Dec/Alt axis,
+  `'3'` = both axes (where applicable)
+- **1 to 6 bytes** of data payload — ASCII hex digits `'0'`–`'9'`,
+  `'A'`–`'F'`
+- **1 byte** trailing `\r`
+
+### Response parts (normal)
+
+- **1 byte** leading `=`
+- **1 to 6 bytes** of data — ASCII hex digits
+- **1 byte** trailing `\r`
+
+### Response parts (error)
+
+- **1 byte** leading `!`
+- **2 bytes** of error code (ASCII hex digits)
+- **1 byte** trailing `\r`
+
+### Data encoding — 24-bit values are sent low byte first
+
+For HEX value `0x123456`, the wire bytes are ASCII:
+
+```
+  "5" "6"   "3" "4"   "1" "2"
+   ^^^^^     ^^^^^     ^^^^^
+   byte 0    byte 1    byte 2
+   (low)               (high)
+```
+
+Each byte's nibbles appear in normal high-then-low order; only the byte
+order itself is reversed.
+
+For 16-bit values: bytes 0 then byte 1 (low first).
+For 8-bit values: a single byte's nibbles in normal order ("12" for
+`0x12`).
+
+### Data encoding — position offset 0x800000
+
+Axis positions on the wire are biased by `+0x800000` so that the unsigned
+hex representation can carry both signed-positive and signed-negative
+encoder counts:
+
+```
+true encoder count 0       → wire 0x800000
+true encoder count +0x1234 → wire 0x801234
+true encoder count -0x1234 → wire 0x7FEDCC
+```
+
+The controller adds the bias when reporting; the master adds the bias
+when sending. (See `:E`, `:S`, `:H`, `:j`, `:h`, etc.)
+
+## 5. Command Set
+
+Channel column conventions: `*1` = `'1'` / `'2'` / `'3'` (CH1, CH2, or
+both). `*2` = `'1'` / `'2'` (CH1 or CH2 only). Literal `'1'` = CH1 only.
+
+### Setters / motion commands
+
+| Cmd | Letter | Channel | Data        | Response | Notes |
+|---|---|---|---|---|---|
+| Set Position                  | `E` | `*1` | 6 hex      | A, X | Motor must be full stopped |
+| Initialization Done           | `F` | `*1` | —          | A, X | |
+| Set Motion Mode               | `G` | `*1` | 2 hex flags| A, X | Motor must be full stopped. See [§6 Motion Mode bits](#6-motion-mode-flags-data-of-g) |
+| Set Goto Target Increment     | `H` | `*2` | 6 hex      | A, X | |
+| Set Brake Point Increment     | `M` | `*1` | 6 hex      | A, X | |
+| Set Goto Target               | `S` | `*1` | 6 hex      | A, X | Motor must be full stopped |
+| Set Step Period (T1 preset)   | `I` | `*1` | 6 hex      | A, X | Cannot change while motor is high-speed slewing |
+| Set Long Goto Step Period     | `T` | `*1` | 6 hex      | A, X | |
+| Set Brake Steps               | `U` | `*1` | 6 hex      | A, X | |
+| Start Motion                  | `J` | `*1` | —          | A, X | |
+| Stop Motion                   | `K` | `*1` | —          | A, X | Channel reverts to Tracking Mode after stop |
+| Instant Stop                  | `L` | `*1` | —          | A, X | Channel reverts to Tracking Mode after stop |
+| Set Sleep                     | `B` | `*1` | `'0'` wake / `'1'` sleep | A, X | |
+| Set Aux Switch On/Off         | `O` | `*1` | `'0'` off / `'1'` on     | A, X | |
+| Set AutoGuide Speed           | `P` | `*1` | `'0'`=1×, `'1'`=0.75×, `'2'`=0.5×, `'3'`=0.25×, `'4'`=0.125× | A, X | |
+| Run Bootloader Mode           | `Q` | `*1` | `"55AA"`   | (none) | No response — caution |
+| Set Polar Scope LED brightness| `V` | `*1` | 2 hex      | A, X | |
+| Set Debug Flag                | `z` | `*1` | —          | (none) | |
+| Extended Setting              | `W` | `*1` | 6 hex (ID + payload) | X | See [§7](#7-extended-setting--inquire) |
+
+### Inquiries
+
+| Cmd | Letter | Channel | Data | Response | Notes |
+|---|---|---|---|---|---|
+| Inquire Counts Per Revolution | `a` | `*2` | —     | B, X | per-axis CPR |
+| Inquire Timer Interrupt Freq  | `b` | `'1'` | —     | B, X | TMR_Freq |
+| Inquire Brake Steps           | `c` | `*2` | —     | B, X | |
+| Inquire Goto Target Position  | `h` | `*2` | —     | B, X | |
+| Inquire Step Period           | `i` | `*2` | —     | B, X | |
+| Inquire Position              | `j` | `*2` | —     | B, X | with 0x800000 bias |
+| Inquire Increment             | `k` | `*2` | `'0'` no-reset / `'1'` reset | B, X | |
+| Inquire Brake Point           | `m` | `*2` | —     | B, X | |
+| Inquire Status                | `f` | `*2` | —     | E, X | See [§8 Status response](#8-status-response-of-f) |
+| Inquire High Speed Ratio      | `g` | `*2` | —     | D, X | the **N** factor |
+| Inquire 1X Tracking Period    | `D` | `'1'` | —     | B, X | |
+| Inquire Tele. Axis Position   | `d` | `*1` | —     | B, X | |
+| Inquire Motor Board Version   | `e` | `*1` | —     | B, X | Last byte indicates EQ (`0`) vs AZ (`1`); see [§9](#9-motor-board-version-of-e) |
+| Inquire PEC period            | `s` | `*1` | —     | B, X | |
+| Extended Inquire              | `q` | `*1` | 6 hex (ID + payload) | X | See [§7](#7-extended-setting--inquire) |
+
+### EEPROM access
+
+| Cmd | Letter | Channel | Data | Response |
+|---|---|---|---|---|
+| Set EEPROM Address    | `C` | `'1'` | 4 hex address | (none) |
+| Set EEPROM Value      | `N` | `'1'` | 2 hex value   | (none) |
+| Inquire EEPROM Value  | `n` | `'1'` | —             | (B-format response) |
+
+### Register access
+
+| Cmd | Letter | Channel | Data | Response |
+|---|---|---|---|---|
+| Set Register Address  | `A` | `*1` | 2 hex address | (none) |
+| Set Register Value    | `R` | `*1` | 2 hex value   | (none) |
+| Inquire Register Value| `r` | `*1` | —             | (response) |
+
+### Response payload widths
+
+| Tag | Format       | Data width |
+|---|---|---|
+| A   | `=\r`        | 0 bytes    |
+| B   | `=<6 hex>\r` | 24 bits (low byte first, with 0x800000 bias for position commands) |
+| C   | `=<4 hex>\r` | 16 bits (low byte first) |
+| D   | `=<2 hex>\r` | 8 bits     |
+| E   | `=<3 hex>\r` | 3 status nibbles — see [§8](#8-status-response-of-f) |
+| X   | `!<2 hex>\r` | 8-bit error code |
+
+## 6. Motion Mode Flags (data of `:G`)
+
+The `:G` data field is two ASCII hex nibbles. The first nibble selects
+GOTO vs Tracking and the speed regime; the second nibble selects axis
+direction and (for Alt/Az mounts) the hemisphere.
+
+The exact bit semantics differ between Goto and Tracking flavours and
+between firmware revisions; consult the upstream PDF page §"Set Motion
+Mode" plus the [INDI `indi-eqmod` source][indi-eqmod] for the
+authoritative bit map. Driver code should encapsulate motion-mode
+construction behind a typed builder rather than spread raw nibble values
+through the codebase.
+
+[indi-eqmod]: https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod
+
+The general shape (low → high bit, nibble 0):
+
+- **B0:** `0` = GOTO mode, `1` = Tracking mode
+- **B1:** speed regime — exact meaning depends on B0
+  (in Tracking: `0` = fast, `1` = slow; in GOTO: `0` = slow, `1` = fast)
+- **B2:** medium-speed flag (Tracking only) / Coarse Goto flag (GOTO only)
+- **B3:** 1× Slow Goto flag (GOTO only)
+
+Nibble 1:
+
+- **B0:** `0` = CW, `1` = CCW
+- **B1:** `0` = North hemisphere, `1` = South hemisphere
+
+After `:K` (Stop) or `:L` (Instant Stop), the channel always reverts to
+Tracking Mode for the next Start.
+
+## 7. Extended Setting / Inquire
+
+The `:W` (set) and `:q` (inquire) commands carry a 6-hex-digit payload
+where the leading 6 bits are an **ID** code and the remainder is
+ID-specific.
+
+### Extended Inquire (`:q`)
+
+| ID       | Function                         | Returned bytes |
+|---|---|---|
+| `000000` | Inquire Axis (Original) Indexer Position | 6 hex |
+| `000001` | Inquire Status EX                | 6 hex (see below) |
+
+`Inquire Status EX` (ID `000001`) returns 6 hex nibbles encoding multiple
+capability flags:
+
+- Byte 0: B0 = PEC Training on/off, B1 = PEC Tracking on/off
+- Byte 1: B0 = Supports dual encoder, B1 = Supports PPEC,
+  B2 = Supports original-position indexer, B3 = Supports EQ/AZ mode
+- Byte 2: B0 = Has polar-scope LED, B1 = Two axes must start separately,
+  B2 = Supports tracking-torque selection
+- Bytes 3–5: reserved
+
+### Extended Setting (`:W`)
+
+| ID       | Function                                |
+|---|---|
+| `000000` | Start PEC Training                      |
+| `000001` | Cancel PEC Training                     |
+| `000002` | Start PEC Tracking                      |
+| `000003` | Cancel PEC Tracking                     |
+| `000004` | Enable Dual Encoder                     |
+| `000005` | Disable Dual Encoder                    |
+| `000006` | Disable full current (torque) at low speed |
+| `000106` | Enable  full current (torque) at low speed |
+| `xxxx07` | Set Stride for Slewing (`xxxx` = stride) |
+| `000008` | Reset Axis Indexer Position             |
+| `000009` | Write flash buffer in RAM to flash ROM  |
+
+## 8. Status Response (of `:f`)
+
+Returns 3 hex nibbles; each nibble is one status byte.
+
+### Status byte 0 (mode, direction, speed regime)
+
+| Bit | Meaning |
+|---|---|
+| B0  | `0` = Goto, `1` = Tracking |
+| B1  | `0` = CW, `1` = CCW |
+| B2  | `0` = Slow, `1` = Fast |
+
+### Status byte 1 (motor state)
+
+| Bit | Meaning |
+|---|---|
+| B0  | `0` = Stopped, `1` = Running |
+| B1  | `0` = Normal, `1` = Blocked |
+
+### Status byte 2 (initialization, sensors)
+
+| Bit | Meaning |
+|---|---|
+| B0  | `0` = Not initialized, `1` = Init done |
+| B1  | `0` = Level switch off, `1` = Level switch on |
+
+## 9. Motor Board Version (of `:e`)
+
+The `:e<axis>` reply payload (6 hex digits, low byte first) decodes as:
+
+```
+byte 0 — minor firmware version
+byte 1 — major firmware version
+byte 2 — mount-family code: last hex digit is 0 = EQ, 1 = AZ
+```
+
+Empirically on a Star Adventurer GTi: `=03300C\r` →
+bytes `0x03`, `0x30`, `0x0C` → fw `0x30.0x0C` on mount-family `0x03`
+(EQ family; the `3` low-nibble of the last byte does not match the
+"`0` = EQ, `1` = AZ" rule literally — the rule applies to the **last
+hex character** of the wire string, not the high byte's low nibble; see
+PDF §*6 footnote).
+
+## 10. Error Codes
+
+| Code | Name                       |
+|---|---|
+| `0` | Unknown Command             |
+| `1` | Command Length Error        |
+| `2` | Motor not Stopped           |
+| `3` | Invalid Character           |
+| `4` | Not Initialized             |
+| `5` | Driver Sleeping             |
+| `7` | PEC Training is running     |
+| `8` | No Valid PEC data           |
+
+Codes `6`, `9`, `A`–`F` are reserved.
+
+## 11. Hardware
+
+### UART (serial transport)
+
+- **9600 bps**, 8 data bits, 1 start bit, 1 stop bit, no parity.
+  - In practice the Star Adventurer GTi's USB-CDC port also accepts
+    **115200 bps**, which the EQMOD project recommends and which our
+    driver uses by default.
+- Signal level: 5 V or 3.3 V.
+- **EQ mounts** have separate TX and RX lines. The controller sends its
+  response immediately after receiving and processing the command.
+- **Alt/Az mounts** typically have TX and RX wired together with a
+  separate `Drop` line indicating bus-busy. The master pulls `Drop` low
+  during transmission and keeps it low until either the response is
+  received in full or a timeout expires. The controller pulls TX high
+  with a 5.1 kΩ–10 kΩ resistor only — soft enough that the master can
+  drive it low without contention.
+
+### WiFi transport
+
+- The same protocol runs on the **SynScan WiFi dongle** and on mounts
+  with a **built-in WiFi module**.
+- The WiFi dongle/module hosts a **UDP server on port 11880**.
+- **One UDP packet per command, one UDP packet per response.** The
+  packet must contain exactly one well-formed frame; trailing junk
+  causes silent drop.
+- In **AP mode**, the dongle/module IP is `192.168.4.1`. In **station
+  mode**, the upstream router allocates the IP via DHCP.
+
+## 12. Useful Resources
+
+- [Sample code archive (Google Code, archived)](https://code.google.com/archive/p/skywatcher/)
+- [Sky-Watcher application development page (canonical PDFs)](http://www.skywatcher.com/download/manual/application-development/)
+- [INDI `indi-eqmod` source](https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod)
+- [EQMOD project](https://eq-mod.sourceforge.net/)

--- a/docs/references/skywatcher-motor-controller-command-set.md
+++ b/docs/references/skywatcher-motor-controller-command-set.md
@@ -1,415 +1,150 @@
-# Sky-Watcher Motor Controller Command Set
+# Sky-Watcher Motor-Controller Command Set — Engineering Notes
 
-> **Authoritative source:** [skywatcher_motor_controller_command_set.pdf](https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf)
-> (Sky-Watcher application notes, no version number on the file). The
-> file below is a clean markdown rendering of the same content for
-> in-tree reference; if it disagrees with the upstream PDF, the PDF wins.
-> All material here is © Sky-Watcher and reproduced for engineering
-> reference under fair-use; the canonical URL is the public-facing copy.
+**Canonical specification:**
+[skywatcher_motor_controller_command_set.pdf](https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf)
+(Sky-Watcher Application Notes, no version number on the file).
 
-This is the wire-protocol specification used by:
+This file is **not** a copy of the upstream specification. It contains
+the project's own engineering notes about how we use the protocol —
+compatibility, empirically-verified behaviour on our hardware, and the
+load-bearing implementation gotchas the codec needs to handle. For the
+authoritative command list, frame format, status-bit layout, motion-mode
+flags, and error codes, follow the link above.
+
+## What this protocol is
+
+The wire protocol the [Sky-Watcher motor-controller command set] PDF
+defines. Used by:
 
 - The [`star-adventurer-gti`](../services/star-adventurer-gti.md) ASCOM
   Telescope driver (USB at 115200 baud, or UDP/11880 over WiFi).
 - The `skywatcher-motor-protocol` crate (codec; transport-agnostic).
 
-The same protocol is shared by Sky-Watcher mounts including (per the EQMOD
-project's published compatibility list) EQ4, EQ5, HEQ5, NEQ6, EQ6-R Pro,
-EQ8, EQ8-R, EQ8-Rh, EQM-35 Pro, AZ-EQ5GT, AZ-EQ6GT, AZ-GTi, Star
-Adventurer GTi, HDX110, and Orion-rebadged variants (Sirius Pro AZ/EQ-G,
-Atlas Pro AZ/EQ-G).
+Per the upstream spec §6 (Wi-Fi Connection), the same protocol runs on
+both serial transports.
 
----
+## Mounts that speak this protocol
 
-## 1. Motor Speed Control
+Compiled from the [EQMOD project compatibility list][eqmod] and the
+[INDI `indi-eqmod` driver manifest][indi-eqmod-xml] — not from the
+Sky-Watcher PDF.
 
-The motor controller has a hardware timer **T1** that generates stepping
-pulses for stepper motors (or reference positions for servomotors). T1's
-input clock frequency plus its preset value determine slew speed.
+**Sky-Watcher branded:** EQ4, EQ5, HEQ5, NEQ6, EQ6-R Pro, EQ8, EQ8-R,
+EQ8-Rh, EQM-35 Pro, AZ-EQ5GT, AZ-EQ6GT, AZ-GTi, Star Adventurer GTi,
+HDX110.
 
-When T1 generates an interrupt, the controller might:
+**Orion branded (Synta OEM):** Sirius Pro AZ/EQ-G, Atlas Pro AZ/EQ-G.
 
-- Drive the motor **1 step** (1 micro-step or 1 encoder tick) for low-speed
-  slewing.
-- Drive the motor **up to 32 steps** for high-speed slewing. (Firmware
-  v2.x only — firmware v3.x and above always advance 1 step per
-  interrupt.)
+This is the same wire protocol on every mount in the list, but
+mount-side parameters (counts-per-revolution, timer-interrupt
+frequency, high-speed ratio, capability flags) vary, so the driver
+queries them at connect time rather than hard-coding.
 
-## 2. Two Motion Modes
+## Implementation gotchas
 
-**GOTO mode.** The master device tells the motor controller the desired
-destination, then sends a "Start" command. The controller moves the motor
-to that destination. The master can poll status, position, and cancel the
-slew during the GOTO.
+These two are the most common source of codec bugs and are worth
+flagging at the top of the codec module.
 
-**Speed (Tracking) mode.** The master computes a T1 preset value for the
-desired speed and sends it to the controller, then sends "Start". The
-controller drives the motor at that constant speed. The master can poll
-status, position, and stop the slew.
+### 24-bit data is sent low byte first
 
-The mode for the next "Start" is selected by a separate command. The motor
-should be at full-stop status before changing motion mode.
+For a 24-bit value `0x123456`, the wire bytes are ASCII
+`"5" "6" "3" "4" "1" "2"` — low byte first, with each byte's nibbles in
+normal high-then-low order. Only the byte order is reversed; nibble
+order within each byte is normal.
 
-When a motor stops automatically (i.e. arrives at GOTO target), the
-controller returns to Speed mode by default.
+### Axis positions carry a `0x800000` bias
 
-A typical slewing session:
+Axis positions are conveyed with a fixed bias of `+0x800000` so that the
+unsigned hex on the wire can carry both signed-positive and
+signed-negative encoder counts. Subtract on decode, add on encode;
+service code should see signed encoder counts only.
 
-1. Confirm motor is at full stop. If not, stop it.
-2. Set motion mode.
-3. Set parameters (destination or T1 preset).
-4. Send "Start".
-5. For GOTO: poll status until motor stops (= arrived).
-   For Speed: send "Stop" to end the session.
+### UDP framing is strict
 
-## 3. Master-Side Calculations
+Empirically verified on the Star Adventurer GTi (see `:e1` probe table
+below): the controller silently drops UDP packets that contain anything
+beyond a single well-formed `:cmd<axis><payload>\r` frame.
 
-A Sky-Watcher motor controller does not perform complex calculations.
-The master device does, using values it queries from the controller.
+| UDP payload | Result |
+|---|---|
+| `:e1\r` | reply received |
+| `:e1\r\n` | reply received (trailing `\n` tolerated) |
+| `:e1` (no `\r`) | silent — controller waits for terminator |
+| `:e1\r` + zero-padding | silent — extra bytes after `\r` reject the frame |
+| `\xff…:e1\r` (junk-prefixed) | silent — bytes before `:` reject the frame |
 
-### Encoder counts ↔ angle
+The codec must enforce: exactly one well-formed frame per UDP packet,
+nothing trailing. (This is implied by the spec's framing rules but not
+called out directly.)
 
-The controller counts encoder ticks. The master inquires **CPR** (Counts
-Per Revolution) from the controller and converts angle ↔ counts.
-**CPR may differ between the two axes of a mount.**
+### Resync on mid-frame `:`
 
-### T1 preset for tracking-mode speed
+Per the spec, if the controller sees a second `:` before `\r`, it
+discards the partial frame and starts fresh. Useful for recovering from
+a corrupted half-sent command.
 
-The master inquires **TMR_Freq** (T1 input clock frequency).
+## Empirically verified on the Star Adventurer GTi
 
-```
-Speed_CountsPerSec = Speed_DegPerSec × CPR / 360
-T1_Preset          = TMR_Freq / Speed_CountsPerSec
-                   = TMR_Freq × 360 / (Speed_DegPerSec × CPR)
-```
+These are observations from our own probing on this physical mount, not
+content from the upstream PDF.
 
-### T1 preset for high-speed slewing
+### USB-CDC accepts 115200 baud
 
-When required slew speed is high (e.g. > 128× sidereal), T1's preset can
-become unworkably small. The controller offers a high-speed mode that
-moves **N micro-steps per T1 interrupt** instead of 1, where **N** is a
-fixed mount-specific value (typically 16, 32, or 64) inquired from the
-controller.
+The spec specifies **9600 8N1** for the UART. The Star Adventurer GTi's
+USB-C virtual COM port additionally accepts **115200 baud** (matches
+EQMOD documentation; faster). We use 115200 by default.
 
-```
-T1_Preset_HighSpeed = N × TMR_Freq × 360 / (Speed_DegPerSec × CPR)
-```
+### WiFi requires explicit local-IP source binding
 
-When entering Speed mode the master must tell the controller whether it
-intends low-speed or high-speed slewing. In GOTO mode the controller
-selects automatically.
+The mount's built-in WiFi answers UDP/11880 at `192.168.4.1` in AP mode.
+The host **must** bind the local socket to a `192.168.4.x` source
+address explicitly. Relying on the kernel's default-route source-IP
+selection picks the wrong address when a competing default route is
+present, and the mount silently drops packets it can't reply to.
 
-## 4. Command Format
+### Sample probe values on this mount
 
-### Frame structure
+A clean reply to each handshake command, useful as a smoke-test target
+for the mock transport:
 
-```
-Command:    : <cmd> <axis> <payload?> \r
-Response:   = <payload?>             \r        (success)
-Response:   ! <2-hex-errcode>        \r        (error)
-```
-
-- Every command starts with `:` (`0x3A`) and ends with carriage return
-  `\r` (`0x0D`).
-- If a second `:` is received before `\r`, the controller discards the
-  partial frame and starts receiving a new one. (Useful for resync.)
-- The controller processes the command and replies after it has read the
-  complete frame.
-- A normal response starts with `=`. An error response starts with `!`
-  followed by 2 hex digits of error code.
-- All bytes are ASCII.
-
-### Command parts
-
-- **1 byte** leading `:`
-- **1 byte** command word (see command set table)
-- **1 byte** channel word: `'1'` = RA/Az axis, `'2'` = Dec/Alt axis,
-  `'3'` = both axes (where applicable)
-- **1 to 6 bytes** of data payload — ASCII hex digits `'0'`–`'9'`,
-  `'A'`–`'F'`
-- **1 byte** trailing `\r`
-
-### Response parts (normal)
-
-- **1 byte** leading `=`
-- **1 to 6 bytes** of data — ASCII hex digits
-- **1 byte** trailing `\r`
-
-### Response parts (error)
-
-- **1 byte** leading `!`
-- **2 bytes** of error code (ASCII hex digits)
-- **1 byte** trailing `\r`
-
-### Data encoding — 24-bit values are sent low byte first
-
-For HEX value `0x123456`, the wire bytes are ASCII:
-
-```
-  "5" "6"   "3" "4"   "1" "2"
-   ^^^^^     ^^^^^     ^^^^^
-   byte 0    byte 1    byte 2
-   (low)               (high)
-```
-
-Each byte's nibbles appear in normal high-then-low order; only the byte
-order itself is reversed.
-
-For 16-bit values: bytes 0 then byte 1 (low first).
-For 8-bit values: a single byte's nibbles in normal order ("12" for
-`0x12`).
-
-### Data encoding — position offset 0x800000
-
-Axis positions on the wire are biased by `+0x800000` so that the unsigned
-hex representation can carry both signed-positive and signed-negative
-encoder counts:
-
-```
-true encoder count 0       → wire 0x800000
-true encoder count +0x1234 → wire 0x801234
-true encoder count -0x1234 → wire 0x7FEDCC
-```
-
-The controller adds the bias when reporting; the master adds the bias
-when sending. (See `:E`, `:S`, `:H`, `:j`, `:h`, etc.)
-
-## 5. Command Set
-
-Channel column conventions: `*1` = `'1'` / `'2'` / `'3'` (CH1, CH2, or
-both). `*2` = `'1'` / `'2'` (CH1 or CH2 only). Literal `'1'` = CH1 only.
-
-### Setters / motion commands
-
-| Cmd | Letter | Channel | Data        | Response | Notes |
-|---|---|---|---|---|---|
-| Set Position                  | `E` | `*1` | 6 hex      | A, X | Motor must be full stopped |
-| Initialization Done           | `F` | `*1` | —          | A, X | |
-| Set Motion Mode               | `G` | `*1` | 2 hex flags| A, X | Motor must be full stopped. See [§6 Motion Mode bits](#6-motion-mode-flags-data-of-g) |
-| Set Goto Target Increment     | `H` | `*2` | 6 hex      | A, X | |
-| Set Brake Point Increment     | `M` | `*1` | 6 hex      | A, X | |
-| Set Goto Target               | `S` | `*1` | 6 hex      | A, X | Motor must be full stopped |
-| Set Step Period (T1 preset)   | `I` | `*1` | 6 hex      | A, X | Cannot change while motor is high-speed slewing |
-| Set Long Goto Step Period     | `T` | `*1` | 6 hex      | A, X | |
-| Set Brake Steps               | `U` | `*1` | 6 hex      | A, X | |
-| Start Motion                  | `J` | `*1` | —          | A, X | |
-| Stop Motion                   | `K` | `*1` | —          | A, X | Channel reverts to Tracking Mode after stop |
-| Instant Stop                  | `L` | `*1` | —          | A, X | Channel reverts to Tracking Mode after stop |
-| Set Sleep                     | `B` | `*1` | `'0'` wake / `'1'` sleep | A, X | |
-| Set Aux Switch On/Off         | `O` | `*1` | `'0'` off / `'1'` on     | A, X | |
-| Set AutoGuide Speed           | `P` | `*1` | `'0'`=1×, `'1'`=0.75×, `'2'`=0.5×, `'3'`=0.25×, `'4'`=0.125× | A, X | |
-| Run Bootloader Mode           | `Q` | `*1` | `"55AA"`   | (none) | No response — caution |
-| Set Polar Scope LED brightness| `V` | `*1` | 2 hex      | A, X | |
-| Set Debug Flag                | `z` | `*1` | —          | (none) | |
-| Extended Setting              | `W` | `*1` | 6 hex (ID + payload) | X | See [§7](#7-extended-setting--inquire) |
-
-### Inquiries
-
-| Cmd | Letter | Channel | Data | Response | Notes |
-|---|---|---|---|---|---|
-| Inquire Counts Per Revolution | `a` | `*2` | —     | B, X | per-axis CPR |
-| Inquire Timer Interrupt Freq  | `b` | `'1'` | —     | B, X | TMR_Freq |
-| Inquire Brake Steps           | `c` | `*2` | —     | B, X | |
-| Inquire Goto Target Position  | `h` | `*2` | —     | B, X | |
-| Inquire Step Period           | `i` | `*2` | —     | B, X | |
-| Inquire Position              | `j` | `*2` | —     | B, X | with 0x800000 bias |
-| Inquire Increment             | `k` | `*2` | `'0'` no-reset / `'1'` reset | B, X | |
-| Inquire Brake Point           | `m` | `*2` | —     | B, X | |
-| Inquire Status                | `f` | `*2` | —     | E, X | See [§8 Status response](#8-status-response-of-f) |
-| Inquire High Speed Ratio      | `g` | `*2` | —     | D, X | the **N** factor |
-| Inquire 1X Tracking Period    | `D` | `'1'` | —     | B, X | |
-| Inquire Tele. Axis Position   | `d` | `*1` | —     | B, X | |
-| Inquire Motor Board Version   | `e` | `*1` | —     | B, X | Last byte indicates EQ (`0`) vs AZ (`1`); see [§9](#9-motor-board-version-of-e) |
-| Inquire PEC period            | `s` | `*1` | —     | B, X | |
-| Extended Inquire              | `q` | `*1` | 6 hex (ID + payload) | X | See [§7](#7-extended-setting--inquire) |
-
-### EEPROM access
-
-| Cmd | Letter | Channel | Data | Response |
-|---|---|---|---|---|
-| Set EEPROM Address    | `C` | `'1'` | 4 hex address | (none) |
-| Set EEPROM Value      | `N` | `'1'` | 2 hex value   | (none) |
-| Inquire EEPROM Value  | `n` | `'1'` | —             | (B-format response) |
-
-### Register access
-
-| Cmd | Letter | Channel | Data | Response |
-|---|---|---|---|---|
-| Set Register Address  | `A` | `*1` | 2 hex address | (none) |
-| Set Register Value    | `R` | `*1` | 2 hex value   | (none) |
-| Inquire Register Value| `r` | `*1` | —             | (response) |
-
-### Response payload widths
-
-| Tag | Format       | Data width |
+| Command | Wire reply | Decoded |
 |---|---|---|
-| A   | `=\r`        | 0 bytes    |
-| B   | `=<6 hex>\r` | 24 bits (low byte first, with 0x800000 bias for position commands) |
-| C   | `=<4 hex>\r` | 16 bits (low byte first) |
-| D   | `=<2 hex>\r` | 8 bits     |
-| E   | `=<3 hex>\r` | 3 status nibbles — see [§8](#8-status-response-of-f) |
-| X   | `!<2 hex>\r` | 8-bit error code |
+| `:e1\r` (motor-board version) | `=03300C\r` | mount-type byte `0x03`, fw `0x30`/`0x0C` |
+| `:a1\r` (CPR axis 1) | `=005F37\r` | `0x375F00` = 3,628,800 counts/revolution |
+| `:b1\r` (TMR_Freq) | `=0024F4\r` | `0xF42400` ≈ 16 MHz |
+| `:j1\r` (position axis 1) | `=000080\r` | `0x800000` (with bias) → 0 ticks (home) |
+| `:f1\r` (status axis 1) | `=100\r` | tracking-mode preset, motor stopped, not initialised |
+| `:F1\r` (initialize axis 1) | `=\r` | empty-payload ack |
 
-## 6. Motion Mode Flags (data of `:G`)
+CPR is per-axis; the driver also queries `:a2` for the Dec axis. CPR
+varies between mount models, so do not bake `3,628,800` into anything
+beyond test fixtures.
 
-The `:G` data field is two ASCII hex nibbles. The first nibble selects
-GOTO vs Tracking and the speed regime; the second nibble selects axis
-direction and (for Alt/Az mounts) the hemisphere.
+### Initialization sequence we use on connect
 
-The exact bit semantics differ between Goto and Tracking flavours and
-between firmware revisions; consult the upstream PDF page §"Set Motion
-Mode" plus the [INDI `indi-eqmod` source][indi-eqmod] for the
-authoritative bit map. Driver code should encapsulate motion-mode
-construction behind a typed builder rather than spread raw nibble values
-through the codebase.
+After opening the transport, before the first motion command:
 
-[indi-eqmod]: https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod
+1. `:F1`, `:F2` — initialize both axes
+2. `:a1`, `:a2` — record CPR per axis
+3. `:b1` — record TMR_Freq
+4. `:g1`, `:g2` — record high-speed ratio per axis
+5. `:e1` — log mount type / firmware version
+6. `:j1`, `:j2` — record initial encoder positions
 
-The general shape (low → high bit, nibble 0):
+These values seed the in-memory parameter cache used by the coordinate
+module and the slew planner.
 
-- **B0:** `0` = GOTO mode, `1` = Tracking mode
-- **B1:** speed regime — exact meaning depends on B0
-  (in Tracking: `0` = fast, `1` = slow; in GOTO: `0` = slow, `1` = fast)
-- **B2:** medium-speed flag (Tracking only) / Coarse Goto flag (GOTO only)
-- **B3:** 1× Slow Goto flag (GOTO only)
+## See also
 
-Nibble 1:
-
-- **B0:** `0` = CW, `1` = CCW
-- **B1:** `0` = North hemisphere, `1` = South hemisphere
-
-After `:K` (Stop) or `:L` (Instant Stop), the channel always reverts to
-Tracking Mode for the next Start.
-
-## 7. Extended Setting / Inquire
-
-The `:W` (set) and `:q` (inquire) commands carry a 6-hex-digit payload
-where the leading 6 bits are an **ID** code and the remainder is
-ID-specific.
-
-### Extended Inquire (`:q`)
-
-| ID       | Function                         | Returned bytes |
-|---|---|---|
-| `000000` | Inquire Axis (Original) Indexer Position | 6 hex |
-| `000001` | Inquire Status EX                | 6 hex (see below) |
-
-`Inquire Status EX` (ID `000001`) returns 6 hex nibbles encoding multiple
-capability flags:
-
-- Byte 0: B0 = PEC Training on/off, B1 = PEC Tracking on/off
-- Byte 1: B0 = Supports dual encoder, B1 = Supports PPEC,
-  B2 = Supports original-position indexer, B3 = Supports EQ/AZ mode
-- Byte 2: B0 = Has polar-scope LED, B1 = Two axes must start separately,
-  B2 = Supports tracking-torque selection
-- Bytes 3–5: reserved
-
-### Extended Setting (`:W`)
-
-| ID       | Function                                |
-|---|---|
-| `000000` | Start PEC Training                      |
-| `000001` | Cancel PEC Training                     |
-| `000002` | Start PEC Tracking                      |
-| `000003` | Cancel PEC Tracking                     |
-| `000004` | Enable Dual Encoder                     |
-| `000005` | Disable Dual Encoder                    |
-| `000006` | Disable full current (torque) at low speed |
-| `000106` | Enable  full current (torque) at low speed |
-| `xxxx07` | Set Stride for Slewing (`xxxx` = stride) |
-| `000008` | Reset Axis Indexer Position             |
-| `000009` | Write flash buffer in RAM to flash ROM  |
-
-## 8. Status Response (of `:f`)
-
-Returns 3 hex nibbles; each nibble is one status byte.
-
-### Status byte 0 (mode, direction, speed regime)
-
-| Bit | Meaning |
-|---|---|
-| B0  | `0` = Goto, `1` = Tracking |
-| B1  | `0` = CW, `1` = CCW |
-| B2  | `0` = Slow, `1` = Fast |
-
-### Status byte 1 (motor state)
-
-| Bit | Meaning |
-|---|---|
-| B0  | `0` = Stopped, `1` = Running |
-| B1  | `0` = Normal, `1` = Blocked |
-
-### Status byte 2 (initialization, sensors)
-
-| Bit | Meaning |
-|---|---|
-| B0  | `0` = Not initialized, `1` = Init done |
-| B1  | `0` = Level switch off, `1` = Level switch on |
-
-## 9. Motor Board Version (of `:e`)
-
-The `:e<axis>` reply payload (6 hex digits, low byte first) decodes as:
-
-```
-byte 0 — minor firmware version
-byte 1 — major firmware version
-byte 2 — mount-family code: last hex digit is 0 = EQ, 1 = AZ
-```
-
-Empirically on a Star Adventurer GTi: `=03300C\r` →
-bytes `0x03`, `0x30`, `0x0C` → fw `0x30.0x0C` on mount-family `0x03`
-(EQ family; the `3` low-nibble of the last byte does not match the
-"`0` = EQ, `1` = AZ" rule literally — the rule applies to the **last
-hex character** of the wire string, not the high byte's low nibble; see
-PDF §*6 footnote).
-
-## 10. Error Codes
-
-| Code | Name                       |
-|---|---|
-| `0` | Unknown Command             |
-| `1` | Command Length Error        |
-| `2` | Motor not Stopped           |
-| `3` | Invalid Character           |
-| `4` | Not Initialized             |
-| `5` | Driver Sleeping             |
-| `7` | PEC Training is running     |
-| `8` | No Valid PEC data           |
-
-Codes `6`, `9`, `A`–`F` are reserved.
-
-## 11. Hardware
-
-### UART (serial transport)
-
-- **9600 bps**, 8 data bits, 1 start bit, 1 stop bit, no parity.
-  - In practice the Star Adventurer GTi's USB-CDC port also accepts
-    **115200 bps**, which the EQMOD project recommends and which our
-    driver uses by default.
-- Signal level: 5 V or 3.3 V.
-- **EQ mounts** have separate TX and RX lines. The controller sends its
-  response immediately after receiving and processing the command.
-- **Alt/Az mounts** typically have TX and RX wired together with a
-  separate `Drop` line indicating bus-busy. The master pulls `Drop` low
-  during transmission and keeps it low until either the response is
-  received in full or a timeout expires. The controller pulls TX high
-  with a 5.1 kΩ–10 kΩ resistor only — soft enough that the master can
-  drive it low without contention.
-
-### WiFi transport
-
-- The same protocol runs on the **SynScan WiFi dongle** and on mounts
-  with a **built-in WiFi module**.
-- The WiFi dongle/module hosts a **UDP server on port 11880**.
-- **One UDP packet per command, one UDP packet per response.** The
-  packet must contain exactly one well-formed frame; trailing junk
-  causes silent drop.
-- In **AP mode**, the dongle/module IP is `192.168.4.1`. In **station
-  mode**, the upstream router allocates the IP via DHCP.
-
-## 12. Useful Resources
-
-- [Sample code archive (Google Code, archived)](https://code.google.com/archive/p/skywatcher/)
+- [INDI `indi-eqmod` driver source][indi-eqmod] — the canonical
+  open-source reference implementation; we cross-check ambiguous bits of
+  the spec against this driver.
+- [EQMOD project][eqmod] — Windows-side reference driver and
+  protocol-decoding documentation.
+- [Sky-Watcher sample code archive (Google Code, archived)](https://code.google.com/archive/p/skywatcher/)
 - [Sky-Watcher application development page (canonical PDFs)](http://www.skywatcher.com/download/manual/application-development/)
-- [INDI `indi-eqmod` source](https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod)
-- [EQMOD project](https://eq-mod.sourceforge.net/)
+
+[Sky-Watcher motor-controller command set]: https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf
+[indi-eqmod]: https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod
+[indi-eqmod-xml]: https://github.com/indilib/indi-3rdparty/blob/master/indi-eqmod/indi_eqmod.xml.cmake
+[eqmod]: https://eq-mod.sourceforge.net/

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -641,11 +641,11 @@ as `qhy-focuser` and `ppba-driver`.)
 
 ### Authoritative
 
-- [Sky-Watcher motor controller command set] — the wire protocol
+- [Sky-Watcher motor-controller command set] — the wire protocol
   specification, including the §6 Wi-Fi note that the same protocol runs
-  on UDP/11880. An in-tree markdown rendering is at
-  [`docs/references/skywatcher-motor-controller-command-set.md`](../references/skywatcher-motor-controller-command-set.md)
-  for offline / version-pinned reference.
+  on UDP/11880. In-tree engineering notes (compatibility list, our
+  empirical findings, implementation gotchas) live alongside at
+  [`docs/references/skywatcher-motor-controller-command-set.md`](../references/skywatcher-motor-controller-command-set.md).
 - [INDI eqmod driver source](https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod)
   — the canonical open-source reference implementation; we cross-check
   ambiguous bits of the spec against this driver.

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1,0 +1,686 @@
+# Star Adventurer GTi Service
+
+## Overview
+
+The `star-adventurer-gti` service is an ASCOM Alpaca Telescope driver for the
+Sky-Watcher Star Adventurer GTi German Equatorial Mount. It speaks the
+[Sky-Watcher motor-controller command set] over either USB-CDC serial or WiFi
+(UDP/11880) — the same wire protocol on both transports — and exposes the
+mount as an ASCOM Telescope for any Alpaca-compatible client (NINA, SGPro,
+`rp`, etc.).
+
+The driver implements the subset of `ITelescopeV3` that the rusty-photon
+ecosystem actually needs (slew, sync, track, park, abort, side-of-pier),
+plus the standard device metadata. PulseGuide, MoveAxis, custom tracking
+rates, and polar-alignment helpers are explicitly deferred (see [§MVP
+Scope](#mvp-scope)).
+
+[Sky-Watcher motor-controller command set]: https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf
+
+## Architecture
+
+```
+┌──────────────────────────────┐         ┌──────────────────────────────┐
+│  ASCOM Alpaca clients        │         │  rp service                  │
+│  (NINA, SGPro, Voyager, ...) │         │  (mount tools)               │
+└──────────────┬───────────────┘         └──────────────┬───────────────┘
+               │ HTTP                                    │ HTTP
+               └──────────────────┬─────────────────────┘
+                                  ▼
+                ┌─────────────────────────────────┐
+                │  star-adventurer-gti service    │
+                │                                 │
+                │   ┌──────────────────────────┐  │
+                │   │ MountDevice              │  │
+                │   │  (ASCOM Telescope impl)  │  │
+                │   └────────────┬─────────────┘  │
+                │                │ commands       │
+                │                ▼                │
+                │   ┌──────────────────────────┐  │
+                │   │ TransportManager         │  │
+                │   │  (ref-counted, polls     │  │
+                │   │   axis status + posn)    │  │
+                │   └────────────┬─────────────┘  │
+                │                │ bytes          │
+                │                ▼                │
+                │   ┌──────────────────────────┐  │
+                │   │ Transport (trait)        │  │
+                │   │  ┌──────┐    ┌──────┐    │  │
+                │   │  │serial│    │ udp  │    │  │
+                │   │  └───┬──┘    └───┬──┘    │  │
+                │   └──────┼───────────┼───────┘  │
+                └──────────┼───────────┼──────────┘
+                           ▼           ▼
+                       /dev/ttyACM0   192.168.4.1:11880
+                       (USB-CDC)      (WiFi UDP)
+                           │           │
+                           └─────┬─────┘
+                                 ▼
+                    ┌────────────────────────────┐
+                    │  Star Adventurer GTi mount │
+                    │  (Sky-Watcher motor ctrl)  │
+                    └────────────────────────────┘
+```
+
+The wire protocol is the same on both transports — the [Sky-Watcher
+motor-controller command set] §6 (Wi-Fi Connection) is explicit that the
+WiFi adapter / built-in WiFi module simply runs a UDP server on port 11880
+and accepts the same `:cmd<axis><payload>\r` frames the serial port does.
+Empirically verified on this mount in both modes.
+
+### Crate vs service boundary
+
+Protocol logic lives in the `skywatcher-motor-protocol` crate (under
+`crates/`); transport, polling, state, and ASCOM mapping live in the
+service. The crate is pure (no I/O, no async, no ASCOM types) so it is
+miri-clean and trivially property-testable.
+
+| Component | Crate (`skywatcher-motor-protocol`) | Service (`star-adventurer-gti`) |
+|---|---|---|
+| Frame encode (`Command` → `Vec<u8>`) | ✓ | |
+| Frame decode (`&[u8]` → `Response` / `ProtocolError`) | ✓ | |
+| 24-bit LE nibble-pair hex codec | ✓ | |
+| 0x800000 position-bias add/subtract | ✓ | |
+| Mount-error-code → `ProtocolError` | ✓ | |
+| Async I/O (serial, UDP) | | ✓ |
+| Polling loop, state machine | | ✓ |
+| ASCOM trait implementation | | ✓ |
+| RA/Dec ↔ encoder-tick math | | ✓ |
+| Local-sidereal-time computation | | ✓ |
+| Mount-side parameter discovery (`:a`, `:b`, `:g`) | | ✓ |
+
+The crate is intentionally not Sky-Watcher-mount-specific beyond the wire
+format: it does not know about RA/Dec, ASCOM, or any particular mount's
+gear ratios. A future `az-gti` service or any other mount that speaks this
+protocol could reuse the crate verbatim.
+
+## Hardware Constraints
+
+The Star Adventurer GTi is a portable German Equatorial Mount with a
+counterweight bar. Two control paths from the host:
+
+- **USB-CDC** (USB-C on the mount). Enumerates as `/dev/ttyACM*`
+  (Linux), `/dev/cu.usbmodem*` (macOS), or `COM*` (Windows). The vendor
+  spec says **9600 8N1**; in practice the GTi USB also accepts
+  **115200 baud**, which we recommend (matches EQMOD documentation and
+  is faster). Use the stable `/dev/serial/by-id/...` symlink rather
+  than `/dev/ttyACM0` — the unsuffixed device path can shuffle on
+  reboot when other USB-CDC peripherals (PPBA, focuser, etc.) are
+  present.
+- **WiFi** (built-in, AP mode by default). The mount self-hosts an open
+  access point and listens on **UDP/11880** at `192.168.4.1`. Same
+  protocol; one command per UDP packet, one response per UDP packet.
+  The host **must bind the local socket to a 192.168.4.x source
+  address** explicitly — relying on the kernel to pick a source IP
+  fails when there is a competing default route, and the mount
+  silently drops packets it can't reply to.
+
+Mount-side parameters are queried at connect time rather than hard-coded:
+
+| Parameter | Command | Typical GTi value | Used for |
+|---|---|---|---|
+| Counts per revolution (per axis) | `:a1` / `:a2` | `0x375F00` = 3,628,800 | encoder-tick ↔ angle conversion |
+| Timer-interrupt frequency | `:b1` | `0xF42400` ≈ 16 MHz | step-period (T1 preset) calculation |
+| High-speed ratio | `:g1` / `:g2` | mount-specific (e.g. 16, 32, 64) | high-speed-slew step-period scaling |
+| Motor board version | `:e1` | `0x03300C` (mount type 0x03, fw v0x30.0x0C) | mount-family detection (EQ vs AZ) |
+
+CPR varies between the GTi's RA and Dec axes and between firmware
+revisions; the driver reads both rather than assuming.
+
+The protocol exposes **no native park position** and **no site lat/lon**.
+We implement software park (slew to encoder 0/0) and require site lat/lon
+in the config (see [§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
+
+## Protocol Reference
+
+The motor-controller protocol is a request/response ASCII protocol with
+unusual hex encoding and a position-bias convention. Both are easy to get
+wrong and both are codec-layer concerns the crate isolates.
+
+### Frame format
+
+```
+Command:    : <cmd> <axis> <payload?> \r           1–9 bytes
+Response:   = <payload?>                  \r       1–8 bytes  (success)
+Response:   ! <2-hex-errcode>             \r       4 bytes    (error)
+```
+
+- `<cmd>` is one ASCII letter (case-sensitive). Uppercase = setter / motion
+  command; lowercase = inquiry.
+- `<axis>` is `'1'` (RA / Az motor), `'2'` (Dec / Alt motor), or `'3'`
+  (both axes — only valid for some commands).
+- `<payload>` is 1–6 ASCII hex bytes (`'0'`–`'9'`, `'A'`–`'F'`). Empty for
+  payload-less commands.
+- All frames terminate with a single `\r` (`0x0D`). **No `\n`.** UDP
+  responses do include a trailing `\r`.
+- If the controller sees a second `:` before `\r`, it discards the partial
+  frame and starts fresh — useful for resync after a corrupted packet.
+
+### UDP framing strictness
+
+When the transport is UDP, framing is unforgiving (empirically verified on
+the GTi):
+
+| Variant | Behaviour |
+|---|---|
+| `:e1\r` | reply received |
+| `:e1\r\n` | reply received (trailing `\n` tolerated) |
+| `:e1` (no `\r`) | silent — controller waits for terminator |
+| `:e1\r` + trailing zero-padding | silent — extra bytes after `\r` reject the packet |
+| `\xff…:e1\r` (junk-prefixed) | silent — bytes before `:` reject the packet |
+
+The codec must enforce: exactly one well-formed frame per UDP packet,
+nothing trailing.
+
+### Hex encoding (24-bit data — low byte first, nibbles in order)
+
+For the 24-bit value `0x123456`, the wire bytes are ASCII
+`"5" "6" "3" "4" "1" "2"` — i.e., low byte first, with each byte's nibbles
+in normal high-then-low order.
+
+```
+0x123456  →  bytes 0x56, 0x34, 0x12  →  ASCII "56" "34" "12"
+                                      →  "563412"
+```
+
+This is the source of the most common implementation bug; the codec
+exposes typed `encode_u24` / `decode_u24` (and `_i24`) helpers and the
+service is forbidden from rolling its own hex translation.
+
+### Position-bias offset 0x800000
+
+Axis positions are conveyed with a fixed bias of `0x800000` to keep them
+unsigned on the wire while permitting signed-positive and signed-negative
+encoder counts:
+
+| Encoder count (true) | Wire value |
+|---|---|
+| `0` | `0x800000` |
+| `+1` | `0x800001` |
+| `-1` | `0x7FFFFF` |
+| `+0x1234` | `0x801234` |
+| `-0x1234` | `0x7FEDCC` |
+
+The codec subtracts on decode and adds on encode; service code sees
+signed-`i32` encoder counts only.
+
+### Error codes
+
+| Code | Name | ASCOM mapping |
+|---|---|---|
+| `0` | UnknownCommand | `INVALID_OPERATION` (programmer error, log) |
+| `1` | CommandLengthError | `INVALID_OPERATION` (programmer error, log) |
+| `2` | MotorNotStopped | `INVALID_OPERATION` |
+| `3` | InvalidCharacter | `INVALID_OPERATION` (programmer error, log) |
+| `4` | NotInitialized | propagate as transport error; driver re-issues `:F` |
+| `5` | DriverSleeping | propagate; user must re-power mount |
+| `7` | PECTrainingRunning | `INVALID_OPERATION` (PEC out of MVP scope) |
+| `8` | NoValidPECData | `INVALID_OPERATION` (PEC out of MVP scope) |
+
+### Initialisation sequence
+
+After opening the transport and before the first motion command:
+
+1. `:F1` → expect `=\r` (Initialize axis 1)
+2. `:F2` → expect `=\r` (Initialize axis 2)
+3. `:a1` → record RA-axis CPR
+4. `:a2` → record Dec-axis CPR
+5. `:b1` → record TMR_Freq
+6. `:g1` → record RA-axis high-speed ratio
+7. `:g2` → record Dec-axis high-speed ratio
+8. `:e1` → log mount type / firmware version
+9. `:j1` / `:j2` → record initial encoder positions
+
+These values seed the in-memory mount-parameters cache used by the
+coordinate module and the slew planner.
+
+### Commands used by the MVP
+
+| Command | Purpose | MVP usage |
+|---|---|---|
+| `:E<axis><pos24>` | Set axis position (sync) | implements `SyncToCoordinatesAsync` |
+| `:F<axis>` | Initialize axis | connect handshake |
+| `:G<axis><mode2>` | Set motion mode (Goto/Tracking, fast/slow, dir, etc.) | every slew, every track-state change |
+| `:H<axis><inc24>` | Set goto-target by increment | not used (we use absolute target) |
+| `:S<axis><pos24>` | Set goto absolute target | every slew |
+| `:I<axis><period24>` | Set step period (T1 preset) | tracking rate, slew rate |
+| `:J<axis>` | Start motion | every slew, every track start |
+| `:K<axis>` | Stop motion (decelerate) | end of tracking, abort |
+| `:L<axis>` | Instant stop | `AbortSlew` |
+| `:a<axis>` | Inquire CPR | connect handshake |
+| `:b1` | Inquire TMR_Freq | connect handshake |
+| `:e<axis>` | Inquire motor-board version | connect handshake (logging only) |
+| `:f<axis>` | Inquire status | polled while slewing / tracking |
+| `:g<axis>` | Inquire high-speed ratio | connect handshake |
+| `:j<axis>` | Inquire current position | every position-read |
+
+## ASCOM Telescope Mapping
+
+Every property/method on `ITelescopeV3`, what the driver returns, and why.
+
+### Capability flags
+
+| Flag | Value | Reason |
+|---|---|---|
+| `AlignmentMode` | `GermanPolar` | GTi is a true GEM with counterweight; meridian-flip semantics apply |
+| `EquatorialSystem` | `Topocentric` | Driver convention; the wire protocol is epoch-agnostic, and topocentric matches what host planning code (rp) is wired for |
+| `CanSlew` | `true` | implemented |
+| `CanSlewAsync` | `true` | implemented (non-blocking; poll `Slewing`) |
+| `CanSlewAltAz` | `false` | RA/Dec only in MVP |
+| `CanSlewAltAzAsync` | `false` | RA/Dec only in MVP |
+| `CanSync` | `true` | implemented via `:E` |
+| `CanSyncAltAz` | `false` | RA/Dec only in MVP |
+| `CanSetTracking` | `true` | implemented (sidereal only) |
+| `CanSetTrackingRate` | `false` | sidereal only in MVP |
+| `CanSetRightAscensionRate` | `false` | custom rates deferred |
+| `CanSetDeclinationRate` | `false` | custom rates deferred |
+| `CanSetGuideRates` | `false` | PulseGuide deferred |
+| `CanPulseGuide` | `false` | PulseGuide deferred |
+| `CanMoveAxis(any)` | `false` | manual slew deferred |
+| `CanFindHome` | `false` | no hardware home position |
+| `CanPark` | `true` | implemented (software park) |
+| `CanUnpark` | `true` | implemented |
+| `CanSetPark` | `false` | park position fixed at encoder 0/0 in MVP |
+| `CanSetPierSide` | `false` | mount manages pier side via slew direction |
+| `CanSetSideOfPier` | `false` | same as above |
+| `DoesRefraction` | `false` | mount applies no refraction model; host (rp) provides refracted coords |
+| `TrackingRates` | `[Sidereal]` | sidereal only in MVP |
+
+### Reads
+
+| Property | Implementation |
+|---|---|
+| `RightAscension` | from current RA-axis encoder + LST + sync offset |
+| `Declination` | from current Dec-axis encoder + sync offset |
+| `Azimuth` | derived from RA/Dec + site lat/lon + LST |
+| `Altitude` | derived as above |
+| `TargetRightAscension` | last `SlewToCoordinatesAsync` / `SlewToTargetAsync` target; `INVALID_OPERATION` if not set |
+| `TargetDeclination` | as above |
+| `Slewing` | `true` while either axis status (`:f`) reports running in Goto mode; cleared when both stop |
+| `Tracking` | driver-state mirror of last `Tracking` setter |
+| `TrackingRate` | always `Sidereal` in MVP |
+| `AtPark` | driver-state flag; set by `Park`, cleared by `Unpark` and by any motion command |
+| `AtHome` | `false` (no hardware home concept) |
+| `SideOfPier` | derived from RA-axis encoder + site latitude (sign matters: spec defines E/W meaning differently in N vs S hemisphere) |
+| `SiteLatitude` | from config (read-only; setter returns `NOT_IMPLEMENTED`) |
+| `SiteLongitude` | as above |
+| `SiteElevation` | from config; defaults to `0` |
+| `UTCDate` | host clock (per ASCOM convention; setter writes a host-side offset only) |
+| `SiderealTime` | computed from `UTCDate` + `SiteLongitude` |
+| `SlewSettleTime` | from config; setter is allowed (writes the in-memory cache only, not config file) |
+
+### Writes / methods
+
+| Method | Implementation |
+|---|---|
+| `Connected = true` | open transport, run init handshake, populate parameter cache, start polling |
+| `Connected = false` | stop polling, close transport, clear parameter cache |
+| `SlewToCoordinatesAsync(ra, dec)` | validate (not parked, valid coords), compute target encoder positions, issue `:G` `:S` `:J` per axis, set `Slewing=true`. Returns immediately; caller polls `Slewing` |
+| `SlewToTargetAsync()` | uses last-set `TargetRightAscension`/`Declination` |
+| `SyncToCoordinates(ra, dec)` | issue `:E<axis><pos>` for each axis (set encoder position) and update sync offset |
+| `SyncToTarget()` | uses last-set target |
+| `AbortSlew()` | issue `:L1` `:L2` (instant stop), clear `Slewing`, do NOT auto-restore tracking |
+| `Park()` | stop tracking, slew both axes to encoder 0/0, when both report stopped set `AtPark=true`. **Tracking remains off after park** (per ASCOM) |
+| `Unpark()` | clear `AtPark`. Does NOT auto-enable tracking |
+| `SetPark()` | `NOT_IMPLEMENTED` in MVP |
+| `Tracking = true` | issue `:G<RA>` (Tracking + sidereal) + `:I<RA>` (sidereal step period) + `:J<RA>`. Dec axis untouched |
+| `Tracking = false` | issue `:K<RA>` (decelerate to stop) |
+| `FindHome()` | `NOT_IMPLEMENTED` |
+| `MoveAxis(*)` | `NOT_IMPLEMENTED` |
+| `PulseGuide(*)` | `NOT_IMPLEMENTED` |
+| `Action(name, parameters)` | `ACTION_NOT_IMPLEMENTED` for all action names in MVP |
+
+### Slew lifecycle
+
+```
+SlewToCoordinatesAsync(ra, dec)
+   │
+   ├─ validate: !AtPark, ra ∈ [0,24), dec ∈ [-90,90]
+   ├─ remember: TargetRightAscension/Declination = (ra, dec)
+   ├─ compute: (ra_target_ticks, dec_target_ticks) from
+   │           ra/dec + LST + sync offset + side-of-pier choice
+   │
+   ├─ for each axis:
+   │     :K<axis>      stop motor (no-op if already stopped)
+   │     poll :f<axis> until Running=0 (max 1 s)
+   │     :G<axis><mode>  motion mode = Goto, direction by sign of delta
+   │     :S<axis><pos>   target = wire(target_ticks)  (with 0x800000 bias)
+   │     :J<axis>      start motion
+   │
+   ├─ Slewing = true
+   └─ background poll :f1 / :f2 every 200 ms
+        └─ when both axes report Running=0 in Goto mode → Slewing = false
+        └─ if Tracking was on: re-issue tracking-mode :G + :I + :J on RA axis
+        └─ apply config.settle_after_slew before returning Slewing=false
+```
+
+### Park lifecycle
+
+```
+Park()
+   │
+   ├─ if AtPark: return immediately (idempotent)
+   ├─ Tracking = false (issue :K on RA axis)
+   │
+   ├─ for each axis:
+   │     :G<axis><goto-mode>
+   │     :S<axis>800000     target = encoder 0
+   │     :J<axis>
+   │
+   ├─ background poll :f1 / :f2 until both stopped
+   │     (no auto-abort on timeout — caller must AbortSlew if stuck;
+   │      matches rp.md park behaviour)
+   ├─ AtPark = true
+   └─ Tracking remains false
+```
+
+### Side-of-pier
+
+`SideOfPier` is derived from the RA-axis encoder position and the site
+latitude:
+
+- Convert RA-axis encoder ticks → mechanical hour-angle (signed, range
+  `[-12, +12)`).
+- In **northern hemisphere** (`SiteLatitude > 0`): mechanical HA in
+  `[-6, +6)` → OTA on the **east** side of the pier (`PierSide::East`);
+  `[+6, +18) ≡ [-12, -6) ∪ [+6, +12)` → **west** side.
+- In **southern hemisphere**: the convention inverts (per
+  Sky-Watcher's hand-control protocol §"Get Mount Pointing State").
+
+The MVP does **not** implement `DestinationSideOfPier` (slew-target
+prediction); reads always return one of `East` / `West` based on current
+encoder position.
+
+## Configuration
+
+JSON, deserialised with `serde` + `humantime-serde` for `Duration`
+fields. The transport block is a tagged enum: `usb` or `udp`.
+
+```json
+{
+  "transport": {
+    "kind": "usb",
+    "port": "/dev/serial/by-id/usb-STMicroelectronics_STM32_Virtual_ComPort_4E8741795300-if00",
+    "baud_rate": 115200,
+    "command_timeout": "2s",
+    "polling_interval": "200ms"
+  },
+  "server": {
+    "port": 11117,
+    "discovery_port": 32227,
+    "tls": null,
+    "auth": null
+  },
+  "mount": {
+    "name": "Star Adventurer GTi",
+    "unique_id": "skywatcher-sa-gti-001",
+    "description": "Sky-Watcher Star Adventurer GTi German Equatorial Mount",
+    "enabled": true,
+    "site_latitude_deg": 37.7749,
+    "site_longitude_deg": -122.4194,
+    "site_elevation_m": 0.0,
+    "settle_after_slew": "2s",
+    "tracking_rate": "sidereal"
+  }
+}
+```
+
+The WiFi variant of `transport`:
+
+```json
+"transport": {
+  "kind": "udp",
+  "address": "192.168.4.1",
+  "port": 11880,
+  "bind_address": "192.168.4.2",
+  "command_timeout": "2s",
+  "polling_interval": "200ms"
+}
+```
+
+Notes:
+
+- `bind_address` is **mandatory** for UDP (must be a 192.168.4.0/24 host
+  IP when the mount is in AP mode). Without it, the kernel may select a
+  source IP that the mount cannot reach, and packets are silently
+  dropped.
+- `polling_interval` controls the rate at which the background loop reads
+  `:f` (axis status) and `:j` (axis position). 200 ms is a reasonable
+  default; `rp` polls `Slewing` no faster than 100 ms so this gives the
+  driver headroom.
+- `settle_after_slew` is applied *after* both axes report stopped, before
+  `Slewing` clears. Mirrors `rp`'s `mount.settle_after_slew` config.
+- `site_latitude_deg` is in WGS84 degrees, `+N`. `site_longitude_deg` is
+  WGS84 degrees, `+E`. (ASCOM convention.)
+- `tracking_rate` accepts `"sidereal"` only in MVP. Field is reserved
+  for future expansion.
+
+### CLI arguments
+
+| Argument | Description |
+|---|---|
+| `-c, --config <PATH>` | Path to JSON config file |
+| `--transport <usb\|udp>` | Override `transport.kind` |
+| `--port <DEVICE_OR_HOST>` | Override `transport.port` (USB) or `transport.address` (UDP) |
+| `--baud <RATE>` | Override `transport.baud_rate` (USB only) |
+| `--server-port <PORT>` | Override `server.port` |
+| `-l, --log-level <LEVEL>` | `trace` / `debug` / `info` / `warn` / `error` |
+
+## Module Structure
+
+### `crates/skywatcher-motor-protocol`
+
+```
+src/
+  lib.rs       — re-exports, crate-level docs, the protocol overview
+  error.rs     — ProtocolError (FrameError, HexError, MountError(code))
+  command.rs   — Command enum, Command::encode_into(&mut Vec<u8>)
+  response.rs  — Response enum, Response::decode(&[u8])
+  codec.rs     — encode_u24 / decode_u24 (LE nibble-pair),
+                 encode_position / decode_position (with 0x800000 bias),
+                 frame helpers
+```
+
+Pure functions; no I/O, no async, no `tokio`, no `ascom-alpaca`. Unit
+tests live alongside each module as `#[cfg(test)] mod tests` blocks;
+property tests for round-trip invariants live in
+`tests/property_tests.rs`.
+
+### `services/star-adventurer-gti`
+
+```
+src/
+  config.rs              — Config types (TransportConfig, ServerConfig,
+                           MountConfig); humantime-serde for durations
+  error.rs               — StarAdvError + ASCOM-error mapping
+  transport/
+    mod.rs               — Transport trait (async send_frame + recv_frame)
+    serial.rs            — tokio-serial impl
+    udp.rs               — tokio UdpSocket impl (with bind-IP enforcement)
+    mock.rs              — feature("mock") in-memory state-machine impl
+  transport_manager.rs   — ref-counted shared transport, background polling,
+                           parameter cache (CPR, TMR_Freq, hsr per axis)
+  coordinates.rs         — encoder-tick ↔ angle, LST, sync offset,
+                           side-of-pier derivation
+  mount_device.rs        — ASCOM Device + Telescope trait impl
+  lib.rs                 — ServerBuilder, module declarations
+  main.rs                — CLI entry point
+tests/
+  bdd.rs                 — cucumber harness (harness = false)
+  bdd/
+    world.rs             — World struct + helpers
+    steps/
+      mod.rs
+      connection_steps.rs
+      slew_steps.rs
+      tracking_steps.rs
+      park_steps.rs
+      sync_steps.rs
+      side_of_pier_steps.rs
+  features/
+    connection_lifecycle.feature
+    device_metadata.feature
+    coordinate_reads.feature
+    slew.feature
+    sync.feature
+    tracking.feature
+    park.feature
+    abort.feature
+    side_of_pier.feature
+  test_lib.rs            — server-startup + CLI tests (gated on `mock`)
+  conformu_integration.rs — ASCOM compliance (gated on `conformu`)
+```
+
+## Testing
+
+The strategy follows
+[`docs/skills/testing.md`](../skills/testing.md): BDD scenarios are the
+canonical contract; unit tests cover protocol parsing and coordinate math;
+ConformU verifies ASCOM compliance.
+
+| Layer | Coverage |
+|---|---|
+| Crate unit tests (`#[cfg(test)]`) | command/response encode-decode, codec edge cases (0x000000, 0xFFFFFF, signed boundaries), error parsing, frame framing rules |
+| Crate property tests (`tests/property_tests.rs`) | round-trip: random `Command` → bytes → `Command`; same for `Response`; bias-offset preservation across signed `i32` range |
+| Service unit tests (`#[cfg(test)]` per module) | `coordinates`: encoder ↔ RA/Dec across edge cases (poles, meridian, hemisphere flip); `config`: defaults, JSON round-trips, CLI overrides; `error`: ASCOM mapping |
+| Service BDD (cucumber) | every behaviour table-row above as a scenario, with the mock transport |
+| Service `test_lib.rs` (gated on `mock`) | server starts, binds the configured port, exposes the configured device |
+| `conformu_integration.rs` (gated on `conformu`) | ASCOM Telescope compliance |
+
+The mock transport is a feature-gated in-memory state machine that
+simulates the motor controller — it accepts the same `:cmd<axis>...\r`
+frames and emits well-formed `=...\r` / `!XX\r` responses, with internal
+state for axis position, motion mode, running/stopped, and tracking. BDD
+tests use the mock by default; ConformU and `test_lib.rs` use the
+feature-gated mock so the binary itself runs against a fake mount.
+
+## Connection Lifecycle
+
+```
+Connected = true
+   ↓
+open transport (serial: tokio-serial open + raw mode;
+                UDP: bind to config.bind_address, set timeout)
+   ↓
+init handshake:
+  :F1, :F2          (initialize axes)
+  :a1, :a2          (CPR per axis)         → cache
+  :b1               (TMR_Freq)             → cache
+  :g1, :g2          (high-speed ratio)     → cache
+  :e1               (motor board version)  → debug! log
+  :j1, :j2          (initial positions)    → cache
+   ↓
+start background polling task (interval = config.polling_interval)
+   ↓
+Connected reports true once handshake completes
+```
+
+```
+Connected = false
+   ↓
+abort any in-progress motion (:L1, :L2 — instant stop)
+   ↓
+stop tracking if running (:K1)
+   ↓
+cancel polling task
+   ↓
+close transport
+   ↓
+clear parameter cache
+```
+
+The transport is reference-counted: if multiple Alpaca clients each call
+`Connected = true`, the underlying transport is opened once and shared.
+Disconnect tears down only when the last reference drops. (Same pattern
+as `qhy-focuser` and `ppba-driver`.)
+
+## MVP Scope
+
+### In-scope (Phase 3 will turn these green)
+
+- USB transport at 115200 baud (`/dev/serial/by-id/...` path in config)
+- UDP transport at 192.168.4.1:11880 (bind to local 192.168.4.x)
+- Connect / disconnect lifecycle, ref-counted transport
+- Init handshake: `:F`, `:a`, `:b`, `:g`, `:e`, `:j`
+- ASCOM device metadata (`Description`, `DriverInfo`, `DriverVersion`,
+  `InterfaceVersion`, `Name`, `SupportedActions = []`)
+- Site lat/lon/elevation from config (read-only via ASCOM)
+- `RightAscension` / `Declination` reads (encoder + LST + sync offset)
+- `Azimuth` / `Altitude` reads (derived from RA/Dec)
+- `SyncToCoordinates` / `SyncToTarget`
+- `SlewToCoordinatesAsync` / `SlewToTargetAsync`
+- `AbortSlew`
+- `Tracking` setter / getter (sidereal only)
+- `Park` / `Unpark` (software park to encoder 0/0)
+- `AtPark` / `AtHome` reads
+- `SideOfPier` read
+- `Slewing` poll
+- `UTCDate` / `SiderealTime` (host-clock-derived)
+- Mock transport for BDD tests; feature-gated mock for `test_lib.rs` and
+  ConformU
+- ASCOM Alpaca discovery on the standard port
+
+### Deferred (not in MVP)
+
+| Capability | Why deferred |
+|---|---|
+| `PulseGuide`, `CanPulseGuide`, `GuideRate*` | autoguiding via the mount's ST4-equivalent — protocol command exists (`P`) but driver-side rate calibration plus BDD coverage is a substantial extension; PHD2 already drives guide pulses through `phd2-guider`'s direct-mount path, so no rp-side dependency |
+| `MoveAxis`, `CanMoveAxis(*)` | manual hand-paddle-style slew rates; not needed by `rp`; deferred along with custom tracking rates |
+| `SlewToAltAz*`, `SyncToAltAz`, `CanSlewAltAz*` | RA/Dec coverage is sufficient for `rp`'s tools; Alt/Az slew is a separate path through the coordinate module |
+| `RightAscensionRate`, `DeclinationRate` setters | custom-rate tracking; not needed for sidereal-only MVP |
+| `TrackingRate` setter (lunar / solar / king) | sidereal covers astrophotography; lunar/solar are uncommon and add a small mode-switch matrix |
+| `SetPark`, `CanSetPark` | park position is fixed at encoder 0/0 (the mount's natural power-up state); user-defined park positions are a follow-up |
+| `FindHome`, `CanFindHome` | no hardware home sensor on the GTi |
+| `Action` / custom commands | no driver-specific actions in MVP |
+| `DestinationSideOfPier` | requires slew planner; current-pier read is enough for `rp`'s built-in tools |
+| Polar-alignment helpers, TPOINT, cone error | observational pointing model is the host's concern, not the driver's |
+| WiFi station mode (mount on a routed network) | AP-mode UDP is verified; station mode just changes the bind-address selection — straightforward to add once a station-mode test setup exists |
+| Multi-mount support on a single binary | `rp` assumes one mount per service; multi-mount is a separate concern |
+
+## References
+
+### Authoritative
+
+- [Sky-Watcher motor controller command set] — the wire protocol
+  specification, including the §6 Wi-Fi note that the same protocol runs
+  on UDP/11880. An in-tree markdown rendering is at
+  [`docs/references/skywatcher-motor-controller-command-set.md`](../references/skywatcher-motor-controller-command-set.md)
+  for offline / version-pinned reference.
+- [INDI eqmod driver source](https://github.com/indilib/indi-3rdparty/tree/master/indi-eqmod)
+  — the canonical open-source reference implementation; we cross-check
+  ambiguous bits of the spec against this driver.
+- [EQMOD project](https://eq-mod.sourceforge.net/) — Windows-side
+  reference driver and protocol-decoding documentation.
+
+### Misleading and explicitly out-of-scope
+
+The Sky-Watcher developer downloads page hosts two other protocol PDFs
+that look superficially relevant but are *not* applicable to the GTi USB
+or WiFi connection — recording here so future readers don't fall into
+the same trap:
+
+- [SynScan v3.3 hand-control protocol](https://inter-static.skywatcher.com/downloads/synscanserialcommunicationprotocol_version33.pdf)
+  — describes commands the SynScan **hand controller** accepts on its
+  RS-232 port at 9600 baud (single-char ASCII, `#`-terminated, J2000
+  RA/Dec). The GTi has no hand controller and its USB / WiFi do not
+  speak this protocol. Empirically verified.
+- [SynScan App Protocol](https://inter-static.skywatcher.com/downloads/synscan_app_protocol_20250930.pdf)
+  — describes a remote-control protocol for the **SynScan app itself**
+  (third-party software → SynScan app on phone/desktop → mount on
+  UDP/TCP 11881). Useless as a direct-to-mount protocol because it
+  requires SynScan app as a middleman.
+
+### Related rusty-photon docs
+
+- [`docs/services/rp.md`](rp.md) — the mount-tool consumer; defines the
+  high-level slew/park/track/sync/abort tool surface and the
+  `EquatorialCoordinateType` and `SiteLatitude`/`SiteLongitude`
+  expectations.
+- [`docs/services/qhy-focuser.md`](qhy-focuser.md) — the closest
+  architectural sibling; same transport/manager/device/mock pattern,
+  feature-flags, and BDD layout.
+- [`docs/references/ascom-alpaca.md`](../references/ascom-alpaca.md) —
+  ASCOM Alpaca protocol overview and error-code reference.
+- [`docs/skills/development-workflow.md`](../skills/development-workflow.md)
+  — the design-first / test-first / implementation workflow this doc
+  is the Phase 1 deliverable for.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -17,6 +17,7 @@ belong in any single service design doc.
 | [plate-solver](services/plate-solver.md) | — (rp-managed service wrapping ASTAP) | 11131 | `docs/services/plate-solver.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
+| [star-adventurer-gti](services/star-adventurer-gti.md) | Telescope | 11117 | `docs/services/star-adventurer-gti.md` (design only — Phase 1) |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |
 
 ## Documentation Index
@@ -31,6 +32,7 @@ belong in any single service design doc.
 | [docs/skills/pre-push.md](skills/pre-push.md) | Skill: running CI quality gates before pushing |
 | **References** | |
 | [docs/references/ascom-alpaca.md](references/ascom-alpaca.md) | ASCOM Alpaca protocol reference |
+| [docs/references/skywatcher-motor-controller-command-set.md](references/skywatcher-motor-controller-command-set.md) | Sky-Watcher motor-controller wire protocol (USB + UDP/11880) — used by `star-adventurer-gti` |
 | **Decisions** (Architecture Decision Records — see [docs/decisions/](decisions/)) | |
 | [ADR-001](decisions/001-fits-file-support.md) | FITS file support |
 | [ADR-002](decisions/002-tls-for-inter-service-communication.md) | TLS for inter-service communication |


### PR DESCRIPTION
## Summary

- Phase 1 (design-doc-only) deliverable for the Sky-Watcher Star Adventurer GTi ASCOM Telescope driver, per [`docs/skills/development-workflow.md`](docs/skills/development-workflow.md). BDD scaffolding (Phase 2) and implementation (Phase 3) will follow in separate PRs.
- New `docs/services/star-adventurer-gti.md` (~686 lines) covers: architecture (the `skywatcher-motor-protocol` crate vs service split), USB and UDP/11880 WiFi transports (same wire format on both, empirically verified on this mount), the `0x800000` position bias and low-byte-first nibble-pair hex encoding, ASCOM Telescope mapping with capability flags and rationale, slew/park/track lifecycles, configuration JSON for both transports, module layout, testing strategy, and the explicit MVP-vs-deferred boundary.
- New `docs/references/skywatcher-motor-controller-command-set.md` (~415 lines) is an in-tree markdown rendering of the canonical Sky-Watcher PDF for offline / version-pinned reference; canonical URL and attribution preserved.
- `docs/workspace.md` indexes both new files.

The design-doc References section explicitly rules out two superficially-similar but inapplicable Sky-Watcher protocols (SynScan v3.3 hand-control and the SynScan App Protocol) — both verified inapplicable via direct USB and WiFi probes — so future readers don't fall into the same research traps.

## Test plan

- [ ] CI green on docs-only changes (`cargo rail plan` reports `surfaces: docs`, `scope: empty`, so no Rust packages affected)
- [ ] Internal links in the design doc and reference doc resolve
- [ ] No Markdown formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)