### PR TITLE
docs(star-adventurer-gti): mark Phase 2/3 landed; add service to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cross-platform [ASCOM Alpaca](https://ascom-standards.org/Developer/Alpaca.htm) 
 | [sentinel](services/sentinel) | Monitoring service | 11114 | [![coverage][cov-sentinel]][cov-sentinel-link] | Polls devices, sends notifications, serves web dashboard |
 | [calibrator-flats](services/calibrator-flats) | Orchestrator plugin | 11170 | [![coverage][cov-calibrator-flats]][cov-calibrator-flats-link] | Flat field calibration with CoverCalibrator device |
 | [sky-survey-camera](services/sky-survey-camera) | ASCOM Camera (simulator) | 11116 | [![coverage][cov-sky-survey-camera]][cov-sky-survey-camera-link] | Camera simulator that returns NASA SkyView cutouts for the configured optics |
+| [star-adventurer-gti](services/star-adventurer-gti) | ASCOM Telescope | 11117 | [![coverage][cov-star-adventurer-gti]][cov-star-adventurer-gti-link] | Driver for Sky-Watcher Star Adventurer GTi (USB and WiFi/UDP) |
 
 ### RP (Main Application)
 
@@ -64,6 +65,12 @@ See [docs/services/calibrator-flats.md](docs/services/calibrator-flats.md) for d
 ASCOM Alpaca Camera **simulator** that synthesises exposures from NASA SkyView cutouts. Given a configured optical system (focal length, sensor pixel count, pixel size) and a sky position (RA/Dec, settable at runtime via a custom HTTP endpoint), it returns an `ImageArray` matching the field of view the equivalent real telescope would see. Useful for driving ASCOM clients and the rest of the rusty-photon stack end-to-end without hardware.
 
 See [docs/services/sky-survey-camera.md](docs/services/sky-survey-camera.md) for design documentation.
+
+### Star Adventurer GTi
+
+ASCOM Alpaca Telescope driver for the Sky-Watcher Star Adventurer GTi, an entry-level GoTo equatorial mount. Speaks the Sky-Watcher motor-controller protocol over USB-CDC serial (115200 baud) and UDP (192.168.4.1:11880 in mount-AP mode). Implements the MVP slice — connect/disconnect, RA/Dec reads, sync, async slew, sidereal tracking, software park, abort — leaving guiding, custom rates, and Alt/Az slew for follow-up. The shared codec lives in the `skywatcher-motor-protocol` workspace crate so other Sky-Watcher mounts can reuse it.
+
+See [docs/services/star-adventurer-gti.md](docs/services/star-adventurer-gti.md) for design documentation.
 
 ## Getting Started
 
@@ -212,3 +219,5 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT L
 [cov-calibrator-flats-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=calibrator-flats
 [cov-sky-survey-camera]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=sky-survey-camera
 [cov-sky-survey-camera-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=sky-survey-camera
+[cov-star-adventurer-gti]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=star-adventurer-gti
+[cov-star-adventurer-gti-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=star-adventurer-gti

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -601,10 +601,11 @@ as `qhy-focuser` and `ppba-driver`.)
 | Phase | Status |
 |---|---|
 | **Phase 1 — Design doc** | ✓ landed (this document, PR #178) |
-| **Phase 2 — BDD scaffold** | ✓ landed: codec crate skeleton, service skeleton, all feature files (`@wip`), step stubs |
-| **Phase 3 — Implementation** | not started — turns the `@wip` scenarios green and removes the tags |
+| **Phase 2 — BDD scaffold** | ✓ landed: codec crate skeleton, service skeleton, all feature files (`@wip`), step stubs (PR #180) |
+| **Phase 3 — Implementation** | ✓ landed: codec, transports (USB+UDP), `MountDevice`, ConformU integration (PR #188); BDD step bodies + `@wip` removal (PR #189). All 9 feature files / 77 scenarios green on Linux/Windows/macOS CI. |
+| **Phase 4 — Real-hardware bringup** | not started — first connect to a physical GTi, validate protocol assumptions, optionally add clock injection so BDD can pin LST literals |
 
-### In-scope (Phase 3 will turn these green)
+### In-scope (Phases 1–3, all landed)
 
 - USB transport at 115200 baud (`/dev/serial/by-id/...` path in config)
 - UDP transport at 192.168.4.1:11880 (bind to local 192.168.4.x)


### PR DESCRIPTION
## Summary

- Update `docs/services/star-adventurer-gti.md` Phase status table — Phase 2/3 landed (PRs #180 / #188 / #189), Phase 4 (real-hardware bringup) added as the next slot.
- Add Star Adventurer GTi to the main `README.md`: row in the Services table (port 11117, ASCOM Telescope, coverage badge), subsection in the same shape as the other services, codecov badge link refs.

The codecov flag (`star-adventurer-gti`) already exists from the auto-generated per-package coverage upload in `test.yml`, so no workflow changes are needed — the badge resolves immediately. Coverage today is 74.85% (below the repo's 85% target); a separate PR will tighten it.

## Test plan

- [x] README renders cleanly (table row + section + badge link refs aligned with the existing pattern)
- [x] Design doc Phase status reflects merged PRs #180 / #188 / #189
- [x] No code changes — `cargo build` / `cargo test` not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)