### PR TITLE
chore(deps): document why fluent-langneg stays on 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,14 @@ fluent-syntax = "0.12"
 # a sandbox path that does not exist at runtime. We always want translations
 # embedded, never lazy-loaded.
 rust-embed = { version = "8", features = ["debug-embed"] }
+# Pinned to 0.13 until the rest of the Fluent stack moves off `unic-langid`.
+# 0.14.0 swapped `LanguageIdentifier` from `unic-langid` to `icu-locid`, but
+# `i18n-embed` 0.16, `i18n-embed-fl` 0.10, and `fluent-bundle` 0.16 still
+# require `fluent-langneg ^0.13` + `unic-langid ^0.9` on their public APIs.
+# Bumping here would either duplicate `fluent-langneg` in the graph or force
+# string-roundtrip conversions at every `negotiate_languages` call site.
+# Revisit when https://github.com/kellpossible/cargo-i18n ships a release
+# that requires `fluent-langneg ^0.14`.
 fluent-langneg = "0.13"
 sys-locale = "0.3"
 unic-langid = "0.9"


### PR DESCRIPTION
## Summary
- Adds an inline `Cargo.toml` comment at the `fluent-langneg = "0.13"` workspace pin documenting why the crate is not on `0.14.2`.
- Formalises the skip-policy already recorded in the body of commit `0ec4d87` ("Fluent-langneg 0.13 -> 0.14 (#213) intentionally skipped..."), so future bump attempts (dependabot reruns, manual `cargo update`, new contributors) carry the context at the source.
- No code or build impact: comment-only change.

## Why
`fluent-langneg` 0.14.0 (Dec 2023) swapped its `LanguageIdentifier` type from `unic-langid` to `icu-locid`. The rest of our Fluent stack — `i18n-embed` 0.16, `i18n-embed-fl` 0.10, and `fluent-bundle` 0.16 (all the latest releases) — still requires `fluent-langneg ^0.13` and `unic-langid ^0.9` on its public API. Bumping `fluent-langneg` alone would:

1. Duplicate `fluent-langneg` in the dependency graph (`0.13` transitively via `i18n-embed → fluent → fluent-bundle`, `0.14` directly via us), and
2. Force string-roundtrip conversions (`unic_langid → string → icu_locid` and back) at the single `negotiate_languages` call site in `crates/rusty-photon-i18n/src/lib.rs`.

The dual Apache-2.0/MIT relicense from `0.14.2` is already backported to `0.13.1`, so we lose nothing by staying. Revisit when [`kellpossible/cargo-i18n`](https://github.com/kellpossible/cargo-i18n) ships a release that requires `fluent-langneg ^0.14`.

## Test plan
- [x] `cargo rail run --profile commit -q` — 1634 tests pass, full workspace scope (rail detected the workspace `Cargo.toml` change)
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hook (`cargo clippy --all --all-targets --all-features -- -D warnings` + `cargo fmt --all -- --check`) — clean
- No runtime behaviour to exercise; this is a comment-only edit.