### PR TITLE
feat(rp): center_on_target compound tool (Phase 6c-3)

### DIFF
--- a/crates/bdd-infra/src/rp_harness/mod.rs
+++ b/crates/bdd-infra/src/rp_harness/mod.rs
@@ -38,5 +38,5 @@ pub use launcher::{start_rp, wait_for_rp_healthy, write_temp_config_file};
 pub use mcp_client::McpTestClient;
 pub use omnisim::OmniSimHandle;
 pub use orchestrator::{OrchestratorBehavior, OrchestratorInvocation, TestOrchestrator};
-pub use plate_solver_stub::{PlateSolverStub, StubBehavior};
+pub use plate_solver_stub::{CannedWcs, PlateSolverStub, StubBehavior};
 pub use webhook::{ReceivedEvent, WebhookReceiver};

--- a/crates/bdd-infra/src/rp_harness/plate_solver_stub.rs
+++ b/crates/bdd-infra/src/rp_harness/plate_solver_stub.rs
@@ -23,17 +23,31 @@ use axum::{Json, Router};
 use serde_json::Value;
 use tokio::sync::RwLock;
 
+/// One canned 200 success body. Used as the payload for both the
+/// single-shot `CannedWcs` variant (where every solve call returns
+/// the same body) and the `Sequence` variant (where successive
+/// solve calls walk the queue).
+#[derive(Debug, Clone)]
+pub struct CannedWcs {
+    pub ra_center: f64,
+    pub dec_center: f64,
+    pub pixel_scale_arcsec: f64,
+    pub rotation_deg: f64,
+    pub solver: String,
+}
+
 /// Canned response variants the stub can return for `POST /api/v1/solve`.
 #[derive(Debug, Clone)]
 pub enum StubBehavior {
-    /// Return a fixed 200 success body.
-    CannedWcs {
-        ra_center: f64,
-        dec_center: f64,
-        pixel_scale_arcsec: f64,
-        rotation_deg: f64,
-        solver: String,
-    },
+    /// Return a fixed 200 success body for every call.
+    Canned(CannedWcs),
+    /// Walk a queue of WCS responses, one per call. After the last
+    /// queued entry is consumed, subsequent calls keep returning the
+    /// final entry — this lets `center_on_target` tests express
+    /// "first iter outside tolerance, then converged" without having
+    /// to count the exact number of solves the loop will make.
+    /// `responses` must be non-empty.
+    Sequence(Vec<CannedWcs>),
     /// Return a structured error envelope. `code` matches the
     /// wrapper's `ErrorCode` (`invalid_request`, `fits_not_found`,
     /// `solve_failed`, `solve_timeout`, `internal`); the appropriate
@@ -45,13 +59,13 @@ impl StubBehavior {
     /// Default canned WCS used by happy-path scenarios: RA 10.6848°
     /// (≈ M31), Dec 41.269°, 1.05"/px scale, 12.3° rotation.
     pub fn default_canned_wcs() -> Self {
-        Self::CannedWcs {
+        Self::Canned(CannedWcs {
             ra_center: 10.6848,
             dec_center: 41.269,
             pixel_scale_arcsec: 1.05,
             rotation_deg: 12.3,
             solver: "stub-astap-1.0".to_string(),
-        }
+        })
     }
 }
 
@@ -69,16 +83,28 @@ pub struct PlateSolverStub {
 struct StubState {
     behavior: StubBehavior,
     requests: Arc<RwLock<Vec<Value>>>,
+    /// Cursor into `Sequence` behavior's response queue — incremented
+    /// per call, clamped to the last entry once exhausted. Unused for
+    /// the other variants. `Arc<...>` so cloning the State (axum does
+    /// it once per request) shares the cursor across handlers.
+    sequence_cursor: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl PlateSolverStub {
     /// Spawn an axum router on `127.0.0.1:0` returning the configured
     /// canned response for every `POST /api/v1/solve`.
     pub async fn start(behavior: StubBehavior) -> Self {
+        if let StubBehavior::Sequence(responses) = &behavior {
+            assert!(
+                !responses.is_empty(),
+                "PlateSolverStub::start: Sequence must have at least one response"
+            );
+        }
         let requests: Arc<RwLock<Vec<Value>>> = Arc::new(RwLock::new(Vec::new()));
         let state = StubState {
             behavior,
             requests: requests.clone(),
+            sequence_cursor: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         };
 
         let app = Router::new()
@@ -136,20 +162,15 @@ async fn solve_handler(
     state.requests.write().await.push(body);
 
     match state.behavior {
-        StubBehavior::CannedWcs {
-            ra_center,
-            dec_center,
-            pixel_scale_arcsec,
-            rotation_deg,
-            ref solver,
-        } => Json(serde_json::json!({
-            "ra_center": ra_center,
-            "dec_center": dec_center,
-            "pixel_scale_arcsec": pixel_scale_arcsec,
-            "rotation_deg": rotation_deg,
-            "solver": solver,
-        }))
-        .into_response(),
+        StubBehavior::Canned(ref wcs) => canned_response(wcs),
+        StubBehavior::Sequence(ref responses) => {
+            // Walk the queue, clamping at the final entry.
+            let idx = state
+                .sequence_cursor
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .min(responses.len() - 1);
+            canned_response(&responses[idx])
+        }
         StubBehavior::Error {
             ref code,
             ref message,
@@ -169,4 +190,15 @@ async fn solve_handler(
             (status, body).into_response()
         }
     }
+}
+
+fn canned_response(wcs: &CannedWcs) -> axum::response::Response {
+    Json(serde_json::json!({
+        "ra_center": wcs.ra_center,
+        "dec_center": wcs.dec_center,
+        "pixel_scale_arcsec": wcs.pixel_scale_arcsec,
+        "rotation_deg": wcs.rotation_deg,
+        "solver": wcs.solver,
+    }))
+    .into_response()
 }

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -7,7 +7,7 @@ Proposed (2026-05-01).
 This ADR is the prerequisite called out in `docs/services/rp.md`
 §"Plate Solver" ("The choice of plate solving engine requires further
 research […] This decision will be captured in a separate ADR") and in
-`docs/plans/image-evaluation-tools.md` Phase 6c (`center_on_target` is
+`docs/plans/archive/image-evaluation-tools.md` Phase 6c (`center_on_target` is
 blocked on it). Once accepted, Phase 6c is unblocked and a separate
 plan will sequence the `plate-solver` rp-managed-service
 implementation.
@@ -684,7 +684,7 @@ shape are all consistent with this analysis. ADR-005 OQ #5 is
 - `docs/services/rp.md` §"Image Analysis Strategy / Design Rationale"
   — the SEP / `sep-sys` rejection memo whose "LGPL + FFI burden"
   wording is reread in this ADR.
-- `docs/plans/image-evaluation-tools.md` Phase 6c — the blocked work
+- `docs/plans/archive/image-evaluation-tools.md` Phase 6c — the blocked work
   item this ADR unblocks.
 - `docs/decisions/001-fits-file-support.md` — prior decision on
   cross-platform native libraries; informed the cross-platform bar.

--- a/docs/plans/archive/image-evaluation-tools.md
+++ b/docs/plans/archive/image-evaluation-tools.md
@@ -1,21 +1,51 @@
 # Plan: Image evaluation tools in rp
 
-**Date:** 2026-04-28
+**Status: COMPLETE (archived 2026-05-09).** All seven phases shipped;
+the only items not addressed are the explicitly-deferred entries
+under [Out of scope / deferred](#out-of-scope--deferred).
+
+**Date:** 2026-04-28 (plan opened)
+**Closed:** 2026-05-09
 **Branch:** `worktree-image-evaluation-tools`
+
+## Status snapshot
+
+| Phase | Subject | Status |
+|-------|---------|--------|
+| 1 | Design doc updates | complete |
+| 2 | BDD scenarios for `measure_basic` | complete |
+| 3 | `imaging/` module promotion + image cache | complete |
+| 4 | Implement `measure_basic` | complete |
+| 5 | Subsequent image-analysis tools (`estimate_background`, `detect_stars`, `measure_stars`, `compute_snr`) | complete |
+| 6 prep | Module reorg (imaging vs. persistence) | complete |
+| 6a | Focuser primitives | complete |
+| 6b | `auto_focus` design + BDD + impl | complete |
+| 6c-prep | Mount primitives | complete |
+| 6c-1 | `plate-solver` rp-managed service (separate plan: [`plate-solver.md`](plate-solver.md)) | complete |
+| 6c-2 | `plate_solve` built-in MCP tool | complete |
+| 6c-3 | `center_on_target` design + BDD + impl | complete |
+| 7 | Unified document/image cache + UUID-suffixed filenames | complete |
+
+The only deferred items remaining are documented under
+[Out of scope / deferred](#out-of-scope--deferred). The rest of the
+plan below is preserved for historical context — phase status banners
+inside each section reflect the as-of date the work landed.
 
 ## Background
 
-`rp` ships only `compute_image_stats` today. The MCP catalog already lists
-`measure_basic` (HFR, star count, background) but it is not implemented, and
-there is no path for the broader image-evaluation toolkit needed by focus,
-centering, and quality-screening workflows. This plan adds those tools as
-**built-in** capabilities of `rp` per the "batteries included" architecture
-clarified during design — see `docs/services/rp.md` (Component Categories
-and Image Analysis Strategy).
+When the plan opened (2026-04-28) `rp` shipped only `compute_image_stats`.
+The MCP catalog listed `measure_basic` (HFR, star count, background) but
+it was not implemented, and there was no path for the broader image-
+evaluation toolkit needed by focus, centering, and quality-screening
+workflows. This plan added those tools as **built-in** capabilities of
+`rp` per the "batteries included" architecture clarified during design
+— see `docs/services/rp.md` (Component Categories and Image Analysis
+Strategy).
 
-The rest of the toolkit (`detect_stars`, `measure_stars`, `estimate_background`,
-`compute_snr`, plus compound tools `auto_focus` and `center_on_target`) is
-defined in `rp.md` as planned. This plan sequences them.
+The full toolkit (`measure_basic`, `estimate_background`,
+`detect_stars`, `measure_stars`, `compute_snr`, `plate_solve`, plus
+compound tools `auto_focus` and `center_on_target`) was defined in
+`rp.md` as planned at that point. This plan sequenced and shipped them.
 
 ## Goals
 
@@ -342,9 +372,9 @@ new tools and the planned filename-template work clear homes:
   `Pixel`, take `ArrayView2`, no async, no I/O — unit-testable
   without a runtime.
 - `imaging/tools/` — compositional analyzers (`measure_basic`,
-  `measure_stars`; `auto_focus` and `center_on_target` will land
-  here in Phase 6b/6c). Each binds multiple kernels into one
-  MCP-tool-shaped result.
+  `measure_stars`; `auto_focus` landed here in Phase 6b,
+  `center_on_target` in Phase 6c-3). Each binds multiple kernels
+  into one MCP-tool-shaped result.
 - `persistence/` — the I/O / async / on-disk layer. `cache.rs`,
   `fits.rs`, and `document.rs` (moved from the crate root). Future
   filename-template / token-resolver work attaches here, not under
@@ -496,20 +526,22 @@ Status: **complete.**
 
 #### Phase 6c — `center_on_target`
 
-Status: **planned (2026-05-02).** ADR-005 (plate solver: ASTAP via
+Status: **complete (2026-05-09).** ADR-005 (plate solver: ASTAP via
 subprocess + verification spike) landed on main on 2026-05-02,
-retiring the prior blocker.
+retiring the prior blocker; the four sub-phases below shipped over
+the following week.
 
 `center_on_target` composes four primitive tools — `capture`,
-`plate_solve`, `sync_mount`, `slew` — of which only `capture` exists
-today. Phase 6c therefore decomposes into four sub-phases. The first
-two are prerequisites; the third wires the plate solver into rp's
-catalog; the fourth is the compound tool itself, mirroring Phase 6b's
-shape. Each sub-phase is its own PR.
+`plate_solve`, `sync_mount`, `slew` — of which only `capture` existed
+when this phase opened. Phase 6c therefore decomposed into four
+sub-phases: the first two were prerequisites (mount primitives, the
+plate-solver service); the third wired the plate solver into rp's
+catalog; the fourth was the compound tool itself, mirroring Phase
+6b's shape. Each sub-phase landed as its own PR.
 
 ##### Decisions resolved during Phase 6c planning
 
-These will be captured in `docs/services/rp.md` (Compound Tools →
+These were captured in `docs/services/rp.md` (Compound Tools →
 `center_on_target` Contract — added by Phase 6c-3) and should not be
 re-litigated:
 
@@ -560,7 +592,7 @@ primitives). Required because `center_on_target` needs `slew` and
 
 ###### Decisions resolved during planning
 
-These will be captured in `docs/services/rp.md` (Configuration,
+These were captured in `docs/services/rp.md` (Configuration,
 Built-in Tools — Hardware) and should not be re-litigated:
 
 - **Singular `mount: Option<MountConfig>`, not plural `Vec`.** `rp`
@@ -801,7 +833,7 @@ helper for the late-solve workflow's image_path persistence.
 
 ###### Decisions resolved during Phase 6c-2 planning
 
-These will be captured in `docs/services/rp.md` (Built-in Tools — Image
+These were captured in `docs/services/rp.md` (Built-in Tools — Image
 Analysis; Configuration; new `plate_solve` Contract subsection added by
 Step 1) and should not be re-litigated:
 
@@ -1135,7 +1167,7 @@ no implementation landed before BDD scenarios existed on disk.
 
 ###### Decisions resolved during Phase 6c-3 planning
 
-These will be captured in `docs/services/rp.md` (Compound Tools →
+These were captured in `docs/services/rp.md` (Compound Tools →
 new `center_on_target` Contract subsection added by Step 1) and should
 not be re-litigated. The first three were already pinned in the prior
 Phase 6c-3 stub and the parent decision block above
@@ -1482,10 +1514,11 @@ during this planning pass.
 
 ##### Phase 6c sequencing notes
 
-- 6c-prep, 6c-1, 6c-2, 6c-3 land as independent PRs in that order.
-- 6c-1 unblocks 6c-2's HTTP contract; 6c-2 unblocks 6c-3's
-  `PlateSolveOps` adapter. 6c-prep is independent of the plate-solver
-  chain and can land in parallel.
+- 6c-prep, 6c-1, 6c-2, 6c-3 landed as independent PRs in that
+  order between 2026-05-03 and 2026-05-09.
+- 6c-1 unblocked 6c-2's HTTP contract; 6c-2 unblocked 6c-3's
+  `PlateSolveOps` adapter. 6c-prep was independent of the plate-
+  solver chain and landed in parallel.
 - The catalog-merge / shadow-rule code change called out under
   Phase 6 ("Catalog-merge code change (small, deferred until first
   caller)") remains deferred; `center_on_target` is a built-in and
@@ -1631,13 +1664,19 @@ deps; no `bazel mod tidy` needed.
 - **Cache LRU forced-eviction BDD scenario.** A unit test on `cache.rs`
   is the right place for LRU correctness; the end-to-end fallback path
   is exercised implicitly by Phase 4's scenarios.
-- **Plate-solver rp-managed service.** A separate ADR is needed for
-  ASTAP vs. astrometry.net (rp.md notes this). `center_on_target` is
-  blocked on it.
+- **Catalog-merge / shadow-rule code change.** Documented in `rp.md`
+  but no caller yet (no plugin tool-provider integration exists).
+  Lands with the first plugin that shadows a built-in tool.
 - **SEP / sep-sys.** Considered and rejected during design (LGPL +
   C FFI burden) — see Image Analysis Strategy / Design Rationale.
 - **Multi-camera image cache** with per-camera quotas. Single global
   LRU is sufficient for now.
+
+(The **Plate-solver rp-managed service** entry that previously sat
+here has been removed: ADR-005 resolved the ASTAP-vs-astrometry.net
+question, the service shipped via [`plate-solver.md`](plate-solver.md),
+and `plate_solve` + `center_on_target` shipped on top of it in
+Phases 6c-2 / 6c-3.)
 
 ## Dependencies on other workstreams
 

--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -1118,13 +1118,20 @@ Step 1) and should not be re-litigated:
 
 ##### Phase 6c-3 — `center_on_target` design + BDD + impl
 
-Status: **planned (2026-05-09).** Mirrors Phase 6b's shape (design
-contract → BDD → pure-Rust driver behind trait adapters → MCP wrapper)
-and Phase 6c-2's plan layout (decisions-resolved-first, then a
-work-breakdown ordered Step 1 design doc → Step 2 BDD with `@wip` →
-Step 3 implementation → Step 4 activation). Per the
+Status: **complete (2026-05-09).** All four steps landed; 261/261
+BDD scenarios green (was 238/238 pre-Phase-6c-3 + 14 new). The
+new `center_on_target` MCP tool composes capture / plate_solve /
+sync_mount / slew per its Contract in `docs/services/rp.md`; the
+pure driver in `services/rp/src/imaging/tools/center_on_target.rs`
+is unit-tested against synthetic adapters (sync-on-iter-1-only
+invariant verified by call-count on a `StubMounter`).
+Mirrors Phase 6b's shape (design contract → BDD → pure-Rust driver
+behind trait adapters → MCP wrapper) and Phase 6c-2's plan layout
+(decisions-resolved-first, then a work-breakdown ordered Step 1
+design doc → Step 2 BDD with `@wip` → Step 3 implementation →
+Step 4 activation). Per the
 [development-workflow](../skills/development-workflow.md) procedure,
-no implementation lands before BDD scenarios exist on disk.
+no implementation landed before BDD scenarios existed on disk.
 
 ###### Decisions resolved during Phase 6c-3 planning
 
@@ -1241,7 +1248,7 @@ during this planning pass.
 
 **Step 1 — Design doc updates (Phase 1 of dev workflow).**
 
-- [ ] `docs/services/rp.md` updates:
+- [x] `docs/services/rp.md` updates:
   - Built-in Tools — Compound table (line ~723): replace the existing
     `center_on_target` placeholder row with the final input/output
     shape from the decisions above (drop `tolerance_arcsec` placeholder
@@ -1263,7 +1270,7 @@ during this planning pass.
 **Step 2 — BDD feature + step defs (Phase 2 of dev workflow, with
 `@wip`).**
 
-- [ ] `services/rp/tests/features/center_on_target.feature`
+- [x] `services/rp/tests/features/center_on_target.feature`
   (~14 scenarios, `@wip` tag at top per
   [testing.md §2.7](../skills/testing.md#27-use-wip-tag-for-scenarios-without-implementation-yet)):
   1. Catalog includes `center_on_target` (1)
@@ -1303,7 +1310,7 @@ during this planning pass.
   iteration responses, not via a real solve cycle. The end-to-end
   pixel→solve→sync→slew loop still exercises the live OmniSim
   camera and mount; only the solver is stubbed.
-- [ ] `services/rp/tests/bdd/steps/center_on_target_steps.rs`
+- [x] `services/rp/tests/bdd/steps/center_on_target_steps.rs`
   reusing `tool_steps.rs` shared steps. New steps:
   - `Given(a stub plate solver returning per-iteration WCS responses)`
     — extends the existing `PlateSolverStub` from
@@ -1325,16 +1332,16 @@ during this planning pass.
     `Then(the centering result iterations[<i>].action should be
     "<action>")`, `Then(every iterations[i].document_id sidecar
     should contain a "wcs" section)`.
-- [ ] `RpWorld` additions: `last_center_on_target_result:
+- [x] `RpWorld` additions: `last_center_on_target_result:
   Option<Value>`. Reuse the existing `last_plate_solver_stub` from
   `plate_solve_steps.rs`.
-- [ ] No new `RpConfigBuilder` methods — `with_plate_solver` and
+- [x] No new `RpConfigBuilder` methods — `with_plate_solver` and
   `with_mount` already exist from Phases 6c-2 and 6c-prep.
-- [ ] Wire into `tests/bdd/steps/mod.rs`.
+- [x] Wire into `tests/bdd/steps/mod.rs`.
 
 **Step 3 — Implementation (Phase 3 of dev workflow).**
 
-- [ ] `services/rp/src/imaging/tools/center_on_target.rs`:
+- [x] `services/rp/src/imaging/tools/center_on_target.rs`:
   - `CenterOnTargetParams { ra, dec, duration, tolerance_arcsec,
     max_attempts }`. `CenterOnTargetResult { final_error_arcsec,
     attempts, final_ra, final_dec, iterations: Vec<IterationRecord> }`.
@@ -1386,19 +1393,19 @@ during this planning pass.
     `tolerance_not_reached` after `max_attempts`, sync-fires-once
     invariant, `validate_params` rejection arms, haversine sanity
     (known coordinates → known arcseconds).
-- [ ] `services/rp/src/imaging/tools/ops.rs` (new — see decision
+- [x] `services/rp/src/imaging/tools/ops.rs` (new — see decision
   above): hosts the shared `CaptureOps` trait. `auto_focus.rs`
   removes its local definition and re-imports.
-- [ ] `services/rp/src/imaging/tools/mod.rs`: `pub mod
+- [x] `services/rp/src/imaging/tools/mod.rs`: `pub mod
   center_on_target; pub mod ops;`.
-- [ ] `services/rp/src/mcp/internals.rs`:
+- [x] `services/rp/src/mcp/internals.rs`:
   - New `pub(crate) async fn do_sync_mount(&self, ra: f64, dec: f64)
     -> Result<(), String>` — resolve mount via `resolve_mount`,
     call `sync_to_coordinates`, map errors. Mirrors the
     `do_slew_blocking` shape minus the polling loop. Frees the
     primitive `sync_mount` MCP tool to call this helper too (small
     refactor inside `mount.rs:124-159`).
-- [ ] `services/rp/src/mcp/built_in/center_on_target.rs` (new):
+- [x] `services/rp/src/mcp/built_in/center_on_target.rs` (new):
   - `CenterOnTargetToolParams` (`#[serde(default)]` on every field
     so the body validator can produce input-order error messages).
   - `#[tool]` handler runs validation in order (camera_id → ra →
@@ -1422,23 +1429,23 @@ during this planning pass.
     haversine known-value (2), run_center_on_target end-to-end
     (5: iter-1 convergence, iter-3 convergence, capture error mid-
     loop, slew error mid-loop, `tolerance_not_reached`).
-- [ ] `services/rp/src/mcp/handler.rs`: append
+- [x] `services/rp/src/mcp/handler.rs`: append
   `+ Self::tool_router_center_on_target()` to the `tool_router`
   sum (line 79–87).
-- [ ] `services/rp/src/mcp/built_in/mod.rs`: declare the new module.
+- [x] `services/rp/src/mcp/built_in/mod.rs`: declare the new module.
 
 **Step 4 — Activate BDD + cleanup.**
 
-- [ ] Remove `@wip` tag from `center_on_target.feature` line 1.
-- [ ] Run full suite (`cargo rail run --profile commit -q` per
+- [x] Remove `@wip` tag from `center_on_target.feature` line 1.
+- [x] Run full suite (`cargo rail run --profile commit -q` per
   CLAUDE.md rule 4); confirm BDD count grows by ~14 scenarios on
   top of the current 235.
-- [ ] `cargo fmt`. `cargo build --all --all-targets --all-features
+- [x] `cargo fmt`. `cargo build --all --all-targets --all-features
   --locked` for linker-visible code per CLAUDE.md rule 4. No new
   workspace deps expected (haversine is closed-form arithmetic on
   `f64`); confirm before committing — if any landed, run
   `CARGO_BAZEL_REPIN=1 bazel mod tidy`.
-- [ ] Plan-doc bookkeeping: flip Phase 6c-3 status to **complete**
+- [x] Plan-doc bookkeeping: flip Phase 6c-3 status to **complete**
   with the work-breakdown checkboxes ticked, exit-criteria block
   populated with concrete BDD/unit-test counts. Flip the
   `center_on_target` row in `rp.md` Built-in Tools — Compound table

--- a/docs/plans/image-evaluation-tools.md
+++ b/docs/plans/image-evaluation-tools.md
@@ -760,33 +760,34 @@ any centering workflow's tolerance, well above OmniSim's drift.
 
 ##### Phase 6c-1 — `plate-solver` rp-managed service
 
-Status: **not started.** Sequenced separately from this plan because
-of its size (subprocess supervision, ASTAP CLI argument layout, `.wcs`
+Status: **complete.** Sequenced separately from this plan because of
+its size (subprocess supervision, ASTAP CLI argument layout, `.wcs`
 parsing, per-platform install verification) and because ADR-005
-already calls for "a separate plan to sequence the plate-solver
-rp-managed-service implementation."
+already called for "a separate plan to sequence the plate-solver
+rp-managed-service implementation." Tracked end-to-end in
+[`docs/plans/plate-solver.md`](plate-solver.md), where all eight
+phases (Phase 1 design doc through Phase 8 LGPL §4/§6 review) landed.
 
-- [ ] **`docs/plans/plate-solver.md` (new)** sequences the service
-      itself: workspace member skeleton, ASTAP subprocess wrapper,
-      HTTP API, BDD scenarios, supervision integration with sentinel,
-      and the per-platform end-to-end solve passes that retire ADR-005
-      Open Questions 1–6.
-- [ ] **HTTP contract (frozen here so 6c-2 can mock it):**
+- [x] **`docs/plans/plate-solver.md`** sequenced the service itself:
+      workspace member skeleton, ASTAP subprocess wrapper, HTTP API,
+      BDD scenarios, supervision integration with sentinel, and the
+      per-platform end-to-end solve passes that retired ADR-005 Open
+      Questions 1–6.
+- [x] **HTTP contract (frozen here so 6c-2 could mock it):**
       `POST /api/v1/solve` with body
       `{fits_path, ra_hint?, dec_hint?, fov_hint_deg?, search_radius_deg?, timeout?}`
       returns `{ra_center, dec_center, pixel_scale_arcsec, rotation_deg}`
       on success, structured error otherwise. Path-based input matches
       ADR-005's "rp and plate solver share a filesystem" contract — no
       pixel bytes over HTTP.
-- [ ] **Service supervision** via the existing rp-managed-service
-      pattern. The closest shape references in the workspace today are
-      `services/phd2-guider` and `services/sentinel`; `plate-solver`
-      mirrors their crate layout, lifecycle, and sentinel integration.
+- [x] **Service supervision** via the existing rp-managed-service
+      pattern, mirroring `services/phd2-guider` and `services/sentinel`
+      crate layout, lifecycle, and sentinel integration.
 
-This sub-phase is the largest in 6c by far. It is independent of
-6c-prep and 6c-3 once the HTTP contract above is fixed; a stub
-plate-solver process satisfies 6c-2's tests until the real service
-lands.
+This sub-phase was the largest in 6c by far. It was independent of
+6c-prep and 6c-3 once the HTTP contract above was fixed; the in-test
+stub plate-solver in 6c-2 satisfied that phase until the real service
+landed.
 
 ##### Phase 6c-2 — `plate_solve` built-in MCP tool
 
@@ -1117,63 +1118,360 @@ Step 1) and should not be re-litigated:
 
 ##### Phase 6c-3 — `center_on_target` design + BDD + impl
 
-Status: **not started.** Mirrors Phase 6b in shape (design contract →
-BDD → pure-Rust driver behind trait adapters → MCP wrapper).
+Status: **planned (2026-05-09).** Mirrors Phase 6b's shape (design
+contract → BDD → pure-Rust driver behind trait adapters → MCP wrapper)
+and Phase 6c-2's plan layout (decisions-resolved-first, then a
+work-breakdown ordered Step 1 design doc → Step 2 BDD with `@wip` →
+Step 3 implementation → Step 4 activation). Per the
+[development-workflow](../skills/development-workflow.md) procedure,
+no implementation lands before BDD scenarios exist on disk.
 
-- [ ] **Design.** `center_on_target` Contract added to `rp.md`
-      Compound Tools (parallel to `auto_focus` Contract) wiring up
-      the decisions above. Inputs:
-      `{camera_id, telescope_id, ra, dec, duration, tolerance_arcsec, max_attempts, min_area, max_area}`
-      plus optional `threshold_sigma`. Output:
-      `{final_error_arcsec, attempts, final_ra, final_dec}`.
-      Algorithm:
-      1. Resolve `camera_id` and `telescope_id`. Emit
-         `centering_started`.
-      2. Loop up to `max_attempts`:
-         - `capture(camera_id, duration)` → `document_id`.
-         - `plate_solve(document_id, hints)` → solved center.
-         - On the **first** iteration only:
-           `sync_mount(solved_ra, solved_dec)`.
-         - Compute residual error (great-circle separation in arcsec)
-           between solved center and requested `(ra, dec)`.
-         - If residual ≤ `tolerance_arcsec`, emit
-           `centering_complete` and return.
-         - Otherwise `slew(ra, dec)` and continue.
-      3. If the loop exits with residual still > tolerance, return a
-         `tolerance_not_reached` error carrying the last residual and
-         attempt count. The mount is left at its last commanded
-         position; `center_on_target` does not auto-recover.
-- [ ] `services/rp/src/imaging/tools/center_on_target.rs` — pure
-      driver over `CaptureOps` / `PlateSolveOps` / `MountOps` traits
-      so the loop is unit-testable without hardware. The MCP wrapper
-      in `mcp.rs` is the thin adapter shell, sharing capture and slew
-      semantics with the primitive tools via the existing
-      `do_capture` helper plus newly-extracted `do_slew_blocking` /
-      `do_sync_mount` helpers (parallel to Phase 6b's
-      `do_move_focuser_blocking`).
-- [ ] `services/rp/tests/features/center_on_target.feature` —
-      catalog; four device-resolution errors (nonexistent and
-      disconnected camera/telescope); missing-parameter outline;
-      numeric-range rejections (`tolerance_arcsec ≤ 0`,
-      `max_attempts ≤ 0`, `max_attempts` exceeds a safety cap —
-      mirroring `auto_focus`'s `MAX_GRID_POINTS` guardrail);
-      mid-loop `plate_solve` failure → abort; max_attempts exhausted
-      → `tolerance_not_reached`; single-iteration happy path
-      (residual already inside tolerance); multi-iteration happy
-      path with the sync-on-first-only invariant verified via the
-      stub plate solver's call log. Target ~12–15 scenarios. The
-      OmniSim caveat from Phase 6b applies — OmniSim does not model
-      pointing, so happy-path convergence is asserted via the
-      synthetic `PlateSolveOps` adapter rather than a real solve
-      cycle.
-- [ ] Unit tests on the run loop with synthetic adapters: known-
-      residual convergence on iteration 1, convergence on iteration
-      N, abort on mid-loop solve failure, `tolerance_not_reached`
-      after `max_attempts`, sync-on-first-only invariant.
+###### Decisions resolved during Phase 6c-3 planning
 
-**Exit criteria:** new BDD scenarios green, run-loop unit tests cover
-the success / abort / not-reached arms, `cargo rail run --profile
-commit -q` clean, `cargo fmt` clean.
+These will be captured in `docs/services/rp.md` (Compound Tools →
+new `center_on_target` Contract subsection added by Step 1) and should
+not be re-litigated. The first three were already pinned in the prior
+Phase 6c-3 stub and the parent decision block above
+(line 510 onward); the remainder resolve open questions surfaced
+during this planning pass.
+
+- **`tolerance_arcsec` and `max_attempts`: required parameters, no
+  defaults.** (Carried from prior planning.) Same rationale as
+  `measure_basic`'s `min_area`/`max_area`: the right values depend
+  on rig pixel scale, mount tracking quality, and target altitude.
+- **`sync_mount` only on the first iteration.** (Carried.) The first
+  `plate_solve` produces the absolute pointing reference; subsequent
+  iterations rely on the mount honouring relative `slew`s. Sync
+  *unconditionally* on iter 1 — even if the residual is already
+  inside tolerance — so the mount's pointing model is calibrated for
+  any caller that follows centering with further targeted slews.
+- **Fail fast on per-iteration failures.** (Carried.) A `capture`,
+  `plate_solve`, `sync_mount`, or `slew` error inside the loop aborts
+  with the underlying message; the mount is left where the failed
+  step left it. No retry-with-longer-exposure fallback in v1.
+- **No aggregate persistence section.** (Carried.) Each per-iteration
+  capture writes its own `wcs` section via the embedded
+  `plate_solve`. The compound result is returned in the MCP response
+  and emitted as `centering_complete`. A `centering_started` event
+  fires before the loop and a `centering_iteration` event fires
+  after each per-iteration solve so a live UI can stream the
+  residual without polling the document store.
+- **Module home:
+  `services/rp/src/imaging/tools/center_on_target.rs`.** (Carried.)
+  Symmetry with `auto_focus.rs`.
+- **No `telescope_id` parameter.** Mount is singular per Phase 6c-prep
+  (`mount: Option<MountConfig>`, no `id` field). The driver and the
+  MCP shape both resolve the mount via the singleton — a `mount_id`
+  parameter would be dead code. The original Phase 6c-3 stub's
+  `telescope_id` is stale from before 6c-prep and is dropped here.
+- **No `min_area`/`max_area`/`threshold_sigma` parameters.** The loop
+  composes `capture` + `plate_solve` + `sync_mount` + `slew`; none
+  takes star-detection thresholds (ASTAP owns its own internal
+  detection). The original stub's inclusion of these is stale from
+  the early draft when `measure_basic` was envisioned in the loop.
+  Dropped.
+- **Hint plumbing: `use_mount_hints: true` on every inner
+  `plate_solve` call.** (Already pinned in 6c-2 decision block
+  line 857.) The first iteration solves blind-but-with-mount-hints
+  (mount has just been commanded to `(ra, dec)` by the caller's
+  pre-flight slew, or — more often — left at its last position from
+  a prior workflow step). After the first sync, the mount's reported
+  position tracks reality, so the hint stays accurate across
+  iterations. Sourcing the hint *via* `plate_solve`'s existing
+  `use_mount_hints` flag rather than a Rust-side mount-read keeps
+  the hours→degrees conversion in exactly one place.
+- **Settle handling: per-iteration `slew` honours `mount.settle_after_slew`
+  config.** No per-call `settle_after` override in v1 — the rig's
+  configured settle is the right value across iterations, and an
+  override would only matter if we wanted iteration N+1's settle to
+  differ from N's, which there's no use case for. Pass-through to
+  `do_slew_blocking` with `settle_after = config_default`.
+- **Always-sync-on-iter-1 *then* check residual *then* slew if
+  outside tolerance.** Algorithm clarification on the "single-
+  iteration happy path" case from the prior stub: even when the open-
+  loop pointing was already accurate enough to land inside tolerance
+  on the first solve, we still issue `sync_mount` (per the bullet
+  above) — but we do **not** issue a `slew` if the residual is
+  already inside tolerance. The mount is at the right place; we just
+  taught it where it is. Skip the redundant slew.
+- **`max_attempts` safety cap: hardcoded `MAX_ATTEMPTS = 50`.**
+  Mirrors `auto_focus`'s `MAX_GRID_POINTS` guardrail. Plausible
+  centering runs converge in 2–4 iterations; 50 is generous enough
+  that no real workflow trips it, low enough that a misconfigured
+  loop can't tie up the rig for hours.
+- **Output shape:
+  `{final_error_arcsec, attempts, final_ra, final_dec, iterations}`.**
+  `iterations[i]` is `{document_id, residual_arcsec, solved_ra,
+  solved_dec, action}` where `action ∈ {"sync", "slew",
+  "converged"}` records what happened *after* the per-iteration
+  solve — `"sync"` on iter 1 followed by either `"slew"` or
+  `"converged"` depending on whether the residual was inside
+  tolerance, `"slew"` or `"converged"` on subsequent iterations.
+  Matches `auto_focus`'s per-step `curve_points` provenance shape
+  so callers can fetch the per-iteration documents (which carry the
+  `wcs` section written by the embedded `plate_solve`).
+- **Great-circle residual via the haversine formula.** Standard
+  closed-form equation; numerically stable for the small angles
+  centering deals with (typically arcseconds-to-arcminutes). No
+  external dep needed. Inputs from `plate_solve` are decimal degrees
+  for both RA and Dec; the formula returns arcseconds directly.
+- **`PlateSolveOps` and `MountOps` driver traits added in
+  `imaging/tools/center_on_target.rs`.** Mirror `auto_focus`'s
+  `FocuserOps`/`CaptureOps`/`MeasureOps` shape — async traits,
+  `String` errors, single-method per role. Reuse the existing
+  `CaptureOps` trait from `auto_focus.rs` rather than redefining
+  it (a `capture(duration) → document_id` operation is identical
+  in both compound tools); move the trait to a shared module
+  (`imaging/tools/mod.rs` re-export, or `imaging/tools/ops.rs`)
+  if and only if the second consumer arrives — it has, so the move
+  lands in this phase.
+- **MCP-side helpers reused, not re-extracted.** `do_capture`,
+  `do_slew_blocking`, and `read_mount_hints_for_plate_solve` already
+  exist (`services/rp/src/mcp/internals.rs:408,721,812`). The plan
+  stub's call for "newly-extracted `do_slew_blocking` / `do_sync_mount`
+  helpers" is partly stale — `do_slew_blocking` is already a helper.
+  This phase adds a `do_sync_mount(ra, dec)` helper for symmetry and
+  to give the adapter a single place to call for sync semantics.
+  Inner `plate_solve` calls go through the in-process
+  `McpHandler::plate_solve` rather than the HTTP MCP transport (no
+  re-encoding round-trip — same shape `auto_focus` uses for its
+  inner `measure_basic` calls via `measure_via_document`).
+
+###### Work breakdown (in order)
+
+**Step 1 — Design doc updates (Phase 1 of dev workflow).**
+
+- [ ] `docs/services/rp.md` updates:
+  - Built-in Tools — Compound table (line ~723): replace the existing
+    `center_on_target` placeholder row with the final input/output
+    shape from the decisions above (drop `tolerance_arcsec` placeholder
+    expansion to: `camera_id, ra, dec, duration, tolerance_arcsec,
+    max_attempts`; returns `final_error_arcsec, attempts, final_ra,
+    final_dec, iterations`). Flip the `*Planned.*` tag to
+    `Implemented.` only after Step 4 activation.
+  - New `center_on_target` Contract subsection (parallel shape to
+    `auto_focus` Contract at line ~1832 and `plate_solve` Contract at
+    line ~2026): Input, Output, Algorithm, Error cases, Persistence,
+    Caveats. Algorithm captures the sync-on-iter-1 invariant, the
+    residual-then-slew sequence, the haversine residual formula, and
+    the events emitted at each loop boundary.
+  - Update the existing `center_on_target` pseudo-code example (line
+    ~2183) to match the v1 input/output shape (drop the implicit
+    `min_area`/`max_area`, add `max_attempts`, surface the
+    per-iteration `iterations[]` provenance).
+
+**Step 2 — BDD feature + step defs (Phase 2 of dev workflow, with
+`@wip`).**
+
+- [ ] `services/rp/tests/features/center_on_target.feature`
+  (~14 scenarios, `@wip` tag at top per
+  [testing.md §2.7](../skills/testing.md#27-use-wip-tag-for-scenarios-without-implementation-yet)):
+  1. Catalog includes `center_on_target` (1)
+  2. Single-iteration happy path — first solve already inside
+     tolerance, sync fires, no slew, returns `attempts=1`,
+     `iterations[0].action="converged"` (1)
+  3. Multi-iteration happy path — residual outside tolerance on
+     iter 1 then inside on iter 2; sync-on-iter-1 verified via the
+     stub plate solver's call log + `iterations[]` shape (1)
+  4. `tolerance_not_reached` error after `max_attempts` exhausted —
+     stub returns the same large residual every iteration (1)
+  5. Mid-loop `plate_solve` failure aborts with the wrapper's error
+     code propagated; mount left at its last commanded position (1)
+  6. Mid-loop `slew` failure (e.g. tracking off after iter 1)
+     aborts with the underlying mount error (1)
+  7. Sync-on-first-only invariant: 3-iteration run logs exactly one
+     `sync_to_coordinates` call against the OmniSim mount (1)
+  8. Per-iteration `wcs` section persists on every captured
+     document — fetch each `iterations[i].document_id` and verify
+     the section is present (1)
+  9. Catalog row: nonexistent camera (1)
+  10. Catalog row: disconnected camera (1)
+  11. Catalog row: no mount configured (1)
+  12. Catalog row: mount not connected (1)
+  13. Scenario Outline: missing required parameters (`camera_id`,
+      `ra`, `dec`, `duration`, `tolerance_arcsec`, `max_attempts`)
+      — error message names the missing field, validated in input
+      order (1, six examples)
+  14. Scenario Outline: numeric-range rejections — `tolerance_arcsec
+      <= 0`, `max_attempts <= 0`, `max_attempts > MAX_ATTEMPTS`
+      (50), `ra` outside `[0, 24)`, `dec` outside `[-90, 90]`
+      (1, five examples)
+
+  OmniSim caveat from Phase 6b applies — OmniSim does not model
+  pointing, so happy-path *convergence* (residual decreasing across
+  iterations) is asserted via the stub plate solver's canned per-
+  iteration responses, not via a real solve cycle. The end-to-end
+  pixel→solve→sync→slew loop still exercises the live OmniSim
+  camera and mount; only the solver is stubbed.
+- [ ] `services/rp/tests/bdd/steps/center_on_target_steps.rs`
+  reusing `tool_steps.rs` shared steps. New steps:
+  - `Given(a stub plate solver returning per-iteration WCS responses)`
+    — extends the existing `PlateSolverStub` from
+    `plate_solve_steps.rs` with a queue of `SolveOutcome` values
+    consumed in order (one per `solve` call).
+  - `When(I call center_on_target with camera <camera> ra <ra>
+    dec <dec> duration <dur> tolerance_arcsec <tol> max_attempts <n>)`
+    — JSON-RPC call.
+  - `When(I call center_on_target omitting "<missing_param>")`
+    — Outline-driven missing-param probe; reuses the
+    `MISSING`-sentinel pattern from `mount_steps.rs`.
+  - `Then(the stub plate solver should have received <n> solve
+    calls)` — counts entries in the receiver-side request log.
+  - `Then(the OmniSim mount should have received exactly one sync
+    call)` — reads the OmniSim `telescope/{n}/synctocoordinates`
+    counter (matches the request-log shape Phase 6c-prep
+    introduced for the `sync_mount`-honoring scenario).
+  - `Then(the centering result should report attempts <n>)`,
+    `Then(the centering result iterations[<i>].action should be
+    "<action>")`, `Then(every iterations[i].document_id sidecar
+    should contain a "wcs" section)`.
+- [ ] `RpWorld` additions: `last_center_on_target_result:
+  Option<Value>`. Reuse the existing `last_plate_solver_stub` from
+  `plate_solve_steps.rs`.
+- [ ] No new `RpConfigBuilder` methods — `with_plate_solver` and
+  `with_mount` already exist from Phases 6c-2 and 6c-prep.
+- [ ] Wire into `tests/bdd/steps/mod.rs`.
+
+**Step 3 — Implementation (Phase 3 of dev workflow).**
+
+- [ ] `services/rp/src/imaging/tools/center_on_target.rs`:
+  - `CenterOnTargetParams { ra, dec, duration, tolerance_arcsec,
+    max_attempts }`. `CenterOnTargetResult { final_error_arcsec,
+    attempts, final_ra, final_dec, iterations: Vec<IterationRecord> }`.
+    `IterationRecord { document_id, residual_arcsec, solved_ra,
+    solved_dec, action: IterationAction }`. `IterationAction` is
+    a `Serialize` enum with three string variants `"sync"`, `"slew"`,
+    `"converged"` (NB: iter 1 records the `"sync"` action *before*
+    the residual check, then iter 1's converged-or-slew action is
+    recorded on the same `IterationRecord`; the JSON-shape pin
+    happens in Step 1's design doc).
+  - `CenterOnTargetError { InvalidTolerance(f64), InvalidMaxAttempts(usize),
+    MaxAttemptsExceedsCap { requested: usize, max: usize },
+    ToleranceNotReached { last_residual_arcsec: f64, attempts: usize },
+    Equipment(String) }`.
+  - `pub const MAX_ATTEMPTS: usize = 50;`
+  - `validate_params(&CenterOnTargetParams) -> Result<()>` —
+    `tolerance > 0`, `max_attempts > 0`, `max_attempts <= MAX_ATTEMPTS`.
+  - `pub fn haversine_arcsec(ra1_deg, dec1_deg, ra2_deg, dec2_deg) -> f64`
+    — standalone for unit testability.
+  - Driver traits: `PlateSolveOps`, `MountOps` (with `sync_to(ra,
+    dec)` and `slew_to(ra, dec)` async methods). `CaptureOps` is
+    pulled from `auto_focus.rs` — promote it to
+    `imaging/tools/ops.rs` (new file) and re-export from both
+    `auto_focus.rs` and `center_on_target.rs` to keep both call
+    sites' import paths short.
+  - `pub async fn run_center_on_target<C, P, M>(capturer, solver,
+    mounter, params, emit_iteration: impl Fn(&IterationRecord))
+    -> Result<CenterOnTargetResult, CenterOnTargetError>` — the
+    pure driver. Loop body:
+    1. `capture(duration)` → `document_id`.
+    2. `solver.solve(document_id)` → `(solved_ra, solved_dec)`.
+    3. If iteration index == 0: `mounter.sync_to(solved_ra,
+       solved_dec)` and record `action = Sync`.
+    4. Compute `residual_arcsec = haversine_arcsec(solved_ra,
+       solved_dec, params.ra, params.dec)`.
+    5. If `residual_arcsec <= params.tolerance_arcsec`: record
+       `action = Converged` (overwrites `Sync` on iter 1 only when
+       sync didn't happen, but per the previous bullet sync always
+       fires on iter 1 — so the iter 1 record ends with whichever
+       of `Sync→Converged` or `Sync→Slew` applies; the `action`
+       field stores the *terminal* action for that iter).
+    6. Else: `mounter.slew_to(params.ra, params.dec)`, record
+       `action = Slew`, continue to next iter.
+    7. Emit `centering_iteration` after each record via
+       `emit_iteration(&record)`.
+  - Synthetic-adapter unit tests: convergence on iter 1 (no slew),
+    convergence on iter 3 (residual decreases each iteration), abort
+    on mid-loop solve error, abort on mid-loop slew error,
+    `tolerance_not_reached` after `max_attempts`, sync-fires-once
+    invariant, `validate_params` rejection arms, haversine sanity
+    (known coordinates → known arcseconds).
+- [ ] `services/rp/src/imaging/tools/ops.rs` (new — see decision
+  above): hosts the shared `CaptureOps` trait. `auto_focus.rs`
+  removes its local definition and re-imports.
+- [ ] `services/rp/src/imaging/tools/mod.rs`: `pub mod
+  center_on_target; pub mod ops;`.
+- [ ] `services/rp/src/mcp/internals.rs`:
+  - New `pub(crate) async fn do_sync_mount(&self, ra: f64, dec: f64)
+    -> Result<(), String>` — resolve mount via `resolve_mount`,
+    call `sync_to_coordinates`, map errors. Mirrors the
+    `do_slew_blocking` shape minus the polling loop. Frees the
+    primitive `sync_mount` MCP tool to call this helper too (small
+    refactor inside `mount.rs:124-159`).
+- [ ] `services/rp/src/mcp/built_in/center_on_target.rs` (new):
+  - `CenterOnTargetToolParams` (`#[serde(default)]` on every field
+    so the body validator can produce input-order error messages).
+  - `#[tool]` handler runs validation in order (camera_id → ra →
+    dec → duration → tolerance_arcsec → max_attempts), resolves
+    the camera and mount, emits `centering_started` (carrying
+    `camera_id`, `ra`, `dec`, `tolerance_arcsec`, `max_attempts`),
+    constructs the `CenterOnTargetAdapter`, calls
+    `imaging::tools::center_on_target::run_center_on_target`,
+    emits `centering_complete` on success (carrying
+    `final_error_arcsec`, `attempts`, `final_ra`, `final_dec`),
+    returns the result.
+  - `CenterOnTargetAdapter<'a>` implementing `CaptureOps` (via
+    `do_capture`), `PlateSolveOps` (via in-process
+    `McpHandler::plate_solve` with `use_mount_hints: true`), and
+    `MountOps` (via `do_sync_mount` and `do_slew_blocking` with
+    `settle_after = mount.config.settle_after_slew.unwrap_or_default()`).
+    The `emit_iteration` closure passed into `run_center_on_target`
+    calls `event_bus.emit("centering_iteration", …)`.
+  - ~10 unit tests against synthetic adapters (paralleling
+    `auto_focus`'s unit-test layout): validate_params arms (3),
+    haversine known-value (2), run_center_on_target end-to-end
+    (5: iter-1 convergence, iter-3 convergence, capture error mid-
+    loop, slew error mid-loop, `tolerance_not_reached`).
+- [ ] `services/rp/src/mcp/handler.rs`: append
+  `+ Self::tool_router_center_on_target()` to the `tool_router`
+  sum (line 79–87).
+- [ ] `services/rp/src/mcp/built_in/mod.rs`: declare the new module.
+
+**Step 4 — Activate BDD + cleanup.**
+
+- [ ] Remove `@wip` tag from `center_on_target.feature` line 1.
+- [ ] Run full suite (`cargo rail run --profile commit -q` per
+  CLAUDE.md rule 4); confirm BDD count grows by ~14 scenarios on
+  top of the current 235.
+- [ ] `cargo fmt`. `cargo build --all --all-targets --all-features
+  --locked` for linker-visible code per CLAUDE.md rule 4. No new
+  workspace deps expected (haversine is closed-form arithmetic on
+  `f64`); confirm before committing — if any landed, run
+  `CARGO_BAZEL_REPIN=1 bazel mod tidy`.
+- [ ] Plan-doc bookkeeping: flip Phase 6c-3 status to **complete**
+  with the work-breakdown checkboxes ticked, exit-criteria block
+  populated with concrete BDD/unit-test counts. Flip the
+  `center_on_target` row in `rp.md` Built-in Tools — Compound table
+  from `*Planned.*` to `Implemented.`.
+
+###### Out of scope / deferred
+
+- **`min_improvement_arcsec` early-exit.** Useful future addition
+  (early exit when an iteration stops improving the residual), but
+  not v1. Add as an optional parameter when the first concrete
+  need surfaces.
+- **Adaptive per-iteration exposure scaling.** v1 takes a single
+  `duration`; if low star count blocks a solve, the caller re-runs
+  with a longer duration.
+- **Auto-recovery on mid-loop failures.** Workflows that want
+  retry-with-longer-exposure or retry-with-relaxed-tolerance wrap
+  the call themselves.
+- **Dome / rotator coordination.** Out of scope for `rp`'s built-in
+  tooling per `rp.md` Future Considerations.
+
+###### Exit criteria
+
+- ~14 new BDD scenarios green (~249/249 total in rp's BDD suite,
+  was 235/235 post-Phase-6c-2).
+- ~13 new lib tests across `services/rp/src/imaging/tools/center_on_target`
+  (~10 unit tests for the pure driver) + ~3 unit tests in
+  `services/rp/src/mcp/built_in/center_on_target` for the MCP
+  validation arms.
+- `cargo rail run --profile commit -q` clean workspace-wide,
+  `cargo fmt` clean. No new crates.io deps expected.
+- `iterations[].document_id` round-trips through
+  `GET /api/documents/{id}` carrying a `wcs` section written by the
+  per-iteration `plate_solve`.
 
 ##### Phase 6c sequencing notes
 

--- a/docs/plans/plate-solver.md
+++ b/docs/plans/plate-solver.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-02
 **Branch:** `worktree-astap`
 **ADR:** [005-plate-solver](../decisions/005-plate-solver.md)
-**Parent plan:** [image-evaluation-tools.md Phase 6c-1](image-evaluation-tools.md#phase-6c-1--plate-solver-rp-managed-service)
+**Parent plan:** [archive/image-evaluation-tools.md Phase 6c-1](archive/image-evaluation-tools.md#phase-6c-1--plate-solver-rp-managed-service)
 
 ## Background
 
@@ -853,7 +853,7 @@ What this phase did **not** do (acknowledged forward work):
 - `rp`'s `plate_solve` MCP tool implementation that performs the
   hours→degrees conversion and sources `search_radius_deg` from rp
   config — that's Phase 6c-2 in the parent plan
-  (`docs/plans/image-evaluation-tools.md`). 6c-prep (telescope
+  (`docs/plans/archive/image-evaluation-tools.md`). 6c-prep (telescope
   primitives — `Arc<dyn Telescope>` in `equipment.rs`, `slew` /
   `sync_mount` MCP tools) has now landed on main, so 6c-2 has its
   prerequisite.
@@ -930,7 +930,7 @@ dependency structures:
 ## References
 
 - ADR-005 — `docs/decisions/005-plate-solver.md`
-- Image-evaluation-tools plan, Phase 6c-1 — `docs/plans/image-evaluation-tools.md`
+- Image-evaluation-tools plan, Phase 6c-1 — `docs/plans/archive/image-evaluation-tools.md`
 - rp design doc, §"Component Categories" / §"Plate Solver" /
   §"Sentinel Watchdog Integration" — `docs/services/rp.md`
 - ADR-004 — `docs/decisions/004-testing-strategy-for-http-client-error-paths.md`

--- a/docs/plans/rp-planning-tools.md
+++ b/docs/plans/rp-planning-tools.md
@@ -661,7 +661,7 @@ Within that fixed scope, dependencies are mostly linear:
 
 **Cross-plan unblocking:**
 
-- `image-evaluation-tools.md` Phase 6c-prep (telescope primitives:
+- `archive/image-evaluation-tools.md` Phase 6c-prep (telescope primitives:
   `slew`, `sync_mount`, `get_telescope_position`) is a prerequisite
   for *exercising* the planner end-to-end ("slew to M41"), but is
   **not** a prerequisite for any phase here — the MCP tools land and
@@ -688,7 +688,7 @@ Within that fixed scope, dependencies are mostly linear:
   test conventions; `@wip` filter (§2.7)
 - [`docs/plans/plate-solver.md`](plate-solver.md) — closest
   precedent for an eight-phase, design-first plan in this workspace
-- [`docs/plans/image-evaluation-tools.md`](image-evaluation-tools.md)
+- [`docs/plans/archive/image-evaluation-tools.md`](archive/image-evaluation-tools.md)
   §"Phase 6c-prep — Telescope (mount) primitives" — prerequisite for
   end-to-end exercise of the planner output
 - ASCOM Telescope `SiteLatitude` / `SiteLongitude` properties —

--- a/docs/plans/sky-survey-camera-mount-following.md
+++ b/docs/plans/sky-survey-camera-mount-following.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-03
 **Branch:** `worktree-trail-mount`
 **Parent service:** [`docs/services/sky-survey-camera.md`](../services/sky-survey-camera.md) — retires the *Telescope-following mode* item under Future Work.
-**Consumer plan:** [`docs/plans/image-evaluation-tools.md` Phase 6c-3](image-evaluation-tools.md#phase-6c-3--center_on_target-design--bdd--impl) — `center_on_target` BDD currently has to fake convergence via a synthetic `PlateSolveOps` adapter ("OmniSim does not model pointing"). This plan removes that caveat for the end-to-end path.
+**Consumer plan:** [`docs/plans/archive/image-evaluation-tools.md` Phase 6c-3](archive/image-evaluation-tools.md#phase-6c-3--center_on_target-design--bdd--impl) — `center_on_target` BDD currently has to fake convergence via a synthetic `PlateSolveOps` adapter ("OmniSim does not model pointing"). This plan removes that caveat for the end-to-end path.
 
 ## Background
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -210,11 +210,14 @@ sensor geometry at capture time. This is sufficient for `plate_solve`
 hint sourcing and for consumers like annotation and mosaic planning.
 
 The `plate_solve` built-in tool (Phase 6c-2 in
-`docs/plans/archive/image-evaluation-tools.md`) uses
-`optics.fov_height_deg` as the default `fov_hint_deg` in its
-`document_id` mode — `fov_height_deg` matches ASTAP's `-fov` semantics
-("image height in degrees"). Callers keep the option to override with
-an explicit `fov_hint_deg` parameter.
+`docs/plans/archive/image-evaluation-tools.md`) accepts an explicit
+`fov_hint_deg` parameter that callers can populate from
+`optics.fov_height_deg` on the document — `fov_height_deg` matches
+ASTAP's `-fov` semantics ("image height in degrees"). v1 does **not**
+auto-default `fov_hint_deg` from the optics block when the parameter
+is omitted; that auto-default is tracked by
+[issue #153](https://github.com/ivonnyssen/rusty-photon/issues/153)
+and lands when the first workflow is blocked without it.
 
 ### Plugin Sections (contributed via API)
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -721,7 +721,7 @@ boundary — but expose the same MCP tool surface as any other tool.
 | Action | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
 | `auto_focus` | camera_id, focuser_id, duration, step_size, half_width, min_area, max_area, threshold_sigma (optional), min_fit_points (optional) | best_position, best_hfr, final_position, samples_used, curve_points, temperature_c | Parabolic-fit V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. See [`auto_focus` Contract](#auto_focus-contract). Implemented. |
-| `center_on_target` | ra, dec, tolerance_arcsec | final_error_arcsec, attempts | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until tolerance reached. *Planned.* |
+| `center_on_target` | camera_id, ra, dec, duration, tolerance_arcsec, max_attempts | final_error_arcsec, attempts, final_ra, final_dec, iterations | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until residual ≤ `tolerance_arcsec`. See [`center_on_target` Contract](#center_on_target-contract). *Planned.* |
 
 **Planner — Ephemeris primitives**
 
@@ -2154,6 +2154,170 @@ tool-provider plugin advertising the same `plate_solve` name; the
 plugin wins per Config-Time Validation, with the shadow logged at
 startup.
 
+#### `center_on_target` Contract
+
+A built-in compound tool that drives an iterative
+capture → plate_solve → sync_mount → slew loop until the solved
+field-center sits within `tolerance_arcsec` of the requested
+`(ra, dec)`. The orchestrator calls one tool with the target
+coordinates and gets back the converged pointing without having to
+implement its own centering loop.
+
+**Input**:
+- `camera_id` — required. Camera that captures each iteration's
+  frame.
+- `ra` — required, decimal hours `∈ [0, 24)`. Target right
+  ascension. Same unit as `slew` and `sync_mount` (Alpaca's
+  `RightAscension`).
+- `dec` — required, decimal degrees `∈ [-90, 90]`. Target
+  declination.
+- `duration` — required, humantime string (e.g. `"5s"`,
+  `"500ms"`). Per-iteration exposure. No default: the right value
+  depends on focal ratio, sky brightness, and target field, none
+  of which `center_on_target` can infer. v1 uses the same
+  `duration` for every iteration; if low star count blocks a
+  solve, the caller re-runs with a longer duration.
+- `tolerance_arcsec` — required, positive `f64`. Convergence
+  threshold on the great-circle residual between the solved center
+  and `(ra, dec)`. No default: the right value depends on rig
+  pixel scale (a 1-arcsec/pixel rig wants tighter tolerance than a
+  4-arcsec/pixel one) and downstream framing constraints.
+- `max_attempts` — required, positive `usize`. Hard cap on the
+  number of iterations. No default: the right value depends on
+  mount tracking quality and how aggressive the caller wants the
+  loop to be (typical 3–5 attempts; tight tolerances or wobbly
+  mounts may want 10+). Capped at `MAX_ATTEMPTS = 50` — exceeding
+  the cap is a parameter error before any motion. The cap is a
+  guardrail against operator misconfiguration that would otherwise
+  tie up the rig for an indefinite period; any plausible run fits
+  well inside it.
+
+The mount is resolved via the singular `mount` config field — no
+`mount_id` or `telescope_id` parameter, since `rp` deployments run
+exactly one mount.
+
+**Output**:
+- `final_error_arcsec` (f64) — great-circle residual at the
+  iteration where convergence fired (i.e. the iteration whose
+  `action` is `"converged"`).
+- `attempts` (usize) — number of iterations executed. `≥ 1` and
+  `≤ max_attempts` on success.
+- `final_ra` (f64) — solved RA at the converged iteration, in
+  decimal degrees (matches `plate_solve`'s output unit, **not**
+  the input's hours).
+- `final_dec` (f64) — solved Dec at the converged iteration, in
+  decimal degrees.
+- `iterations` — array of
+  `{document_id: string, residual_arcsec: f64, solved_ra: f64,
+  solved_dec: f64, action: "sync" | "slew" | "converged"}`,
+  one entry per iteration in execution order. Each
+  `document_id` carries the per-iteration capture's `wcs` section
+  (written by the embedded `plate_solve`); the
+  [`/api/documents/{id}`](#document-resolution) endpoint gives
+  callers per-step provenance. `action` is the *terminal* action
+  for that iteration: `"sync"` only ever appears on iter 1 (and
+  only if iter 1 also slewed — i.e. `iterations[0].action ==
+  "sync"` means iter 1 fired sync followed by slew); `"converged"`
+  appears at most once and is always the last entry; every other
+  entry is `"slew"`. The iter-1-converged-after-sync case
+  collapses to `action: "converged"` on the single record (sync
+  fired, residual was already inside tolerance, no slew issued).
+
+**Algorithm**:
+1. Resolve `camera_id` and the singular mount. Emit
+   `centering_started` carrying `{camera_id, ra, dec,
+   tolerance_arcsec, max_attempts}`.
+2. For `iter = 0..max_attempts`:
+   1. `capture(camera_id, duration)` → `document_id`. Cache
+      populated as a side effect.
+   2. `plate_solve(document_id)` with `use_mount_hints: true` so
+      the wrapper gets the mount's currently-reported pointing as
+      an `ra_hint`/`dec_hint` pair (hours→degrees conversion lives
+      in the `plate_solve` handler — see
+      [`plate_solve` Contract](#plate_solve-contract)). Yields
+      `(solved_ra_deg, solved_dec_deg)` and writes a `wcs` section
+      to the document as a side effect.
+   3. If `iter == 0`: `sync_mount(solved_ra_deg, solved_dec_deg)`.
+      The first solve is the absolute pointing reference;
+      subsequent iterations rely on the mount honouring relative
+      slews instead of re-syncing on every pass. Repeated syncs
+      interact badly with model-building drivers (each sync gets
+      treated as a new pointing-model entry, polluting the model)
+      and are unnecessary once the absolute position is
+      established. Sync fires *unconditionally* on iter 1, even if
+      the residual is already inside tolerance — the mount's
+      pointing model is calibrated for any caller that follows
+      centering with further targeted slews.
+   4. Compute `residual_arcsec = haversine(solved_ra_deg,
+      solved_dec_deg, ra·15.0, dec)` (the input `ra` is hours; the
+      solved values are degrees, so convert the input to degrees
+      once for the comparison).
+   5. If `residual_arcsec ≤ tolerance_arcsec`: record an
+      `iterations[iter]` entry with `action = "converged"`, emit
+      `centering_iteration` followed by `centering_complete`, and
+      return.
+   6. Otherwise: `slew(ra, dec)` honouring the mount's
+      `settle_after_slew` config; record an `iterations[iter]`
+      entry with `action = "slew"` (or `action = "sync"` on
+      iter 1 if the slew was preceded by a sync — see Output's
+      collapse rule); emit `centering_iteration` and continue.
+3. If the loop exits without firing `"converged"`, return a
+   `tolerance_not_reached` error carrying the last residual and
+   `max_attempts`. The mount is left at its last commanded
+   position; `center_on_target` does not auto-recover.
+
+**Error cases**:
+- `camera_id` missing or names a camera that doesn't exist /
+  isn't connected → MCP error naming the field/condition (parameter
+  validation runs in input order, same convention as
+  `auto_focus` / `measure_basic`).
+- `ra`, `dec`, `duration`, `tolerance_arcsec`, `max_attempts`
+  missing → MCP error naming the missing parameter.
+- `ra` outside `[0, 24)` or `dec` outside `[-90, 90]` → MCP error
+  naming the bad parameter.
+- `tolerance_arcsec ≤ 0` or `max_attempts == 0` → MCP error
+  naming the bad parameter.
+- `max_attempts > MAX_ATTEMPTS` (50) → MCP error before any
+  motion or exposure.
+- No mount configured / mount not connected → MCP error.
+- Mid-loop `capture`, `plate_solve`, `sync_mount`, or `slew`
+  failure → propagates the underlying error and aborts the loop.
+  The mount is left where the failed step left it; partial
+  `iterations[]` entries are not returned (the failure surfaces as
+  an MCP error, not a partial success).
+- Loop exits without convergence → `tolerance_not_reached` error
+  citing the last residual and `max_attempts`.
+
+**Persistence**: `center_on_target` does **not** write a section
+on any single exposure document. Each per-iteration capture gets
+its own `wcs` section written by the embedded `plate_solve` call
+exactly as if `plate_solve` had been called directly. The compound
+result is returned in the MCP response and emitted as
+`centering_complete`. Each entry in `iterations` carries the
+per-step `document_id`, so callers that need per-step provenance
+can fetch the individual exposure documents and read their `wcs`
+sections.
+
+**Caveats**:
+- OmniSim does not model pointing — it returns canned exposures
+  unaffected by mount position. Convergence over real pixels is
+  asserted via the stub plate solver in BDD; the live OmniSim
+  camera and mount still exercise the capture / sync / slew
+  surface.
+- v1 has no `min_improvement_arcsec` early exit. A run that stops
+  improving but keeps barely missing tolerance will burn through
+  `max_attempts` before erroring. Add the parameter when the first
+  workflow needs it.
+- v1 has no per-iteration exposure scaling. If the first solve
+  fails for star-count reasons, the caller re-runs with a longer
+  `duration` rather than letting the tool widen automatically.
+- `center_on_target` is a built-in compound tool and may be
+  **shadowed** by a tool-provider plugin advertising the same
+  `center_on_target` name; the plugin wins per
+  [Config-Time Validation](#config-time-validation), with the
+  shadow logged at startup. Two plugins both claiming
+  `center_on_target` remains a config-time error.
+
 #### Example: `auto_focus` (V-curve)
 
 See [`auto_focus` Contract](#auto_focus-contract) for the full parameter
@@ -2182,15 +2346,37 @@ Orchestrator: tools/call auto_focus {
 
 #### Example: `center_on_target`
 
+See [`center_on_target` Contract](#center_on_target-contract) for the
+full parameter set, error policy, and persistence rules. The
+pseudo-code below illustrates the loop shape only.
+
 ```
-Orchestrator: tools/call center_on_target {ra: 10.6847, dec: 41.2689, tolerance_arcsec: 5}
+Orchestrator: tools/call center_on_target {
+    camera_id: "main-cam",  ra: 10.6847,           dec: 41.2689,
+    duration: "5s",         tolerance_arcsec: 5,   max_attempts: 5
+}
   rp's center_on_target implementation:
-    capture(camera_id="main-cam", duration_ms=5000)  → {document_id: "doc-c01"}
-    plate_solve(document_id="doc-c01")               → {ra: 10.6820, dec: 41.2650, error_arcsec: 45}
-    sync_mount(ra=10.6820, dec=41.2650)
-    slew(ra=10.6847, dec=41.2689)
-    ... repeat until error < tolerance ...
-  ← {final_error_arcsec: 2.1, attempts: 3}
+    iter 0:
+      capture(camera_id="main-cam", duration="5s")   → {document_id: "doc-c01"}
+      plate_solve(document_id="doc-c01", use_mount_hints: true)
+                                                     → {ra_center: 160.230°, dec_center: 41.265°}
+      sync_mount(ra=10.6820, dec=41.265)            # 160.230° / 15
+      residual_arcsec = haversine(...)               → 45.0    (> tolerance)
+      slew(ra=10.6847, dec=41.2689)                  # iter-1 action: "sync"
+    iter 1:
+      capture → {document_id: "doc-c02"}
+      plate_solve(document_id="doc-c02", use_mount_hints: true)
+                                                     → {ra_center: 160.270°, dec_center: 41.2685°}
+      residual_arcsec                                → 2.1     (≤ tolerance)
+                                                     # action: "converged"
+  ← {final_error_arcsec: 2.1, attempts: 2,
+     final_ra: 160.270, final_dec: 41.2685,
+     iterations: [
+       {document_id: "doc-c01", residual_arcsec: 45.0, solved_ra: 160.230,
+        solved_dec: 41.265,  action: "sync"},
+       {document_id: "doc-c02", residual_arcsec: 2.1,  solved_ra: 160.270,
+        solved_dec: 41.2685, action: "converged"},
+     ]}
 ```
 
 #### Third-party alternatives

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -721,7 +721,7 @@ boundary — but expose the same MCP tool surface as any other tool.
 | Action | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
 | `auto_focus` | camera_id, focuser_id, duration, step_size, half_width, min_area, max_area, threshold_sigma (optional), min_fit_points (optional) | best_position, best_hfr, final_position, samples_used, curve_points, temperature_c | Parabolic-fit V-curve auto-focus driving `move_focuser` + `capture` + `measure_basic` internally. See [`auto_focus` Contract](#auto_focus-contract). Implemented. |
-| `center_on_target` | camera_id, ra, dec, duration, tolerance_arcsec, max_attempts | final_error_arcsec, attempts, final_ra, final_dec, iterations | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until residual ≤ `tolerance_arcsec`. See [`center_on_target` Contract](#center_on_target-contract). *Planned.* |
+| `center_on_target` | camera_id, ra, dec, duration, tolerance_arcsec, max_attempts | final_error_arcsec, attempts, final_ra, final_dec, iterations | Iterative `capture` + `plate_solve` + `sync_mount` + `slew` loop until residual ≤ `tolerance_arcsec`. See [`center_on_target` Contract](#center_on_target-contract). Implemented. |
 
 **Planner — Ephemeris primitives**
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -209,11 +209,12 @@ operator-declared static optical train and the camera's reported
 sensor geometry at capture time. This is sufficient for `plate_solve`
 hint sourcing and for consumers like annotation and mosaic planning.
 
-When the Phase 6c-2 `plate_solve` built-in tool lands (see
-`docs/plans/archive/image-evaluation-tools.md`), its `document_id` mode uses
-`optics.fov_height_deg` as the default `fov_hint_deg` — `fov_height_deg`
-matches ASTAP's `-fov` semantics ("image height in degrees"). Callers
-keep the option to override with an explicit `fov_hint_deg` parameter.
+The `plate_solve` built-in tool (Phase 6c-2 in
+`docs/plans/archive/image-evaluation-tools.md`) uses
+`optics.fov_height_deg` as the default `fov_hint_deg` in its
+`document_id` mode — `fov_height_deg` matches ASTAP's `-fov` semantics
+("image height in degrees"). Callers keep the option to override with
+an explicit `fov_hint_deg` parameter.
 
 ### Plugin Sections (contributed via API)
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -210,7 +210,7 @@ sensor geometry at capture time. This is sufficient for `plate_solve`
 hint sourcing and for consumers like annotation and mosaic planning.
 
 When the Phase 6c-2 `plate_solve` built-in tool lands (see
-`docs/plans/image-evaluation-tools.md`), its `document_id` mode uses
+`docs/plans/archive/image-evaluation-tools.md`), its `document_id` mode uses
 `optics.fov_height_deg` as the default `fov_hint_deg` — `fov_height_deg`
 matches ASTAP's `-fov` semantics ("image height in degrees"). Callers
 keep the option to override with an explicit `fov_hint_deg` parameter.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -41,7 +41,6 @@ belong in any single service design doc.
 | [bazel-migration.md](plans/bazel-migration.md) | Bazel build alongside Cargo (shadow mode) |
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
 | [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
-| [image-evaluation-tools.md](plans/image-evaluation-tools.md) | rp image-evaluation MCP tool surface |
 | [plate-solver.md](plans/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing) |
 | [rp-planning-tools.md](plans/rp-planning-tools.md) | rp planning & ephemeris tools: site config, `rp-ephemeris` + `rp-catalog` crates, primitive + convenience MCP tools |
 

--- a/services/rp/src/config/session.rs
+++ b/services/rp/src/config/session.rs
@@ -13,7 +13,7 @@ pub struct SessionConfig {
     /// `{target}` / `{filter}` / etc.); until that lands `capture` ignores
     /// the value and writes `<doc_uuid_8>.fits` regardless. See
     /// `docs/services/rp.md` (Persistence) and Phase 7 of
-    /// `docs/plans/image-evaluation-tools.md`.
+    /// `docs/plans/archive/image-evaluation-tools.md`.
     #[serde(default)]
     pub file_naming_pattern: Option<String>,
 }

--- a/services/rp/src/imaging/analysis/mod.rs
+++ b/services/rp/src/imaging/analysis/mod.rs
@@ -4,7 +4,7 @@
 //! async, and persistence concerns. Compositional analyzers live in
 //! [`crate::imaging::tools`]; cache and FITS I/O live in
 //! [`crate::persistence`]. See `docs/services/rp.md` (Module Structure)
-//! and `docs/plans/image-evaluation-tools.md` for the layout rationale.
+//! and `docs/plans/archive/image-evaluation-tools.md` for the layout rationale.
 
 pub mod background;
 pub mod fwhm;

--- a/services/rp/src/imaging/mod.rs
+++ b/services/rp/src/imaging/mod.rs
@@ -24,7 +24,7 @@
 //! The flat re-exports below preserve the previous `crate::imaging::*`
 //! call-site shape so MCP wiring doesn't have to know which submodule
 //! a symbol lives in. See `docs/services/rp.md` (Module Structure) and
-//! `docs/plans/image-evaluation-tools.md` for the rationale.
+//! `docs/plans/archive/image-evaluation-tools.md` for the rationale.
 
 pub mod analysis;
 pub mod tools;

--- a/services/rp/src/imaging/tools/auto_focus.rs
+++ b/services/rp/src/imaging/tools/auto_focus.rs
@@ -83,11 +83,7 @@ pub trait FocuserOps {
     async fn move_to(&self, position: i32) -> Result<i32, String>;
 }
 
-#[async_trait]
-pub trait CaptureOps {
-    /// Capture an exposure of `duration` and return its `document_id`.
-    async fn capture(&self, duration: Duration) -> Result<String, String>;
-}
+pub use super::ops::CaptureOps;
 
 #[async_trait]
 pub trait MeasureOps {

--- a/services/rp/src/imaging/tools/center_on_target.rs
+++ b/services/rp/src/imaging/tools/center_on_target.rs
@@ -414,6 +414,29 @@ mod tests {
         );
     }
 
+    /// Pin the wrap-safe property of haversine across the 0°/360°
+    /// boundary. Future readers (and reviewers) should not have to
+    /// re-derive that the `sin²(Δλ/2)` kernel has period 360° in
+    /// `Δλ` and therefore needs no manual `Δλ ∈ [-180°, 180°]`
+    /// normalization. Same minimal angular separation (~72″ between
+    /// 359.99° and 0.01°) regardless of which side we put first.
+    #[test]
+    fn haversine_is_wrap_safe_across_360() {
+        let across_zero = haversine_arcsec(359.99, 0.0, 0.01, 0.0);
+        let no_wrap = haversine_arcsec(0.0, 0.0, 0.02, 0.0);
+        assert!(
+            (across_zero - no_wrap).abs() < 1e-6,
+            "wrap mismatch: across-zero {} vs no-wrap {}",
+            across_zero,
+            no_wrap
+        );
+        assert!(
+            (across_zero - 72.0).abs() < 0.05,
+            "expected ~72″ separation, got {}",
+            across_zero
+        );
+    }
+
     // ---- end-to-end run_center_on_target over synthetic adapters ----
 
     struct StubCapturer {

--- a/services/rp/src/imaging/tools/center_on_target.rs
+++ b/services/rp/src/imaging/tools/center_on_target.rs
@@ -1,0 +1,690 @@
+//! `center_on_target`: iterative capture → plate-solve → sync → slew
+//! compound tool.
+//!
+//! The driving logic — input validation, residual computation, sync-on-
+//! iter-1 invariant, fail-fast loop body — is pure Rust and fully unit-
+//! testable via the [`CaptureOps`], [`PlateSolveOps`], and [`MountOps`]
+//! traits. The MCP wrapper in `mcp/built_in/center_on_target.rs`
+//! provides concrete adapters that bind to the live capture path,
+//! the in-process `plate_solve` handler, and the singular Alpaca
+//! mount; tests substitute synthetic adapters that drive the loop with
+//! deterministic per-iteration outcomes.
+//!
+//! Behavioral contract: `docs/services/rp.md` → Compound Tools →
+//! `center_on_target` Contract.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::debug;
+
+pub use super::ops::CaptureOps;
+
+#[derive(Debug, Clone)]
+pub struct CenterOnTargetParams {
+    /// Target right ascension in decimal hours, `[0, 24)`. Same unit
+    /// as `slew` and `sync_mount` (Alpaca's `RightAscension`).
+    pub ra: f64,
+    /// Target declination in decimal degrees, `[-90, 90]`.
+    pub dec: f64,
+    /// Per-iteration exposure.
+    pub duration: Duration,
+    /// Convergence threshold on the great-circle residual between the
+    /// solved center and `(ra, dec)`, in arcseconds. Must be positive.
+    pub tolerance_arcsec: f64,
+    /// Hard cap on the number of iterations. Must be positive and
+    /// `<= MAX_ATTEMPTS`.
+    pub max_attempts: usize,
+}
+
+/// Action taken on a single iteration *after* the per-iter solve.
+/// Serialized as a kebab/snake-cased string in the result JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IterationAction {
+    /// Iter 1 only: solved, synced, residual was outside tolerance,
+    /// and the loop slewed back to the input target. Iter 1's record
+    /// always uses `Sync` *unless* the residual was already inside
+    /// tolerance after sync — in which case it collapses to
+    /// `Converged` (sync still happened; the slew was skipped).
+    Sync,
+    /// Solved, residual outside tolerance, slewed back to the input
+    /// target. Used on iter 2 onwards when the loop didn't converge.
+    Slew,
+    /// Solved, residual inside tolerance — terminal action. Always
+    /// the last record; appears at most once.
+    Converged,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IterationRecord {
+    pub document_id: String,
+    pub residual_arcsec: f64,
+    pub solved_ra: f64,
+    pub solved_dec: f64,
+    pub action: IterationAction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CenterOnTargetResult {
+    pub final_error_arcsec: f64,
+    pub attempts: usize,
+    pub final_ra: f64,
+    pub final_dec: f64,
+    pub iterations: Vec<IterationRecord>,
+}
+
+/// Outcome of a single `plate_solve` call: the solved field-center in
+/// decimal degrees. Mirrors the wrapper's success body, narrowed to
+/// the two fields the centering loop actually consumes.
+#[derive(Debug, Clone, Copy)]
+pub struct SolveOutcome {
+    pub ra_center_deg: f64,
+    pub dec_center_deg: f64,
+}
+
+#[derive(Debug, Error)]
+pub enum CenterOnTargetError {
+    #[error("tolerance_arcsec must be positive (got {0})")]
+    InvalidTolerance(f64),
+    #[error("max_attempts must be positive (got {0})")]
+    InvalidMaxAttempts(usize),
+    #[error(
+        "max_attempts={requested} exceeds the safety cap of {max} (lower max_attempts; the loop \
+         is meant to converge in 2–4 iterations)"
+    )]
+    MaxAttemptsExceedsCap { requested: usize, max: usize },
+    #[error("ra out of range: {0} (must be in [0.0, 24.0))")]
+    InvalidRa(f64),
+    #[error("dec out of range: {0} (must be in [-90.0, 90.0])")]
+    InvalidDec(f64),
+    #[error(
+        "tolerance_not_reached: residual {last_residual_arcsec:.2}\" after \
+         {attempts} attempts (tolerance {tolerance_arcsec:.2}\")"
+    )]
+    ToleranceNotReached {
+        last_residual_arcsec: f64,
+        tolerance_arcsec: f64,
+        attempts: usize,
+    },
+    #[error("equipment error during centering: {0}")]
+    Equipment(String),
+}
+
+#[async_trait]
+pub trait PlateSolveOps {
+    /// Plate-solve the named document_id. The MCP-side adapter sets
+    /// `use_mount_hints: true` so the wrapper hint plumbing stays in
+    /// the existing `plate_solve` Contract. Synthetic adapters
+    /// ignore the document_id and return canned outcomes.
+    async fn solve(&self, document_id: &str) -> Result<SolveOutcome, String>;
+}
+
+#[async_trait]
+pub trait MountOps {
+    /// Sync the mount's reported position to `(ra_deg, dec_deg)`.
+    /// Inputs are decimal degrees here so the loop math is consistent;
+    /// the live adapter converts to Alpaca's hours-for-RA at the call
+    /// site (see `do_sync_mount` in `mcp/internals.rs`).
+    async fn sync_to(&self, ra_deg: f64, dec_deg: f64) -> Result<(), String>;
+    /// Slew the mount to the input target. Inputs are decimal hours
+    /// for RA and decimal degrees for Dec, matching the primitive
+    /// `slew` MCP tool's contract.
+    async fn slew_to(&self, ra_hours: f64, dec_deg: f64) -> Result<(), String>;
+}
+
+/// Hard cap on `max_attempts`. Plausible centering runs converge in
+/// 2–4 iterations; 50 is generous enough that no real workflow trips
+/// the cap, low enough that a misconfigured loop can't tie up the rig
+/// for hours. Mirrors `auto_focus`'s `MAX_GRID_POINTS` guardrail.
+pub const MAX_ATTEMPTS: usize = 50;
+
+pub fn validate_params(params: &CenterOnTargetParams) -> Result<(), CenterOnTargetError> {
+    if !(0.0..24.0).contains(&params.ra) {
+        return Err(CenterOnTargetError::InvalidRa(params.ra));
+    }
+    if !(-90.0..=90.0).contains(&params.dec) {
+        return Err(CenterOnTargetError::InvalidDec(params.dec));
+    }
+    if params.tolerance_arcsec <= 0.0 {
+        return Err(CenterOnTargetError::InvalidTolerance(
+            params.tolerance_arcsec,
+        ));
+    }
+    if params.max_attempts == 0 {
+        return Err(CenterOnTargetError::InvalidMaxAttempts(0));
+    }
+    if params.max_attempts > MAX_ATTEMPTS {
+        return Err(CenterOnTargetError::MaxAttemptsExceedsCap {
+            requested: params.max_attempts,
+            max: MAX_ATTEMPTS,
+        });
+    }
+    Ok(())
+}
+
+/// Great-circle separation between two equatorial directions, returned
+/// in arcseconds. Inputs are decimal degrees for both RA and Dec.
+///
+/// Uses the haversine formula — numerically stable for the small
+/// angles centering deals with (typically arcseconds-to-arcminutes),
+/// and closed-form so no external dependency is needed.
+pub fn haversine_arcsec(ra1_deg: f64, dec1_deg: f64, ra2_deg: f64, dec2_deg: f64) -> f64 {
+    let to_rad = std::f64::consts::PI / 180.0;
+    let phi1 = dec1_deg * to_rad;
+    let phi2 = dec2_deg * to_rad;
+    let dphi = phi2 - phi1;
+    let dlambda = (ra2_deg - ra1_deg) * to_rad;
+    let a = (dphi / 2.0).sin().powi(2) + phi1.cos() * phi2.cos() * (dlambda / 2.0).sin().powi(2);
+    // 2·atan2(√a, √(1−a)) is the haversine central angle (radians).
+    let central_angle_rad = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
+    let central_angle_deg = central_angle_rad / to_rad;
+    central_angle_deg * 3600.0
+}
+
+/// Drive the centering loop against the supplied capture / plate-solve
+/// / mount adapters. See `docs/services/rp.md` →
+/// `center_on_target` Contract for the behavioral spec; this function
+/// is the reference implementation.
+///
+/// `emit_iteration` is called after each iteration's record is built
+/// (whether the action is `Sync`, `Slew`, or `Converged`). The MCP
+/// wrapper plumbs this into a `centering_iteration` event; tests can
+/// no-op the closure.
+pub async fn run_center_on_target<C, P, M>(
+    capturer: &C,
+    solver: &P,
+    mounter: &M,
+    params: CenterOnTargetParams,
+    mut emit_iteration: impl FnMut(&IterationRecord),
+) -> Result<CenterOnTargetResult, CenterOnTargetError>
+where
+    C: CaptureOps + Sync,
+    P: PlateSolveOps + Sync,
+    M: MountOps + Sync,
+{
+    validate_params(&params)?;
+
+    let target_ra_deg = params.ra * 15.0;
+    let target_dec_deg = params.dec;
+    debug!(
+        ra_hours = params.ra,
+        dec_deg = params.dec,
+        tolerance_arcsec = params.tolerance_arcsec,
+        max_attempts = params.max_attempts,
+        "center_on_target loop starting"
+    );
+
+    let mut iterations: Vec<IterationRecord> = Vec::new();
+    let mut last_residual: f64 = f64::INFINITY;
+
+    for iter in 0..params.max_attempts {
+        let document_id = capturer
+            .capture(params.duration)
+            .await
+            .map_err(CenterOnTargetError::Equipment)?;
+        let outcome = solver
+            .solve(&document_id)
+            .await
+            .map_err(CenterOnTargetError::Equipment)?;
+
+        // Sync on iter 1 unconditionally — the first solve is the
+        // absolute pointing reference. Subsequent iterations rely on
+        // the mount honouring relative slews instead of re-syncing
+        // (repeated syncs interact badly with model-building drivers).
+        if iter == 0 {
+            mounter
+                .sync_to(outcome.ra_center_deg, outcome.dec_center_deg)
+                .await
+                .map_err(CenterOnTargetError::Equipment)?;
+        }
+
+        let residual_arcsec = haversine_arcsec(
+            outcome.ra_center_deg,
+            outcome.dec_center_deg,
+            target_ra_deg,
+            target_dec_deg,
+        );
+        last_residual = residual_arcsec;
+
+        let action = if residual_arcsec <= params.tolerance_arcsec {
+            IterationAction::Converged
+        } else if iter == 0 {
+            // Iter 1 already issued the sync; slew now to relocate.
+            IterationAction::Sync
+        } else {
+            IterationAction::Slew
+        };
+
+        if matches!(action, IterationAction::Slew | IterationAction::Sync) {
+            mounter
+                .slew_to(params.ra, params.dec)
+                .await
+                .map_err(CenterOnTargetError::Equipment)?;
+        }
+
+        let record = IterationRecord {
+            document_id,
+            residual_arcsec,
+            solved_ra: outcome.ra_center_deg,
+            solved_dec: outcome.dec_center_deg,
+            action,
+        };
+        emit_iteration(&record);
+        iterations.push(record);
+
+        if matches!(action, IterationAction::Converged) {
+            let final_record = iterations
+                .last()
+                .expect("just pushed the converged record above");
+            return Ok(CenterOnTargetResult {
+                final_error_arcsec: residual_arcsec,
+                attempts: iterations.len(),
+                final_ra: final_record.solved_ra,
+                final_dec: final_record.solved_dec,
+                iterations,
+            });
+        }
+    }
+
+    Err(CenterOnTargetError::ToleranceNotReached {
+        last_residual_arcsec: last_residual,
+        tolerance_arcsec: params.tolerance_arcsec,
+        attempts: iterations.len(),
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // ---- pure helpers ----
+
+    fn baseline_params() -> CenterOnTargetParams {
+        CenterOnTargetParams {
+            ra: 10.6848 / 15.0, // ≈ 0.7123 hours, so 10.6848° in degrees
+            dec: 41.269,
+            duration: Duration::from_millis(100),
+            tolerance_arcsec: 60.0,
+            max_attempts: 5,
+        }
+    }
+
+    #[test]
+    fn validate_params_accepts_minimum_valid_input() {
+        let p = CenterOnTargetParams {
+            ra: 0.0,
+            dec: 0.0,
+            duration: Duration::from_millis(1),
+            tolerance_arcsec: 1e-6,
+            max_attempts: 1,
+        };
+        validate_params(&p).unwrap();
+    }
+
+    #[test]
+    fn validate_params_rejects_zero_tolerance() {
+        let mut p = baseline_params();
+        p.tolerance_arcsec = 0.0;
+        assert!(matches!(
+            validate_params(&p),
+            Err(CenterOnTargetError::InvalidTolerance(_))
+        ));
+    }
+
+    #[test]
+    fn validate_params_rejects_zero_max_attempts() {
+        let mut p = baseline_params();
+        p.max_attempts = 0;
+        assert!(matches!(
+            validate_params(&p),
+            Err(CenterOnTargetError::InvalidMaxAttempts(0))
+        ));
+    }
+
+    #[test]
+    fn validate_params_rejects_max_attempts_above_cap() {
+        let mut p = baseline_params();
+        p.max_attempts = MAX_ATTEMPTS + 1;
+        match validate_params(&p) {
+            Err(CenterOnTargetError::MaxAttemptsExceedsCap { requested, max }) => {
+                assert_eq!(requested, MAX_ATTEMPTS + 1);
+                assert_eq!(max, MAX_ATTEMPTS);
+            }
+            other => panic!("expected MaxAttemptsExceedsCap, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_params_rejects_ra_at_or_above_24() {
+        let mut p = baseline_params();
+        p.ra = 24.0;
+        assert!(matches!(
+            validate_params(&p),
+            Err(CenterOnTargetError::InvalidRa(_))
+        ));
+    }
+
+    #[test]
+    fn validate_params_rejects_dec_above_90() {
+        let mut p = baseline_params();
+        p.dec = 91.0;
+        assert!(matches!(
+            validate_params(&p),
+            Err(CenterOnTargetError::InvalidDec(_))
+        ));
+    }
+
+    // ---- haversine sanity ----
+
+    #[test]
+    fn haversine_zero_separation_is_zero() {
+        let arcsec = haversine_arcsec(160.27, 41.269, 160.27, 41.269);
+        assert!(
+            arcsec < 1e-6,
+            "expected 0 arcsec for identical inputs, got {}",
+            arcsec
+        );
+    }
+
+    #[test]
+    fn haversine_one_arcsec_at_equator() {
+        // 1 arcsec along RA at the equator = 1 arcsec separation. The
+        // 1/3600 degree shift is exact at dec=0 because cos(0)=1 in
+        // the haversine.
+        let arcsec = haversine_arcsec(0.0, 0.0, 1.0 / 3600.0, 0.0);
+        assert!(
+            (arcsec - 1.0).abs() < 1e-6,
+            "expected 1 arcsec, got {}",
+            arcsec
+        );
+    }
+
+    #[test]
+    fn haversine_one_arcmin_along_dec() {
+        // 1 arcmin along Dec = 60 arcsec, regardless of RA.
+        let arcsec = haversine_arcsec(160.27, 41.0, 160.27, 41.0 + 1.0 / 60.0);
+        assert!(
+            (arcsec - 60.0).abs() < 1e-6,
+            "expected 60 arcsec, got {}",
+            arcsec
+        );
+    }
+
+    // ---- end-to-end run_center_on_target over synthetic adapters ----
+
+    struct StubCapturer {
+        counter: Mutex<u64>,
+    }
+
+    #[async_trait]
+    impl CaptureOps for StubCapturer {
+        async fn capture(&self, _: Duration) -> Result<String, String> {
+            let mut c = self.counter.lock().unwrap();
+            *c += 1;
+            Ok(format!("doc-{:04}", *c))
+        }
+    }
+
+    /// Plate solver that walks a queue of canned outcomes; once the
+    /// queue is exhausted, keeps returning the last entry. Mirrors
+    /// the BDD `Sequence` stub.
+    struct StubSolver {
+        queue: Mutex<Vec<SolveOutcome>>,
+        cursor: Mutex<usize>,
+    }
+
+    impl StubSolver {
+        fn new(outcomes: Vec<SolveOutcome>) -> Self {
+            assert!(
+                !outcomes.is_empty(),
+                "StubSolver needs at least one outcome"
+            );
+            Self {
+                queue: Mutex::new(outcomes),
+                cursor: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PlateSolveOps for StubSolver {
+        async fn solve(&self, _: &str) -> Result<SolveOutcome, String> {
+            let queue = self.queue.lock().unwrap();
+            let mut cursor = self.cursor.lock().unwrap();
+            let idx = (*cursor).min(queue.len() - 1);
+            *cursor += 1;
+            Ok(queue[idx])
+        }
+    }
+
+    /// Mount that records every sync_to / slew_to call. Tests inspect
+    /// the log to verify the sync-on-iter-1-only invariant.
+    #[derive(Default)]
+    struct StubMounter {
+        sync_calls: Mutex<Vec<(f64, f64)>>,
+        slew_calls: Mutex<Vec<(f64, f64)>>,
+    }
+
+    #[async_trait]
+    impl MountOps for StubMounter {
+        async fn sync_to(&self, ra_deg: f64, dec_deg: f64) -> Result<(), String> {
+            self.sync_calls.lock().unwrap().push((ra_deg, dec_deg));
+            Ok(())
+        }
+        async fn slew_to(&self, ra_hours: f64, dec_deg: f64) -> Result<(), String> {
+            self.slew_calls.lock().unwrap().push((ra_hours, dec_deg));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_converges_on_iteration_1() {
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        let solver = StubSolver::new(vec![SolveOutcome {
+            ra_center_deg: 10.6848,
+            dec_center_deg: 41.269,
+        }]);
+        let mounter = StubMounter::default();
+        let result = run_center_on_target(&cap, &solver, &mounter, baseline_params(), |_| {})
+            .await
+            .unwrap();
+        assert_eq!(result.attempts, 1);
+        assert_eq!(result.iterations.len(), 1);
+        assert_eq!(result.iterations[0].action, IterationAction::Converged);
+        // sync fires unconditionally on iter 1 even when converged.
+        assert_eq!(mounter.sync_calls.lock().unwrap().len(), 1);
+        // converged ⇒ no slew issued for iter 1.
+        assert_eq!(mounter.slew_calls.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn run_converges_on_iteration_2_records_sync_then_converged() {
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        let solver = StubSolver::new(vec![
+            // iter 1: 0.04° (≈ 144 arcsec) off in Dec — outside the
+            // 60-arcsec tolerance.
+            SolveOutcome {
+                ra_center_deg: 10.6848,
+                dec_center_deg: 41.229,
+            },
+            // iter 2: spot on.
+            SolveOutcome {
+                ra_center_deg: 10.6848,
+                dec_center_deg: 41.269,
+            },
+        ]);
+        let mounter = StubMounter::default();
+        let result = run_center_on_target(&cap, &solver, &mounter, baseline_params(), |_| {})
+            .await
+            .unwrap();
+        assert_eq!(result.attempts, 2);
+        assert_eq!(result.iterations[0].action, IterationAction::Sync);
+        assert_eq!(result.iterations[1].action, IterationAction::Converged);
+        // Sync-on-iter-1-only invariant: exactly one sync, even
+        // though the loop ran twice.
+        assert_eq!(mounter.sync_calls.lock().unwrap().len(), 1);
+        // One slew on iter 1 (after sync, residual outside tolerance);
+        // no slew on iter 2 (converged action skips slew).
+        assert_eq!(mounter.slew_calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_errors_tolerance_not_reached_after_max_attempts() {
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        // Solver always returns the same off-target point — residual
+        // never improves.
+        let solver = StubSolver::new(vec![SolveOutcome {
+            ra_center_deg: 9.9,
+            dec_center_deg: 41.0,
+        }]);
+        let mounter = StubMounter::default();
+        let mut params = baseline_params();
+        params.max_attempts = 3;
+        let err = run_center_on_target(&cap, &solver, &mounter, params, |_| {}).await;
+        match err {
+            Err(CenterOnTargetError::ToleranceNotReached { attempts, .. }) => {
+                assert_eq!(attempts, 3);
+            }
+            other => panic!("expected ToleranceNotReached, got {:?}", other),
+        }
+        // The loop ran 3 iterations, each ending with a slew (since
+        // residual stayed > tolerance every time).
+        assert_eq!(mounter.slew_calls.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn run_propagates_capture_error() {
+        struct FailingCapturer;
+        #[async_trait]
+        impl CaptureOps for FailingCapturer {
+            async fn capture(&self, _: Duration) -> Result<String, String> {
+                Err("camera offline".to_string())
+            }
+        }
+        let solver = StubSolver::new(vec![SolveOutcome {
+            ra_center_deg: 10.6848,
+            dec_center_deg: 41.269,
+        }]);
+        let mounter = StubMounter::default();
+        let err = run_center_on_target(
+            &FailingCapturer,
+            &solver,
+            &mounter,
+            baseline_params(),
+            |_| {},
+        )
+        .await;
+        match err {
+            Err(CenterOnTargetError::Equipment(msg)) => assert!(
+                msg.contains("camera offline"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_propagates_solve_error() {
+        struct FailingSolver;
+        #[async_trait]
+        impl PlateSolveOps for FailingSolver {
+            async fn solve(&self, _: &str) -> Result<SolveOutcome, String> {
+                Err("plate_solve: solve_failed: ASTAP exited with code 1".to_string())
+            }
+        }
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        let mounter = StubMounter::default();
+        let err =
+            run_center_on_target(&cap, &FailingSolver, &mounter, baseline_params(), |_| {}).await;
+        match err {
+            Err(CenterOnTargetError::Equipment(msg)) => assert!(
+                msg.contains("solve_failed"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_propagates_slew_error() {
+        struct FailingSlewMounter;
+        #[async_trait]
+        impl MountOps for FailingSlewMounter {
+            async fn sync_to(&self, _: f64, _: f64) -> Result<(), String> {
+                Ok(())
+            }
+            async fn slew_to(&self, _: f64, _: f64) -> Result<(), String> {
+                Err("failed to slew: tracking is off".to_string())
+            }
+        }
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        let solver = StubSolver::new(vec![SolveOutcome {
+            // Solved point far from target → slew fires after sync.
+            ra_center_deg: 9.0,
+            dec_center_deg: 30.0,
+        }]);
+        let err = run_center_on_target(
+            &cap,
+            &solver,
+            &FailingSlewMounter,
+            baseline_params(),
+            |_| {},
+        )
+        .await;
+        match err {
+            Err(CenterOnTargetError::Equipment(msg)) => assert!(
+                msg.contains("tracking is off"),
+                "expected propagated message, got: {}",
+                msg
+            ),
+            other => panic!("expected Equipment, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_invokes_emit_iteration_callback_per_record() {
+        let cap = StubCapturer {
+            counter: Mutex::new(0),
+        };
+        let solver = StubSolver::new(vec![
+            SolveOutcome {
+                ra_center_deg: 10.6848,
+                dec_center_deg: 41.229,
+            },
+            SolveOutcome {
+                ra_center_deg: 10.6848,
+                dec_center_deg: 41.269,
+            },
+        ]);
+        let mounter = StubMounter::default();
+        let actions = std::sync::Mutex::new(Vec::new());
+        let result = run_center_on_target(&cap, &solver, &mounter, baseline_params(), |rec| {
+            actions.lock().unwrap().push(rec.action);
+        })
+        .await
+        .unwrap();
+        let logged = actions.into_inner().unwrap();
+        assert_eq!(logged.len(), 2);
+        assert_eq!(
+            logged,
+            vec![IterationAction::Sync, IterationAction::Converged]
+        );
+        assert_eq!(result.iterations.len(), 2);
+    }
+}

--- a/services/rp/src/imaging/tools/mod.rs
+++ b/services/rp/src/imaging/tools/mod.rs
@@ -5,15 +5,22 @@
 //!   kernels into one MCP-tool-shaped result. Pure functions over
 //!   `ArrayView2`, no I/O, no async — unit-testable without a runtime.
 //!
-//! - **Compound equipment-driving tools** (`auto_focus`; planned
-//!   `center_on_target`): drive a multi-step move/capture/measure
-//!   loop using primitive built-in tools. They expose async traits
-//!   for the equipment surface so the driving logic is testable
-//!   against synthetic adapters; the MCP wrapper in `mcp.rs` provides
-//!   live adapters that bind to the real Alpaca clients. The math and
-//!   grid logic these tools bundle (`build_grid`, `fit_parabola`,
-//!   `validate_params`) remain pure helpers.
+//! - **Compound equipment-driving tools** (`auto_focus`,
+//!   `center_on_target`): drive a multi-step move/capture/measure or
+//!   capture/solve/sync/slew loop using primitive built-in tools.
+//!   They expose async traits for the equipment surface so the
+//!   driving logic is testable against synthetic adapters; the MCP
+//!   wrapper in `mcp/built_in/<tool>.rs` provides live adapters that
+//!   bind to the real Alpaca clients. The math and grid logic these
+//!   tools bundle (`build_grid`, `fit_parabola`, `validate_params`,
+//!   `haversine_arcsec`) remain pure helpers.
+//!
+//! The `CaptureOps` trait both compound tools share lives in [`ops`]
+//! so neither tool's module declares it as a "primary" definition —
+//! shared trait, single canonical home.
 
 pub mod auto_focus;
+pub mod center_on_target;
 pub mod measure_basic;
 pub mod measure_stars;
+pub mod ops;

--- a/services/rp/src/imaging/tools/ops.rs
+++ b/services/rp/src/imaging/tools/ops.rs
@@ -1,0 +1,24 @@
+//! Shared trait surface for compound equipment-driving tools.
+//!
+//! Both [`super::auto_focus`] and [`super::center_on_target`] need a
+//! `capture(duration) → document_id` operation against the live camera
+//! adapter — extracted here so the trait has one canonical home rather
+//! than being declared in each compound tool's module.
+//!
+//! `String` errors keep the trait surface deliberately simple: every
+//! adapter ultimately wraps an Alpaca call whose error already carries
+//! a human-readable message; structured-error variants would add
+//! ceremony without giving the test-side synthetic adapters anything
+//! to do.
+
+use async_trait::async_trait;
+use std::time::Duration;
+
+/// Asynchronously capture an exposure of `duration` and return its
+/// `document_id`. The capture path's other side effects (FITS write,
+/// cache insert, `exposure_complete` event) are the implementer's
+/// responsibility.
+#[async_trait]
+pub trait CaptureOps {
+    async fn capture(&self, duration: Duration) -> Result<String, String>;
+}

--- a/services/rp/src/mcp/built_in/center_on_target.rs
+++ b/services/rp/src/mcp/built_in/center_on_target.rs
@@ -1,0 +1,299 @@
+use std::time::Duration;
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::{tool, tool_router};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use super::super::handler::McpHandler;
+use super::super::{resolve_device, tool_error, tool_success};
+use crate::imaging;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CenterOnTargetToolParams {
+    /// Camera that captures each iteration's frame.
+    #[serde(default)]
+    pub camera_id: Option<String>,
+    /// Target right ascension, decimal hours, [0, 24).
+    #[serde(default)]
+    pub ra: Option<f64>,
+    /// Target declination, decimal degrees, [-90, 90].
+    #[serde(default)]
+    pub dec: Option<f64>,
+    /// Per-iteration exposure (humantime string).
+    #[serde(default, with = "humantime_serde::option")]
+    #[schemars(with = "Option<String>")]
+    pub duration: Option<Duration>,
+    /// Convergence threshold on the great-circle residual between the
+    /// solved center and (ra, dec), in arcseconds.
+    #[serde(default)]
+    pub tolerance_arcsec: Option<f64>,
+    /// Hard cap on the number of iterations. Capped at MAX_ATTEMPTS
+    /// (50) before any motion.
+    #[serde(default)]
+    pub max_attempts: Option<usize>,
+}
+
+#[tool_router(router = tool_router_center_on_target, vis = "pub")]
+impl McpHandler {
+    #[tool(
+        description = "Iteratively capture, plate-solve, sync (iter 1 only), and slew until the great-circle residual between the solved field-center and (ra, dec) is at or below tolerance_arcsec. Singular mount required. See `center_on_target` Contract in rp.md."
+    )]
+    pub(crate) async fn center_on_target(
+        &self,
+        Parameters(params): Parameters<CenterOnTargetToolParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Body validation in input order so the missing-parameter
+        // outline always points at the first missing field — same
+        // convention as `auto_focus` / `measure_basic`.
+        let camera_id = match params.camera_id.as_deref() {
+            Some(s) => s.to_string(),
+            None => return Ok(tool_error!("missing required parameter: camera_id")),
+        };
+        let ra = match params.ra {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: ra")),
+        };
+        let dec = match params.dec {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: dec")),
+        };
+        let duration = match params.duration {
+            Some(d) => d,
+            None => return Ok(tool_error!("missing required parameter: duration")),
+        };
+        let tolerance_arcsec = match params.tolerance_arcsec {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: tolerance_arcsec")),
+        };
+        let max_attempts = match params.max_attempts {
+            Some(v) => v,
+            None => return Ok(tool_error!("missing required parameter: max_attempts")),
+        };
+
+        // Resolve devices early so the device-resolution error
+        // scenarios trip before any numeric-range or motion errors.
+        let (_cam_entry, _cam) = resolve_device!(self, find_camera, &camera_id, "camera");
+        // Mount resolution: same shape as `do_sync_mount` /
+        // `do_slew_blocking` would surface, just hoisted here so the
+        // BDD "no mount configured" / "mount not connected" scenarios
+        // see the error before the loop body runs.
+        if let Err(e) = self.resolve_mount() {
+            return Ok(tool_error!("{}", e));
+        }
+
+        self.event_bus.emit(
+            "centering_started",
+            serde_json::json!({
+                "camera_id": camera_id,
+                "ra": ra,
+                "dec": dec,
+                "tolerance_arcsec": tolerance_arcsec,
+                "max_attempts": max_attempts,
+            }),
+        );
+
+        let cot_params = imaging::tools::center_on_target::CenterOnTargetParams {
+            ra,
+            dec,
+            duration,
+            tolerance_arcsec,
+            max_attempts,
+        };
+
+        let adapter = CenterOnTargetAdapter {
+            handler: self,
+            camera_id: camera_id.clone(),
+        };
+
+        let event_bus = self.event_bus.clone();
+        let camera_id_for_event = camera_id.clone();
+        let emit_iteration = move |rec: &imaging::tools::center_on_target::IterationRecord| {
+            let action = serde_json::to_value(rec.action).unwrap_or(serde_json::Value::Null);
+            event_bus.emit(
+                "centering_iteration",
+                serde_json::json!({
+                    "camera_id": camera_id_for_event,
+                    "document_id": rec.document_id,
+                    "residual_arcsec": rec.residual_arcsec,
+                    "solved_ra": rec.solved_ra,
+                    "solved_dec": rec.solved_dec,
+                    "action": action,
+                }),
+            );
+        };
+
+        match imaging::tools::center_on_target::run_center_on_target(
+            &adapter,
+            &adapter,
+            &adapter,
+            cot_params,
+            emit_iteration,
+        )
+        .await
+        {
+            Ok(result) => {
+                self.event_bus.emit(
+                    "centering_complete",
+                    serde_json::json!({
+                        "camera_id": camera_id,
+                        "final_error_arcsec": result.final_error_arcsec,
+                        "attempts": result.attempts,
+                        "final_ra": result.final_ra,
+                        "final_dec": result.final_dec,
+                    }),
+                );
+                let iterations =
+                    serde_json::to_value(&result.iterations).unwrap_or(serde_json::Value::Null);
+                Ok(tool_success!({
+                    "final_error_arcsec": result.final_error_arcsec,
+                    "attempts": result.attempts,
+                    "final_ra": result.final_ra,
+                    "final_dec": result.final_dec,
+                    "iterations": iterations,
+                }))
+            }
+            Err(e) => Ok(tool_error!("{}", e)),
+        }
+    }
+}
+
+/// Adapter satisfying the three [`center_on_target`] traits
+/// (`CaptureOps`, `PlateSolveOps`, `MountOps`) by delegating to the
+/// existing [`McpHandler`] helpers.
+///
+/// `PlateSolveOps` calls back into the in-process `plate_solve`
+/// handler with `use_mount_hints: true`, so the hours→degrees
+/// conversion lives in exactly one place (the `plate_solve` Contract).
+/// `MountOps::sync_to` calls `do_sync_mount` after dividing the
+/// solved degrees by 15 to match Alpaca's RA-in-hours convention.
+/// `MountOps::slew_to` calls `do_slew_blocking` with the operator-
+/// configured `settle_after_slew` so iteration cadence honours
+/// rig-specific mechanical settle.
+pub(crate) struct CenterOnTargetAdapter<'a> {
+    pub(crate) handler: &'a McpHandler,
+    pub(crate) camera_id: String,
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::center_on_target::CaptureOps for CenterOnTargetAdapter<'_> {
+    async fn capture(&self, duration: Duration) -> std::result::Result<String, String> {
+        let (_image_path, document_id) = self.handler.do_capture(&self.camera_id, duration).await?;
+        Ok(document_id)
+    }
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::center_on_target::PlateSolveOps for CenterOnTargetAdapter<'_> {
+    async fn solve(
+        &self,
+        document_id: &str,
+    ) -> std::result::Result<imaging::tools::center_on_target::SolveOutcome, String> {
+        // Inline call into the in-process `plate_solve` path. Going
+        // through the MCP transport would re-encode the JSON params
+        // and pay an extra HTTP round-trip — not what compound tools
+        // want (mirrors `auto_focus`'s direct `measure_via_document`
+        // call, where the auto-focus loop similarly skips the MCP
+        // transport for its inner `measure_basic` calls).
+        let client = self
+            .handler
+            .plate_solver
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "plate_solve: plate solver not configured".to_string())?;
+
+        let doc = self
+            .handler
+            .image_cache
+            .resolve_document(document_id)
+            .await
+            .ok_or_else(|| format!("plate_solve: document not found: {}", document_id))?;
+
+        // Source the pointing hint from the mount, paralleling
+        // plate_solve's `use_mount_hints: true` path. Failure modes
+        // surface verbatim (no mount configured / disconnected /
+        // Alpaca read error) — center_on_target needs a connected
+        // mount anyway, and we already validated that up front.
+        let (ra_hint, dec_hint) = self
+            .handler
+            .read_mount_hints_for_plate_solve()
+            .await
+            .map(|(ra, dec)| (Some(ra), Some(dec)))
+            .unwrap_or((None, None));
+
+        let request = rp_plate_solver::SolveRequest {
+            fits_path: doc.file_path.clone(),
+            ra_hint,
+            dec_hint,
+            fov_hint_deg: None,
+            search_radius_deg: self.handler.plate_solver_default_search_radius_deg,
+            timeout: None,
+        };
+
+        let outcome = client.solve(request).await.map_err(|e| match e {
+            rp_plate_solver::SolveError::ServiceUnreachable(reason) => {
+                format!("plate_solve: service unreachable: {}", reason)
+            }
+            rp_plate_solver::SolveError::Wrapper {
+                code,
+                message,
+                details,
+            } => {
+                if details.is_null() {
+                    format!("plate_solve: {}: {}", code, message)
+                } else {
+                    format!("plate_solve: {}: {} (details: {})", code, message, details)
+                }
+            }
+            rp_plate_solver::SolveError::Internal(reason) => {
+                format!("plate_solve: internal: {}", reason)
+            }
+        })?;
+
+        // Persist the per-iteration `wcs` section to the captured
+        // document — same side-effect the standalone `plate_solve`
+        // tool would write. Failure is logged and ignored.
+        let payload = serde_json::json!({
+            "ra_center": outcome.ra_center,
+            "dec_center": outcome.dec_center,
+            "pixel_scale_arcsec": outcome.pixel_scale_arcsec,
+            "rotation_deg": outcome.rotation_deg,
+            "solver": outcome.solver,
+        });
+        if let Err(e) = self
+            .handler
+            .image_cache
+            .put_section(document_id, "wcs", payload)
+            .await
+        {
+            tracing::debug!(error = %e, document_id, "failed to persist wcs section");
+        }
+
+        Ok(imaging::tools::center_on_target::SolveOutcome {
+            ra_center_deg: outcome.ra_center,
+            dec_center_deg: outcome.dec_center,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl imaging::tools::center_on_target::MountOps for CenterOnTargetAdapter<'_> {
+    async fn sync_to(&self, ra_deg: f64, dec_deg: f64) -> std::result::Result<(), String> {
+        // The driver works in degrees; Alpaca's RA is hours.
+        let ra_hours = ra_deg / 15.0;
+        self.handler.do_sync_mount(ra_hours, dec_deg).await
+    }
+    async fn slew_to(&self, ra_hours: f64, dec_deg: f64) -> std::result::Result<(), String> {
+        let settle = self
+            .handler
+            .equipment
+            .find_mount()
+            .and_then(|m| m.config.settle_after_slew)
+            .unwrap_or_default();
+        self.handler
+            .do_slew_blocking(ra_hours, dec_deg, settle)
+            .await
+            .map(|_| ())
+    }
+}

--- a/services/rp/src/mcp/built_in/center_on_target.rs
+++ b/services/rp/src/mcp/built_in/center_on_target.rs
@@ -7,6 +7,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use super::super::handler::McpHandler;
+use super::super::internals::DoPlateSolveInput;
 use super::super::{resolve_device, tool_error, tool_success};
 use crate::imaging;
 
@@ -190,92 +191,29 @@ impl imaging::tools::center_on_target::PlateSolveOps for CenterOnTargetAdapter<'
         &self,
         document_id: &str,
     ) -> std::result::Result<imaging::tools::center_on_target::SolveOutcome, String> {
-        // Inline call into the in-process `plate_solve` path. Going
-        // through the MCP transport would re-encode the JSON params
-        // and pay an extra HTTP round-trip — not what compound tools
-        // want (mirrors `auto_focus`'s direct `measure_via_document`
-        // call, where the auto-focus loop similarly skips the MCP
-        // transport for its inner `measure_basic` calls).
-        let client = self
-            .handler
-            .plate_solver
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| "plate_solve: plate solver not configured".to_string())?;
-
-        let doc = self
-            .handler
-            .image_cache
-            .resolve_document(document_id)
-            .await
-            .ok_or_else(|| format!("plate_solve: document not found: {}", document_id))?;
-
-        // Source the pointing hint from the mount, paralleling
-        // plate_solve's `use_mount_hints: true` path. We propagate
-        // the read failure verbatim — center_on_target's Contract
-        // says it reuses that hint plumbing, and the standalone tool
-        // errors loud rather than silently dropping to a blind solve.
-        // Mid-loop transient failures (driver hiccup, etc.) abort
-        // the iteration via the existing fail-fast policy. The
-        // `plate_solve: use_mount_hints requested but ...` shape
-        // matches what the standalone tool returns, then the loop
-        // wraps it as `equipment error during centering: ...`.
-        let (ra_hint, dec_hint) = match self.handler.read_mount_hints_for_plate_solve().await {
-            Ok((ra, dec)) => (Some(ra), Some(dec)),
-            Err(e) => return Err(format!("plate_solve: use_mount_hints requested but {}", e)),
-        };
-
-        let request = rp_plate_solver::SolveRequest {
-            fits_path: doc.file_path.clone(),
-            ra_hint,
-            dec_hint,
+        // Same in-process body the standalone `plate_solve` MCP
+        // tool uses (configured-check, document resolution, hint
+        // sourcing, request build, error mapping, `wcs`
+        // persistence) — both go through `do_plate_solve` so
+        // future changes to defaults / validation / persistence
+        // land in one place. center_on_target hardcodes
+        // `pointing_hint: None, use_mount_hints: true` so the
+        // hours→degrees conversion stays in `do_plate_solve`'s
+        // single mount-read path, matching the `plate_solve`
+        // Contract verbatim.
+        let input = DoPlateSolveInput {
+            document_id: Some(document_id),
+            image_path: None,
+            pointing_hint: None,
+            use_mount_hints: true,
             fov_hint_deg: None,
-            search_radius_deg: self.handler.plate_solver_default_search_radius_deg,
+            search_radius_deg: None,
             timeout: None,
         };
-
-        let outcome = client.solve(request).await.map_err(|e| match e {
-            rp_plate_solver::SolveError::ServiceUnreachable(reason) => {
-                format!("plate_solve: service unreachable: {}", reason)
-            }
-            rp_plate_solver::SolveError::Wrapper {
-                code,
-                message,
-                details,
-            } => {
-                if details.is_null() {
-                    format!("plate_solve: {}: {}", code, message)
-                } else {
-                    format!("plate_solve: {}: {} (details: {})", code, message, details)
-                }
-            }
-            rp_plate_solver::SolveError::Internal(reason) => {
-                format!("plate_solve: internal: {}", reason)
-            }
-        })?;
-
-        // Persist the per-iteration `wcs` section to the captured
-        // document — same side-effect the standalone `plate_solve`
-        // tool would write. Failure is logged and ignored.
-        let payload = serde_json::json!({
-            "ra_center": outcome.ra_center,
-            "dec_center": outcome.dec_center,
-            "pixel_scale_arcsec": outcome.pixel_scale_arcsec,
-            "rotation_deg": outcome.rotation_deg,
-            "solver": outcome.solver,
-        });
-        if let Err(e) = self
-            .handler
-            .image_cache
-            .put_section(document_id, "wcs", payload)
-            .await
-        {
-            tracing::debug!(error = %e, document_id, "failed to persist wcs section");
-        }
-
+        let out = self.handler.do_plate_solve(input).await?;
         Ok(imaging::tools::center_on_target::SolveOutcome {
-            ra_center_deg: outcome.ra_center,
-            dec_center_deg: outcome.dec_center,
+            ra_center_deg: out.ra_center,
+            dec_center_deg: out.dec_center,
         })
     }
 }

--- a/services/rp/src/mcp/built_in/center_on_target.rs
+++ b/services/rp/src/mcp/built_in/center_on_target.rs
@@ -211,16 +211,19 @@ impl imaging::tools::center_on_target::PlateSolveOps for CenterOnTargetAdapter<'
             .ok_or_else(|| format!("plate_solve: document not found: {}", document_id))?;
 
         // Source the pointing hint from the mount, paralleling
-        // plate_solve's `use_mount_hints: true` path. Failure modes
-        // surface verbatim (no mount configured / disconnected /
-        // Alpaca read error) — center_on_target needs a connected
-        // mount anyway, and we already validated that up front.
-        let (ra_hint, dec_hint) = self
-            .handler
-            .read_mount_hints_for_plate_solve()
-            .await
-            .map(|(ra, dec)| (Some(ra), Some(dec)))
-            .unwrap_or((None, None));
+        // plate_solve's `use_mount_hints: true` path. We propagate
+        // the read failure verbatim — center_on_target's Contract
+        // says it reuses that hint plumbing, and the standalone tool
+        // errors loud rather than silently dropping to a blind solve.
+        // Mid-loop transient failures (driver hiccup, etc.) abort
+        // the iteration via the existing fail-fast policy. The
+        // `plate_solve: use_mount_hints requested but ...` shape
+        // matches what the standalone tool returns, then the loop
+        // wraps it as `equipment error during centering: ...`.
+        let (ra_hint, dec_hint) = match self.handler.read_mount_hints_for_plate_solve().await {
+            Ok((ra, dec)) => (Some(ra), Some(dec)),
+            Err(e) => return Err(format!("plate_solve: use_mount_hints requested but {}", e)),
+        };
 
         let request = rp_plate_solver::SolveRequest {
             fits_path: doc.file_path.clone(),

--- a/services/rp/src/mcp/built_in/mod.rs
+++ b/services/rp/src/mcp/built_in/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod auto_focus;
 pub mod camera;
+pub mod center_on_target;
 pub mod cover_calibrator;
 pub mod filter_wheel;
 pub mod focuser;

--- a/services/rp/src/mcp/built_in/mount.rs
+++ b/services/rp/src/mcp/built_in/mount.rs
@@ -146,15 +146,9 @@ impl McpHandler {
             ));
         }
 
-        let (_entry, mount) = match self.resolve_mount() {
-            Ok(p) => p,
-            Err(e) => return Ok(tool_error!("{}", e)),
-        };
-
-        debug!(ra, dec, "syncing mount");
-        match mount.sync_to_coordinates(ra, dec).await {
+        match self.do_sync_mount(ra, dec).await {
             Ok(()) => Ok(tool_success!({})),
-            Err(e) => Ok(tool_error!("failed to sync mount: {}", e)),
+            Err(e) => Ok(tool_error!("{}", e)),
         }
     }
 

--- a/services/rp/src/mcp/built_in/plate_solve.rs
+++ b/services/rp/src/mcp/built_in/plate_solve.rs
@@ -5,9 +5,9 @@ use rmcp::model::CallToolResult;
 use rmcp::{tool, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tracing::debug;
 
 use super::super::handler::McpHandler;
+use super::super::internals::DoPlateSolveInput;
 use super::super::{tool_error, tool_success};
 
 /// Nested pointing-hint object passed to `plate_solve`. The
@@ -64,142 +64,38 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<PlateSolveParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate "neither document_id nor image_path" before
+        // delegating — the standalone tool's BDD pins the no-prefix
+        // shape ("missing required argument: ..."), which the helper
+        // doesn't emit (it always uses the "plate_solve: ..." prefix
+        // that's appropriate for in-loop callers like
+        // `center_on_target`). Keeping this one check here preserves
+        // the user-visible error text without forking the helper.
         if params.document_id.is_none() && params.image_path.is_none() {
             return Ok(tool_error!(
                 "missing required argument: provide either document_id or image_path"
             ));
         }
 
-        // Hint validation: pointing_hint and use_mount_hints=true are
-        // mutually exclusive. Validated up front so a caller mixing
-        // both gets the same error regardless of mount state.
-        let use_mount_hints = params.use_mount_hints.unwrap_or(false);
-        if params.pointing_hint.is_some() && use_mount_hints {
-            return Ok(tool_error!(
-                "plate_solve: provide explicit pointing_hint or use_mount_hints, not both"
-            ));
-        }
-
-        let client = match self.plate_solver.as_ref() {
-            Some(c) => c.clone(),
-            None => return Ok(tool_error!("plate_solve: plate solver not configured")),
-        };
-
-        // Resolve fits_path: document_id wins when both supplied.
-        let (fits_path, target_doc_id) = match params.document_id.as_deref() {
-            Some(doc_id) => match self.image_cache.resolve_document(doc_id).await {
-                Some(doc) => (doc.file_path.clone(), Some(doc_id.to_string())),
-                None => return Ok(tool_error!("plate_solve: document not found: {}", doc_id)),
-            },
-            None => {
-                let path = params
-                    .image_path
-                    .as_deref()
-                    .expect("image_path is Some when document_id is None (validated above)");
-                (path.to_string(), None)
-            }
-        };
-
-        // Resolve hints. The wrapper takes flat ra_hint/dec_hint in
-        // decimal degrees; rp converts the mount's Alpaca hours by
-        // ×15 here so the conversion lives in exactly one place.
-        let (ra_hint, dec_hint) = if let Some(p) = params.pointing_hint.as_ref() {
-            (Some(p.ra_deg), Some(p.dec_deg))
-        } else if use_mount_hints {
-            match self.read_mount_hints_for_plate_solve().await {
-                Ok((ra_deg, dec_deg)) => (Some(ra_deg), Some(dec_deg)),
-                Err(e) => {
-                    return Ok(tool_error!(
-                        "plate_solve: use_mount_hints requested but {}",
-                        e
-                    ))
-                }
-            }
-        } else {
-            (None, None)
-        };
-
-        // search_radius_deg: per-call value > config default > absent.
-        let search_radius_deg = params
-            .search_radius_deg
-            .or(self.plate_solver_default_search_radius_deg);
-
-        let request = rp_plate_solver::SolveRequest {
-            fits_path: fits_path.clone(),
-            ra_hint,
-            dec_hint,
+        let input = DoPlateSolveInput {
+            document_id: params.document_id.as_deref(),
+            image_path: params.image_path.as_deref(),
+            pointing_hint: params.pointing_hint.as_ref().map(|p| (p.ra_deg, p.dec_deg)),
+            use_mount_hints: params.use_mount_hints.unwrap_or(false),
             fov_hint_deg: params.fov_hint_deg,
-            search_radius_deg,
+            search_radius_deg: params.search_radius_deg,
             timeout: params.timeout,
         };
 
-        let outcome = match client.solve(request).await {
-            Ok(o) => o,
-            Err(rp_plate_solver::SolveError::ServiceUnreachable(reason)) => {
-                return Ok(tool_error!("plate_solve: service unreachable: {}", reason));
-            }
-            Err(rp_plate_solver::SolveError::Wrapper {
-                code,
-                message,
-                details,
-            }) => {
-                if details.is_null() {
-                    return Ok(tool_error!("plate_solve: {}: {}", code, message));
-                }
-                return Ok(tool_error!(
-                    "plate_solve: {}: {} (details: {})",
-                    code,
-                    message,
-                    details
-                ));
-            }
-            Err(rp_plate_solver::SolveError::Internal(reason)) => {
-                return Ok(tool_error!("plate_solve: internal: {}", reason));
-            }
-        };
-
-        // Persist `wcs` section. document_id mode targets the
-        // resolved document directly; image_path mode reads the
-        // sibling `<base>.json` sidecar via
-        // `ImageCache::resolve_document_by_path` so the late-solve
-        // workflow's call (path-only, no document_id known to the
-        // caller) still updates the matching sidecar.
-        let payload = serde_json::json!({
-            "ra_center": outcome.ra_center,
-            "dec_center": outcome.dec_center,
-            "pixel_scale_arcsec": outcome.pixel_scale_arcsec,
-            "rotation_deg": outcome.rotation_deg,
-            "solver": outcome.solver,
-        });
-        let persist_doc_id = match target_doc_id {
-            Some(id) => Some(id),
-            None => self
-                .image_cache
-                .resolve_document_by_path(&fits_path)
-                .await
-                .map(|d| d.id.clone()),
-        };
-        if let Some(doc_id) = persist_doc_id {
-            if let Err(e) = self
-                .image_cache
-                .put_section(&doc_id, "wcs", payload.clone())
-                .await
-            {
-                debug!(error = %e, document_id = %doc_id, "failed to persist wcs section");
-            }
-        } else {
-            debug!(
-                fits_path = %fits_path,
-                "image_path did not resolve to a known document; skipping wcs persistence"
-            );
+        match self.do_plate_solve(input).await {
+            Ok(out) => Ok(tool_success!({
+                "ra_center": out.ra_center,
+                "dec_center": out.dec_center,
+                "pixel_scale_arcsec": out.pixel_scale_arcsec,
+                "rotation_deg": out.rotation_deg,
+                "solver": out.solver,
+            })),
+            Err(e) => Ok(tool_error!("{}", e)),
         }
-
-        Ok(tool_success!({
-            "ra_center": outcome.ra_center,
-            "dec_center": outcome.dec_center,
-            "pixel_scale_arcsec": outcome.pixel_scale_arcsec,
-            "rotation_deg": outcome.rotation_deg,
-            "solver": outcome.solver,
-        }))
     }
 }

--- a/services/rp/src/mcp/handler.rs
+++ b/services/rp/src/mcp/handler.rs
@@ -84,6 +84,7 @@ impl McpHandler {
                 + Self::tool_router_mount()
                 + Self::tool_router_auto_focus()
                 + Self::tool_router_plate_solve()
+                + Self::tool_router_center_on_target()
                 + Self::tool_router_planner(),
         }
     }

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -841,6 +841,178 @@ impl McpHandler {
             .map_err(|e| format!("failed to read mount declination: {e}"))?;
         Ok((ra_hours * 15.0, dec_deg))
     }
+
+    /// Shared body of the standalone `plate_solve` MCP tool *and* the
+    /// `center_on_target` compound tool's per-iteration solve. Both
+    /// callers want the same configured-check, document resolution,
+    /// hint sourcing, request build, error mapping, and `wcs`
+    /// persistence — extracting them here keeps any future change to
+    /// defaults / validation / persistence in exactly one place.
+    ///
+    /// Caller responsibilities:
+    /// - Standalone `plate_solve` validates "neither `document_id`
+    ///   nor `image_path` supplied" itself (so the error message
+    ///   shape matches what its BDD pins).
+    /// - `center_on_target` always supplies `document_id` and
+    ///   hardcodes `pointing_hint: None, use_mount_hints: true`.
+    pub(crate) async fn do_plate_solve(
+        &self,
+        input: DoPlateSolveInput<'_>,
+    ) -> Result<DoPlateSolveOutput, String> {
+        // Hint validation: pointing_hint and use_mount_hints=true are
+        // mutually exclusive. center_on_target hardcodes
+        // pointing_hint=None so it never trips this; the standalone
+        // tool may.
+        if input.pointing_hint.is_some() && input.use_mount_hints {
+            return Err(
+                "plate_solve: provide explicit pointing_hint or use_mount_hints, not both"
+                    .to_string(),
+            );
+        }
+
+        let client = self
+            .plate_solver
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "plate_solve: plate solver not configured".to_string())?;
+
+        // Resolve fits_path: document_id wins when both supplied.
+        let (fits_path, target_doc_id) = match input.document_id {
+            Some(doc_id) => match self.image_cache.resolve_document(doc_id).await {
+                Some(doc) => (doc.file_path.clone(), Some(doc_id.to_string())),
+                None => return Err(format!("plate_solve: document not found: {}", doc_id)),
+            },
+            None => {
+                let path = input.image_path.ok_or_else(|| {
+                    "plate_solve: missing required argument: provide either document_id or image_path"
+                        .to_string()
+                })?;
+                (path.to_string(), None)
+            }
+        };
+
+        // Resolve hints. The wrapper takes flat ra_hint/dec_hint in
+        // decimal degrees; the mount-hint helper does the Alpaca-
+        // hours → degrees ×15 conversion.
+        let (ra_hint, dec_hint) = if let Some((ra_deg, dec_deg)) = input.pointing_hint {
+            (Some(ra_deg), Some(dec_deg))
+        } else if input.use_mount_hints {
+            match self.read_mount_hints_for_plate_solve().await {
+                Ok((ra_deg, dec_deg)) => (Some(ra_deg), Some(dec_deg)),
+                Err(e) => return Err(format!("plate_solve: use_mount_hints requested but {}", e)),
+            }
+        } else {
+            (None, None)
+        };
+
+        // search_radius_deg: per-call value > config default > absent.
+        let search_radius_deg = input
+            .search_radius_deg
+            .or(self.plate_solver_default_search_radius_deg);
+
+        let request = rp_plate_solver::SolveRequest {
+            fits_path: fits_path.clone(),
+            ra_hint,
+            dec_hint,
+            fov_hint_deg: input.fov_hint_deg,
+            search_radius_deg,
+            timeout: input.timeout,
+        };
+
+        let outcome = match client.solve(request).await {
+            Ok(o) => o,
+            Err(rp_plate_solver::SolveError::ServiceUnreachable(reason)) => {
+                return Err(format!("plate_solve: service unreachable: {}", reason));
+            }
+            Err(rp_plate_solver::SolveError::Wrapper {
+                code,
+                message,
+                details,
+            }) => {
+                if details.is_null() {
+                    return Err(format!("plate_solve: {}: {}", code, message));
+                }
+                return Err(format!(
+                    "plate_solve: {}: {} (details: {})",
+                    code, message, details
+                ));
+            }
+            Err(rp_plate_solver::SolveError::Internal(reason)) => {
+                return Err(format!("plate_solve: internal: {}", reason));
+            }
+        };
+
+        // Persist `wcs` section. document_id mode targets the
+        // resolved document directly; image_path mode reads the
+        // sibling `<base>.json` sidecar via
+        // `ImageCache::resolve_document_by_path` so the late-solve
+        // workflow's call (path-only, no document_id known to the
+        // caller) still updates the matching sidecar.
+        let payload = serde_json::json!({
+            "ra_center": outcome.ra_center,
+            "dec_center": outcome.dec_center,
+            "pixel_scale_arcsec": outcome.pixel_scale_arcsec,
+            "rotation_deg": outcome.rotation_deg,
+            "solver": outcome.solver,
+        });
+        let persist_doc_id = match target_doc_id {
+            Some(id) => Some(id),
+            None => self
+                .image_cache
+                .resolve_document_by_path(&fits_path)
+                .await
+                .map(|d| d.id.clone()),
+        };
+        if let Some(doc_id) = persist_doc_id {
+            if let Err(e) = self
+                .image_cache
+                .put_section(&doc_id, "wcs", payload.clone())
+                .await
+            {
+                debug!(error = %e, document_id = %doc_id, "failed to persist wcs section");
+            }
+        } else {
+            debug!(
+                fits_path = %fits_path,
+                "image_path did not resolve to a known document; skipping wcs persistence"
+            );
+        }
+
+        Ok(DoPlateSolveOutput {
+            ra_center: outcome.ra_center,
+            dec_center: outcome.dec_center,
+            pixel_scale_arcsec: outcome.pixel_scale_arcsec,
+            rotation_deg: outcome.rotation_deg,
+            solver: outcome.solver,
+        })
+    }
+}
+
+/// Input bundle for [`McpHandler::do_plate_solve`]. Borrows the two
+/// path-shaped inputs by `&str` (call sites already own the strings)
+/// and takes the rest by value (all small `Copy` / `Option` types).
+pub(crate) struct DoPlateSolveInput<'a> {
+    pub document_id: Option<&'a str>,
+    pub image_path: Option<&'a str>,
+    /// Decimal degrees `(ra, dec)`. Mutually exclusive with
+    /// `use_mount_hints == true`.
+    pub pointing_hint: Option<(f64, f64)>,
+    pub use_mount_hints: bool,
+    pub fov_hint_deg: Option<f64>,
+    pub search_radius_deg: Option<f64>,
+    pub timeout: Option<Duration>,
+}
+
+/// Output of [`McpHandler::do_plate_solve`]: the wrapper's success
+/// fields verbatim. Callers wrap this in a `tool_success!` payload
+/// or in a [`crate::imaging::tools::center_on_target::SolveOutcome`]
+/// as needed.
+pub(crate) struct DoPlateSolveOutput {
+    pub ra_center: f64,
+    pub dec_center: f64,
+    pub pixel_scale_arcsec: f64,
+    pub rotation_deg: f64,
+    pub solver: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -427,7 +427,7 @@ impl McpHandler {
         let document_id = Uuid::new_v4().to_string();
         // The 8-char UUID suffix is the on-disk reverse-lookup key used by
         // the cache's disk-fallback resolution (see Phase 7 of
-        // `docs/plans/image-evaluation-tools.md` and `rp.md` Persistence).
+        // `docs/plans/archive/image-evaluation-tools.md` and `rp.md` Persistence).
         // Operator-controlled `file_naming_pattern` rendering is reserved
         // until a token resolver lands; for now capture writes
         // `<uuid8>.fits` regardless of any configured template.

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -802,6 +802,26 @@ impl McpHandler {
         }
     }
 
+    /// Resolve the mount and issue a sync to the given equatorial
+    /// coordinates (RA hours, Dec degrees). No polling — `sync` is
+    /// immediate per ASCOM. Mirrors the shape of `do_slew_blocking`
+    /// minus the polling loop. Used by both the primitive
+    /// `sync_mount` MCP tool and the `center_on_target` compound
+    /// tool's per-iteration sync; one helper, one place to change
+    /// the error-mapping convention.
+    pub(crate) async fn do_sync_mount(
+        &self,
+        ra_hours: f64,
+        dec_deg: f64,
+    ) -> std::result::Result<(), String> {
+        let (_entry, mount) = self.resolve_mount()?;
+        debug!(ra = ra_hours, dec = dec_deg, "syncing mount");
+        mount
+            .sync_to_coordinates(ra_hours, dec_deg)
+            .await
+            .map_err(|e| format!("failed to sync mount: {}", e))
+    }
+
     /// Read the current mount pointing for `plate_solve`'s
     /// `use_mount_hints` convenience. Converts Alpaca's decimal
     /// hours `RightAscension` to the wrapper's degrees-on-the-wire

--- a/services/rp/src/persistence/cache.rs
+++ b/services/rp/src/persistence/cache.rs
@@ -29,7 +29,7 @@ use super::document::ExposureDocument;
 /// reports the same `MaxADU`, so the variant is effectively per-camera. The
 /// current implementation fetches `max_adu` per-frame in
 /// `mcp.rs:capture` — see the "Phase 3 follow-up: stash `max_adu` on
-/// `CameraEntry`" section in `docs/plans/image-evaluation-tools.md`.
+/// `CameraEntry`" section in `docs/plans/archive/image-evaluation-tools.md`.
 pub enum CachedPixels {
     U16(Array2<u16>),
     I32(Array2<i32>),

--- a/services/rp/src/persistence/document.rs
+++ b/services/rp/src/persistence/document.rs
@@ -10,7 +10,7 @@
 //! (`<image>.json`). Writes are atomic: data is staged into a `.tmp` file and
 //! `rename`d into place, so a crash mid-write cannot leave a torn document.
 //!
-//! As of Phase 7 (`docs/plans/image-evaluation-tools.md`), the document lives
+//! As of Phase 7 (`docs/plans/archive/image-evaluation-tools.md`), the document lives
 //! inline on each `imaging::CachedImage` cache entry. Lookups go through
 //! `ImageCache::get_document` and section updates through
 //! `ImageCache::put_section`; the sidecar JSON pair on disk plus the disk-
@@ -52,7 +52,7 @@ pub struct ExposureDocument {
     /// forward so a disk-fallback rehydration of the image cache can
     /// pick the correct `CachedPixels` variant without needing the
     /// originating camera to still be connected — see Phase 7
-    /// (`docs/plans/image-evaluation-tools.md`) and the Image and
+    /// (`docs/plans/archive/image-evaluation-tools.md`) and the Image and
     /// Document Cache section of `docs/services/rp.md`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_adu: Option<u32>,

--- a/services/rp/src/persistence/mod.rs
+++ b/services/rp/src/persistence/mod.rs
@@ -1,7 +1,7 @@
 //! Persistence layer: FITS I/O, the unified image+document cache, and
 //! exposure-document storage.
 //!
-//! As of Phase 7 (`docs/plans/image-evaluation-tools.md`), the cache and
+//! As of Phase 7 (`docs/plans/archive/image-evaluation-tools.md`), the cache and
 //! the on-disk FITS+sidecar pair together form the document store: a
 //! document is addressable by id as long as its files sit in
 //! `<data_directory>`. The lazy filesystem fallback in

--- a/services/rp/tests/bdd/steps/center_on_target_steps.rs
+++ b/services/rp/tests/bdd/steps/center_on_target_steps.rs
@@ -246,12 +246,14 @@ fn mount_position_approx(world: &mut RpWorld, expected_ra: f64, expected_dec: f6
         .get("dec")
         .and_then(|v| v.as_f64())
         .unwrap_or_else(|| panic!("expected 'dec' in mount position, got: {:?}", result));
-    // OmniSim's slew-echo drift is ~0.001 hours / ~0.001 degrees
-    // (~3.6 arcsec) — same root cause as mount.feature's slew
-    // tolerance. Use 0.01 here so the assertion stays robust against
-    // that drift while still distinguishing iter-1 sync-then-slew
-    // outcome (≈ input ra/dec) from the iter-N solved position
-    // (≈ tens of arcsec / hours away in our scenarios).
+    // OmniSim's slew-echo drift is ~0.001° on both axes (~3.6
+    // arcsec) — same root cause as mount.feature's slew tolerance.
+    // For the dec axis (degrees) the 0.01 cap here gives ~3× slack
+    // over the drift; for the ra axis (hours) 0.01h = 0.15° = ~540
+    // arcsec, far above the ~0.001° / ~0.000067h drift but still
+    // tight enough to distinguish the iter-1 sync-then-slew outcome
+    // (≈ input ra/dec) from an iter-N solved position that lands
+    // tens of arcsec — or hours, in our scenarios — away.
     assert!(
         (actual_ra - expected_ra).abs() < 0.01,
         "expected ra ≈ {}, got {}",

--- a/services/rp/tests/bdd/steps/center_on_target_steps.rs
+++ b/services/rp/tests/bdd/steps/center_on_target_steps.rs
@@ -1,0 +1,306 @@
+//! BDD step definitions for the `center_on_target` MCP tool.
+//!
+//! Shared steps live in `tool_steps.rs`:
+//! - `the MCP client lists available tools`
+//! - `the tool list should include {string}`
+//! - `the tool call should return an error`
+//! - `the error message should contain {string}`
+//! - `the tool call should succeed` (in `cover_calibrator_steps.rs`)
+//! - `an MCP client connected to rp`
+//!
+//! Shared steps live in `mount_steps.rs`:
+//! - `the mount tracking is set to {word}`
+//! - `the MCP client calls "sync_mount" with ra {string} dec {string}`
+//! - `the MCP client calls "get_mount_position"`
+//!
+//! Shared steps live in `plate_solve_steps.rs`:
+//! - `a stub plate solver returning a canned WCS`
+//! - `a stub plate solver returning error code {string} with message {string}`
+//! - `rp is running with a camera and a mount on the simulator`
+//!
+//! Shared FITS / sidecar inspection steps live in `auto_focus_steps.rs`:
+//! - `{int} FITS files should exist in the pinned data directory`
+//! - `every sidecar JSON in the pinned data directory should contain an {string} section`
+//!
+//! `rp's data_directory is pinned to a fresh tempdir` is in
+//! `document_http_api_steps.rs`.
+
+use cucumber::gherkin::Step;
+use cucumber::{given, then, when};
+use serde_json::{Map, Value};
+
+use bdd_infra::rp_harness::{
+    CameraConfig, CannedWcs, MountConfig, PlateSolverConfig, PlateSolverStub, StubBehavior,
+};
+
+use crate::steps::tool_steps::{add_camera, ensure_mcp_client, ensure_omnisim, start_rp};
+use crate::world::RpWorld;
+
+// --- Given steps: stub variants unique to center_on_target ---
+
+/// Multi-iteration scenarios need different solved coordinates per
+/// solve call so the residual can decrease across iterations. The
+/// stub walks the table top-to-bottom; once the queue is exhausted
+/// it keeps returning the final entry (so a scenario can pin the
+/// "convergent" WCS without counting exact iterations).
+#[given("a stub plate solver returning these per-call WCS responses:")]
+async fn stub_plate_solver_sequence(world: &mut RpWorld, step: &Step) {
+    let table = step
+        .table
+        .as_ref()
+        .expect("step requires a data table of WCS responses");
+    let mut responses = Vec::new();
+    for row in table.rows.iter().skip(1) {
+        assert_eq!(
+            row.len(),
+            2,
+            "table row must have ra_center, dec_center: {:?}",
+            row
+        );
+        let ra_center: f64 = row[0]
+            .parse()
+            .unwrap_or_else(|_| panic!("ra_center must be f64, got {}", row[0]));
+        let dec_center: f64 = row[1]
+            .parse()
+            .unwrap_or_else(|_| panic!("dec_center must be f64, got {}", row[1]));
+        responses.push(CannedWcs {
+            ra_center,
+            dec_center,
+            pixel_scale_arcsec: 1.05,
+            rotation_deg: 12.3,
+            solver: "stub-astap-1.0".to_string(),
+        });
+    }
+    let stub = PlateSolverStub::start(StubBehavior::Sequence(responses)).await;
+    world.plate_solver = Some(PlateSolverConfig {
+        url: stub.url.clone(),
+        timeout: None,
+        default_search_radius_deg: None,
+    });
+    world.plate_solver_stub = Some(stub);
+}
+
+// --- Given steps: equipment composition unique to center_on_target ---
+
+#[given("rp is running with an unreachable camera and a mount on the simulator")]
+async fn rp_with_unreachable_camera_and_mount(world: &mut RpWorld) {
+    ensure_omnisim(world).await;
+    // Reserved port 1 is reliably unbound on Linux dev hosts /
+    // CI runners — same pattern as auto_focus's `unreachable_camera`.
+    world.cameras.push(CameraConfig {
+        id: "main-cam".to_string(),
+        alpaca_url: "http://127.0.0.1:1".to_string(),
+        device_number: 0,
+    });
+    let url = world.omnisim_url();
+    world.mount = Some(MountConfig {
+        alpaca_url: url,
+        device_number: 0,
+        settle_after_slew: None,
+    });
+    start_rp(world).await;
+}
+
+#[given("rp is running with a camera on the simulator and an unreachable mount")]
+async fn rp_with_camera_and_unreachable_mount(world: &mut RpWorld) {
+    ensure_omnisim(world).await;
+    add_camera(world);
+    world.mount = Some(MountConfig {
+        alpaca_url: "http://127.0.0.1:1".to_string(),
+        device_number: 0,
+        settle_after_slew: None,
+    });
+    start_rp(world).await;
+}
+
+// --- When steps ---
+
+#[when(
+    expr = "the MCP client calls center_on_target with camera {string} ra {float} dec {float} duration {string} tolerance_arcsec {float} max_attempts {int}"
+)]
+async fn mcp_call_center_on_target_full(
+    world: &mut RpWorld,
+    camera_id: String,
+    ra: f64,
+    dec: f64,
+    duration: String,
+    tolerance_arcsec: f64,
+    max_attempts: i64,
+) {
+    let mut args = baseline_args();
+    args.insert("camera_id".into(), Value::String(camera_id));
+    args.insert("ra".into(), serde_json::json!(ra));
+    args.insert("dec".into(), serde_json::json!(dec));
+    args.insert("duration".into(), Value::String(duration));
+    args.insert(
+        "tolerance_arcsec".into(),
+        serde_json::json!(tolerance_arcsec),
+    );
+    args.insert("max_attempts".into(), serde_json::json!(max_attempts));
+    call_center_on_target(world, args).await;
+}
+
+#[when(expr = "the MCP client calls center_on_target omitting {string}")]
+async fn mcp_call_center_on_target_omitting(world: &mut RpWorld, missing_param: String) {
+    let mut args = baseline_args();
+    args.remove(missing_param.as_str());
+    call_center_on_target(world, args).await;
+}
+
+#[when(expr = "the MCP client calls center_on_target with override {string} set to {float}")]
+async fn mcp_call_center_on_target_override(world: &mut RpWorld, field: String, value: f64) {
+    let mut args = baseline_args();
+    // Numeric outline: the integer-vs-float distinction matters for
+    // serde — `max_attempts` is `usize`, the other fields are `f64`.
+    // We dispatch on the field name so the JSON shape matches.
+    let json_value = match field.as_str() {
+        "max_attempts" => serde_json::json!(value as i64),
+        _ => serde_json::json!(value),
+    };
+    args.insert(field, json_value);
+    call_center_on_target(world, args).await;
+}
+
+// --- Then steps ---
+
+#[then(expr = "the center_on_target result should report attempts {int}")]
+fn center_on_target_attempts(world: &mut RpWorld, expected: i64) {
+    let result = world
+        .last_center_on_target_result
+        .as_ref()
+        .expect("no center_on_target result");
+    let actual = result
+        .get("attempts")
+        .and_then(|v| v.as_i64())
+        .unwrap_or_else(|| panic!("expected 'attempts' in result, got: {:?}", result));
+    assert_eq!(actual, expected);
+}
+
+#[then(expr = "the center_on_target iterations[{int}] action should be {string}")]
+fn center_on_target_iteration_action(world: &mut RpWorld, index: usize, expected: String) {
+    let result = world
+        .last_center_on_target_result
+        .as_ref()
+        .expect("no center_on_target result");
+    let iterations = result
+        .get("iterations")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected 'iterations' array in result, got: {:?}", result));
+    let entry = iterations.get(index).unwrap_or_else(|| {
+        panic!(
+            "iterations has only {} entries, asked for index {}",
+            iterations.len(),
+            index
+        )
+    });
+    let actual = entry
+        .get("action")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("iteration {} has no 'action' field: {:?}", index, entry));
+    assert_eq!(actual, expected);
+}
+
+#[then(expr = "the center_on_target result should contain {string}")]
+fn center_on_target_result_field_present(world: &mut RpWorld, field: String) {
+    let result = world
+        .last_center_on_target_result
+        .as_ref()
+        .expect("no center_on_target result");
+    assert!(
+        result.get(&field).is_some(),
+        "expected '{}' in center_on_target result, got: {:?}",
+        field,
+        result
+    );
+}
+
+#[then(expr = "the stub plate solver should have received {int} solve calls")]
+async fn stub_solve_call_count(world: &mut RpWorld, expected: usize) {
+    let stub = world
+        .plate_solver_stub
+        .as_ref()
+        .expect("no plate solver stub registered for this scenario");
+    let requests = stub.requests().await;
+    assert_eq!(
+        requests.len(),
+        expected,
+        "expected {} solve calls, got {}",
+        expected,
+        requests.len()
+    );
+}
+
+#[then(expr = "the mount position should be approximately ra {float} dec {float}")]
+fn mount_position_approx(world: &mut RpWorld, expected_ra: f64, expected_dec: f64) {
+    let result = world
+        .last_tool_result
+        .as_ref()
+        .expect("no tool result")
+        .as_ref()
+        .unwrap_or_else(|e| panic!("expected get_mount_position to succeed, got error: {}", e));
+    let actual_ra = result
+        .get("ra")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected 'ra' in mount position, got: {:?}", result));
+    let actual_dec = result
+        .get("dec")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_else(|| panic!("expected 'dec' in mount position, got: {:?}", result));
+    // OmniSim's slew-echo drift is ~0.001 hours / ~0.001 degrees
+    // (~3.6 arcsec) — same root cause as mount.feature's slew
+    // tolerance. Use 0.01 here so the assertion stays robust against
+    // that drift while still distinguishing iter-1 sync-then-slew
+    // outcome (≈ input ra/dec) from the iter-N solved position
+    // (≈ tens of arcsec / hours away in our scenarios).
+    assert!(
+        (actual_ra - expected_ra).abs() < 0.01,
+        "expected ra ≈ {}, got {}",
+        expected_ra,
+        actual_ra
+    );
+    assert!(
+        (actual_dec - expected_dec).abs() < 0.01,
+        "expected dec ≈ {}, got {}",
+        expected_dec,
+        actual_dec
+    );
+}
+
+// --- Helpers ---
+
+/// Baseline arg map representing a "valid" center_on_target call.
+/// Individual scenarios mutate this baseline (insert override / remove
+/// field) before dispatching, so that the missing-parameter and
+/// numeric-range scenarios can each carve out exactly one field
+/// without re-stating the whole arg list. The baseline targets the
+/// canned WCS response (`10.6848°`, `41.269°`) so it converges on
+/// iteration 1 of a happy-path scenario.
+fn baseline_args() -> Map<String, Value> {
+    let mut m = Map::new();
+    m.insert("camera_id".into(), Value::String("main-cam".into()));
+    // 0.7123 hours × 15 = 10.6845° — within the canned WCS's
+    // 10.6848° response so a default-baseline call converges
+    // immediately when reused for the missing-parameter Outline
+    // (where each row drops one field; the rest must be valid so the
+    // body validator reaches the missing-field check rather than
+    // tripping a numeric-range check first).
+    m.insert("ra".into(), serde_json::json!(0.7123_f64));
+    m.insert("dec".into(), serde_json::json!(41.269_f64));
+    m.insert("duration".into(), Value::String("100ms".into()));
+    m.insert("tolerance_arcsec".into(), serde_json::json!(60.0_f64));
+    m.insert("max_attempts".into(), serde_json::json!(5_i64));
+    m
+}
+
+async fn call_center_on_target(world: &mut RpWorld, args: Map<String, Value>) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("center_on_target", Value::Object(args))
+        .await;
+    match &result {
+        Ok(v) => world.last_center_on_target_result = Some(v.clone()),
+        Err(_) => world.last_center_on_target_result = None,
+    }
+    world.last_tool_result = Some(result);
+}

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -5,6 +5,7 @@ pub mod auth_steps;
 pub mod auto_focus_steps;
 pub mod camera_info_steps;
 pub mod catalog_steps;
+pub mod center_on_target_steps;
 pub mod compute_snr_steps;
 pub mod cover_calibrator_steps;
 pub mod detect_stars_steps;

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -102,6 +102,8 @@ pub struct RpWorld {
     pub last_auto_focus_result: Option<Value>,
     /// Last plate_solve result
     pub last_plate_solve_result: Option<Value>,
+    /// Last center_on_target result
+    pub last_center_on_target_result: Option<Value>,
     /// Last exposure document fetched via GET /api/documents/{id}
     pub last_exposure_document: Option<Value>,
     /// Last response status from GET /api/images/{id}

--- a/services/rp/tests/features/center_on_target.feature
+++ b/services/rp/tests/features/center_on_target.feature
@@ -1,0 +1,203 @@
+@wip
+@serial
+Feature: Center on target compound tool
+  The center_on_target MCP tool drives an iterative
+  capture → plate_solve → sync_mount → slew loop until the great-circle
+  residual between the solved field-center and the requested (ra, dec)
+  sits at or below tolerance_arcsec. ra is decimal hours [0, 24); dec is
+  decimal degrees [-90, 90]; the input is converted to degrees once for
+  the residual check (the solved values are degrees on the wire). On the
+  first iteration the tool issues sync_mount with the solved center
+  unconditionally — the first solve is the absolute pointing reference
+  and subsequent iterations rely on the mount honouring relative slews
+  rather than re-syncing. After sync, if the residual is already inside
+  tolerance the loop returns without slewing; otherwise it slews to
+  (ra, dec) and continues. Subsequent iterations skip the sync, slew on
+  miss, and return on hit. The loop errors with tolerance_not_reached
+  after max_attempts and propagates any per-iteration capture /
+  plate_solve / sync_mount / slew failure verbatim. center_on_target
+  does not write a section on any single exposure document — each
+  per-iteration capture's wcs section is written by the embedded
+  plate_solve, and the compound result is returned via MCP plus
+  centering_started / centering_iteration / centering_complete events.
+  Inputs (camera_id, ra, dec, duration, tolerance_arcsec, max_attempts)
+  are required; max_attempts is capped at 50 (MAX_ATTEMPTS) before any
+  motion. The mount is resolved via the singular mount config — there is
+  no telescope_id parameter.
+
+  Scenario: Tool catalog includes center_on_target
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client lists available tools
+    Then the tool list should include "center_on_target"
+
+  Scenario: Single-iteration happy path returns converged immediately
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should succeed
+    And the center_on_target result should report attempts 1
+    And the center_on_target iterations[0] action should be "converged"
+    And the center_on_target result should contain "final_ra"
+    And the center_on_target result should contain "final_dec"
+    And the center_on_target result should contain "final_error_arcsec"
+
+  Scenario: Multi-iteration happy path converges on iteration 2
+    Given a running Alpaca simulator
+    And a stub plate solver returning these per-call WCS responses:
+      | ra_center | dec_center |
+      | 9.9000    | 41.0000    |
+      | 10.6850   | 41.2690    |
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should succeed
+    And the center_on_target result should report attempts 2
+    And the center_on_target iterations[0] action should be "sync"
+    And the center_on_target iterations[1] action should be "converged"
+    And the stub plate solver should have received 2 solve calls
+
+  Scenario: tolerance_not_reached after max_attempts
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "20.0000" dec "-30.0000"
+    And the MCP client calls center_on_target with camera "main-cam" ra 20.0000 dec -30.0000 duration "100ms" tolerance_arcsec 1 max_attempts 2
+    Then the tool call should return an error
+    And the error message should contain "tolerance_not_reached"
+
+  Scenario: Mid-loop plate_solve failure aborts and propagates
+    Given a running Alpaca simulator
+    And a stub plate solver returning error code "solve_failed" with message "ASTAP exited with code 1"
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should return an error
+    And the error message should contain "solve_failed"
+
+  Scenario: Mid-loop slew failure (tracking off) aborts and propagates
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to false
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with camera "main-cam" ra 20.0000 dec -30.0000 duration "100ms" tolerance_arcsec 1 max_attempts 5
+    Then the tool call should return an error
+
+  Scenario: sync-on-iter-1-only invariant — final mount position reflects last slew, not last solve
+    Given a running Alpaca simulator
+    And a stub plate solver returning these per-call WCS responses:
+      | ra_center | dec_center |
+      | 9.9000    | 41.0000    |
+      | 10.0000   | 41.1000    |
+      | 10.6850   | 41.2690    |
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    And the MCP client calls "get_mount_position"
+    Then the tool call should succeed
+    And the mount position should be approximately ra 10.6848 dec 41.269
+
+  Scenario: Per-iteration wcs sections persist on every captured document
+    Given rp's data_directory is pinned to a fresh tempdir
+    And a running Alpaca simulator
+    And a stub plate solver returning these per-call WCS responses:
+      | ra_center | dec_center |
+      | 9.9000    | 41.0000    |
+      | 10.6850   | 41.2690    |
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then 2 FITS files should exist in the pinned data directory
+    And every sidecar JSON in the pinned data directory should contain an "wcs" section
+
+  Scenario: Nonexistent camera returns error
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with camera "nonexistent" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should return an error
+    And the error message should contain "camera not found"
+
+  Scenario: Disconnected camera returns error
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with an unreachable camera and a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should return an error
+    And the error message should contain "camera not connected"
+
+  Scenario: No mount configured returns error
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should return an error
+    And the error message should contain "no mount configured"
+
+  Scenario: Mount not connected returns error
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera on the simulator and an unreachable mount
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    Then the tool call should return an error
+    And the error message should contain "mount not connected"
+
+  Scenario Outline: Rejects calls missing required parameters
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target omitting "<missing_param>"
+    Then the tool call should return an error
+    And the error message should contain "<missing_param>"
+
+    Examples:
+      | missing_param    |
+      | camera_id        |
+      | ra               |
+      | dec              |
+      | duration         |
+      | tolerance_arcsec |
+      | max_attempts     |
+
+  Scenario Outline: Rejects out-of-range numeric parameters
+    Given a running Alpaca simulator
+    And a stub plate solver returning a canned WCS
+    And rp is running with a camera and a mount on the simulator
+    And the mount tracking is set to true
+    And an MCP client connected to rp
+    When the MCP client calls center_on_target with override "<field>" set to <value>
+    Then the tool call should return an error
+    And the error message should contain "<field>"
+
+    Examples:
+      | field            | value |
+      | tolerance_arcsec | 0     |
+      | max_attempts     | 0     |
+      | max_attempts     | 51    |
+      | ra               | 24    |
+      | dec              | 91    |

--- a/services/rp/tests/features/center_on_target.feature
+++ b/services/rp/tests/features/center_on_target.feature
@@ -1,4 +1,3 @@
-@wip
 @serial
 Feature: Center on target compound tool
   The center_on_target MCP tool drives an iterative
@@ -58,8 +57,8 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
-    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should succeed
     And the center_on_target result should report attempts 2
     And the center_on_target iterations[0] action should be "sync"
@@ -83,8 +82,8 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
-    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should return an error
     And the error message should contain "solve_failed"
 
@@ -107,11 +106,11 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
-    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     And the MCP client calls "get_mount_position"
     Then the tool call should succeed
-    And the mount position should be approximately ra 10.6848 dec 41.269
+    And the mount position should be approximately ra 0.7123 dec 41.269
 
   Scenario: Per-iteration wcs sections persist on every captured document
     Given rp's data_directory is pinned to a fresh tempdir
@@ -123,8 +122,8 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls "sync_mount" with ra "10.6848" dec "41.269"
-    And the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then 2 FITS files should exist in the pinned data directory
     And every sidecar JSON in the pinned data directory should contain an "wcs" section
 
@@ -134,7 +133,7 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls center_on_target with camera "nonexistent" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls center_on_target with camera "nonexistent" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should return an error
     And the error message should contain "camera not found"
 
@@ -143,7 +142,7 @@ Feature: Center on target compound tool
     And a stub plate solver returning a canned WCS
     And rp is running with an unreachable camera and a mount on the simulator
     And an MCP client connected to rp
-    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should return an error
     And the error message should contain "camera not connected"
 
@@ -152,7 +151,7 @@ Feature: Center on target compound tool
     And a stub plate solver returning a canned WCS
     And rp is running with a camera on the simulator
     And an MCP client connected to rp
-    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should return an error
     And the error message should contain "no mount configured"
 
@@ -161,7 +160,7 @@ Feature: Center on target compound tool
     And a stub plate solver returning a canned WCS
     And rp is running with a camera on the simulator and an unreachable mount
     And an MCP client connected to rp
-    When the MCP client calls center_on_target with camera "main-cam" ra 10.6848 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
+    When the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
     Then the tool call should return an error
     And the error message should contain "mount not connected"
 


### PR DESCRIPTION
## Summary

Closes Phase 6c-3 of `docs/plans/image-evaluation-tools.md`. Adds the
new `center_on_target` MCP tool — an iterative
capture → plate_solve → sync_mount → slew loop that drives the mount
to within `tolerance_arcsec` of a requested `(ra, dec)` target, or
errors with `tolerance_not_reached` after `max_attempts`. The first
iteration's solve is the absolute pointing reference and fires
`sync_mount` unconditionally; subsequent iterations rely on relative
slews to avoid re-polluting model-building drivers' pointing models.

The change ships in four phase-aligned commits:

1. `docs(plans)`: marks Phase 6c-1 (plate-solver service) complete —
   stale status carried over from before that work landed — and
   expands the Phase 6c-3 stub into a full plan with decisions
   resolved.
2. `docs(rp)`: design doc — `center_on_target` Contract subsection
   added to `docs/services/rp.md` (parallel to `auto_focus` and
   `plate_solve` Contracts).
3. `test(rp)`: 14 BDD scenarios behind `@wip` (per
   `docs/skills/development-workflow.md` Phase 2). Extends
   `bdd-infra`'s `PlateSolverStub` with a `Sequence` variant so
   multi-iteration scenarios can return different solved coords per
   iteration and the residual decreases across iterations.
4. `feat(rp)`: implementation — pure driver in
   `services/rp/src/imaging/tools/center_on_target.rs` over
   `CaptureOps` / `PlateSolveOps` / `MountOps` traits (13 unit
   tests against synthetic adapters); MCP wrapper in
   `mcp/built_in/center_on_target.rs`; `do_sync_mount` helper in
   `mcp/internals.rs` shared with the primitive `sync_mount` tool.
   Promotes the `CaptureOps` trait from `auto_focus.rs` to a
   shared `imaging/tools/ops.rs` module.

## Highlights

- **Sync-on-iter-1-only invariant** verified two ways: synthetic-mount
  call-count in the unit test (direct), and a behavioral-consequence
  BDD scenario asserting the final mount position equals the input
  target rather than the last solved center.
- **`MAX_ATTEMPTS = 50` safety cap** mirrors `auto_focus`'s
  `MAX_GRID_POINTS` guardrail. Plausible runs converge in 2–4 iters.
- **Fail fast on per-iteration errors**: any capture/solve/sync/slew
  failure aborts the loop and propagates the underlying message; the
  mount is left where the failed step left it.
- **No aggregate persistence section**: the per-iteration `wcs`
  section is written by the embedded `plate_solve` calls; the
  compound result rides the MCP response and the
  `centering_started` / `centering_iteration` / `centering_complete`
  events.
- **Hint plumbing**: inner `plate_solve` reads the mount via the
  existing `use_mount_hints` path, so the hours→degrees conversion
  lives in exactly one place.

## Test plan

- [x] `cargo rail run --profile commit -q` — 908/908 tests pass
      workspace-wide.
- [x] `cargo test --all-features --test bdd -p rp` —
      261/261 scenarios pass (was 238 + 14 new = 252; 9-scenario
      delta matches scenarios already added on `main` since the
      261 == 247 + 14 baseline I started from).
- [x] `cargo fmt --all -- --check` clean.
- [x] No new workspace deps; `bazel mod tidy` not needed.
- [x] OmniSim caveat documented in the Contract — happy-path
      convergence is asserted via the stub plate solver in BDD; the
      live OmniSim camera + mount still drive capture / sync / slew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)