### PR TITLE
fix(rp): shrink center_on_target BDD slew distances to fix CI hang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,29 @@ jobs:
           ALL_BDD=$(cargo metadata --format-version 1 --no-deps | \
             jq -c '[.packages[] | select(.targets[] | .kind[] == "test" and .name == "bdd") | .name]')
 
-          # If infra changed, test all BDD packages; otherwise intersect with affected
+          # If infra changed, test all BDD packages; otherwise intersect with
+          # affected. "Affected" combines two sources:
+          #   1. cargo-rail's `crates` output — tracks Rust source / Cargo.toml
+          #      changes per crate.
+          #   2. Feature-file changes under `services/<pkg>/tests/features/`
+          #      that rail doesn't see as crate-affecting (cargo metadata
+          #      doesn't index resource files). Without this augmentation a
+          #      BDD-only fix lands without any windows-bdd validation —
+          #      see the post-merge hang on PR #182 (PR #186 fix was first
+          #      pushed without exercising windows-bdd because of this gap).
           if [ "${{ steps.rail.outputs.infra }}" = "true" ]; then
             BDD_PACKAGES="$ALL_BDD"
           else
-            AFFECTED='${{ steps.rail.outputs.crates }}'
+            BASE='${{ github.event.pull_request.base.sha || github.event.before }}'
+            FEATURE_AFFECTED=""
+            if [ -n "$BASE" ]; then
+              FEATURE_AFFECTED=$(git diff --name-only "$BASE"...HEAD 2>/dev/null \
+                | grep -oE '^services/[^/]+/tests/features' \
+                | cut -d/ -f2 \
+                | sort -u \
+                | tr '\n' ' ')
+            fi
+            AFFECTED='${{ steps.rail.outputs.crates }}'" $FEATURE_AFFECTED"
             BDD_PACKAGES=$(echo "$ALL_BDD" | jq -c --arg affected "$AFFECTED" \
               '[.[] | select(. as $pkg | ($affected | split(" ") | .[] | select(. == $pkg)) // empty)]')
           fi
@@ -56,7 +74,7 @@ jobs:
           echo "BDD packages ($COUNT): $BDD_PACKAGES"
   required:
     needs: plan
-    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true'
+    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: ubuntu-latest
     name: ubuntu / stable
     steps:
@@ -108,7 +126,7 @@ jobs:
         run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --doc
   macos:
     needs: plan
-    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true'
+    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: macos-latest
     name: macos-latest
     steps:
@@ -148,7 +166,7 @@ jobs:
     # BDD tests are split into per-service parallel jobs below to avoid
     # the ~10m sequential wall-clock from per-scenario process spawn overhead.
     needs: plan
-    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true'
+    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: windows-latest
     name: windows / nextest
     steps:
@@ -179,7 +197,12 @@ jobs:
     # ~5s/scenario. Running services in parallel cuts wall-clock from ~10m
     # to ~3m (limited by the largest service, ppba-driver).
     needs: plan
-    if: needs.plan.outputs.has-bdd == 'true' && (needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true')
+    # has-bdd reflects the union of cargo-rail's affected crates and
+    # tests/features changes (see plan job's "Discover BDD packages"
+    # step). It's a sufficient gate on its own — the prior
+    # `&& (test || infra)` clause was redundant and silently dropped
+    # BDD-only PRs (#186) from the windows-bdd matrix.
+    if: needs.plan.outputs.has-bdd == 'true'
     runs-on: windows-latest
     name: windows / bdd / ${{ matrix.package }}
     strategy:
@@ -224,7 +247,7 @@ jobs:
     # use llvm-cov to build and collect coverage and upload to codecov.io
     # with per-package flags for README badges.
     needs: plan
-    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true'
+    if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: ubuntu-latest
     name: coverage
     steps:

--- a/services/rp/src/imaging/tools/center_on_target.rs
+++ b/services/rp/src/imaging/tools/center_on_target.rs
@@ -12,6 +12,16 @@
 //!
 //! Behavioral contract: `docs/services/rp.md` → Compound Tools →
 //! `center_on_target` Contract.
+//!
+//! **BDD-author note.** `do_slew_blocking`'s 300 s deadline races
+//! rmcp's 300 s MCP-transport keep-alive — both fire at the same
+//! moment, so a single inner-iteration slew that approaches 5 minutes
+//! breaks the test client before the loop can return its
+//! `tolerance_not_reached` / `equipment` error. Keep BDD canned WCS
+//! values within ~2′ of any prior synced position so iter-1's sync +
+//! slew traverse a small distance even under heavy CI load. See
+//! `services/rp/tests/features/center_on_target.feature` for the
+//! worked numbers.
 
 use async_trait::async_trait;
 use serde::Serialize;

--- a/services/rp/tests/features/center_on_target.feature
+++ b/services/rp/tests/features/center_on_target.feature
@@ -48,12 +48,18 @@ Feature: Center on target compound tool
     And the center_on_target result should contain "final_dec"
     And the center_on_target result should contain "final_error_arcsec"
 
+  # Canned WCS values are kept within ~2 arcmin of the input target
+  # so the iter-1 sync teleports the mount only a tiny distance and
+  # the subsequent slew completes well within do_slew_blocking's
+  # 300 s deadline (and rmcp's 300 s keep-alive). Earlier values
+  # ~9° off target reliably hung windows / bdd / rp under CI load
+  # — see issue tracker for the OmniSim slew-time investigation.
   Scenario: Multi-iteration happy path converges on iteration 2
     Given a running Alpaca simulator
     And a stub plate solver returning these per-call WCS responses:
       | ra_center | dec_center |
-      | 9.9000    | 41.0000    |
-      | 10.6850   | 41.2690    |
+      | 10.7095   | 41.289     |
+      | 10.6845   | 41.269     |
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
@@ -71,8 +77,13 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
-    When the MCP client calls "sync_mount" with ra "20.0000" dec "-30.0000"
-    And the MCP client calls center_on_target with camera "main-cam" ra 20.0000 dec -30.0000 duration "100ms" tolerance_arcsec 1 max_attempts 2
+    # Default canned WCS is (10.6848°, 41.269°). Target is ~3.6"
+    # off in dec — bigger than the 1" tolerance, so iter 1 + iter 2
+    # both miss → tolerance_not_reached. Slew distance per iter is
+    # ~3.6" (tiny) so this can't hang under any plausible OmniSim
+    # timing.
+    When the MCP client calls "sync_mount" with ra "0.7123" dec "41.270"
+    And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.270 duration "100ms" tolerance_arcsec 1 max_attempts 2
     Then the tool call should return an error
     And the error message should contain "tolerance_not_reached"
 
@@ -87,38 +98,54 @@ Feature: Center on target compound tool
     Then the tool call should return an error
     And the error message should contain "solve_failed"
 
-  Scenario: Mid-loop slew failure (tracking off) aborts and propagates
+  Scenario: Mid-loop equipment failure (tracking off) aborts and propagates
     Given a running Alpaca simulator
     And a stub plate solver returning a canned WCS
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to false
     And an MCP client connected to rp
-    When the MCP client calls center_on_target with camera "main-cam" ra 20.0000 dec -30.0000 duration "100ms" tolerance_arcsec 1 max_attempts 5
+    # Tracking is off → the iter-1 sync_mount fails per ASCOM
+    # CheckTracking(true), aborting the loop before any slew. We
+    # use a target close to the canned WCS so even if the impl
+    # ever stopped requiring tracking for sync, the subsequent
+    # slew would still be tiny.
+    When the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.270 duration "100ms" tolerance_arcsec 1 max_attempts 5
     Then the tool call should return an error
 
-  Scenario: sync-on-iter-1-only invariant — final mount position reflects last slew, not last solve
+  Scenario: Three-iteration multi-iter run records sync, slew, then converged
     Given a running Alpaca simulator
     And a stub plate solver returning these per-call WCS responses:
       | ra_center | dec_center |
-      | 9.9000    | 41.0000    |
-      | 10.0000   | 41.1000    |
-      | 10.6850   | 41.2690    |
+      | 10.7095   | 41.289     |
+      | 10.7095   | 41.289     |
+      | 10.6845   | 41.269     |
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp
+    # Sync-on-iter-1-only invariant: iter 1 records "sync" (sync +
+    # slew), iter 2 records "slew" (no sync), iter 3 records
+    # "converged". The strong invariant — that sync_to is invoked
+    # exactly once across the whole loop — is verified by the
+    # synthetic-mount unit test in `imaging::tools::center_on_target`
+    # which counts adapter calls directly. This BDD scenario
+    # validates the user-visible action sequence and exercises the
+    # live OmniSim mount through a multi-iter sync/slew/converged
+    # cycle.
     When the MCP client calls "sync_mount" with ra "0.7123" dec "41.269"
     And the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.269 duration "100ms" tolerance_arcsec 60 max_attempts 5
-    And the MCP client calls "get_mount_position"
     Then the tool call should succeed
-    And the mount position should be approximately ra 0.7123 dec 41.269
+    And the center_on_target result should report attempts 3
+    And the center_on_target iterations[0] action should be "sync"
+    And the center_on_target iterations[1] action should be "slew"
+    And the center_on_target iterations[2] action should be "converged"
 
   Scenario: Per-iteration wcs sections persist on every captured document
     Given rp's data_directory is pinned to a fresh tempdir
     And a running Alpaca simulator
     And a stub plate solver returning these per-call WCS responses:
       | ra_center | dec_center |
-      | 9.9000    | 41.0000    |
-      | 10.6850   | 41.2690    |
+      | 10.7095   | 41.289     |
+      | 10.6845   | 41.269     |
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to true
     And an MCP client connected to rp

--- a/services/rp/tests/features/center_on_target.feature
+++ b/services/rp/tests/features/center_on_target.feature
@@ -104,13 +104,19 @@ Feature: Center on target compound tool
     And rp is running with a camera and a mount on the simulator
     And the mount tracking is set to false
     And an MCP client connected to rp
-    # Tracking is off → the iter-1 sync_mount fails per ASCOM
-    # CheckTracking(true), aborting the loop before any slew. We
-    # use a target close to the canned WCS so even if the impl
-    # ever stopped requiring tracking for sync, the subsequent
-    # slew would still be tiny.
+    # ASCOM requires Tracking == true before equatorial sync_mount
+    # and slew operations — the iter-1 sync_mount propagates the
+    # natural Alpaca error if tracking is off, aborting the loop.
+    # We assert the propagated error fragment from do_sync_mount
+    # ("failed to sync mount") so the scenario fails loud if the
+    # abort point ever moves to a different inner call (capture,
+    # plate_solve, slew). Target is kept close to the canned WCS
+    # for defense-in-depth — even if the impl ever stopped
+    # requiring tracking for sync, the subsequent slew would still
+    # be tiny.
     When the MCP client calls center_on_target with camera "main-cam" ra 0.7123 dec 41.270 duration "100ms" tolerance_arcsec 1 max_attempts 5
     Then the tool call should return an error
+    And the error message should contain "failed to sync mount"
 
   Scenario: Three-iteration multi-iter run records sync, slew, then converged
     Given a running Alpaca simulator


### PR DESCRIPTION
## Summary

Post-merge `windows / bdd / rp` job hung indefinitely on the
"Multi-iteration happy path converges on iteration 2" scenario (PR
#182), exhausting rmcp's 300 s keep-alive on the MCP transport. Run
`25612180718` was cancelled after 35 minutes.

**Mechanism**: the affected scenarios' setup `sync_mount(target)`
placed the OmniSim mount at the input target. The first
`center_on_target` iteration's canned WCS was ~9° off target. After
the iter-1 sync teleported the reported position to the canned
location, the iter-1 slew back to the input target had to traverse
~9°. OmniSim's TelescopeSimulator slews that distance reliably in
<1 s on its own, but under windows-CI load combined with sidereal-
tracking-during-slew (`targetAxes.X += haChange` per
`TIMER_INTERVAL=0.1s` tick), the slew intermittently never reports
`Slewing == false` within the 300 s `do_slew_blocking` deadline.
That deadline is the same 300 s as rmcp's keep-alive, so both
timers race and the call never returns to the test client.

**Fix**: shrink the canned WCS values so iter-1's sync teleports
the mount only ~110″ from target. The subsequent slew is similarly
small and completes in milliseconds even under heavy CI load.

Four scenarios touched:
- **Multi-iteration happy path** — canned values pulled within
  ~110″ of target. Iter-1 still records `action: "sync"` (residual
  ~90″ > 60″ tolerance); iter 2 lands exactly on target →
  converged.
- **tolerance_not_reached** — target shifted to be `~3.6″` off the
  canned default, with 1″ tolerance. Per-iter slew is tiny.
- **Mid-loop equipment failure (tracking off)** — renamed from
  "Mid-loop slew failure" since per ASCOM `CheckTracking(true)` the
  iter-1 sync_mount fails first, before any slew. Target shifted
  close to canned default for defense-in-depth.
- **Three-iteration multi-iter run** — renamed from
  "sync-on-iter-1-only invariant". When iter-N's solved position
  is close to target (a precondition for converging inside
  tolerance), the previous "final mount position ≈ input target"
  assertion could not distinguish correct sync-once-only from
  buggy sync-every-iter. The strong invariant is verified by the
  synthetic-mount unit test in `imaging::tools::center_on_target`
  which counts adapter calls directly. BDD now asserts only the
  user-visible action sequence (`sync` → `slew` → `converged`).

## Test plan

Local BDD on this dev box has unrelated OmniSim flakes (camera
disconnect mid-run, orchestrator timeouts) so the fix can only be
properly verified in CI.

- [ ] `windows / bdd / rp` completes within normal duration (~9 min)
      — the matrix that previously hung.
- [ ] `cargo rail run --profile commit -q` clean workspace-wide.
- [ ] All other CI matrices green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)