### PR TITLE
fix(star-adventurer-gti): de-flake slew_async_marks_slewing_until_watcher_clears_it

### DIFF
--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1122,11 +1122,19 @@ mod tests {
         d.slew_to_coordinates_async(6.0, 30.0).await.unwrap();
         // slew_in_progress is set immediately on return.
         assert!(d.slewing().await.unwrap());
-        // Wait long enough for the polling task to refresh snapshot AND
-        // the watcher to run (mock completes a slew in one poll, settle
-        // is 0, polling interval is 20ms).
-        tokio::time::sleep(Duration::from_millis(200)).await;
-        assert!(!d.slewing().await.unwrap());
+        // Poll for completion: the slew distance is LST-dependent so
+        // the number of mock polls to reach the target varies with the
+        // wall clock. Bound the wait at 5s — vastly more than the
+        // ~100ms a 100_000-tick-per-step mock needs to walk a typical
+        // ±6h HA, but loose enough that a slow CI runner can't flake.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if !d.slewing().await.unwrap() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("slewing did not become false within 5s");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`mount_device::tests::slew_async_marks_slewing_until_watcher_clears_it` allowed a flat 200ms wall-clock window for the slew-completion watcher to finish. The slew distance is LST-dependent (RA target maps current mechanical HA -> encoder ticks at the current LST), and the mock advances 100,000 ticks per :j poll on a 20ms polling cadence -> worst case ~9 polls -> 180ms. On slow runners (or in coverage instrumentation) this slips past 200ms and the test fires before the watcher clears \`slew_in_progress\`.

GHA scheduling has been favourable enough that this never fired in CI, but it reproduces deterministically locally on my machine (5/5 runs).

Replaced the fixed sleep with a polling deadline (5s, 20ms cadence) -- the same shape the BDD steps already use for "Slewing should eventually be ..." assertions. 5s vastly exceeds the ~100-400ms a typical slew takes on the mock and bounds against a genuine watcher hang.

## Test plan

- [x] \`cargo test -p star-adventurer-gti --features mock --lib slew_async_marks_slewing_until_watcher_clears_it\` passes deterministically (3x in a row, locally) -- previously failed deterministically
- [x] Full \`cargo test --features mock --lib\` (88 tests) and \`--test bdd\` (77 scenarios) still green
- [x] \`cargo clippy -p star-adventurer-gti --all-targets --all-features -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)