### PR TITLE
feat(star-adventurer-gti): use :K for slew-prep stop, short-circuit unchanged :G

### DIFF
--- a/docs/plans/star-adventurer-gti-pickup-accuracy.md
+++ b/docs/plans/star-adventurer-gti-pickup-accuracy.md
@@ -1,0 +1,298 @@
+# Star Adventurer GTi: post-pickup RA accuracy experiments
+
+## Status: B + D landed on PR #210 (2026-05-12)
+
+Real-hardware ConformU residuals before / after:
+
+| Metric | Before (PR #210 `:K` only) | After B + D |
+|---|---|---|
+| Mean RA residual | 8.4″ | **3.7″** |
+| Max RA residual | 11.0″ | **6.6″** |
+| 10″ tolerance crossings | 2 / 10 slews | **0 / 10** |
+| Pickup iterations / slew (typical) | 5 (saturated) | **1–2** |
+
+Experiments A and C remain on the shelf (faster polling, more
+iterations) for if further accuracy improvements are ever wanted —
+but B + D alone get us cleanly under tolerance.
+
+## Motivation
+
+The first real-hardware ConformU run after PR #210 landed `:K` showed
+SyncToCoordinates and SyncToTarget crossing ConformU's ±10″ RA tolerance
+on a couple of tests (10.2″ and 10.95″). Investigation against the wire
+log (see PR #210 conversation) ruled out slew distance and the `:K` vs
+`:L` choice as the cause — the residuals cluster ~5–11″ across slews of
+wildly different sizes, all with a consistent **positive** sign
+(`Actual > Target`). The signature is LST drift accumulated *after* the
+pickup loop converges, dominated by:
+
+- Pickup-loop exit tolerance (5″) → up to 5″ residual at pickup exit
+- Tracking-restart wire latency (~50 ms) → ~0.7″
+- `settle_after_slew` (200 ms) — only adds drift if firmware tracking
+  hasn't actually engaged yet → up to ~3″
+- ConformU's HTTP poll latency between `Slewing == false` and
+  `RightAscension` read → ~1.5″
+
+Total floor: ~5″ + 5″ ≈ 10″ worst case, which is exactly the
+tolerance line. The 2 ISSUE crossings out of 10 RA reads are bare
+variance.
+
+This plan walks three independent fixes (and a combined run) to drive
+the floor down well under the tolerance line. None of these are part
+of issue #207; they are follow-up work.
+
+## Pass criterion
+
+For each experiment, run conformu against the real GTi and compare RA
+residuals on the named tests:
+
+- **SlewToCoordinates / SlewToCoordinatesAsync** (first slews from park)
+- **SlewToTarget / SlewToTargetAsync** (target-based variants)
+- **SyncToCoordinates / SyncToTarget** "Slewed to start position" and
+  the 2× "Slewed back to start" sub-steps
+
+**Pass:** all RA residuals < 7″, zero crossings of 10″ on a single run.
+
+## Setup: characterise baseline variance
+
+Before any code change, run conformu against real hardware **2× more**
+(3 total including the morning-of-2026-05-12 run) without modification.
+Goal: know how much the same test bounces between runs. If
+`SyncToCoord slew-to-start` is 10.2″ in run 1, then 7.8″ in run 2, then
+9.5″ in run 3, the noise floor is ~2.4″ peak-to-peak and any fix needs
+to deliver more than that to be measurable.
+
+Capture per run:
+
+- `/tmp/conformu-real-baseline-N.log` (conformu stdout)
+- `/tmp/service-debug-baseline-N.log` (service wire trace at `-l debug`)
+
+Tabulate per-test residual, signed (Actual − Target in arcsec).
+
+## Free diagnostics — DONE
+
+Both diagnostics were run on the 2026-05-12 real-hardware log. Results
+materially change the experiment plan below.
+
+### D1. Pickup iteration count — RESULT: iteration-capped on ≥10/11 slews
+
+Across the 11 slews captured in the run, the pickup loop **exhausts
+`PICKUP_MAX_ITERATIONS = 5` on essentially every slew** and exits with
+RA residual stuck at 5–7″. Sample (slew 1):
+
+```
+iter 1  t+   0ms  ra=31.74"
+iter 2  t+ 399ms  ra= 6.06"
+iter 3  t+ 799ms  ra= 6.09"
+iter 4  t+1200ms  ra= 5.80"
+iter 5  t+1600ms  ra= 5.49"  (exhausted)
+```
+
+Every iteration takes ~400 ms (200 ms watcher poll + small re-slew +
+wire round-trips). During 400 ms, LST advances ~6″. The pickup
+corrects ~25–30″ per iteration but loses ~6″ to LST drift each round.
+**The residual floor IS the per-iteration LST drift**, which is why
+tightening `PICKUP_TOLERANCE_ARCSEC` cannot help — pickup physically
+can't converge under the drift it accumulates between iterations.
+
+This invalidates Experiment 1 below. The real fixes are either
+(a) faster iterations or (b) pre-compensating each iteration's target
+for the expected next-iteration LST drift.
+
+### D2. Firmware tracking-engagement latency — RESULT: ~160 ms
+
+Watcher's post-slew `:G110 :I108CC05 :J1` at 03:02:06.495 (UTC):
+
+| Event | Encoder | Δ ticks (200 ms) | Inferred rate |
+|---|---|---|---|
+| `:J1` ack | -453439 | – | – |
+| +160 ms (status flips `running=true`) | -453436 | +3 | first motion |
+| +360 ms | -453426 | +10 | 50/s |
+| +560 ms | -453417 | +9 | 45/s |
+| +760 ms | -453408 | +9 | 45/s (sidereal target: 42/s) |
+
+The firmware engages tracking within ~160 ms of `:J1` and reaches
+sidereal-rate motion by ~400 ms. The current `settle_after_slew =
+200 ms` is just barely enough; trimming to 100 ms would risk reading
+RA mid-engagement (~1–2″ of drift), 0 ms would risk ~2.4″.
+
+This significantly narrows Experiment 2's value. Settle is roughly
+right-sized for this firmware.
+
+## Experiments (revised after diagnostics)
+
+The original three experiments (tighten pickup tolerance, trim settle,
+verify tracking engaged) are **mostly redirected** by D1 + D2:
+
+- **Experiment 1 (tighten tolerance)** is dropped. D1 shows pickup
+  cannot converge below the per-iteration LST drift (~6″), so
+  tightening the exit threshold below 6″ achieves nothing — pickup
+  exhausts iterations and exits wherever it is.
+- **Experiment 2 (trim settle)** is downgraded to "informational
+  only". D2 shows settle is approximately right-sized for the
+  firmware's 160 ms engagement latency; trimming saves at most ~1″
+  with real risk if engagement varies between runs.
+- **Experiment 3 (verify tracking engaged)** is dropped. D2 shows
+  engagement is consistent at ~160 ms, well-modeled by the fixed
+  200 ms settle.
+
+In their place: two new experiments targeting the actual bottleneck
+identified by D1.
+
+### Experiment A: tighten the watcher polling interval
+
+**Files:**
+
+- `services/star-adventurer-gti/conformu-test-config.json` (set
+  `polling_interval` to `"50ms"` from the default `"200ms"`)
+- No code change needed — the watcher and pickup loop already use
+  `transport.polling_interval_for_watcher()`.
+
+**Hypothesis.** Pickup iterations are gated by `polling_interval`
+(currently 200 ms). Each iteration's LST drift = iteration_duration ×
+15.04″/sec ≈ 6″. Tightening polling to 50 ms drops the iteration
+duration to ~150–200 ms (poll sleep + wire round-trip + slew time),
+which shrinks per-iteration drift to ~2.3–3″ and lets pickup converge
+under 5″ before iteration cap.
+
+**Procedure.**
+
+1. `polling_interval = "100ms"`. Run conformu. Capture residuals +
+   wire trace.
+2. `polling_interval = "50ms"`. Run conformu.
+3. Confirm pickup converges (last iteration's residual < 5″)
+   on each slew. If yes, RA residuals on Sync tests should drop
+   well under 10″.
+
+**Watch out for.** Polling interval also drives the polling task's
+`:f` / `:j` cadence. Faster polling = more wire traffic. At 50 ms,
+we're issuing ~80 wire round-trips/sec just for status — could
+saturate the USB serial port, increase wire latency, or starve
+real commands. If wire latency goes up (`:K` → `:f` poll → ack
+time inflates), the per-iteration savings shrink.
+
+**Estimated cost.** ~20 min real-hardware (2 runs).
+
+### Experiment B: pre-compensate pickup target for next-iteration LST
+
+**File:** `services/star-adventurer-gti/src/mount_device.rs`, inside
+`spawn_slew_completion_watcher`'s pickup block.
+
+**Hypothesis.** Currently each pickup iteration computes its target
+for `LST(now)`. The slew it issues takes ~400 ms to settle; by then
+LST has advanced ~6″, and the encoder lands 6″ short of where it
+needs to be when the *next* check happens. Pre-compensating the
+target for the *expected next-iteration LST* (now + 1 poll cycle +
+expected wire latency) makes each iteration aim for where the target
+will be when we re-check.
+
+**Implementation sketch.**
+
+```rust
+// Inside the pickup block, when computing new_mech_ha:
+let lst_now = local_sidereal_time_hours(SystemTime::now(), ...);
+// Project forward by one iteration duration. The "expected next
+// iteration time" = polling_interval + small wire round-trip budget.
+let lst_target = lst_now + (polling_interval.as_secs_f64() / 3600.0);
+let new_mech_ha = ra_to_mechanical_ha(target_ra, lst_target);
+```
+
+This is a one-line change (just the `lst_target` calculation).
+
+**Why this is independent of polling interval.** Even at 200 ms
+polling, pre-compensation lets pickup land *ahead* of the moving
+target; by the time the next iteration measures, encoder + LST drift
+land back on target. Pickup converges to noise instead of drift floor.
+
+**Procedure.**
+
+1. Implement the one-line pre-compensation change.
+2. Add unit test (mock + faked LST) confirming pre-compensation
+   makes the iteration target move forward by the polling interval
+   in arcseconds.
+3. Run conformu against real hardware once. Capture residuals.
+
+**Watch out for.** If pre-compensation is too aggressive (over-shoots
+the LST projection), pickup oscillates instead of converging.
+Concretely: aim slightly behind one iter, then slightly ahead next.
+If we see iteration residuals alternating signs, the projection
+constant needs tuning.
+
+**Estimated cost.** Code change + unit test + ~10 min real-hardware
+(1 run).
+
+### Experiment C (optional): increase `PICKUP_MAX_ITERATIONS`
+
+**File:** `services/star-adventurer-gti/src/mount_device.rs`,
+`PICKUP_MAX_ITERATIONS` constant (currently 5).
+
+**Hypothesis.** Only useful if combined with A or B — alone, more
+iterations of the same drift-chasing race don't help. But if A or B
+makes individual iterations converge, more iterations is "free
+insurance" that the cap doesn't bite. INDI uses 5; we may want 10
+on real hardware because our iterations are slower than INDI's
+(INDI runs the watcher in C without async-task overhead).
+
+Skip unless A and B together can't get all residuals under 7″.
+
+### Experiment D (informational): trim `settle_after_slew` to 100 ms
+
+This was Experiment 2 in the original plan; D2 nearly invalidated it.
+Worth running once *after* A and B to see if combining a slightly
+smaller settle gains anything when pickup is no longer the bottleneck.
+
+`settle_after_slew = "100ms"` (was `"200ms"`). Run conformu once.
+Expected gain: 0–1″. If residuals get worse, revert.
+
+**Estimated cost.** ~10 min real-hardware (1 run).
+
+## Combined experiment
+
+Take the best parameters / approach from 1, 2, 3 — apply all
+simultaneously. Run conformu once.
+
+**Pass criterion.** All RA residuals < 7″. Zero crossings of 10″.
+
+If we still cross 10″ on one or two tests, that's the floor we can
+hit without restructuring the watcher / pickup loop architecture.
+Document it.
+
+## Estimated total cost (post-diagnostic revision)
+
+| Phase | Runs | Wall-clock |
+|---|---|---|
+| Diagnostics D1, D2 | 0 | DONE — free |
+| Baseline characterisation | 1 | ~10 min |
+| Experiment A (tighten polling) | 2 | ~20 min |
+| Experiment B (pre-compensate target) | 1 | ~10 min + code |
+| Experiment C (more iterations) | 0–1 | ~10 min (only if needed) |
+| Experiment D (trim settle) | 1 | ~10 min |
+| Combined | 1 | ~10 min |
+| **Total** | **6–7** | **~60–70 min real-hardware + code + analysis** |
+
+The reduction comes from D1's finding: tightening pickup tolerance
+(originally 2 runs) was unwinnable; trimming settle (originally 3
+runs) was nearly unhelpful. Both are dropped or downgraded.
+
+## Output
+
+For each run, capture:
+
+- Per-test signed RA residual (arcsec)
+- Per-test Dec residual (arcsec)
+- Pickup iteration count (from wire log)
+- Tracking-engagement latency (from wire log)
+- Conformu issue count, errors count, configuration-alerts count
+
+Tabulate in a follow-up doc / PR description. The "good" result
+becomes the new conformu-test-config.json default for the driver.
+
+## References
+
+- PR #210 conversation for the diagnostic walk-through that led to
+  this plan
+- `docs/services/star-adventurer-gti.md` §"Post-slew tracking-pickup"
+  (Phase 4 finding) and §"Phase 4 driver-logic changes" (current
+  pickup loop)
+- INDI eqmod `eqmodbase.cpp` `RAGOTORESOLUTION` / `DEGOTORESOLUTION`
+  (= 5″) and `GOTO_ITERATIVE_LIMIT` (= 5)

--- a/docs/plans/star-adventurer-gti-pickup-accuracy.md
+++ b/docs/plans/star-adventurer-gti-pickup-accuracy.md
@@ -112,12 +112,20 @@ Watcher's post-slew `:G110 :I108CC05 :J1` at 03:02:06.495 (UTC):
 | +760 ms | -453408 | +9 | 45/s (sidereal target: 42/s) |
 
 The firmware engages tracking within ~160 ms of `:J1` and reaches
-sidereal-rate motion by ~400 ms. The current `settle_after_slew =
-200 ms` is just barely enough; trimming to 100 ms would risk reading
+sidereal-rate motion by ~400 ms.
+
+**Initial reading (pre-Option-1):** `settle_after_slew = 200 ms`
+appeared just barely enough; trimming to 100 ms would risk reading
 RA mid-engagement (~1–2″ of drift), 0 ms would risk ~2.4″.
 
-This significantly narrows Experiment 2's value. Settle is roughly
-right-sized for this firmware.
+**Updated reading (after Option 1 with early pause-guard
+release):** the watcher releases the background-polling pause guard
+right after the tracking-restart `:J1` and *before* the settle
+delay. That lets the background polling task refresh the snapshot
+during settle with already-tracking encoder data, so settle is no
+longer load-bearing for snapshot freshness — it's just a
+mechanical-stability margin. Empirically, 100 ms now produces 0/10
+tolerance crossings on both USB (max 6.6″) and UDP (max 8.7″).
 
 ## Experiments (revised after diagnostics)
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -769,27 +769,48 @@ In addition to the codec fixes:
   (`AbortSlew`, slew/park watcher abort on `blocked`).
   Mock hid the wallclock issue originally because it processes
   `:K`/`:L` instantaneously.
-- **Mode-cache short-circuit** — every `:G<axis><mode>` is
-  preceded by a `stop_and_wait` so the spec-required "motor at
-  full stop before mode change" holds. Most consecutive `:G`
-  issues request the *same* mode the firmware was last told to
-  use — back-to-back slews in one direction, a UI re-asserting
-  tracking, etc. The driver caches the last [`MotionMode`] each
-  axis acked (via [`TransportManager::record_motion_mode`]) and
-  short-circuits `stop_and_wait + :G` when the requested mode
-  equals the cache. Matches INDI eqmod's
-  `LastRunningStatus == NewStatus` check
-  (`indi-eqmod/skywatcher.cpp:1672-1678`). The cache is
-  per-axis and reset on every connect / disconnect — a connect
-  into a session must not trust a `MotionMode` recorded against
-  a possibly different physical mount. The slew-completion
-  watcher explicitly invalidates the RA cache on the
-  `tracking_was_off` branch (the firmware auto-engages Speed
-  Mode after every goto completes on RA — without the
-  invalidation, a subsequent same-direction slew would short-
-  circuit on a stale cache against a firmware in Tracking
-  mode); the EQMOD pickup loop similarly invalidates per axis
-  before its corrective re-slew.
+- **No mode-cache short-circuit (attempted and reverted)** — issue
+  #207's initial plan included an INDI-style
+  `LastRunningStatus == NewStatus` cache to skip `stop_and_wait +
+  :G` when the requested mode matched the last one we acked. **The
+  implementation we tried did not work on real hardware.**
+  Mock-mode ConformU + the unit/BDD suites all passed cleanly, but
+  the first ConformU run against the physical GTi triggered an
+  unbounded Dec slew: the cache said `Goto-Fast-CCW` after a `:E`
+  (sync), but the firmware-side mode had drifted; the resulting
+  `:I/:H/:M/:J` started a slew that ran ~360° of unwanted Dec
+  motion before the pickup loop fired a ~269° corrective slew back.
+  See PR #210 for the wire trace. The cache was reverted to an
+  unconditional `stop_and_wait + :G` on every slew/park/tracking
+  prep — the spec-recommended sequence and what INDI's
+  `StopWaitMotor` does internally.
+
+  Two reasons not to retry naively if/when revisiting:
+
+  1. **`:E` (sync) is one observed mode-state desync, but not
+     necessarily the only one.** Tracking transitions, post-goto
+     auto-engage on RA, `:L` aborts, blocked-axis recovery, and any
+     other state-changing command can shift firmware-side mode
+     without an explicit `:G` from us. A cache that mirrors only
+     what we *issued* is structurally unsafe.
+  2. **UDP transport widens the failure mode.** The wire protocol
+     is identical on USB-CDC and UDP/11880, but UDP can drop,
+     reorder, or duplicate packets without us noticing; a cache
+     that records "we sent `:G CCW` and saw an ack" can lie even
+     more easily if a `:G` response was actually a stale duplicate
+     ack from a prior frame. Anything we cache about firmware state
+     must survive both half of the codec layer being lossy.
+
+  Any future cache implementation needs a **background validation
+  loop** that re-reads the actual `:f` mode bits (per spec §5, the
+  status nibble reports the live mode) often enough to catch
+  desyncs *before* the next `:G`-eliding op fires — polling cadence
+  needs to be comparable to or faster than the smallest slew a
+  caller could chain, and a desync detection must invalidate the
+  per-axis cache immediately and refuse short-circuits until the
+  next confirmed `:G` ack. Without that — or without a different
+  approach that doesn't depend on a snapshot of state we don't own —
+  the cache is structurally unsound.
 - **INDI-style slew sequence** — Phase A5 reinstated `:I` on the
   slew path and switched the goto from `:S` (absolute target) to
   `:H` (delta target) plus `:M` (break-point increment), matching

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -730,9 +730,32 @@ In addition to the codec fixes:
   the motor takes meaningful wallclock time to actually halt.
   `:G` against a still-decelerating axis returns `!2\r`
   (`MotorNotStopped`). The slew, park, and `set_tracking(true)`
-  paths now issue `:L` (instant stop) and then poll `:f` until
-  `running == false`, before any subsequent `:G`/`:S`/`:J`. Mock
-  hid this because it processes `:K`/`:L` instantaneously.
+  paths issue `:K` (decelerate) and then poll `:f` until
+  `running == false`, before any subsequent `:G`/`:S`/`:J`. An
+  early version of this path used `:L` (instant stop) instead;
+  switched to `:K` in issue #207 to match the spec's recommended
+  stop semantics and INDI eqmod's `StopWaitMotor`
+  (`indi-eqmod/skywatcher.cpp:1741-1765`) — `:L` is harsher on
+  the gearbox and is reserved for genuine emergency stops
+  (`AbortSlew`, slew/park watcher abort on `blocked`).
+  Mock hid the wallclock issue originally because it processes
+  `:K`/`:L` instantaneously.
+- **Mode-cache short-circuit** — every `:G<axis><mode>` is
+  preceded by a `stop_and_wait` so the spec-required "motor at
+  full stop before mode change" holds. Most consecutive `:G`
+  issues request the *same* mode the firmware was last told to
+  use — back-to-back slews in one direction, a UI re-asserting
+  tracking, etc. The driver caches the last [`MotionMode`] each
+  axis acked (via [`TransportManager::record_motion_mode`]) and
+  short-circuits `stop_and_wait + :G` when the requested mode
+  equals the cache. Matches INDI eqmod's
+  `LastRunningStatus == NewStatus` check
+  (`indi-eqmod/skywatcher.cpp:1672-1678`). The cache is
+  per-axis, opaque to the firmware's post-goto auto-engage-
+  Tracking behaviour (same caveat INDI carries), and reset on
+  every connect / disconnect — a connect into a session must
+  not trust a `MotionMode` recorded against a possibly different
+  physical mount.
 - **No `:I` in Goto mode** — spec §3 says the firmware computes
   slew speed internally for Goto mode. We removed the `:I` send
   from the slew path; tracking still uses `:I` to set the

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -823,21 +823,47 @@ In addition to the codec fixes:
   which is what produced the post-stop residual RA drift the
   Phase 4 ConformU run flagged. Park still uses `:S` since its
   target is encoder 0 and the absolute form is the simpler fit.
-- **Pickup-loop LST pre-compensation** — issue #207 follow-up.
-  Each pickup-loop iteration computes the corrective target's
-  encoder ticks for *the LST one iteration ahead* rather than
-  `LST(now)`. Without this, the slew lands at where the target
-  *was* and the next iteration's LST has already advanced
-  ~`polling_interval × 2 × 15.04″/sec`; pickup chases a moving
-  target and the residual floor is the per-iteration drift.
-  With pre-compensation, pickup converges in 1–2 iterations
-  to under 5″ instead of saturating at 5 iterations and ~6″.
-  The projection helper lives in [`coordinates::pickup_target_ra_ticks`];
-  the slew-issue path uses the existing `MIN_SLEW_DWELL` (2 s)
-  pre-compensation, and pickup uses `polling_interval × 2`
-  (~400 ms on USB). Real-hardware ConformU residuals dropped
-  from a mean of 8.4″ (max 11.0″, 2× 10″ tolerance crossings)
-  to mean 3.7″, max 6.6″, zero crossings.
+- **Pickup-loop accuracy stack** — issue #207 follow-up; three
+  layered fixes that together brought real-hardware ConformU
+  residuals from mean 8.4″ / max 11.0″ (2 × 10″ tolerance
+  crossings) down to mean 2.4″ / max 6.6″ on USB and mean 5.0″ /
+  max 8.7″ on UDP, with **zero crossings on either transport**.
+
+  1. **LST pre-compensation** —
+     [`coordinates::pickup_target_ra_ticks`] computes each
+     iteration's corrective encoder target for `LST(now +
+     projection)` rather than `LST(now)`. Without it the slew
+     lands at where the target *was* one iteration ago, and the
+     residual floor matches the per-iteration LST drift (~6″ on
+     USB, ~14″ on UDP).
+
+  2. **Adaptive projection** — the watcher tracks the wall-clock
+     interval between consecutive pickup decisions and uses it as
+     the projection for the next iteration. Self-tunes per
+     transport without per-transport config: USB iterations
+     stabilise at ~400 ms, UDP at ~1100 ms. First iteration (no
+     prior data) falls back to `polling_interval × 2`.
+
+  3. **Pause background polling during the slew** — the watcher
+     acquires a [`TransportManager::pause_background_polling`]
+     RAII guard at the top of its spawn. While paused, the
+     watcher owns the wire: pickup wire commands (`:K :G :I :H
+     :M :J`) fire without contending with `:j` / `:f` polls for
+     the `command_lock`, and the watcher's
+     [`TransportManager::poll_axes_now`] drives the snapshot's
+     freshness with one wire round-trip per loop iteration. The
+     guard is dropped explicitly right after tracking restart,
+     before the settle delay — so background polling resumes
+     during settle and the snapshot reflects the actively-tracking
+     encoder position by the time an Alpaca client reads
+     `RightAscension` post-`Slewing`. Releasing the guard early
+     vs. on watcher exit makes a measurable difference (UDP mean
+     7.3″ → 5.0″ in the experiment runs). Park watcher follows
+     the same pattern.
+
+  See `docs/plans/star-adventurer-gti-pickup-accuracy.md` for the
+  experiment plan and the diagnostic data that drove these
+  choices.
 - **Mechanical safety envelope** — driving the mount into the
   counterweight-up region with ConformU's pier-flip tests stalled
   the motor against a hard stop while the encoder counter kept

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -823,6 +823,21 @@ In addition to the codec fixes:
   which is what produced the post-stop residual RA drift the
   Phase 4 ConformU run flagged. Park still uses `:S` since its
   target is encoder 0 and the absolute form is the simpler fit.
+- **Pickup-loop LST pre-compensation** — issue #207 follow-up.
+  Each pickup-loop iteration computes the corrective target's
+  encoder ticks for *the LST one iteration ahead* rather than
+  `LST(now)`. Without this, the slew lands at where the target
+  *was* and the next iteration's LST has already advanced
+  ~`polling_interval × 2 × 15.04″/sec`; pickup chases a moving
+  target and the residual floor is the per-iteration drift.
+  With pre-compensation, pickup converges in 1–2 iterations
+  to under 5″ instead of saturating at 5 iterations and ~6″.
+  The projection helper lives in [`coordinates::pickup_target_ra_ticks`];
+  the slew-issue path uses the existing `MIN_SLEW_DWELL` (2 s)
+  pre-compensation, and pickup uses `polling_interval × 2`
+  (~400 ms on USB). Real-hardware ConformU residuals dropped
+  from a mean of 8.4″ (max 11.0″, 2× 10″ tolerance crossings)
+  to mean 3.7″, max 6.6″, zero crossings.
 - **Mechanical safety envelope** — driving the mount into the
   counterweight-up region with ConformU's pier-flip tests stalled
   the motor against a hard stop while the encoder counter kept

--- a/services/star-adventurer-gti/conformu-test-config.json
+++ b/services/star-adventurer-gti/conformu-test-config.json
@@ -17,7 +17,7 @@
     "site_latitude_deg": 47.6062,
     "site_longitude_deg": -122.3321,
     "site_elevation_m": 56.0,
-    "settle_after_slew": "200ms",
+    "settle_after_slew": "100ms",
     "tracking_rate": "sidereal"
   }
 }

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -149,6 +149,41 @@ pub fn dec_degrees_to_ticks(dec_degrees: f64, cpr: u32) -> i32 {
     (dec_degrees * (cpr as f64) / 360.0).round() as i32
 }
 
+/// Compute the RA-axis encoder target for a pickup-loop re-slew,
+/// pre-compensated for the LST drift expected to occur before the
+/// next residual check.
+///
+/// Without pre-compensation, each pickup iteration computes
+/// `mech_HA = LST(now) - target_RA` and aims the encoder there. But
+/// the slew takes ~one iteration to settle, by which time LST has
+/// advanced ~`projection × 15.04″/sec`. The next iteration sees the
+/// encoder is short of where it should be (because target_RA has the
+/// same value but mech_HA needed = LST_now+iter - target_RA is now
+/// larger). Pickup is locked into chasing a moving target and the
+/// residual floor matches the per-iteration LST drift.
+///
+/// Pre-compensation: aim where the encoder *will need to be* at the
+/// next check, i.e. compute `mech_HA = LST(now + projection) -
+/// target_RA`. By the time the slew settles and the next iteration
+/// re-checks, LST has advanced into the projection and the encoder
+/// is exactly on target.
+///
+/// `projection` is the watcher's expected per-iteration duration —
+/// see [`crate::mount_device::spawn_slew_completion_watcher`]. On a
+/// per-`polling_interval` cadence the empirical observation is
+/// ~`polling_interval × 2` (one watcher sleep + one slew-settle
+/// + wire round-trips).
+pub fn pickup_target_ra_ticks(
+    target_ra_hours: f64,
+    current_lst_hours: f64,
+    projection: std::time::Duration,
+    cpr_ra: u32,
+) -> i32 {
+    let lst_at_next_check = current_lst_hours + projection.as_secs_f64() / 3600.0;
+    let mech_ha = ra_to_mechanical_ha(target_ra_hours, lst_at_next_check);
+    mechanical_ha_to_ra_ticks(mech_ha, cpr_ra)
+}
+
 /// Convert RA / Dec → topocentric (altitude, azimuth) given the site
 /// latitude and the current LST.
 ///
@@ -385,5 +420,70 @@ mod tests {
         // tmr_freq = 16M, cpr = 3,628,800 → period ≈ 379,887.
         let p = sidereal_step_period(0x00F4_2400, GTI_CPR);
         assert!((379_000..=380_000).contains(&p), "expected ~380K, got {p}");
+    }
+
+    #[test]
+    fn pickup_target_zero_projection_matches_unprojected_math() {
+        // With zero projection, pickup target must equal the same
+        // mech_ha → ticks math the slew-issue path uses. This is the
+        // backwards-compat case: pre-compensation off ⇒ identical
+        // wire behaviour to before the change.
+        let target_ra = 6.0;
+        let lst = 12.0;
+        let mech_ha = ra_to_mechanical_ha(target_ra, lst);
+        let unprojected = mechanical_ha_to_ra_ticks(mech_ha, GTI_CPR);
+        let projected_zero =
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+        assert_eq!(projected_zero, unprojected);
+    }
+
+    #[test]
+    fn pickup_target_400ms_projection_advances_by_sidereal_drift() {
+        // 400 ms of LST drift at sidereal rate = 400 ms × 15.04″/s ≈ 6.016″.
+        // Converted to encoder ticks at GTi CPR: 6.016″ / 3600 = 0.001671°
+        // of RA = (0.001671° × 4 min/°) hours of mech_HA. At 15°/hour, 1
+        // sidereal second of mech_HA = (1/3600) hours, and 400 ms = 0.4
+        // sidereal seconds → 0.4/3600 hours of mech_HA.
+        // Ticks per hour of mech_HA = cpr/24 = 151,200. So 400 ms ≈
+        // 0.4/3600 × 151,200 ≈ 16.8 ticks.
+        let target_ra = 6.0;
+        let lst = 12.0;
+        let no_proj = pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+        let projected = pickup_target_ra_ticks(
+            target_ra,
+            lst,
+            std::time::Duration::from_millis(400),
+            GTI_CPR,
+        );
+        let delta = projected - no_proj;
+        // Expected: ~16-17 ticks. Tolerance +/-1 for round() boundary.
+        assert!(
+            (15..=18).contains(&delta),
+            "expected delta of ~16-17 ticks for 400ms LST projection, got {delta}"
+        );
+    }
+
+    #[test]
+    fn pickup_target_projection_scales_linearly_with_duration() {
+        // Doubling the projection should double the tick delta (within
+        // round-to-int noise).
+        let target_ra = 6.0;
+        let lst = 12.0;
+        let d1 = pickup_target_ra_ticks(
+            target_ra,
+            lst,
+            std::time::Duration::from_millis(200),
+            GTI_CPR,
+        ) - pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+        let d2 = pickup_target_ra_ticks(
+            target_ra,
+            lst,
+            std::time::Duration::from_millis(400),
+            GTI_CPR,
+        ) - pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+        assert!(
+            (d2 - 2 * d1).abs() <= 1,
+            "expected ~2× scaling: 200ms→{d1}, 400ms→{d2}"
+        );
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -177,9 +177,12 @@ impl MountDevice {
 
     /// `ASCOMResult` wrapper over the free-function
     /// [`stop_axis_and_wait`] — issues `:K<axis>` and polls `:f<axis>`
-    /// until the running flag clears. Used by `set_tracking(true)` and
-    /// `park`, which need ASCOM error mapping. The slew path calls
-    /// `stop_axis_and_wait` directly through `issue_slew_axis`.
+    /// until the running flag clears. Used by every `MountDevice`
+    /// caller that needs ASCOM error mapping: `set_tracking(true)`,
+    /// `park`, and the per-axis stop preceding each `issue_slew_axis`
+    /// in `slew_to_coordinates_async`. The slew-completion and park
+    /// watchers run inside spawned tasks and call `stop_axis_and_wait`
+    /// directly (no `MountDevice` to wrap the error).
     async fn stop_and_wait(&self, axis: Axis) -> ASCOMResult<()> {
         stop_axis_and_wait(&self.transport, axis, AXIS_STOP_TIMEOUT)
             .await

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1010,7 +1010,31 @@ fn spawn_slew_completion_watcher(
 ) {
     let started = std::time::Instant::now();
     tokio::spawn(async move {
+        // Pause the background polling task for the duration of the
+        // slew. With polling paused the watcher owns the wire: pickup
+        // commands fire without contending with `:j` / `:f` polls for
+        // `command_lock`, and the watcher's own `poll_axes_now` reads
+        // give us mount state within one wire round-trip of any
+        // change — vs up to `polling_interval` of snapshot staleness
+        // under the always-on polling model.
+        //
+        // `_poll_guard` is held by value so the polling task resumes
+        // automatically on every exit path (early-return for abort,
+        // disconnect, blocked-axis, panic, or normal completion).
+        let _poll_guard = transport.pause_background_polling();
         let mut pickup_iterations: u32 = 0;
+        // Adaptive pickup-target projection: track the instant of each
+        // prior pickup re-slew so the next iteration can project the
+        // residual target forward by *the actually-observed* iteration
+        // duration rather than a hardcoded `polling_interval × 2`
+        // multiplier. USB on the GTi sees ~400 ms per iteration; UDP
+        // sees ~950 ms because the per-round-trip latency adds up
+        // across the 5-frame re-slew sequence. The fixed multiplier
+        // worked on USB but under-compensated on UDP by ~550 ms (~8″
+        // of unaccounted LST drift per iteration). Measuring once a
+        // prior iteration is available makes the projection self-tune
+        // per transport.
+        let mut last_pickup_at: Option<std::time::Instant> = None;
         loop {
             tokio::time::sleep(polling_interval).await;
 
@@ -1031,7 +1055,17 @@ fn spawn_slew_completion_watcher(
                 return;
             }
 
-            let snap = transport.snapshot().await;
+            // Direct poll instead of reading the (now-paused) background
+            // snapshot. On failure (transport closed mid-slew, command
+            // timeout, ...), treat as an abort to avoid spinning.
+            let snap = match transport.poll_axes_now().await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("watcher poll_axes_now failed: {e}");
+                    state.write().await.slew_in_progress = false;
+                    return;
+                }
+            };
             // Sky-Watcher spec §5 reports `Blocked` in the `:f`
             // status when the motor is stepping but the encoder
             // isn't advancing — typically the axis is against a
@@ -1130,17 +1164,25 @@ fn spawn_slew_completion_watcher(
                         }
                         // Pre-compensate the RA target for the LST drift
                         // that will accumulate before the next pickup
-                        // iteration re-checks the residual. Empirically
-                        // (D1 diagnostic, 2026-05-12 run) each iteration
-                        // takes ~`polling_interval × 2` wall-clock —
-                        // one watcher sleep + slew settle + ~5 wire
-                        // round-trips. Projecting the target by that
-                        // amount eliminates the "chasing a moving
-                        // target" floor that pegged pickup residuals to
-                        // ~6″ (the per-iteration sidereal drift). See
+                        // iteration re-checks the residual. Without it
+                        // pickup chases a moving target and the residual
+                        // floor matches per-iteration sidereal drift
+                        // (~6″ on USB, ~14″ on UDP). See
                         // `docs/plans/star-adventurer-gti-pickup-accuracy.md`
                         // §"Experiment B".
-                        let projection = polling_interval * 2;
+                        //
+                        // Adaptive: use the actually-observed time delta
+                        // between consecutive pickup decisions; this
+                        // self-tunes for the transport's wire latency
+                        // (USB ≈ 400 ms/iter, UDP ≈ 950 ms/iter).
+                        // First iteration has no prior data → fall back
+                        // to `polling_interval × 2` (the USB-tuned heuristic).
+                        let now = std::time::Instant::now();
+                        let projection = match last_pickup_at {
+                            Some(t) => now.duration_since(t),
+                            None => polling_interval * 2,
+                        };
+                        last_pickup_at = Some(now);
                         let new_ra_ticks =
                             pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
                         let new_dec_ticks = dec_degrees_to_ticks(target_dec, params.cpr_dec);
@@ -1217,6 +1259,19 @@ fn spawn_slew_completion_watcher(
                     }
                 }
             }
+            // Resume background polling *now*, before the settle delay.
+            // The pickup loop is done; from here on the watcher is just
+            // waiting for the firmware tracking to engage (~160 ms) and
+            // applying the settle margin. While we wait, the background
+            // polling task should refresh the snapshot at its regular
+            // cadence so an Alpaca client reading `RightAscension` right
+            // after `Slewing` flips to `false` sees a snapshot that
+            // reflects the encoder at its now-actively-tracking
+            // position, not the watcher's last `poll_axes_now` from
+            // before tracking restart. Without this, the snap is stale
+            // by the duration `(tracking_engagement + settle)` and the
+            // reported RA lags by that × sidereal rate (~5-10″).
+            drop(_poll_guard);
             tokio::time::sleep(settle).await;
             state.write().await.slew_in_progress = false;
             return;
@@ -1269,6 +1324,14 @@ fn spawn_park_completion_watcher(
     settle: Duration,
 ) {
     tokio::spawn(async move {
+        // Same wire-ownership trick as the slew watcher: pause
+        // background polling and drive snapshot freshness from
+        // `poll_axes_now`. Park doesn't have a pickup loop so the
+        // win here is smaller, but the consistency is worth it
+        // and the background-polling pause also frees up the wire
+        // for the `:K` + `:L` abort sequence on a blocked-axis
+        // mechanical stop.
+        let _poll_guard = transport.pause_background_polling();
         loop {
             tokio::time::sleep(polling_interval).await;
             // External abort / disconnect path: clears slew_in_progress.
@@ -1280,7 +1343,14 @@ fn spawn_park_completion_watcher(
                 state.write().await.slew_in_progress = false;
                 return;
             }
-            let snap = transport.snapshot().await;
+            let snap = match transport.poll_axes_now().await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("park watcher poll_axes_now failed: {e}");
+                    state.write().await.slew_in_progress = false;
+                    return;
+                }
+            };
             // Park can also hit a mechanical stop — same `:L` + bail
             // treatment as in the slew watcher. Do *not* set
             // `at_park = true` on a blocked stop: the OTA isn't at
@@ -1300,6 +1370,11 @@ fn spawn_park_completion_watcher(
             if snap.ra.running || snap.dec.running {
                 continue;
             }
+            // Resume background polling before the settle so an
+            // Alpaca client reading `AtPark`-related position data
+            // right after `Slewing` clears sees fresh snapshot data.
+            // See the matching note in `spawn_slew_completion_watcher`.
+            drop(_poll_guard);
             tokio::time::sleep(settle).await;
             let mut s = state.write().await;
             s.at_park = true;

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -175,14 +175,13 @@ impl MountDevice {
         }
     }
 
-    /// Thin `ASCOMResult` wrapper over the free-function
-    /// [`set_motion_mode_with_cache`] — short-circuits
-    /// `stop_and_wait + :G` when the requested mode equals the cached
-    /// one. Used by `set_tracking(true)` and `park`, which need ASCOM
-    /// error mapping. The slew path goes through `issue_slew_axis`,
-    /// which calls the same helper internally.
-    async fn ensure_motion_mode(&self, axis: Axis, mode: MotionMode) -> ASCOMResult<()> {
-        set_motion_mode_with_cache(&self.transport, axis, mode)
+    /// `ASCOMResult` wrapper over the free-function
+    /// [`stop_axis_and_wait`] — issues `:K<axis>` and polls `:f<axis>`
+    /// until the running flag clears. Used by `set_tracking(true)` and
+    /// `park`, which need ASCOM error mapping. The slew path calls
+    /// `stop_axis_and_wait` directly through `issue_slew_axis`.
+    async fn stop_and_wait(&self, axis: Axis) -> ASCOMResult<()> {
+        stop_axis_and_wait(&self.transport, axis, AXIS_STOP_TIMEOUT)
             .await
             .map_err(Self::ascom)
     }
@@ -268,41 +267,6 @@ const PICKUP_TOLERANCE_ARCSEC: f64 = 5.0;
 /// stalled, encoder oscillating, …) from running forever.
 const PICKUP_MAX_ITERATIONS: u32 = 5;
 
-/// Ensure the firmware's `:G` mode on `axis` equals `mode`, doing
-/// `stop_axis_and_wait` + `:G` only when the cached last-issued mode
-/// differs from the request. Records the mode in the cache on a
-/// successful `:G` ack. Short-circuits with a debug log when the
-/// cache already matches — saves a deceleration wait and a `:G`
-/// round-trip on back-to-back same-mode operations.
-///
-/// Mirrors INDI eqmod's `SetMotion` short-circuit
-/// (`indi-eqmod/skywatcher.cpp:1672-1678`,
-/// `LastRunningStatus == NewStatus`). Callers that know the
-/// firmware state has drifted from the cache (e.g. the pickup loop
-/// after a goto, where the firmware auto-engages Tracking on RA)
-/// must call [`TransportManager::invalidate_motion_mode`] before
-/// invoking this helper.
-async fn set_motion_mode_with_cache(
-    transport: &TransportManager,
-    axis: Axis,
-    mode: MotionMode,
-) -> crate::error::Result<()> {
-    if transport.last_motion_mode(axis).await == Some(mode) {
-        debug!(
-            ?axis,
-            ?mode,
-            "motion mode unchanged, skipping stop_and_wait + :G"
-        );
-        return Ok(());
-    }
-    stop_axis_and_wait(transport, axis, AXIS_STOP_TIMEOUT).await?;
-    transport
-        .send(Command::SetMotionMode { axis, mode })
-        .await?;
-    transport.record_motion_mode(axis, mode).await;
-    Ok(())
-}
-
 /// Issue the per-axis INDI slew sequence:
 /// `:G<axis>` (goto + fast, direction by sign of `delta`) →
 /// `:I<axis>6` (step period) →
@@ -310,12 +274,9 @@ async fn set_motion_mode_with_cache(
 /// `:M<axis><breaks>` (break-point increment) →
 /// `:J<axis>` (start motion).
 ///
-/// The `:G` step routes through [`set_motion_mode_with_cache`], so
-/// when the requested mode matches the cached one the function
-/// jumps straight to `:I`/`:H`/`:M`/`:J` and never touches `:K` or
-/// `:G`. Otherwise `stop_axis_and_wait` + `:G` runs first; `:G`
-/// returns `!2 MotorNotStopped` if it lands against a still-
-/// decelerating motor, and the poll-until-stopped loop avoids that.
+/// The caller must have already issued `:K<axis>` and waited for the
+/// running flag to clear — `:G` returns `!2 MotorNotStopped` if the
+/// motor is still decelerating from a prior command.
 async fn issue_slew_axis(
     transport: &TransportManager,
     axis: Axis,
@@ -328,7 +289,9 @@ async fn issue_slew_axis(
         speed: skywatcher_motor_protocol::command::Speed::Fast,
         ccw: delta < 0,
     };
-    set_motion_mode_with_cache(transport, axis, mode).await?;
+    transport
+        .send(Command::SetMotionMode { axis, mode })
+        .await?;
     transport
         .send(Command::SetStepPeriod {
             axis,
@@ -364,19 +327,19 @@ async fn watcher_should_abort(
 }
 
 /// Per-axis pickup re-slew used by the watcher's EQMOD pickup loop.
-/// Invalidates the motion-mode cache, then calls [`issue_slew_axis`]
-/// — which drains any residual goto deceleration via its internal
-/// `stop_axis_and_wait` and re-runs the INDI wire sequence with the
-/// freshly-computed `delta`. The cache invalidation is load-bearing:
-/// after a goto completes, the firmware auto-engages Speed (Tracking)
-/// Mode on RA even though the cache still reads Goto. Without the
-/// invalidate, `set_motion_mode_with_cache` would short-circuit on
-/// the same direction and the subsequent `:I`/`:H`/`:M`/`:J` would
-/// land while the firmware is in Tracking mode. Failures are
-/// best-effort: the watcher has nothing useful to do with the error
-/// other than retry on the next iteration.
+/// Calls [`stop_axis_and_wait`] (drains any residual goto deceleration)
+/// then [`issue_slew_axis`] (re-runs the INDI wire sequence with the
+/// freshly-computed `delta`). Both calls are best-effort: a failure
+/// from either is logged at `warn` and swallowed because the watcher
+/// has nothing useful to do with the error other than retry on the
+/// next iteration. Wrapping the pair in this helper keeps the watcher
+/// body free of nested `if let Err` branches that codecov flags as
+/// uncovered for the rare-but-real failure paths.
 async fn pickup_reslew_axis(transport: &TransportManager, axis: Axis, delta: i32) {
-    transport.invalidate_motion_mode(axis).await;
+    if let Err(e) = stop_axis_and_wait(transport, axis, AXIS_STOP_TIMEOUT).await {
+        tracing::warn!("pickup stop {axis:?} failed: {e}");
+        return;
+    }
     if let Err(e) = issue_slew_axis(transport, axis, delta).await {
         tracing::warn!("pickup re-slew {axis:?} failed: {e}");
     }
@@ -594,13 +557,17 @@ impl Telescope for MountDevice {
             // status before setting the motion mode." The RA axis
             // may already be running — from a prior tracking enable,
             // or because the firmware auto-engages Speed (Tracking)
-            // Mode after every goto completes. `ensure_motion_mode`
-            // does the stop + `:G` only when the mode actually
-            // changed; back-to-back `set_tracking(true)` calls (e.g.
-            // a UI button mash) short-circuit straight to the
-            // `:I` / `:J` re-issue.
-            self.ensure_motion_mode(Axis::Ra, MotionMode::TRACKING)
-                .await?;
+            // Mode after every goto completes. Force a stop and wait
+            // for the running flag to clear before re-issuing the
+            // tracking-mode `:G`/`:I`/`:J` sequence.
+            self.stop_and_wait(Axis::Ra).await?;
+            self.transport
+                .send(Command::SetMotionMode {
+                    axis: Axis::Ra,
+                    mode: MotionMode::TRACKING,
+                })
+                .await
+                .map_err(Self::ascom)?;
             self.transport
                 .send(Command::SetStepPeriod {
                     axis: Axis::Ra,
@@ -832,30 +799,24 @@ impl Telescope for MountDevice {
         let snap = self.transport.snapshot().await;
         let ra_delta = ra_ticks - snap.ra.position_ticks;
         let dec_delta = dec_ticks - snap.dec.position_ticks;
-        // Both axes use the INDI wire sequence; `issue_slew_axis`
-        // encapsulates the per-axis `:K`-and-wait + `:G goto+fast` +
-        // `:I 6` + `:H |delta|` + `:M breaks` + `:J` sequence. The
-        // `:G` step inside `issue_slew_axis` is routed through
-        // `set_motion_mode_with_cache`, so when the requested
-        // goto-fast mode matches the cached last-issued mode on
-        // that axis the `:K`+`:G` round-trips short-circuit — only
-        // the per-slew `:I`/`:H`/`:M`/`:J` go to the wire.
-        //
-        // On the RA path, `issue_slew_axis`'s stop is also the wire
-        // event that halts sidereal tracking; the cache-short-circuit
-        // branch implies tracking-off because the cache only matches
-        // when we previously issued Goto on this axis. Clear the
-        // in-memory `tracking_requested` flag only after the call
-        // returns Ok so a transport failure cannot leave the driver
-        // claiming tracking-off while the mount is still tracking.
-        for (axis, delta) in [(Axis::Ra, ra_delta), (Axis::Dec, dec_delta)] {
-            issue_slew_axis(&self.transport, axis, delta)
-                .await
-                .map_err(Self::ascom)?;
-            if axis == Axis::Ra {
-                self.state.write().await.tracking_requested = false;
-            }
-        }
+        // Both axes use the INDI wire sequence: `:K` + poll `:f`
+        // (decelerate stop — the spec's "motor must be at full stop
+        // before setting the motion mode" requirement) → `:G goto+fast`
+        // → `:I 6` → `:H |delta|` → `:M breaks` → `:J`. The RA-axis
+        // `:K` is also the wire event that halts any in-progress
+        // sidereal tracking; mirror that into the in-memory
+        // `tracking_requested` flag once the stop has actually
+        // succeeded so the state never gets ahead of the wire on
+        // transport failures.
+        self.stop_and_wait(Axis::Ra).await?;
+        self.state.write().await.tracking_requested = false;
+        issue_slew_axis(&self.transport, Axis::Ra, ra_delta)
+            .await
+            .map_err(Self::ascom)?;
+        self.stop_and_wait(Axis::Dec).await?;
+        issue_slew_axis(&self.transport, Axis::Dec, dec_delta)
+            .await
+            .map_err(Self::ascom)?;
 
         // Mark slew in progress and spawn the completion watcher. The
         // watcher polls until both axes report stopped, runs the
@@ -912,34 +873,34 @@ impl Telescope for MountDevice {
         if self.state.read().await.at_park {
             return Ok(());
         }
+        // Stop tracking before slewing home (per ASCOM, tracking remains
+        // off after Park). The wire `:K1` is issued first so the in-memory
+        // flag flip only follows a successful stop.
+        if self.state.read().await.tracking_requested {
+            self.transport
+                .send(Command::StopMotion(Axis::Ra))
+                .await
+                .map_err(Self::ascom)?;
+            self.state.write().await.tracking_requested = false;
+        }
         // Slew both axes to encoder 0. Same wire sequence as
-        // `slew_to_coordinates_async`: `stop_and_wait` (`:K`), `:G` with
-        // direction chosen from `sign(0 - current)`, `:S 0`, `:J` — all
-        // via `ensure_motion_mode` so a same-mode short-circuit is
-        // possible. The earlier explicit `:K1` tracking-stop before
-        // this loop has been removed: `ensure_motion_mode(Ra, …)`'s
-        // `stop_and_wait` branch already halts the RA axis (and the
-        // short-circuit branch implies tracking-off — the cache only
-        // matches when we previously issued Goto on this axis).
-        // `tracking_requested` is cleared inside the loop, *after*
-        // the RA-axis wire op completes, so a failed
-        // `ensure_motion_mode` cannot leave the driver claiming
-        // tracking-off while the mount is still tracking. Per ASCOM,
-        // tracking stays off after Park.
+        // `slew_to_coordinates_async`: `:K`-and-wait, `:G` with
+        // direction chosen from `sign(0 - current)`, `:S 0`, `:J`.
         let snap = self.transport.snapshot().await;
         for (axis, current_ticks) in [
             (Axis::Ra, snap.ra.position_ticks),
             (Axis::Dec, snap.dec.position_ticks),
         ] {
+            self.stop_and_wait(axis).await?;
             let mode = MotionMode {
                 kind: skywatcher_motor_protocol::command::ModeKind::Goto,
                 speed: skywatcher_motor_protocol::command::Speed::Fast,
                 ccw: current_ticks > 0,
             };
-            self.ensure_motion_mode(axis, mode).await?;
-            if axis == Axis::Ra {
-                self.state.write().await.tracking_requested = false;
-            }
+            self.transport
+                .send(Command::SetMotionMode { axis, mode })
+                .await
+                .map_err(Self::ascom)?;
             // No `:I` in Goto mode — the firmware computes slew speed
             // internally. See the matching note in
             // `slew_to_coordinates_async`.
@@ -1209,19 +1170,14 @@ fn spawn_slew_completion_watcher(
             if tracking_was_on {
                 if let Some(params) = transport.parameters().await {
                     let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
-                    match transport
+                    if let Err(e) = transport
                         .send(Command::SetMotionMode {
                             axis: Axis::Ra,
                             mode: MotionMode::TRACKING,
                         })
                         .await
                     {
-                        Ok(_) => {
-                            transport
-                                .record_motion_mode(Axis::Ra, MotionMode::TRACKING)
-                                .await
-                        }
-                        Err(e) => tracing::warn!("post-slew SetMotionMode TRACKING failed: {e}"),
+                        tracing::warn!("post-slew SetMotionMode TRACKING failed: {e}");
                     }
                     if let Err(e) = transport
                         .send(Command::SetStepPeriod {
@@ -1243,15 +1199,6 @@ fn spawn_slew_completion_watcher(
                         }
                     }
                 }
-            } else {
-                // tracking_was_off branch: the goto completed and the
-                // firmware auto-engages Speed (Tracking) Mode on RA
-                // after every goto — even when we never asked for it.
-                // Our motion-mode cache was last set to Goto by
-                // `issue_slew_axis`, which now lies. Invalidate so the
-                // next `set_motion_mode_with_cache` on RA falls through
-                // the short-circuit and issues a full stop + `:G`.
-                transport.invalidate_motion_mode(Axis::Ra).await;
             }
             tokio::time::sleep(settle).await;
             state.write().await.slew_in_progress = false;
@@ -1558,50 +1505,6 @@ mod tests {
         assert_eq!(&interesting[1][..3], b":G1", "2nd RA setter should be :G1");
         assert_eq!(&interesting[2][..3], b":I1", "3rd RA setter should be :I1");
         assert_eq!(*interesting[3], b":J1\r", "4th RA setter should be :J1");
-    }
-
-    #[tokio::test]
-    async fn set_tracking_true_twice_short_circuits_the_second_stop_and_g() {
-        // Per-issue #207 (matches INDI eqmod's `LastRunningStatus ==
-        // NewStatus` short-circuit): when the requested motion mode
-        // already equals the last one the driver issued on the axis,
-        // skip `stop_and_wait + :G` and go straight to `:I` + `:J`.
-        // Saves a deceleration wait plus two wire round-trips on the
-        // back-to-back same-mode case (e.g. a UI button mash, or a
-        // client re-asserting tracking after an idempotent action).
-        use crate::transport::mock::CapturingMockFactory;
-        let factory = CapturingMockFactory::new();
-        let mock = factory.mock.clone();
-        let cfg = Config::default();
-        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
-        let d = MountDevice::new(cfg.mount, manager);
-        d.set_connected(true).await.unwrap();
-
-        // First call: full sequence (`:K1` + `:G1` + `:I1` + `:J1`).
-        d.set_tracking(true).await.unwrap();
-        let baseline_len = mock.state.lock().await.command_log.len();
-
-        // Second call with the same requested state: cache hit must
-        // skip the stop and the :G entirely; only :I and :J remain.
-        d.set_tracking(true).await.unwrap();
-        let log = mock.state.lock().await.command_log.clone();
-        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
-        let interesting: Vec<&&[u8]> = new_frames
-            .iter()
-            .filter(|f| {
-                f.len() >= 3
-                    && f[0] == b':'
-                    && f[2] == b'1'
-                    && matches!(f[1], b'G' | b'I' | b'J' | b'L' | b'K')
-            })
-            .collect();
-        assert_eq!(
-            interesting.len(),
-            2,
-            "second set_tracking(true) should issue only :I1 + :J1, got {interesting:?}"
-        );
-        assert_eq!(&interesting[0][..3], b":I1", "1st RA setter should be :I1");
-        assert_eq!(*interesting[1], b":J1\r", "2nd RA setter should be :J1");
     }
 
     #[tokio::test]
@@ -2392,10 +2295,8 @@ mod tests {
     #[tokio::test]
     async fn stop_axis_and_wait_returns_transport_error_when_axis_never_stops() {
         // The free-function helper is called from
-        // `set_motion_mode_with_cache` (which the slew/park happy
-        // paths reach via `issue_slew_axis` and
-        // `MountDevice::ensure_motion_mode`) and from the pickup
-        // loop (covered by
+        // `MountDevice::stop_and_wait` (covered by the slew/park
+        // happy paths) and the pickup loop (covered by
         // `slew_watcher_pickup_loop_reissues_when_residual_exceeds_tolerance`).
         // Its *timeout* branch is unreachable from those paths
         // because the mock always responds to `:K` instantly; this

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -810,19 +810,18 @@ impl Telescope for MountDevice {
                 speed: skywatcher_motor_protocol::command::Speed::Fast,
                 ccw: delta < 0,
             };
-            // On the RA path, the `stop_and_wait` inside
-            // `ensure_motion_mode` is also the wire event that halts
-            // sidereal tracking. Mirror it in `tracking_requested`
-            // before the call so the in-memory state never claims
-            // tracking after we have committed to stopping the axis.
-            // (`ensure_motion_mode` may short-circuit when mode is
-            // unchanged, in which case the RA axis was already in
-            // goto-fast and tracking was already off — the write
-            // below is a no-op affirmation in that case.)
+            self.ensure_motion_mode(axis, mode).await?;
+            // On the RA path, `ensure_motion_mode`'s `stop_and_wait`
+            // branch is the wire event that halts sidereal tracking;
+            // the short-circuit branch also implies tracking-off
+            // because the cache only matches when we previously
+            // issued a Goto on this axis. Either way the wire has
+            // committed before we touch the in-memory flag, so a
+            // failed `ensure_motion_mode` cannot leave the driver
+            // claiming tracking-off while the mount is still tracking.
             if axis == Axis::Ra {
                 self.state.write().await.tracking_requested = false;
             }
-            self.ensure_motion_mode(axis, mode).await?;
             // Per Sky-Watcher spec §3 / §5: in Goto mode the motor
             // controller computes the slew speed internally — there is
             // no `:I` to issue before `:J`. (`:I` is only meaningful
@@ -900,11 +899,15 @@ impl Telescope for MountDevice {
         // direction chosen from `sign(0 - current)`, `:S 0`, `:J` — all
         // via `ensure_motion_mode` so a same-mode short-circuit is
         // possible. The earlier explicit `:K1` tracking-stop before
-        // this loop has been removed: `ensure_motion_mode(Ra, …)` (or
-        // its `stop_and_wait` branch) already halts the RA axis, and
-        // the in-memory `tracking_requested` flag is cleared below.
-        // Per ASCOM, tracking stays off after Park.
-        self.state.write().await.tracking_requested = false;
+        // this loop has been removed: `ensure_motion_mode(Ra, …)`'s
+        // `stop_and_wait` branch already halts the RA axis (and the
+        // short-circuit branch implies tracking-off — the cache only
+        // matches when we previously issued Goto on this axis).
+        // `tracking_requested` is cleared inside the loop, *after*
+        // the RA-axis wire op completes, so a failed
+        // `ensure_motion_mode` cannot leave the driver claiming
+        // tracking-off while the mount is still tracking. Per ASCOM,
+        // tracking stays off after Park.
         let snap = self.transport.snapshot().await;
         for (axis, current_ticks) in [
             (Axis::Ra, snap.ra.position_ticks),
@@ -916,6 +919,9 @@ impl Telescope for MountDevice {
                 ccw: current_ticks > 0,
             };
             self.ensure_motion_mode(axis, mode).await?;
+            if axis == Axis::Ra {
+                self.state.write().await.tracking_requested = false;
+            }
             // No `:I` in Goto mode — the firmware computes slew speed
             // internally. See the matching note in
             // `slew_to_coordinates_async`.

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -175,23 +175,29 @@ impl MountDevice {
         }
     }
 
-    /// Issue `:L<axis>` (instant stop) and then poll `:f<axis>` until
+    /// Issue `:K<axis>` (decelerate stop) and then poll `:f<axis>` until
     /// `running == false` or [`AXIS_STOP_TIMEOUT`] elapses.
     ///
     /// Sky-Watcher spec §2: "Motor must be at full stop status before
-    /// setting the motion mode." `:K` (decelerate) takes non-trivial
-    /// wall-clock time on real hardware; ConformU's back-to-back
-    /// "set mode + slew" flow then trips `!2\r` (`MotorNotStopped`)
-    /// from the firmware. `:L` is the spec's "instant stop" — used
-    /// here for the goto-prep stop because we are about to switch
-    /// mode anyway, and the goto-style slew always starts from
-    /// stationary. A second `:f<axis>` poll covers the edge case
-    /// where the controller hasn't yet flushed the running flag.
-    /// The mock processes `:L` instantaneously, which hid this from
-    /// BDD coverage; Phase 4 hardware bring-up confirmed it.
+    /// setting the motion mode." The earlier driver used `:L` (instant
+    /// stop) here because `:K` returns its ack while the motor is still
+    /// decelerating and a back-to-back `:G` against a moving axis trips
+    /// `!2\r` (`MotorNotStopped`) on real hardware. The poll-until-
+    /// `running == false` loop already handles that: deceleration
+    /// finishes within a few `:f` cycles and the next `:G` sees a
+    /// stopped axis. `:K` is the spec's recommended "stop" and is
+    /// gentler on the gearbox than `:L` — `:L` remains the right
+    /// choice only for emergency stops (`AbortSlew`, watcher-side
+    /// `blocked` aborts), where instant halt is the point. Matches
+    /// INDI eqmod's `StopWaitMotor`
+    /// (`indi-eqmod/skywatcher.cpp:1741-1765`).
+    ///
+    /// The mock processes `:K` instantaneously, which keeps the BDD
+    /// coverage green; the real-hardware deceleration is observed by
+    /// the `:f` poll loop.
     async fn stop_and_wait(&self, axis: Axis) -> ASCOMResult<()> {
         self.transport
-            .send(Command::InstantStop(axis))
+            .send(Command::StopMotion(axis))
             .await
             .map_err(Self::ascom)?;
         let deadline = std::time::Instant::now() + AXIS_STOP_TIMEOUT;
@@ -217,6 +223,41 @@ impl MountDevice {
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+    }
+
+    /// Short-circuit `stop_and_wait + :G` when the requested motion mode
+    /// equals the last one the driver successfully issued on `axis`.
+    ///
+    /// **Why:** every slew, park, and `set_tracking(true)` issues `:G`
+    /// against the prior motion state. Most of the time the requested
+    /// mode is identical to the one already in effect (back-to-back
+    /// goto-fast-CW slews, re-asserting tracking, etc.). INDI eqmod's
+    /// `SetMotion` short-circuits in exactly this case
+    /// (`indi-eqmod/skywatcher.cpp:1672-1678` —
+    /// `LastRunningStatus == NewStatus`), saving the deceleration
+    /// wait and a wire round-trip.
+    ///
+    /// When the cache differs (or is empty after connect):
+    /// `stop_and_wait` → `:G<axis><mode>` → cache update on `:G` ack.
+    /// The cache write happens only after the wire ack so a transport
+    /// failure mid-send doesn't leave the cache claiming a mode the
+    /// firmware never accepted.
+    async fn ensure_motion_mode(&self, axis: Axis, mode: MotionMode) -> ASCOMResult<()> {
+        if self.transport.last_motion_mode(axis).await == Some(mode) {
+            debug!(
+                ?axis,
+                ?mode,
+                "motion mode unchanged, skipping stop_and_wait + :G"
+            );
+            return Ok(());
+        }
+        self.stop_and_wait(axis).await?;
+        self.transport
+            .send(Command::SetMotionMode { axis, mode })
+            .await
+            .map_err(Self::ascom)?;
+        self.transport.record_motion_mode(axis, mode).await;
+        Ok(())
     }
 
     /// Block until the slew-completion watcher clears `slew_in_progress`,
@@ -267,10 +308,11 @@ const SYNC_SLEW_TIMEOUT: Duration = Duration::from_secs(300);
 const MIN_SLEW_DWELL: Duration = Duration::from_secs(2);
 
 /// Upper bound on how long `stop_and_wait` will poll `:f<axis>`
-/// after a `:L` (instant stop) before giving up. The firmware
-/// flushes the running flag within ~100 ms on the GTi after a
-/// `:L`; 2 s is a comfortable margin, and bounding the wait
-/// prevents a stuck axis from wedging a slew indefinitely.
+/// after a `:K` (decelerate stop) before giving up. The firmware
+/// finishes deceleration within ~1 s for typical Goto-Fast slew
+/// rates on the GTi; 2 s is a comfortable margin for the slow
+/// case, and bounding the wait prevents a stuck axis from wedging
+/// a slew indefinitely.
 const AXIS_STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[async_trait]
@@ -485,17 +527,13 @@ impl Telescope for MountDevice {
             // status before setting the motion mode." The RA axis
             // may already be running — from a prior tracking enable,
             // or because the firmware auto-engages Speed (Tracking)
-            // Mode after every goto completes. Force a stop and wait
-            // for the running flag to clear before re-issuing the
-            // tracking-mode `:G`/`:I`/`:J` sequence.
-            self.stop_and_wait(Axis::Ra).await?;
-            self.transport
-                .send(Command::SetMotionMode {
-                    axis: Axis::Ra,
-                    mode: MotionMode::TRACKING,
-                })
-                .await
-                .map_err(Self::ascom)?;
+            // Mode after every goto completes. `ensure_motion_mode`
+            // does the stop + `:G` only when the mode actually
+            // changed; back-to-back `set_tracking(true)` calls (e.g.
+            // a UI button mash) short-circuit straight to the
+            // `:I` / `:J` re-issue.
+            self.ensure_motion_mode(Axis::Ra, MotionMode::TRACKING)
+                .await?;
             self.transport
                 .send(Command::SetStepPeriod {
                     axis: Axis::Ra,
@@ -761,27 +799,30 @@ impl Telescope for MountDevice {
             (Axis::Ra, ra_ticks, ra_delta),
             (Axis::Dec, dec_ticks, dec_delta),
         ] {
-            // Stop the axis *and wait until it actually reports
-            // not-running*. Required on real hardware: `:G` returns
-            // `!2 MotorNotStopped` if issued against a still-
-            // decelerating axis.
-            self.stop_and_wait(axis).await?;
-            if axis == Axis::Ra {
-                // RA :K is the wire event that halts sidereal tracking;
-                // mirror it in `tracking_requested` only after the send
-                // has actually succeeded so the in-memory state never
-                // gets ahead of the wire on transport failures.
-                self.state.write().await.tracking_requested = false;
-            }
+            // `ensure_motion_mode` issues `stop_and_wait + :G` only when
+            // the requested goto-fast mode differs from the cached one.
+            // Required on real hardware: `:G` returns `!2 MotorNotStopped`
+            // if issued against a still-decelerating axis. Successive
+            // same-direction slews short-circuit to just the `:S` + `:J`
+            // re-issue.
             let mode = MotionMode {
                 kind: skywatcher_motor_protocol::command::ModeKind::Goto,
                 speed: skywatcher_motor_protocol::command::Speed::Fast,
                 ccw: delta < 0,
             };
-            self.transport
-                .send(Command::SetMotionMode { axis, mode })
-                .await
-                .map_err(Self::ascom)?;
+            // On the RA path, the `stop_and_wait` inside
+            // `ensure_motion_mode` is also the wire event that halts
+            // sidereal tracking. Mirror it in `tracking_requested`
+            // before the call so the in-memory state never claims
+            // tracking after we have committed to stopping the axis.
+            // (`ensure_motion_mode` may short-circuit when mode is
+            // unchanged, in which case the RA axis was already in
+            // goto-fast and tracking was already off — the write
+            // below is a no-op affirmation in that case.)
+            if axis == Axis::Ra {
+                self.state.write().await.tracking_requested = false;
+            }
+            self.ensure_motion_mode(axis, mode).await?;
             // Per Sky-Watcher spec §3 / §5: in Goto mode the motor
             // controller computes the slew speed internally — there is
             // no `:I` to issue before `:J`. (`:I` is only meaningful
@@ -854,33 +895,27 @@ impl Telescope for MountDevice {
         if self.state.read().await.at_park {
             return Ok(());
         }
-        // Stop tracking before slewing home (per ASCOM, tracking remains
-        // off after Park).
-        if self.state.read().await.tracking_requested {
-            self.transport
-                .send(Command::StopMotion(Axis::Ra))
-                .await
-                .map_err(Self::ascom)?;
-            self.state.write().await.tracking_requested = false;
-        }
         // Slew both axes to encoder 0. Same wire sequence as
-        // `slew_to_coordinates_async`: `:K`-and-wait, `:G` with
-        // direction chosen from `sign(0 - current)`, `:S 0`, `:J`.
+        // `slew_to_coordinates_async`: `stop_and_wait` (`:K`), `:G` with
+        // direction chosen from `sign(0 - current)`, `:S 0`, `:J` — all
+        // via `ensure_motion_mode` so a same-mode short-circuit is
+        // possible. The earlier explicit `:K1` tracking-stop before
+        // this loop has been removed: `ensure_motion_mode(Ra, …)` (or
+        // its `stop_and_wait` branch) already halts the RA axis, and
+        // the in-memory `tracking_requested` flag is cleared below.
+        // Per ASCOM, tracking stays off after Park.
+        self.state.write().await.tracking_requested = false;
         let snap = self.transport.snapshot().await;
         for (axis, current_ticks) in [
             (Axis::Ra, snap.ra.position_ticks),
             (Axis::Dec, snap.dec.position_ticks),
         ] {
-            self.stop_and_wait(axis).await?;
             let mode = MotionMode {
                 kind: skywatcher_motor_protocol::command::ModeKind::Goto,
                 speed: skywatcher_motor_protocol::command::Speed::Fast,
                 ccw: current_ticks > 0,
             };
-            self.transport
-                .send(Command::SetMotionMode { axis, mode })
-                .await
-                .map_err(Self::ascom)?;
+            self.ensure_motion_mode(axis, mode).await?;
             // No `:I` in Goto mode — the firmware computes slew speed
             // internally. See the matching note in
             // `slew_to_coordinates_async`.
@@ -1054,14 +1089,19 @@ fn spawn_slew_completion_watcher(
             if tracking_was_on {
                 if let Some(params) = transport.parameters().await {
                     let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
-                    if let Err(e) = transport
+                    match transport
                         .send(Command::SetMotionMode {
                             axis: Axis::Ra,
                             mode: MotionMode::TRACKING,
                         })
                         .await
                     {
-                        tracing::warn!("post-slew SetMotionMode TRACKING failed: {e}");
+                        Ok(_) => {
+                            transport
+                                .record_motion_mode(Axis::Ra, MotionMode::TRACKING)
+                                .await
+                        }
+                        Err(e) => tracing::warn!("post-slew SetMotionMode TRACKING failed: {e}"),
                     }
                     if let Err(e) = transport
                         .send(Command::SetStepPeriod {
@@ -1315,12 +1355,15 @@ mod tests {
 
         // Drive SetTracking(true) and assert that the driver issues
         // the wire sequence the design doc + spec require:
-        //   1. `:L1`  (instant-stop the RA axis — needed because the
+        //   1. `:K1`  (decelerate the RA axis — needed because the
         //              spec disallows changing motion mode while the
         //              motor is running, and the axis may be in
         //              Speed Mode either because we just enabled
         //              tracking on it before or because the firmware
-        //              auto-engages Speed Mode after a goto.)
+        //              auto-engages Speed Mode after a goto. `:K`
+        //              is gentler on the gearbox than `:L`; the
+        //              `:f` poll loop below waits out the
+        //              deceleration.)
         //   2. `:f1`  (one or more polls — `stop_and_wait` polls
         //              until the running flag clears.)
         //   3. `:G1<mode>` (tracking-slow-CW)
@@ -1332,7 +1375,7 @@ mod tests {
         let log = mock.state.lock().await.command_log.clone();
         let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
         // Look only at setter / motion-start frames on the RA axis:
-        // `:G1`, `:I1`, `:J1`, `:L1` (in order of appearance). The
+        // `:G1`, `:I1`, `:J1`, `:K1` (in order of appearance). The
         // polling task's `:f1` / `:j1` / `:f2` / `:j2` inquiries are
         // noise here.
         let interesting: Vec<&&[u8]> = new_frames
@@ -1347,12 +1390,56 @@ mod tests {
         assert_eq!(
             interesting.len(),
             4,
-            "expected exactly 4 RA setter frames (:L1 :G1 :I1 :J1), got {interesting:?}"
+            "expected exactly 4 RA setter frames (:K1 :G1 :I1 :J1), got {interesting:?}"
         );
-        assert_eq!(*interesting[0], b":L1\r", "1st RA setter should be :L1");
+        assert_eq!(*interesting[0], b":K1\r", "1st RA setter should be :K1");
         assert_eq!(&interesting[1][..3], b":G1", "2nd RA setter should be :G1");
         assert_eq!(&interesting[2][..3], b":I1", "3rd RA setter should be :I1");
         assert_eq!(*interesting[3], b":J1\r", "4th RA setter should be :J1");
+    }
+
+    #[tokio::test]
+    async fn set_tracking_true_twice_short_circuits_the_second_stop_and_g() {
+        // Per-issue #207 (matches INDI eqmod's `LastRunningStatus ==
+        // NewStatus` short-circuit): when the requested motion mode
+        // already equals the last one the driver issued on the axis,
+        // skip `stop_and_wait + :G` and go straight to `:I` + `:J`.
+        // Saves a deceleration wait plus two wire round-trips on the
+        // back-to-back same-mode case (e.g. a UI button mash, or a
+        // client re-asserting tracking after an idempotent action).
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+
+        // First call: full sequence (`:K1` + `:G1` + `:I1` + `:J1`).
+        d.set_tracking(true).await.unwrap();
+        let baseline_len = mock.state.lock().await.command_log.len();
+
+        // Second call with the same requested state: cache hit must
+        // skip the stop and the :G entirely; only :I and :J remain.
+        d.set_tracking(true).await.unwrap();
+        let log = mock.state.lock().await.command_log.clone();
+        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
+        let interesting: Vec<&&[u8]> = new_frames
+            .iter()
+            .filter(|f| {
+                f.len() >= 3
+                    && f[0] == b':'
+                    && f[2] == b'1'
+                    && matches!(f[1], b'G' | b'I' | b'J' | b'L' | b'K')
+            })
+            .collect();
+        assert_eq!(
+            interesting.len(),
+            2,
+            "second set_tracking(true) should issue only :I1 + :J1, got {interesting:?}"
+        );
+        assert_eq!(&interesting[0][..3], b":I1", "1st RA setter should be :I1");
+        assert_eq!(*interesting[1], b":J1\r", "2nd RA setter should be :J1");
     }
 
     #[tokio::test]
@@ -1671,19 +1758,21 @@ mod tests {
             "watcher must have cleared slew_in_progress after seeing blocked"
         );
 
-        // Both axes must have seen a :L issued by the watcher's
-        // abort path. (The driver's slew-issue prefix uses :L too,
-        // so we count occurrences and assert >= 2 each.)
+        // Both axes must have seen a `:L` issued by the watcher's
+        // abort path. (The driver's slew-prep stop uses the gentler
+        // `:K` since issue #207 — `:L` is reserved for genuine
+        // emergency stops like this blocked-axis abort and
+        // `AbortSlew`.)
         let log = mock.state.lock().await.command_log.clone();
         let l1_count = log.iter().filter(|f| f.as_slice() == b":L1\r").count();
         let l2_count = log.iter().filter(|f| f.as_slice() == b":L2\r").count();
         assert!(
-            l1_count >= 2,
-            ":L1 should be issued by both slew-prep and watcher-abort; log={log:?}"
+            l1_count >= 1,
+            ":L1 should be issued by the watcher abort path; log={log:?}"
         );
         assert!(
-            l2_count >= 2,
-            ":L2 should be issued by both slew-prep and watcher-abort; log={log:?}"
+            l2_count >= 1,
+            ":L2 should be issued by the watcher abort path; log={log:?}"
         );
     }
 

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -25,8 +25,8 @@ use tracing::debug;
 use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, dec_ticks_to_degrees, local_sidereal_time_hours, mechanical_ha_to_ra,
-    mechanical_ha_to_ra_ticks, ra_dec_to_alt_az, ra_ticks_to_mechanical_ha, ra_to_mechanical_ha,
-    side_of_pier as side_of_pier_calc, sidereal_step_period,
+    mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, ra_dec_to_alt_az, ra_ticks_to_mechanical_ha,
+    ra_to_mechanical_ha, side_of_pier as side_of_pier_calc, sidereal_step_period,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::TransportManager;
@@ -1128,15 +1128,32 @@ fn spawn_slew_completion_watcher(
                             state.write().await.slew_in_progress = false;
                             return;
                         }
-                        let new_mech_ha = ra_to_mechanical_ha(target_ra, lst);
-                        let new_ra_ticks = mechanical_ha_to_ra_ticks(new_mech_ha, params.cpr_ra);
+                        // Pre-compensate the RA target for the LST drift
+                        // that will accumulate before the next pickup
+                        // iteration re-checks the residual. Empirically
+                        // (D1 diagnostic, 2026-05-12 run) each iteration
+                        // takes ~`polling_interval × 2` wall-clock —
+                        // one watcher sleep + slew settle + ~5 wire
+                        // round-trips. Projecting the target by that
+                        // amount eliminates the "chasing a moving
+                        // target" floor that pegged pickup residuals to
+                        // ~6″ (the per-iteration sidereal drift). See
+                        // `docs/plans/star-adventurer-gti-pickup-accuracy.md`
+                        // §"Experiment B".
+                        let projection = polling_interval * 2;
+                        let new_ra_ticks =
+                            pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
                         let new_dec_ticks = dec_degrees_to_ticks(target_dec, params.cpr_dec);
                         let ra_delta = new_ra_ticks - snap.ra.position_ticks;
                         let dec_delta = new_dec_ticks - snap.dec.position_ticks;
                         pickup_iterations += 1;
                         debug!(
                             iteration = pickup_iterations,
-                            ra_residual_arcsec, dec_residual_arcsec, "slew pickup iteration"
+                            ra_residual_arcsec,
+                            dec_residual_arcsec,
+                            projection_ms = projection.as_millis() as u64,
+                            ra_delta_ticks = ra_delta,
+                            "slew pickup iteration"
                         );
                         // The pickup re-slew goes through the same
                         // wire sequence as the original goto. `:L` +

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -86,12 +86,39 @@ pub struct TransportManager {
     available: AtomicBool,
     parameters: RwLock<Option<MountParameters>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
+    /// When `true`, the background polling task skips its tick: no
+    /// `:j` / `:f` round-trips, no `command_lock` contention. The
+    /// slew/park watchers acquire a [`PollPauseGuard`] for the
+    /// duration of a slew so that pickup-loop wire commands run
+    /// without contention and the watcher's own targeted polls
+    /// drive the snapshot's freshness during the slew. Auto-cleared
+    /// on guard drop, even if the watcher task is aborted mid-flight.
+    poll_paused: Arc<AtomicBool>,
     /// Background polling task; populated on the 0→1 connect transition,
     /// aborted on the 1→0 disconnect.
     poll_handle: Mutex<Option<JoinHandle<()>>>,
     /// Shutdown channel for the polling task. The task watches the
     /// receiver and exits when the value flips to `true`.
     shutdown_tx: watch::Sender<bool>,
+}
+
+/// RAII guard that pauses background polling while held. Drop
+/// resumes polling. Returned by
+/// [`TransportManager::pause_background_polling`].
+///
+/// While paused, the watcher is the *only* writer on the wire (modulo
+/// concurrent Alpaca-client driven `MountDevice` ops, which are rare
+/// during a slew). The watcher must poll `:f` / `:j` directly via
+/// [`TransportManager::poll_axes_now`] to keep the cached snapshot
+/// fresh for any ASCOM reader that happens to fire during the slew.
+pub struct PollPauseGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl Drop for PollPauseGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::SeqCst);
+    }
 }
 
 impl TransportManager {
@@ -106,6 +133,7 @@ impl TransportManager {
             available: AtomicBool::new(false),
             parameters: RwLock::new(None),
             snapshot: Arc::new(RwLock::new(MountSnapshot::default())),
+            poll_paused: Arc::new(AtomicBool::new(false)),
             poll_handle: Mutex::new(None),
             shutdown_tx,
         }
@@ -153,6 +181,7 @@ impl TransportManager {
             Arc::clone(&transport),
             Arc::clone(&self.command_lock),
             Arc::clone(&self.snapshot),
+            Arc::clone(&self.poll_paused),
             self.shutdown_tx.subscribe(),
             polling_interval,
             command_timeout,
@@ -253,6 +282,56 @@ impl TransportManager {
     /// Latest poll-loop snapshot.
     pub async fn snapshot(&self) -> MountSnapshot {
         *self.snapshot.read().await
+    }
+
+    /// Pause the background polling task and return a guard that
+    /// resumes it on drop. Used by the slew/park watchers to free the
+    /// wire during a slew — pickup-loop commands run without
+    /// contending with `:j` / `:f` polls, and the watcher's own
+    /// [`poll_axes_now`](Self::poll_axes_now) drives snapshot
+    /// freshness while paused.
+    ///
+    /// Idempotent against re-acquisition: if polling is already paused
+    /// (e.g., two slews overlap, which shouldn't happen but might
+    /// during edge-case AbortSlew races), the second guard's drop
+    /// would clear the flag prematurely — callers should not nest
+    /// pauses. Nothing here panics on misuse; the worst case is the
+    /// background poll resumes a hair early, which is harmless.
+    pub fn pause_background_polling(&self) -> PollPauseGuard {
+        self.poll_paused.store(true, Ordering::SeqCst);
+        PollPauseGuard {
+            flag: Arc::clone(&self.poll_paused),
+        }
+    }
+
+    /// Synchronously round-trip `:j` + `:f` on both axes, update the
+    /// cached snapshot, and return the fresh snapshot. Used by the
+    /// slew/park watcher loops *instead of* reading the background
+    /// polling task's cached snapshot — at the cost of 4 wire ops
+    /// per call (~50 ms USB, ~100 ms UDP), the watcher knows the
+    /// motor's actual state within one round-trip of it changing,
+    /// rather than within `polling_interval` of the background task's
+    /// last tick (up to 200 ms stale).
+    ///
+    /// The caller is responsible for ensuring the background polling
+    /// task is paused via [`pause_background_polling`](Self::pause_background_polling)
+    /// during a sequence of `poll_axes_now` calls — otherwise the two
+    /// tasks contend for `command_lock` and the wire load doubles.
+    pub async fn poll_axes_now(&self) -> Result<MountSnapshot> {
+        let transport = self
+            .transport
+            .lock()
+            .await
+            .clone()
+            .ok_or(StarAdvError::NotConnected)?;
+        let _guard = self.command_lock.lock().await;
+        let timeout = self.command_timeout();
+        let mut snap = MountSnapshot::default();
+        poll_axis(&transport, Axis::Ra, &mut snap.ra, timeout).await?;
+        poll_axis(&transport, Axis::Dec, &mut snap.dec, timeout).await?;
+        drop(_guard);
+        *self.snapshot.write().await = snap;
+        Ok(snap)
     }
 
     /// Update the cached snapshot's RA position.
@@ -435,11 +514,14 @@ fn expect_position(r: Response) -> Result<i32> {
 
 /// Spawn the polling task. Polls `:f<axis>` and `:j<axis>` for both axes
 /// at `interval`, updates the snapshot, exits when `shutdown` flips to
-/// `true`.
+/// `true`. Skips the poll cycle entirely while `poll_paused` is set —
+/// the slew/park watchers acquire that flag to free the wire for their
+/// own targeted polls.
 fn spawn_poll_task(
     transport: Arc<dyn Transport>,
     command_lock: Arc<Mutex<()>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
+    poll_paused: Arc<AtomicBool>,
     mut shutdown: watch::Receiver<bool>,
     interval: Duration,
     command_timeout: Duration,
@@ -455,6 +537,13 @@ fn spawn_poll_task(
                     }
                 }
                 _ = tick.tick() => {
+                    if poll_paused.load(Ordering::SeqCst) {
+                        // Watcher owns the wire — skip this tick. The
+                        // watcher's own `poll_axes_now` updates the
+                        // snapshot during the slew so ASCOM readers
+                        // still see fresh data.
+                        continue;
+                    }
                     let _guard = command_lock.lock().await;
                     let mut snap = MountSnapshot::default();
                     if let Err(e) = poll_axis(&transport, Axis::Ra, &mut snap.ra, command_timeout).await {
@@ -732,6 +821,76 @@ mod tests {
         let _ = snap.ra.position_ticks;
         assert!(!snap.ra.running);
         assert!(!snap.dec.running);
+    }
+
+    #[tokio::test]
+    async fn pause_background_polling_freezes_snapshot_refresh() {
+        // While the watcher holds a pause guard, the background poll
+        // task must skip its tick. Verify by:
+        //   1. connect → seed snapshot from handshake
+        //   2. pause polling
+        //   3. mutate the mock's reported encoder position
+        //   4. wait long enough for several polling ticks to pass
+        //   5. confirm the snapshot is *not* updated
+        //   6. drop the guard, wait another tick
+        //   7. confirm the snapshot now reflects the mutation
+        let mut cfg = Config::default();
+        if let TransportConfig::Usb(usb) = &mut cfg.transport {
+            usb.polling_interval = Duration::from_millis(20);
+        }
+        let m = TransportManager::new(cfg, Arc::new(MockTransportFactory));
+        m.connect().await.unwrap();
+        // Let the polling task seat at least one tick.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let seeded = m.snapshot().await;
+
+        let guard = m.pause_background_polling();
+        // Wait long enough for several would-be polling ticks. The
+        // background task is paused; snapshot stays at `seeded`.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let after_pause = m.snapshot().await;
+        assert_eq!(
+            after_pause.ra.position_ticks, seeded.ra.position_ticks,
+            "polling should be paused — snapshot must not refresh"
+        );
+        assert_eq!(after_pause.dec.position_ticks, seeded.dec.position_ticks);
+
+        drop(guard);
+        // After the guard drops the polling task resumes on its next
+        // tick. Wait long enough for at least one refresh.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // The mock's :j reply is constant in the default state, so the
+        // post-resume snapshot equals the seeded value — but the
+        // `running` / `goto` flags should be cleanly readable. The
+        // primary contract here is "polling resumed and didn't panic."
+        let after_resume = m.snapshot().await;
+        assert!(!after_resume.ra.running);
+        assert!(!after_resume.dec.running);
+    }
+
+    #[tokio::test]
+    async fn poll_axes_now_returns_fresh_snapshot_and_updates_cache() {
+        // `poll_axes_now` must do its own :j + :f round-trip
+        // (synchronous round-trips, no waiting on the polling task)
+        // and update the cached snapshot so ASCOM readers via
+        // `snapshot()` see the same data.
+        let m = manager();
+        m.connect().await.unwrap();
+        let polled = m.poll_axes_now().await.unwrap();
+        let cached = m.snapshot().await;
+        assert_eq!(polled.ra.position_ticks, cached.ra.position_ticks);
+        assert_eq!(polled.dec.position_ticks, cached.dec.position_ticks);
+        assert_eq!(polled.ra.running, cached.ra.running);
+        assert_eq!(polled.dec.running, cached.dec.running);
+    }
+
+    #[tokio::test]
+    async fn poll_axes_now_returns_not_connected_when_disconnected() {
+        // Calling poll_axes_now before connect (no transport open)
+        // must propagate the NotConnected error rather than panicking.
+        let m = manager();
+        let err = m.poll_axes_now().await.unwrap_err();
+        assert!(matches!(err, StarAdvError::NotConnected));
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use skywatcher_motor_protocol::command::MotionMode;
 use skywatcher_motor_protocol::{Axis, Command, Response};
 use tokio::sync::{watch, Mutex, RwLock};
 use tokio::task::JoinHandle;
@@ -56,6 +57,23 @@ pub struct MountSnapshot {
     pub dec: AxisSnapshot,
 }
 
+/// Per-axis cache of the last [`MotionMode`] the driver successfully issued
+/// via `:G<axis><mode>`. `None` until the driver issues a `:G` on that axis,
+/// and reset to `None` on every connect / disconnect (the firmware is not
+/// guaranteed to retain mode state across a session boundary, and trusting
+/// stale-across-reconnect cache values would let the short-circuit skip a
+/// genuinely needed mode switch).
+///
+/// Used by [`crate::MountDevice`] to short-circuit `stop_and_wait + :G`
+/// when the requested mode equals the cached one. Mirrors INDI eqmod's
+/// `LastRunningStatus == NewStatus` optimisation
+/// (`indi-eqmod/skywatcher.cpp` `SetMotion`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MotionModeCache {
+    pub ra: Option<MotionMode>,
+    pub dec: Option<MotionMode>,
+}
+
 /// Shared, ref-counted transport handle.
 ///
 /// Owns a [`TransportFactory`] (not a pre-built [`Transport`]) so the
@@ -86,6 +104,8 @@ pub struct TransportManager {
     available: AtomicBool,
     parameters: RwLock<Option<MountParameters>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
+    /// Per-axis last-issued motion-mode cache. See [`MotionModeCache`].
+    motion_mode_cache: RwLock<MotionModeCache>,
     /// Background polling task; populated on the 0→1 connect transition,
     /// aborted on the 1→0 disconnect.
     poll_handle: Mutex<Option<JoinHandle<()>>>,
@@ -106,6 +126,7 @@ impl TransportManager {
             available: AtomicBool::new(false),
             parameters: RwLock::new(None),
             snapshot: Arc::new(RwLock::new(MountSnapshot::default())),
+            motion_mode_cache: RwLock::new(MotionModeCache::default()),
             poll_handle: Mutex::new(None),
             shutdown_tx,
         }
@@ -143,6 +164,14 @@ impl TransportManager {
             self.connection_count.fetch_sub(1, Ordering::SeqCst);
             return Err(e);
         }
+
+        // Reset the motion-mode cache: nothing the driver issued in a
+        // previous session can be trusted across a connect, and the
+        // firmware's mode state at session start is not observable from
+        // `:f` (the mode bits there reflect the last `:G`-issued setting
+        // even after the motor has stopped, but they don't tell us
+        // whether the firmware auto-reset on power cycle / re-init).
+        *self.motion_mode_cache.write().await = MotionModeCache::default();
 
         // Spawn the polling task before flipping `available` so the first
         // snapshot read after connect already has fresh data (or at least
@@ -222,6 +251,10 @@ impl TransportManager {
         // releases the last refs and triggers `Transport::close`.
         *self.transport.lock().await = None;
         *self.parameters.write().await = None;
+        // Drop the motion-mode cache too: the next session's first `:G`
+        // must not short-circuit on a value we recorded against a
+        // possibly different physical mount.
+        *self.motion_mode_cache.write().await = MotionModeCache::default();
 
         // Reset the shutdown channel so a subsequent connect starts fresh.
         let _ = self.shutdown_tx.send(false);
@@ -280,6 +313,50 @@ impl TransportManager {
     /// [`seed_ra_position`](Self::seed_ra_position) for rationale.
     pub async fn seed_dec_position(&self, ticks: i32) {
         self.snapshot.write().await.dec.position_ticks = ticks;
+    }
+
+    /// Last [`MotionMode`] the driver successfully issued via `:G` on
+    /// `axis`. `None` until the first successful `:G` on that axis (or
+    /// after a connect / disconnect, which both reset the cache).
+    /// `Axis::Both` is not part of the MVP wire surface for `:G` — calls
+    /// with `Both` return `None` rather than collapsing two
+    /// independently-tracked axes into a single answer.
+    pub async fn last_motion_mode(&self, axis: Axis) -> Option<MotionMode> {
+        let cache = self.motion_mode_cache.read().await;
+        match axis {
+            Axis::Ra => cache.ra,
+            Axis::Dec => cache.dec,
+            Axis::Both => None,
+        }
+    }
+
+    /// Record that the driver just acked a `:G<axis><mode>` on the wire.
+    /// `Axis::Both` is a no-op for the same reason
+    /// [`last_motion_mode`](Self::last_motion_mode) returns `None` —
+    /// the MVP only issues per-axis `:G`.
+    pub async fn record_motion_mode(&self, axis: Axis, mode: MotionMode) {
+        let mut cache = self.motion_mode_cache.write().await;
+        match axis {
+            Axis::Ra => cache.ra = Some(mode),
+            Axis::Dec => cache.dec = Some(mode),
+            Axis::Both => {}
+        }
+    }
+
+    /// Drop the cached mode for `axis`. Used when the driver knows the
+    /// firmware-side mode has changed without an explicit `:G` from us —
+    /// e.g. the post-goto auto-engage-Tracking behaviour the firmware
+    /// applies after a slew completes.
+    pub async fn invalidate_motion_mode(&self, axis: Axis) {
+        let mut cache = self.motion_mode_cache.write().await;
+        match axis {
+            Axis::Ra => cache.ra = None,
+            Axis::Dec => cache.dec = None,
+            Axis::Both => {
+                cache.ra = None;
+                cache.dec = None;
+            }
+        }
     }
 
     /// Send one command, return one reply. Does *not* update the snapshot —

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -14,7 +14,6 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use skywatcher_motor_protocol::command::MotionMode;
 use skywatcher_motor_protocol::{Axis, Command, Response};
 use tokio::sync::{watch, Mutex, RwLock};
 use tokio::task::JoinHandle;
@@ -57,23 +56,6 @@ pub struct MountSnapshot {
     pub dec: AxisSnapshot,
 }
 
-/// Per-axis cache of the last [`MotionMode`] the driver successfully issued
-/// via `:G<axis><mode>`. `None` until the driver issues a `:G` on that axis,
-/// and reset to `None` on every connect / disconnect (the firmware is not
-/// guaranteed to retain mode state across a session boundary, and trusting
-/// stale-across-reconnect cache values would let the short-circuit skip a
-/// genuinely needed mode switch).
-///
-/// Used by [`crate::MountDevice`] to short-circuit `stop_and_wait + :G`
-/// when the requested mode equals the cached one. Mirrors INDI eqmod's
-/// `LastRunningStatus == NewStatus` optimisation
-/// (`indi-eqmod/skywatcher.cpp` `SetMotion`).
-#[derive(Debug, Clone, Copy, Default)]
-pub struct MotionModeCache {
-    pub ra: Option<MotionMode>,
-    pub dec: Option<MotionMode>,
-}
-
 /// Shared, ref-counted transport handle.
 ///
 /// Owns a [`TransportFactory`] (not a pre-built [`Transport`]) so the
@@ -104,8 +86,6 @@ pub struct TransportManager {
     available: AtomicBool,
     parameters: RwLock<Option<MountParameters>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
-    /// Per-axis last-issued motion-mode cache. See [`MotionModeCache`].
-    motion_mode_cache: RwLock<MotionModeCache>,
     /// Background polling task; populated on the 0→1 connect transition,
     /// aborted on the 1→0 disconnect.
     poll_handle: Mutex<Option<JoinHandle<()>>>,
@@ -126,7 +106,6 @@ impl TransportManager {
             available: AtomicBool::new(false),
             parameters: RwLock::new(None),
             snapshot: Arc::new(RwLock::new(MountSnapshot::default())),
-            motion_mode_cache: RwLock::new(MotionModeCache::default()),
             poll_handle: Mutex::new(None),
             shutdown_tx,
         }
@@ -164,14 +143,6 @@ impl TransportManager {
             self.connection_count.fetch_sub(1, Ordering::SeqCst);
             return Err(e);
         }
-
-        // Reset the motion-mode cache: nothing the driver issued in a
-        // previous session can be trusted across a connect, and the
-        // firmware's mode state at session start is not observable from
-        // `:f` (the mode bits there reflect the last `:G`-issued setting
-        // even after the motor has stopped, but they don't tell us
-        // whether the firmware auto-reset on power cycle / re-init).
-        *self.motion_mode_cache.write().await = MotionModeCache::default();
 
         // Spawn the polling task before flipping `available` so the first
         // snapshot read after connect already has fresh data (or at least
@@ -251,10 +222,6 @@ impl TransportManager {
         // releases the last refs and triggers `Transport::close`.
         *self.transport.lock().await = None;
         *self.parameters.write().await = None;
-        // Drop the motion-mode cache too: the next session's first `:G`
-        // must not short-circuit on a value we recorded against a
-        // possibly different physical mount.
-        *self.motion_mode_cache.write().await = MotionModeCache::default();
 
         // Reset the shutdown channel so a subsequent connect starts fresh.
         let _ = self.shutdown_tx.send(false);
@@ -313,50 +280,6 @@ impl TransportManager {
     /// [`seed_ra_position`](Self::seed_ra_position) for rationale.
     pub async fn seed_dec_position(&self, ticks: i32) {
         self.snapshot.write().await.dec.position_ticks = ticks;
-    }
-
-    /// Last [`MotionMode`] the driver successfully issued via `:G` on
-    /// `axis`. `None` until the first successful `:G` on that axis (or
-    /// after a connect / disconnect, which both reset the cache).
-    /// `Axis::Both` is not part of the MVP wire surface for `:G` — calls
-    /// with `Both` return `None` rather than collapsing two
-    /// independently-tracked axes into a single answer.
-    pub async fn last_motion_mode(&self, axis: Axis) -> Option<MotionMode> {
-        let cache = self.motion_mode_cache.read().await;
-        match axis {
-            Axis::Ra => cache.ra,
-            Axis::Dec => cache.dec,
-            Axis::Both => None,
-        }
-    }
-
-    /// Record that the driver just acked a `:G<axis><mode>` on the wire.
-    /// `Axis::Both` is a no-op for the same reason
-    /// [`last_motion_mode`](Self::last_motion_mode) returns `None` —
-    /// the MVP only issues per-axis `:G`.
-    pub async fn record_motion_mode(&self, axis: Axis, mode: MotionMode) {
-        let mut cache = self.motion_mode_cache.write().await;
-        match axis {
-            Axis::Ra => cache.ra = Some(mode),
-            Axis::Dec => cache.dec = Some(mode),
-            Axis::Both => {}
-        }
-    }
-
-    /// Drop the cached mode for `axis`. Used when the driver knows the
-    /// firmware-side mode has changed without an explicit `:G` from us —
-    /// e.g. the post-goto auto-engage-Tracking behaviour the firmware
-    /// applies after a slew completes.
-    pub async fn invalidate_motion_mode(&self, axis: Axis) {
-        let mut cache = self.motion_mode_cache.write().await;
-        match axis {
-            Axis::Ra => cache.ra = None,
-            Axis::Dec => cache.dec = None,
-            Axis::Both => {
-                cache.ra = None;
-                cache.dec = None;
-            }
-        }
     }
 
     /// Send one command, return one reply. Does *not* update the snapshot —

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -86,14 +86,18 @@ pub struct TransportManager {
     available: AtomicBool,
     parameters: RwLock<Option<MountParameters>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
-    /// When `true`, the background polling task skips its tick: no
-    /// `:j` / `:f` round-trips, no `command_lock` contention. The
-    /// slew/park watchers acquire a [`PollPauseGuard`] for the
-    /// duration of a slew so that pickup-loop wire commands run
-    /// without contention and the watcher's own targeted polls
-    /// drive the snapshot's freshness during the slew. Auto-cleared
-    /// on guard drop, even if the watcher task is aborted mid-flight.
-    poll_paused: Arc<AtomicBool>,
+    /// Depth counter for active [`PollPauseGuard`]s. The background
+    /// polling task skips its tick whenever this is > 0: no `:j` /
+    /// `:f` round-trips, no `command_lock` contention. The slew/park
+    /// watchers acquire a guard for the duration of a slew so
+    /// pickup-loop wire commands run without contention and the
+    /// watcher's own targeted polls drive the snapshot's freshness.
+    /// Ref-counted so overlapping guards (e.g. AbortSlew racing the
+    /// post-slew tracking restart, or a future nested-watcher case)
+    /// don't prematurely resume polling while another guard is
+    /// still alive. Auto-decremented on guard drop, even if the
+    /// watcher task is aborted mid-flight.
+    poll_pause_depth: Arc<AtomicU32>,
     /// Background polling task; populated on the 0→1 connect transition,
     /// aborted on the 1→0 disconnect.
     poll_handle: Mutex<Option<JoinHandle<()>>>,
@@ -103,21 +107,34 @@ pub struct TransportManager {
 }
 
 /// RAII guard that pauses background polling while held. Drop
-/// resumes polling. Returned by
+/// decrements a depth counter; the polling task resumes only when
+/// the counter reaches zero. Returned by
 /// [`TransportManager::pause_background_polling`].
 ///
-/// While paused, the watcher is the *only* writer on the wire (modulo
-/// concurrent Alpaca-client driven `MountDevice` ops, which are rare
-/// during a slew). The watcher must poll `:f` / `:j` directly via
-/// [`TransportManager::poll_axes_now`] to keep the cached snapshot
-/// fresh for any ASCOM reader that happens to fire during the slew.
+/// Ref-counted (not a plain bool) so overlapping guards from
+/// different paths (e.g. an AbortSlew racing a still-running slew
+/// watcher) can't prematurely resume polling while another guard
+/// is still active.
+///
+/// While paused, the watcher is the *only* writer on the wire
+/// (modulo concurrent Alpaca-client driven `MountDevice` ops, which
+/// are rare during a slew). The watcher must poll `:f` / `:j`
+/// directly via [`TransportManager::poll_axes_now`] to keep the
+/// cached snapshot fresh for any ASCOM reader that happens to fire
+/// during the slew.
 pub struct PollPauseGuard {
-    flag: Arc<AtomicBool>,
+    depth: Arc<AtomicU32>,
 }
 
 impl Drop for PollPauseGuard {
     fn drop(&mut self) {
-        self.flag.store(false, Ordering::SeqCst);
+        // saturating_sub semantics via fetch_sub is fine: we only
+        // ever increment-and-then-decrement-on-drop, so the counter
+        // can't go negative under normal control flow. If a future
+        // refactor somehow drops a guard twice, fetch_sub at 0
+        // would underflow to MAX_U32 — switch to a CAS-based
+        // saturating decrement here if that risk becomes real.
+        self.depth.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -133,7 +150,7 @@ impl TransportManager {
             available: AtomicBool::new(false),
             parameters: RwLock::new(None),
             snapshot: Arc::new(RwLock::new(MountSnapshot::default())),
-            poll_paused: Arc::new(AtomicBool::new(false)),
+            poll_pause_depth: Arc::new(AtomicU32::new(0)),
             poll_handle: Mutex::new(None),
             shutdown_tx,
         }
@@ -181,7 +198,7 @@ impl TransportManager {
             Arc::clone(&transport),
             Arc::clone(&self.command_lock),
             Arc::clone(&self.snapshot),
-            Arc::clone(&self.poll_paused),
+            Arc::clone(&self.poll_pause_depth),
             self.shutdown_tx.subscribe(),
             polling_interval,
             command_timeout,
@@ -291,16 +308,20 @@ impl TransportManager {
     /// [`poll_axes_now`](Self::poll_axes_now) drives snapshot
     /// freshness while paused.
     ///
-    /// Idempotent against re-acquisition: if polling is already paused
-    /// (e.g., two slews overlap, which shouldn't happen but might
-    /// during edge-case AbortSlew races), the second guard's drop
-    /// would clear the flag prematurely — callers should not nest
-    /// pauses. Nothing here panics on misuse; the worst case is the
-    /// background poll resumes a hair early, which is harmless.
+    /// Ref-counted: each call increments a depth counter; polling
+    /// resumes only when the last guard drops (counter back to 0).
+    /// Safe to nest or overlap across paths (e.g. an AbortSlew that
+    /// happens to fire while the slew watcher is still inside its
+    /// post-pickup tracking restart). The depth counter underflows
+    /// to `u32::MAX` if a guard is double-dropped — which can't
+    /// happen under normal control flow because `PollPauseGuard`
+    /// doesn't implement `Clone` — but if a future refactor allows
+    /// it, switch the `Drop` impl to a CAS-based saturating
+    /// decrement.
     pub fn pause_background_polling(&self) -> PollPauseGuard {
-        self.poll_paused.store(true, Ordering::SeqCst);
+        self.poll_pause_depth.fetch_add(1, Ordering::SeqCst);
         PollPauseGuard {
-            flag: Arc::clone(&self.poll_paused),
+            depth: Arc::clone(&self.poll_pause_depth),
         }
     }
 
@@ -514,14 +535,15 @@ fn expect_position(r: Response) -> Result<i32> {
 
 /// Spawn the polling task. Polls `:f<axis>` and `:j<axis>` for both axes
 /// at `interval`, updates the snapshot, exits when `shutdown` flips to
-/// `true`. Skips the poll cycle entirely while `poll_paused` is set —
-/// the slew/park watchers acquire that flag to free the wire for their
-/// own targeted polls.
+/// `true`. Skips the poll cycle entirely while the pause depth-counter
+/// is > 0 — the slew/park watchers hold one or more
+/// [`PollPauseGuard`]s during a slew to free the wire for their own
+/// targeted polls.
 fn spawn_poll_task(
     transport: Arc<dyn Transport>,
     command_lock: Arc<Mutex<()>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
-    poll_paused: Arc<AtomicBool>,
+    poll_pause_depth: Arc<AtomicU32>,
     mut shutdown: watch::Receiver<bool>,
     interval: Duration,
     command_timeout: Duration,
@@ -537,7 +559,7 @@ fn spawn_poll_task(
                     }
                 }
                 _ = tick.tick() => {
-                    if poll_paused.load(Ordering::SeqCst) {
+                    if poll_pause_depth.load(Ordering::SeqCst) > 0 {
                         // Watcher owns the wire — skip this tick. The
                         // watcher's own `poll_axes_now` updates the
                         // snapshot during the slew so ASCOM readers
@@ -824,48 +846,135 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pause_background_polling_freezes_snapshot_refresh() {
-        // While the watcher holds a pause guard, the background poll
-        // task must skip its tick. Verify by:
-        //   1. connect → seed snapshot from handshake
-        //   2. pause polling
-        //   3. mutate the mock's reported encoder position
-        //   4. wait long enough for several polling ticks to pass
-        //   5. confirm the snapshot is *not* updated
-        //   6. drop the guard, wait another tick
-        //   7. confirm the snapshot now reflects the mutation
+    async fn pause_background_polling_stops_wire_traffic_and_resumes_on_drop() {
+        // Direct observable contract: while a pause guard is held,
+        // the background polling task issues *no* wire round-trips;
+        // after the guard drops, polling resumes on the next tick.
+        // Verified by counting `:j` and `:f` requests in the
+        // CapturingMockFactory's command_log, which is the most
+        // unambiguous evidence that the task actually skipped its
+        // ticks (rather than the snapshot just happening to stay
+        // constant, which a constant-value mock would do anyway).
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
         let mut cfg = Config::default();
         if let TransportConfig::Usb(usb) = &mut cfg.transport {
             usb.polling_interval = Duration::from_millis(20);
         }
-        let m = TransportManager::new(cfg, Arc::new(MockTransportFactory));
+        let m = TransportManager::new(cfg, Arc::new(factory));
         m.connect().await.unwrap();
-        // Let the polling task seat at least one tick.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        let seeded = m.snapshot().await;
+
+        // Helper: count poll-flavoured wire frames in the log. The
+        // background poll task emits exactly `:j1 :f1 :j2 :f2`
+        // per tick; ad-hoc `send()` calls and the handshake hit
+        // different command letters.
+        let poll_count = |log: &[Vec<u8>]| -> usize {
+            log.iter()
+                .filter(|f| {
+                    f.len() >= 3
+                        && f[0] == b':'
+                        && matches!(f[1], b'j' | b'f')
+                        && matches!(f[2], b'1' | b'2')
+                })
+                .count()
+        };
+
+        // Let the polling task tick a few times so we know it's
+        // actively producing traffic.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let baseline_polls = poll_count(&mock.state.lock().await.command_log);
+        assert!(
+            baseline_polls >= 4,
+            "expected background polling to have issued ≥4 :j/:f frames in 80ms (interval=20ms), got {baseline_polls}"
+        );
 
         let guard = m.pause_background_polling();
-        // Wait long enough for several would-be polling ticks. The
-        // background task is paused; snapshot stays at `seeded`.
+        let count_at_pause = poll_count(&mock.state.lock().await.command_log);
+        // Wait long enough for ~5 would-be polling ticks (~20 :j/:f
+        // frames) to elapse. With the guard held, the task should
+        // emit none.
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let after_pause = m.snapshot().await;
+        let count_during_pause = poll_count(&mock.state.lock().await.command_log);
         assert_eq!(
-            after_pause.ra.position_ticks, seeded.ra.position_ticks,
-            "polling should be paused — snapshot must not refresh"
+            count_during_pause,
+            count_at_pause,
+            "polling task issued {} new :j/:f frames while a pause guard was held; expected 0",
+            count_during_pause - count_at_pause
         );
-        assert_eq!(after_pause.dec.position_ticks, seeded.dec.position_ticks);
 
         drop(guard);
-        // After the guard drops the polling task resumes on its next
-        // tick. Wait long enough for at least one refresh.
+        // Wait for the polling task to tick again post-resume.
         tokio::time::sleep(Duration::from_millis(80)).await;
-        // The mock's :j reply is constant in the default state, so the
-        // post-resume snapshot equals the seeded value — but the
-        // `running` / `goto` flags should be cleanly readable. The
-        // primary contract here is "polling resumed and didn't panic."
-        let after_resume = m.snapshot().await;
-        assert!(!after_resume.ra.running);
-        assert!(!after_resume.dec.running);
+        let count_after_resume = poll_count(&mock.state.lock().await.command_log);
+        assert!(
+            count_after_resume > count_during_pause,
+            "polling did not resume after guard drop: {} → {} (expected increase)",
+            count_during_pause,
+            count_after_resume
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_background_polling_is_refcounted_across_overlapping_guards() {
+        // Two overlapping guards: dropping the *first* must NOT
+        // resume polling while the second is still alive. Only when
+        // the depth counter hits 0 should the polling task tick
+        // again. Without ref-counting, a single AtomicBool flag
+        // would have flipped back to false on the first drop and
+        // polling would have resumed while the second guard
+        // claimed to still own the wire.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let mut cfg = Config::default();
+        if let TransportConfig::Usb(usb) = &mut cfg.transport {
+            usb.polling_interval = Duration::from_millis(20);
+        }
+        let m = TransportManager::new(cfg, Arc::new(factory));
+        m.connect().await.unwrap();
+
+        let poll_count = |log: &[Vec<u8>]| -> usize {
+            log.iter()
+                .filter(|f| {
+                    f.len() >= 3
+                        && f[0] == b':'
+                        && matches!(f[1], b'j' | b'f')
+                        && matches!(f[2], b'1' | b'2')
+                })
+                .count()
+        };
+
+        // Acquire two guards.
+        let outer = m.pause_background_polling();
+        let inner = m.pause_background_polling();
+        let count_at_pause = poll_count(&mock.state.lock().await.command_log);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(
+            poll_count(&mock.state.lock().await.command_log),
+            count_at_pause,
+            "depth=2: polling must stay paused"
+        );
+
+        // Drop the inner guard; depth → 1, still paused.
+        drop(inner);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(
+            poll_count(&mock.state.lock().await.command_log),
+            count_at_pause,
+            "depth=1 after inner drop: polling must remain paused while outer is alive"
+        );
+
+        // Drop the outer guard; depth → 0, polling resumes.
+        drop(outer);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let count_after_full_release = poll_count(&mock.state.lock().await.command_log);
+        assert!(
+            count_after_full_release > count_at_pause,
+            "polling must resume after depth returns to 0: {} → {}",
+            count_at_pause,
+            count_after_full_release
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #207, plus follow-up accuracy work driven by real-hardware ConformU runs.

### What ships

1. **`:L` → `:K` in slew-prep stop** (issue #207's primary goal). `stop_axis_and_wait` decelerates with `:K` instead of instant-stopping with `:L`. `:L` reserved for genuine emergency stops (`AbortSlew`, watcher-side `blocked` aborts). Matches the spec's recommended stop semantics and INDI eqmod's `StopWaitMotor`.

2. **Pickup-loop accuracy stack** — three layered fixes from follow-up experiments:
   - **LST pre-compensation** (`coordinates::pickup_target_ra_ticks`): each pickup-loop iteration computes the corrective target's encoder ticks for `LST(now + projection)` instead of `LST(now)`. Without it, pickup chases a moving target and the residual floor matches the per-iteration LST drift.
   - **Adaptive projection**: watcher tracks the wall-clock interval between consecutive pickup decisions and uses it as the projection for the next iteration. Self-tunes per transport (USB ~400 ms, UDP ~1100 ms). First-iteration fallback is `polling_interval × 2`.
   - **Pause background polling during slew** (`TransportManager::pause_background_polling()` RAII guard + `poll_axes_now()` direct-poll method): the watcher owns the wire during a slew so pickup wire commands run without contending with `:j` / `:f` polls. Guard is released *before* the post-slew settle so background polling resumes during settle and the snapshot has fresh tracking-engaged encoder data by the time an Alpaca client reads `RightAscension` post-`Slewing`. Park watcher uses the same pattern.

3. **Documentation**: design doc captures the three-layer accuracy stack with the diagnostic data that drove each fix. A separate `docs/plans/star-adventurer-gti-pickup-accuracy.md` records the experiment plan + results.

### What was tried and reverted (also documented)

An earlier attempt to implement an INDI-style `LastRunningStatus == NewStatus` cache to skip `stop_and_wait + :G` when the requested motion mode matched the last issued one was **reverted** after the first real-hardware ConformU run showed unbounded Dec motion (~360° forward, ~270° corrective back) on slews following a `:E` sync. Root cause: the cache mirrors what we *issued*, not what the firmware is *actually in*; `:E` and other state-changing commands shift firmware-side mode without explicit `:G` from us. Design doc records why and what would be needed to retry (background `:f` validation polling).

### Real-hardware ConformU results (Star Adventurer GTi)

|                  | Pre-PR `:K` only | After full stack |
|------------------|------------------|------------------|
| USB mean RA      | 8.4″             | **2.4″**         |
| USB max RA       | 11.0″            | **6.6″**         |
| UDP mean RA      | 8.3″             | **5.0″**         |
| UDP max RA       | 10.5″            | **8.7″**         |
| USB 10″ crosses  | 2 / 10           | **0 / 10**       |
| UDP 10″ crosses  | 1 / 10           | **0 / 10**       |

ConformU issue count unchanged on both transports: **9 issues / 0 errors / 0 alerts** (the documented baseline of upstream-bug + deferred-MVP entries).

## Test plan

- [x] `cargo rail run --profile commit -q` — 150/150 unit tests, 1 skipped, clippy + fmt clean (pre-commit hook).
- [x] `cargo test -p star-adventurer-gti --features mock --test bdd` — 81/81 BDD scenarios across 9 features.
- [x] New unit tests: `pickup_target_*` (3 tests in `coordinates`), `pause_background_polling_freezes_snapshot_refresh`, `poll_axes_now_returns_fresh_snapshot_and_updates_cache`, `poll_axes_now_returns_not_connected_when_disconnected`.
- [x] Real-hardware ConformU verified on Star Adventurer GTi over both USB (`/dev/serial/by-id/...STM32_Virtual_ComPort`) and UDP (`192.168.4.1:11880`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)