### PR TITLE
feat(star-adventurer-gti): user-defined SetPark + park persistence (#203)

### DIFF
--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -128,8 +128,10 @@ CPR varies between the GTi's RA and Dec axes and between firmware
 revisions; the driver reads both rather than assuming.
 
 The protocol exposes **no native park position** and **no site lat/lon**.
-We implement software park (slew to encoder 0/0) and require site lat/lon
-in the config (see [§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
+We implement software park (target encoder pair sourced from config or
+captured at handshake — see [§Park lifecycle](#park-lifecycle) and
+[§Park persistence](#park-persistence)) and require site lat/lon in the
+config (see [§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
 
 ## Protocol Reference
 
@@ -281,7 +283,7 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `CanFindHome` | `false` | no hardware home position |
 | `CanPark` | `true` | implemented (software park) |
 | `CanUnpark` | `true` | implemented |
-| `CanSetPark` | `false` | park position fixed at encoder 0/0 in MVP |
+| `CanSetPark` | runtime-determined | `true` when the driver was started with `--config <path>` (the path it would write back to); `false` for `Config::default()` runs (smoke-tests, no-arg launches). See [§Park persistence](#park-persistence) |
 | `CanSetPierSide` | `false` | mount manages pier side via slew direction |
 | `CanSetSideOfPier` | `false` | same as above |
 | `DoesRefraction` | `false` | mount applies no refraction model; host (rp) provides refracted coords |
@@ -323,9 +325,9 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `SyncToCoordinates(ra, dec)` | issue `:E<axis><pos>` for each axis (set encoder position), update the cached snapshot so an immediate `RightAscension` / `Declination` read reflects the sync without waiting for the next background poll, and **update `TargetRightAscension` / `TargetDeclination`** to the synced coordinates (per ASCOM ITelescopeV3 — a successful Sync writes Target) |
 | `SyncToTarget()` | uses last-set target |
 | `AbortSlew()` | refuse with `INVALID_WHILE_PARKED` when parked; otherwise issue `:L1` `:L2` (instant stop), clear `Slewing`, do NOT auto-restore tracking |
-| `Park()` | stop tracking, slew both axes to encoder 0/0, when both report stopped set `AtPark=true`. **Tracking remains off after park** (per ASCOM) |
+| `Park()` | stop tracking, slew both axes to the in-memory park-target encoder pair (loaded from config or captured at handshake — see [§Park lifecycle](#park-lifecycle)), when both report stopped set `AtPark=true`. **Tracking remains off after park** (per ASCOM) |
 | `Unpark()` | clear `AtPark`. Does NOT auto-enable tracking |
-| `SetPark()` | `NOT_IMPLEMENTED` in MVP |
+| `SetPark()` | capture current encoder pair, write back into the running config file (only the `mount.park_ra_ticks` / `mount.park_dec_ticks` keys are touched — see [§Park persistence](#park-persistence)), update the in-memory park target. Refuses if the driver was started without `--config`, if not connected, or while slewing |
 | `Tracking = true` | refuse with `INVALID_WHILE_PARKED` when parked; otherwise issue `:G<RA>` (Tracking + sidereal) + `:I<RA>` (sidereal step period) + `:J<RA>`. Dec axis untouched |
 | `Tracking = false` | issue `:K<RA>` (decelerate to stop). Allowed while parked — Park already left tracking off and a caller re-asserting that should not error |
 | `FindHome()` | `NOT_IMPLEMENTED` |
@@ -387,8 +389,8 @@ Park()
    ├─ Tracking = false (issue :K on RA axis)
    │
    ├─ for each axis:
-   │     :G<axis><goto-mode>
-   │     :S<axis>800000     target = encoder 0
+   │     :G<axis><goto-mode>      ccw chosen from sign(target − current)
+   │     :S<axis><park_target>    target = in-memory park-target ticks
    │     :J<axis>
    │
    ├─ background poll :f1 / :f2 until both stopped
@@ -397,6 +399,72 @@ Park()
    ├─ AtPark = true
    └─ Tracking remains false
 ```
+
+The **park-target encoder pair** is loaded once per connect, in this
+order of preference:
+
+1. **Config values** — `mount.park_ra_ticks` and `mount.park_dec_ticks`,
+   if present in the running config (both must be `Some`; a missing or
+   `null` value falls through to step 2 for that axis).
+2. **Handshake-captured fallback** — the encoder positions read during
+   the init handshake's `:j1` / `:j2` step (see
+   [§"Initialisation sequence"](#initialisation-sequence)). On a
+   polar-aligned mount the user typically powered up near the
+   counterweight-down, OTA-on-meridian pose, so this is the closest
+   mechanically-safe "where I started" target available.
+3. **Last resort** — encoder `(0, 0)`. Only reachable if the handshake
+   somehow produced no position reads, which today is unreachable.
+
+Once loaded into the in-memory park target, the value is fixed for the
+session except via `SetPark` (which captures the current encoder pair
+and persists it back to the config file — see
+[§Park persistence](#park-persistence)).
+
+### Park persistence
+
+`SetPark` writes the current encoder pair back into the **same JSON
+config file** the driver was started with (the `--config <path>`
+argument). No separate state file. Concretely:
+
+1. **Capability gate.** `CanSetPark` returns `true` only when the
+   driver was started with `--config <path>`. Running on
+   `Config::default()` (no `--config`) leaves `CanSetPark = false` and
+   `SetPark` returns `ASCOM_NOT_IMPLEMENTED`. The capability flag is
+   computed at startup; clients that cache it once per session see a
+   stable answer.
+2. **Refusal cases.** `SetPark` also refuses (`NOT_CONNECTED` /
+   `INVALID_OPERATION`) when the device is disconnected or while a
+   slew / park is in progress — the "current encoder pair" wouldn't be
+   stable otherwise.
+3. **Read-as-`Value`, write only park keys.** The driver reads the
+   on-disk JSON via `serde_json::Value`, mutates *only*
+   `mount.park_ra_ticks` and `mount.park_dec_ticks`, and serialises the
+   result. Any field the driver doesn't recognise (future schema
+   additions, operator-added comments-as-fields) is preserved verbatim.
+   The driver **never re-serialises its in-memory typed `Config`** to
+   disk — that path would round-trip the CLI overrides (`--port`,
+   `--baud`, `--server-port`, `--transport`) back into the file and is
+   structurally avoided here.
+4. **Atomic rename via `tempfile::NamedTempFile`.** The temp file is
+   created in the **same directory** as the destination (required for
+   `persist` to use POSIX `rename` rather than copy-and-delete) and
+   `persist`'d on success. On any error path the temp file
+   auto-deletes via `Drop`, so a panic mid-write doesn't leave a
+   `*.tmp` artifact behind.
+5. **In-memory update follows disk.** The in-memory park target is
+   updated only after the file write succeeds. If the file write
+   fails, the in-memory park is unchanged and the caller sees an
+   ASCOM error — there is no "partial success" state.
+
+Blast-radius bound: even with a logic bug, the only keys the driver
+ever writes are `mount.park_ra_ticks` and `mount.park_dec_ticks`. A
+broken `SetPark` cannot corrupt `transport`, `server.auth`,
+`server.tls`, or any other operator-managed field.
+
+ASCOM has no notion of `SetPark` being non-durable, so `CanSetPark =
+false` is the right answer when the driver has nowhere to persist to —
+returning `true` and silently losing the park across restarts would
+violate the capability contract.
 
 ### Side-of-pier
 
@@ -450,7 +518,9 @@ fields. The transport block is a tagged enum: `usb` or `udp`.
     "site_longitude_deg": -122.4194,
     "site_elevation_m": 0.0,
     "settle_after_slew": "2s",
-    "tracking_rate": "sidereal"
+    "tracking_rate": "sidereal",
+    "park_ra_ticks": null,
+    "park_dec_ticks": null
   }
 }
 ```
@@ -484,6 +554,13 @@ Notes:
   WGS84 degrees, `+E`. (ASCOM convention.)
 - `tracking_rate` accepts `"sidereal"` only in MVP. Field is reserved
   for future expansion.
+- `park_ra_ticks` / `park_dec_ticks` are written by `SetPark` and read
+  on every connect; absent (or `null`) at first run, populated once
+  `SetPark` is called. Operators may set them by hand to pin a known
+  mechanical pose. See [§Park persistence](#park-persistence) for the
+  rules around when the driver writes to this file. When absent, the
+  park target falls back to the encoder positions captured during the
+  init handshake.
 
 ### CLI arguments
 
@@ -707,6 +784,7 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase 3 — Implementation** | ✓ landed: codec, transports (USB+UDP), `MountDevice`, ConformU integration (PR #188); BDD step bodies + `@wip` removal (PR #189). All 9 feature files / 77 scenarios green on Linux/Windows/macOS CI. |
 | **Phase 4 — Real-hardware bringup** | partially landed — first hardware connect surfaced several protocol-decoding gaps that the mock had hidden. Details below. |
 | **Phase A5 — `:I`/`:M` on slew + EQMOD pickup** | landed (issue #205) — reinstates `:I` on the slew path, switches goto to `:H` (delta target) + `:M` (break-point), and adds an iterative post-stop pickup loop to close the residual RA drift the Phase 4 ConformU run flagged. |
+| **Phase 5 — user-defined `SetPark` + persistence** | landed (issue #203) — park target now sourced from `mount.park_ra_ticks` / `mount.park_dec_ticks` in the config (fallback: encoder positions captured at handshake), `SetPark` writes the current encoder pair back into the running config file via atomic rename, `CanSetPark` flips on when `--config` is provided. See [§Park lifecycle](#park-lifecycle) and [§Park persistence](#park-persistence). |
 
 #### Phase 4 findings (hardware bringup)
 
@@ -912,7 +990,11 @@ What's still outstanding from Phase 4:
 - `SlewToCoordinatesAsync` / `SlewToTargetAsync`
 - `AbortSlew`
 - `Tracking` setter / getter (sidereal only)
-- `Park` / `Unpark` (software park to encoder 0/0)
+- `Park` / `Unpark` (software park; target encoder pair sourced from
+  config or captured at handshake — see [§Park lifecycle](#park-lifecycle))
+- `SetPark` (writes the current encoder pair back into the running
+  config file via atomic rename; `CanSetPark` reflects whether the
+  driver has a config path to write to — see [§Park persistence](#park-persistence))
 - `AtPark` / `AtHome` reads
 - `SideOfPier` read
 - `Slewing` poll
@@ -930,7 +1012,6 @@ What's still outstanding from Phase 4:
 | `SlewToAltAz*`, `SyncToAltAz`, `CanSlewAltAz*` | RA/Dec coverage is sufficient for `rp`'s tools; Alt/Az slew is a separate path through the coordinate module |
 | `RightAscensionRate`, `DeclinationRate` setters | custom-rate tracking; not needed for sidereal-only MVP |
 | `TrackingRate` setter (lunar / solar / king) | sidereal covers astrophotography; lunar/solar are uncommon and add a small mode-switch matrix |
-| `SetPark`, `CanSetPark` | park position is fixed at encoder 0/0 (the mount's natural power-up state); user-defined park positions are a follow-up |
 | `FindHome`, `CanFindHome` | no hardware home sensor on the GTi |
 | `Action` / custom commands | no driver-specific actions in MVP |
 | `DestinationSideOfPier` | requires slew planner; current-pier read is enough for `rp`'s built-in tools |

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -401,25 +401,32 @@ Park()
    └─ Tracking remains false
 ```
 
-The **park-target encoder pair** is loaded once per connect, in this
-order of preference:
+The **park-target encoder pair** is loaded per axis on every connect,
+in this order of preference:
 
-1. **Config values** — `mount.park_ra_ticks` and `mount.park_dec_ticks`,
-   if present in the running config (both must be `Some`; a missing or
-   `null` value falls through to step 2 for that axis).
-2. **Handshake-captured fallback** — the encoder positions read during
-   the init handshake's `:j1` / `:j2` step (see
+1. **Config-file value** (per axis). When the driver was started with
+   `--config <path>`, the file is re-read on every connect and
+   `mount.park_ra_ticks` / `mount.park_dec_ticks` are used when
+   present. Per-axis: if only `park_ra_ticks` is set, RA comes from
+   the file and Dec falls through to step 3.
+2. **In-memory config value** (per axis). When no `--config` was
+   provided (`Config::default()` run), the `MountConfig` defaults are
+   used; in this mode `SetPark` is unreachable so these values do not
+   change in-process.
+3. **Handshake-captured fallback** (per axis). The encoder position
+   read during the init handshake's `:j1` / `:j2` step (see
    [§"Initialisation sequence"](#initialisation-sequence)). On a
    polar-aligned mount the user typically powered up near the
    counterweight-down, OTA-on-meridian pose, so this is the closest
    mechanically-safe "where I started" target available.
-3. **Last resort** — encoder `(0, 0)`. Only reachable if the handshake
-   somehow produced no position reads, which today is unreachable.
+4. **Last resort** — encoder `0`. Only reachable if the handshake
+   somehow produced no position read, which today is unreachable.
 
-Once loaded into the in-memory park target, the value is fixed for the
-session except via `SetPark` (which captures the current encoder pair
-and persists it back to the config file — see
-[§Park persistence](#park-persistence)).
+Re-reading the config file on every connect means a successful
+`SetPark` (or a manual operator edit between connects) takes effect on
+the next reconnect without restarting the driver. After load the
+in-memory target is fixed for the session unless `SetPark` is called
+again (see [§Park persistence](#park-persistence)).
 
 ### Park persistence
 
@@ -440,19 +447,31 @@ argument). No separate state file. Concretely:
 3. **Read-as-`Value`, write only park keys.** The driver reads the
    on-disk JSON via `serde_json::Value`, mutates *only*
    `mount.park_ra_ticks` and `mount.park_dec_ticks`, and serialises the
-   result. Any field the driver doesn't recognise (future schema
-   additions, operator-added comments-as-fields) is preserved verbatim.
-   The driver **never re-serialises its in-memory typed `Config`** to
-   disk — that path would round-trip the CLI overrides (`--port`,
-   `--baud`, `--server-port`, `--transport`) back into the file and is
-   structurally avoided here.
+   result pretty-printed. Any field the driver doesn't recognise
+   (future schema additions, operator-added comments-as-fields) is
+   preserved as a JSON value. Note: this is a JSON-value preservation,
+   not a byte-for-byte one — `serde_json::to_string_pretty` rewrites
+   whitespace, and `serde_json::Map` is alphabetical by default
+   (BTreeMap, without the `preserve_order` feature), so operator
+   formatting and key order do not survive. The *content* outside the
+   two park keys is unchanged. The driver **never re-serialises its
+   in-memory typed `Config`** to disk — that path would round-trip the
+   CLI overrides (`--port`, `--baud`, `--server-port`, `--transport`)
+   back into the file and is structurally avoided here.
 4. **Atomic rename via `tempfile::NamedTempFile`.** The temp file is
    created in the **same directory** as the destination (required for
-   `persist` to use POSIX `rename` rather than copy-and-delete) and
-   `persist`'d on success. On any error path the temp file
-   auto-deletes via `Drop`, so a panic mid-write doesn't leave a
-   `*.tmp` artifact behind.
-5. **In-memory update follows disk.** The in-memory park target is
+   `persist` to use POSIX `rename` rather than copy-and-delete),
+   `sync_all`'d (fsync the file data) so a crash after rename can't
+   surface a renamed-but-zero-length file, `persist`'d on success,
+   then on unix the parent directory is fsync'd so the rename itself
+   is durable. Same pattern as
+   [`services/rp/src/persistence/document.rs::write_sidecar_sync`](../../services/rp/src/persistence/document.rs).
+   On any error path the temp file auto-deletes via `Drop`, so a
+   panic mid-write doesn't leave a `*.tmp` artifact behind.
+5. **Blocking I/O on the blocking pool.** The whole read+parse+stage+
+   fsync+rename sequence runs inside `tokio::task::spawn_blocking` so
+   the async runtime isn't held up. Same pattern as `write_sidecar`.
+6. **In-memory update follows disk.** The in-memory park target is
    updated only after the file write succeeds. If the file write
    fails, the in-memory park is unchanged and the caller sees an
    ASCOM error — there is no "partial success" state.

--- a/services/star-adventurer-gti/Cargo.toml
+++ b/services/star-adventurer-gti/Cargo.toml
@@ -34,6 +34,7 @@ rp-auth = { workspace = true }
 axum = { workspace = true }
 erfars = { workspace = true }
 chrono = { workspace = true }
+tempfile = { workspace = true }
 
 # Intentionally NOT opting in to the nightly ConformU workflow via
 # `[package.metadata.conformu]`: ConformU's `alpacaprotocol` phase
@@ -55,7 +56,6 @@ mockall = { workspace = true }
 proptest = { workspace = true }
 reqwest = { workspace = true }
 cucumber = { workspace = true }
-tempfile = { workspace = true }
 cargo-husky = { workspace = true }
 regex = { workspace = true }
 

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -3,7 +3,7 @@
 //! See [`docs/services/star-adventurer-gti.md`](../../../docs/services/star-adventurer-gti.md)
 //! §"Configuration" for the canonical schema and field meanings.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 use std::time::Duration;
 
@@ -185,9 +185,14 @@ impl Default for UsbConfig {
 impl Default for UdpConfig {
     fn default() -> Self {
         Self {
-            address: "192.168.4.1".parse().unwrap(),
+            // GTi AP-mode address (192.168.4.1) and a typical bind
+            // address on the same /24. Constructed via `Ipv4Addr::new`
+            // rather than parsing a string so `Default::default()`
+            // can't panic on a typo — the compiler validates the
+            // octet literals.
+            address: IpAddr::V4(Ipv4Addr::new(192, 168, 4, 1)),
             port: default_udp_port(),
-            bind_address: "192.168.4.2".parse().unwrap(),
+            bind_address: IpAddr::V4(Ipv4Addr::new(192, 168, 4, 2)),
             command_timeout: default_command_timeout(),
             polling_interval: default_polling_interval(),
         }

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -117,6 +117,17 @@ pub struct MountConfig {
     pub dec_min_degrees: f64,
     #[serde(default = "default_dec_max_degrees")]
     pub dec_max_degrees: f64,
+
+    /// Persisted park-target encoder positions, written by `SetPark`
+    /// and read on every connect. When `None` (default on first run),
+    /// the driver falls back to the encoder positions captured during
+    /// the init handshake (`:j1` / `:j2`). See the design doc's
+    /// [§"Park lifecycle"](../../../docs/services/star-adventurer-gti.md#park-lifecycle)
+    /// and [§"Park persistence"](../../../docs/services/star-adventurer-gti.md#park-persistence).
+    #[serde(default)]
+    pub park_ra_ticks: Option<i32>,
+    #[serde(default)]
+    pub park_dec_ticks: Option<i32>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -210,6 +221,8 @@ impl Default for MountConfig {
             ra_max_hours: default_ra_max_hours(),
             dec_min_degrees: default_dec_min_degrees(),
             dec_max_degrees: default_dec_max_degrees(),
+            park_ra_ticks: None,
+            park_dec_ticks: None,
         }
     }
 }
@@ -286,6 +299,43 @@ mod tests {
             }
             other => panic!("expected Usb, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn mount_config_park_ticks_default_to_none() {
+        let cfg = MountConfig::default();
+        assert_eq!(cfg.park_ra_ticks, None);
+        assert_eq!(cfg.park_dec_ticks, None);
+    }
+
+    #[test]
+    fn mount_config_deserialises_missing_park_ticks_as_none() {
+        // Existing config files written before the SetPark feature
+        // landed do not carry `park_ra_ticks` / `park_dec_ticks`; the
+        // driver must read them as `None` rather than failing.
+        let json = r#"{
+            "name": "T",
+            "unique_id": "t-001",
+            "description": "T",
+            "site_latitude_deg": 0.0,
+            "site_longitude_deg": 0.0
+        }"#;
+        let m: MountConfig = serde_json::from_str(json).expect("deserialise");
+        assert_eq!(m.park_ra_ticks, None);
+        assert_eq!(m.park_dec_ticks, None);
+    }
+
+    #[test]
+    fn mount_config_round_trips_park_ticks_through_json() {
+        let cfg = MountConfig {
+            park_ra_ticks: Some(8000),
+            park_dec_ticks: Some(-3000),
+            ..MountConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialise");
+        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.park_ra_ticks, Some(8000));
+        assert_eq!(back.park_dec_ticks, Some(-3000));
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -16,7 +16,7 @@ pub use config::{
     UsbConfig,
 };
 pub use error::{Result, StarAdvError};
-pub use mount_device::MountDevice;
+pub use mount_device::{probe_park_file_writability, MountDevice};
 pub use transport::serial::SerialTransportFactory;
 pub use transport::udp::UdpTransportFactory;
 pub use transport::{Transport, TransportFactory};

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -16,7 +16,10 @@ pub use config::{
     UsbConfig,
 };
 pub use error::{Result, StarAdvError};
-pub use mount_device::{probe_park_file_writability, MountDevice};
+pub use mount_device::{
+    canonicalise_config_path, probe_park_file_writability, warn_if_park_path_unwritable,
+    MountDevice,
+};
 pub use transport::serial::SerialTransportFactory;
 pub use transport::udp::UdpTransportFactory;
 pub use transport::{Transport, TransportFactory};

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -26,6 +26,7 @@ pub use transport_manager::TransportManager;
 pub use transport::mock::{MockMountState, MockTransport, MockTransportFactory};
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use ascom_alpaca::api::CargoServerInfo;
@@ -43,6 +44,13 @@ use tracing::{debug, info};
 pub struct ServerBuilder {
     config: Config,
     factory: Option<Arc<dyn TransportFactory>>,
+    /// Absolute path of the JSON config file the driver was started with,
+    /// if any. Passed to [`MountDevice`] so `SetPark` knows where to
+    /// persist the park position. `None` when the driver runs on
+    /// [`Config::default()`] — in which case `CanSetPark` returns `false`
+    /// and `SetPark` returns `NOT_IMPLEMENTED`. See the design doc's
+    /// [§"Park persistence"](../../../docs/services/star-adventurer-gti.md#park-persistence).
+    config_file_path: Option<PathBuf>,
     /// Optional handle to a [`MockMountState`] that the build path mounts
     /// at `/debug/v1/mock-commands`. Set by mock-mode code paths
     /// (`main.rs` under `feature = "mock"`, BDD tests) so the test
@@ -59,6 +67,17 @@ impl ServerBuilder {
 
     pub fn with_config(mut self, config: Config) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Set the path of the JSON config file the driver was started with.
+    ///
+    /// When provided, the driver advertises `CanSetPark = true` and
+    /// `SetPark` writes the captured encoder pair back into the file via
+    /// atomic rename. When omitted (e.g. `main.rs` ran without
+    /// `--config`), `CanSetPark` is `false`.
+    pub fn with_config_file_path(mut self, path: Option<PathBuf>) -> Self {
+        self.config_file_path = path;
         self
     }
 
@@ -108,7 +127,11 @@ impl ServerBuilder {
         let manager = Arc::new(TransportManager::new(self.config.clone(), factory));
 
         if self.config.mount.enabled {
-            let device = MountDevice::new(self.config.mount.clone(), Arc::clone(&manager));
+            let device = MountDevice::with_config_file_path(
+                self.config.mount.clone(),
+                Arc::clone(&manager),
+                self.config_file_path.clone(),
+            );
             server.devices.register(device);
             info!("Registered Telescope device: {}", self.config.mount.name);
         }

--- a/services/star-adventurer-gti/src/main.rs
+++ b/services/star-adventurer-gti/src/main.rs
@@ -93,12 +93,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     apply_cli_overrides(&mut config, &args)?;
 
+    // Canonicalise the config path so SetPark writes back to a stable
+    // location even if the process later chdir's away. `canonicalize`
+    // also resolves symlinks, which is what we want for the atomic
+    // rename (the temp file goes in the same physical directory as the
+    // real destination). Errors here are non-fatal — log and fall back
+    // to the path as given.
+    let config_file_path = args.config.as_ref().map(|p| {
+        std::fs::canonicalize(p).unwrap_or_else(|e| {
+            tracing::warn!(
+                "could not canonicalise config path {:?}: {e}; SetPark will write to the path as given",
+                p
+            );
+            p.clone()
+        })
+    });
+
     info!("Starting Star Adventurer GTi driver");
     #[cfg(feature = "mock")]
     info!("Running in MOCK MODE - no real hardware");
     info!("Server port: {}", config.server.port);
 
-    let builder = ServerBuilder::new().with_config(config);
+    let builder = ServerBuilder::new()
+        .with_config(config)
+        .with_config_file_path(config_file_path);
 
     #[cfg(feature = "mock")]
     let builder = {

--- a/services/star-adventurer-gti/src/main.rs
+++ b/services/star-adventurer-gti/src/main.rs
@@ -10,7 +10,8 @@ use tracing::{debug, info, Level};
 #[cfg(feature = "mock")]
 use star_adventurer_gti::transport::mock::CapturingMockFactory;
 use star_adventurer_gti::{
-    load_config, probe_park_file_writability, Config, ServerBuilder, TransportFactory,
+    canonicalise_config_path, load_config, warn_if_park_path_unwritable, Config, ServerBuilder,
+    TransportFactory,
 };
 
 #[derive(Parser)]
@@ -95,38 +96,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     apply_cli_overrides(&mut config, &args)?;
 
-    // Canonicalise the config path so SetPark writes back to a stable
-    // location even if the process later chdir's away. `canonicalize`
-    // also resolves symlinks, which is what we want for the atomic
-    // rename (the temp file goes in the same physical directory as the
-    // real destination). Errors here are non-fatal — log and fall back
-    // to the path as given.
-    let config_file_path = args.config.as_ref().map(|p| {
-        std::fs::canonicalize(p).unwrap_or_else(|e| {
-            tracing::warn!(
-                "could not canonicalise config path {:?}: {e}; SetPark will write to the path as given",
-                p
-            );
-            p.clone()
-        })
-    });
-
-    // Early-warning probe: try staging a temp file in the same
-    // directory `SetPark` would write into. This catches the
-    // "operator pointed `--config` at a read-only location" case
-    // at boot rather than only on the first `SetPark` call. The
-    // probe failing does **not** flip `CanSetPark` to `false` — we
-    // still advertise the capability and let the real `SetPark`
-    // surface a specific error if it ever fires. See
-    // [`probe_park_file_writability`] for the rationale.
+    // Canonicalise the operator-supplied config path so `SetPark` writes
+    // to a stable absolute location; also runs the early-warning
+    // writability probe so a bad path / permissions setup surfaces a
+    // `warn!` at boot instead of only on the first `SetPark` call. Both
+    // helpers live in the library crate so their warn-on-failure
+    // branches are unit-testable.
+    let config_file_path = canonicalise_config_path(args.config.as_ref());
     if let Some(path) = &config_file_path {
-        if let Err(e) = probe_park_file_writability(path) {
-            tracing::warn!(
-                "SetPark writes to {:?} will fail at runtime: {e}. \
-                 Check permissions on the containing directory if SetPark support is required.",
-                path
-            );
-        }
+        warn_if_park_path_unwritable(path);
     }
 
     info!("Starting Star Adventurer GTi driver");

--- a/services/star-adventurer-gti/src/main.rs
+++ b/services/star-adventurer-gti/src/main.rs
@@ -9,7 +9,9 @@ use tracing::{debug, info, Level};
 
 #[cfg(feature = "mock")]
 use star_adventurer_gti::transport::mock::CapturingMockFactory;
-use star_adventurer_gti::{load_config, Config, ServerBuilder, TransportFactory};
+use star_adventurer_gti::{
+    load_config, probe_park_file_writability, Config, ServerBuilder, TransportFactory,
+};
 
 #[derive(Parser)]
 #[command(name = "star-adventurer-gti")]
@@ -108,6 +110,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             p.clone()
         })
     });
+
+    // Early-warning probe: try staging a temp file in the same
+    // directory `SetPark` would write into. This catches the
+    // "operator pointed `--config` at a read-only location" case
+    // at boot rather than only on the first `SetPark` call. The
+    // probe failing does **not** flip `CanSetPark` to `false` — we
+    // still advertise the capability and let the real `SetPark`
+    // surface a specific error if it ever fires. See
+    // [`probe_park_file_writability`] for the rationale.
+    if let Some(path) = &config_file_path {
+        if let Err(e) = probe_park_file_writability(path) {
+            tracing::warn!(
+                "SetPark writes to {:?} will fail at runtime: {e}. \
+                 Check permissions on the containing directory if SetPark support is required.",
+                path
+            );
+        }
+    }
 
     info!("Starting Star Adventurer GTi driver");
     #[cfg(feature = "mock")]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1031,16 +1031,29 @@ impl Telescope for MountDevice {
             self.state.write().await.tracking_requested = false;
         }
         // Slew both axes to the loaded park target. `set_connected(true)`
-        // populated these from config / handshake; we assert their
-        // presence here because the only way they could be `None` after
-        // `ensure_connected()` returned Ok is a logic bug worth surfacing
-        // loudly.
+        // populated these from config / handshake; if either is `None`
+        // here it's an internal invariant violation (only path to reach
+        // this code requires `ensure_connected()` to have observed
+        // `requested_connection = true`, which is only set after
+        // `load_park_target_after_connect` populated both). Surface as
+        // a structured ASCOMError rather than a panic — panicking
+        // inside a tokio task aborts it and leaves the Alpaca client
+        // with a connection-reset rather than a recoverable error code.
         let (target_ra_ticks, target_dec_ticks) = {
             let s = self.state.read().await;
-            (
-                s.park_ra_ticks.expect("park_ra_ticks loaded on connect"),
-                s.park_dec_ticks.expect("park_dec_ticks loaded on connect"),
-            )
+            let ra = s.park_ra_ticks.ok_or_else(|| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "park_ra_ticks not loaded — internal invariant violation",
+                )
+            })?;
+            let dec = s.park_dec_ticks.ok_or_else(|| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "park_dec_ticks not loaded — internal invariant violation",
+                )
+            })?;
+            (ra, dec)
         };
         // Same wire sequence as `slew_to_coordinates_async`:
         // `:K`-and-wait, `:G` with direction chosen from
@@ -1524,6 +1537,34 @@ async fn stop_axis_and_wait(
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// Probe whether the parent directory of `config_path` can host the
+/// staging temp file that `SetPark`'s atomic-rename pattern requires.
+///
+/// Called once at startup from `main.rs` so the operator sees a `warn!`
+/// at boot if `SetPark` will fail at runtime due to filesystem
+/// permissions, rather than only discovering it on the first `SetPark`
+/// call. Does **not** change `CanSetPark` — the capability still
+/// advertises support; the probe is purely an early-warning signal.
+///
+/// The probe creates a `NamedTempFile` in the same directory the real
+/// staging file would live in (`config_path.parent()`) and immediately
+/// drops it. Writability of the **parent directory** is what matters
+/// for the atomic-rename pattern: even if the target config file is
+/// itself read-only, `rename(2)` only needs write access to the
+/// containing directory to swap in a new file. The probe therefore
+/// matches what `write_park_to_config` actually does — a false-positive
+/// would mean the probe passes but the real write fails (or vice
+/// versa), defeating the point.
+pub fn probe_park_file_writability(config_path: &Path) -> std::io::Result<()> {
+    let parent = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    // Drop closes and deletes the temp file; the probe leaves no trace.
+    let _tmp = tempfile::NamedTempFile::new_in(parent)?;
+    Ok(())
 }
 
 /// Read `mount.park_ra_ticks` / `mount.park_dec_ticks` from the on-disk
@@ -3187,6 +3228,41 @@ mod tests {
         let (ra, dec) = read_park_from_config(&path).unwrap();
         assert_eq!(ra, Some(1234));
         assert_eq!(dec, None);
+    }
+
+    #[test]
+    fn probe_park_file_writability_passes_on_a_writable_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        probe_park_file_writability(&path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_park_file_writability_fails_on_a_read_only_directory() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        // Drop write permission on the parent directory so
+        // `NamedTempFile::new_in` cannot stage a sibling.
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+        // Probe should report the underlying I/O error.
+        let err = probe_park_file_writability(&path).unwrap_err();
+        // Restore write perms so TempDir's Drop can clean up.
+        let mut restored = std::fs::metadata(dir.path()).unwrap().permissions();
+        restored.set_mode(0o755);
+        std::fs::set_permissions(dir.path(), restored).unwrap();
+        // PermissionDenied is what Linux/macOS surface; either way
+        // it must be classified as a permission / access issue.
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Other
+            ),
+            "unexpected error kind: {err:?}"
+        );
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -401,22 +401,41 @@ impl Device for MountDevice {
         if connected {
             self.transport.connect().await.map_err(Self::ascom)?;
             // Load the park target now that the handshake has populated
-            // `MountParameters`: prefer config values, fall back to the
-            // encoder positions captured during the handshake. See the
-            // design doc's §"Park lifecycle" for the resolution rules.
+            // `MountParameters`. Source priority, per axis:
+            //   1. `mount.park_*_ticks` from the **on-disk** config file
+            //      when one was supplied via `--config`. Reading fresh
+            //      from disk every connect means a successful `SetPark`
+            //      followed by disconnect/reconnect picks up the new
+            //      target, and an operator hand-edit between connects
+            //      takes effect.
+            //   2. `self.config.park_*_ticks` for `Config::default()`
+            //      runs (no config file) — these never change in-process
+            //      because `SetPark` is unreachable in that mode.
+            //   3. The encoder positions captured during the init
+            //      handshake (`:j1` / `:j2`) when neither of the above
+            //      provided a value.
+            // See the design doc's §"Park lifecycle" for the resolution
+            // rules.
+            let (config_ra, config_dec) = if let Some(path) = self.config_file_path.clone() {
+                let result = tokio::task::spawn_blocking(move || read_park_from_config(&path))
+                    .await
+                    .map_err(|e| {
+                        ASCOMError::new(
+                            ASCOMErrorCode::INVALID_OPERATION,
+                            format!("park-config read task join error: {e}"),
+                        )
+                    })?;
+                result.map_err(Self::ascom)?
+            } else {
+                (self.config.park_ra_ticks, self.config.park_dec_ticks)
+            };
             let params = self
                 .transport
                 .parameters()
                 .await
                 .ok_or(ASCOMError::NOT_CONNECTED)?;
-            let ra_target = self
-                .config
-                .park_ra_ticks
-                .unwrap_or(params.ra_at_handshake_ticks);
-            let dec_target = self
-                .config
-                .park_dec_ticks
-                .unwrap_or(params.dec_at_handshake_ticks);
+            let ra_target = config_ra.unwrap_or(params.ra_at_handshake_ticks);
+            let dec_target = config_dec.unwrap_or(params.dec_at_handshake_ticks);
             {
                 let mut s = self.state.write().await;
                 s.park_ra_ticks = Some(ra_target);
@@ -425,8 +444,9 @@ impl Device for MountDevice {
             debug!(
                 ra_target,
                 dec_target,
-                from_config_ra = self.config.park_ra_ticks.is_some(),
-                from_config_dec = self.config.park_dec_ticks.is_some(),
+                from_config_ra = config_ra.is_some(),
+                from_config_dec = config_dec.is_some(),
+                from_file = self.config_file_path.is_some(),
                 "park target loaded"
             );
             *req = true;
@@ -1084,7 +1104,19 @@ impl Telescope for MountDevice {
         let snap = self.transport.snapshot().await;
         let ra_ticks = snap.ra.position_ticks;
         let dec_ticks = snap.dec.position_ticks;
-        write_park_to_config(config_path, ra_ticks, dec_ticks).map_err(Self::ascom)?;
+        // Disk I/O runs on the blocking pool so the async runtime
+        // isn't held up while we read+parse+stage+fsync+rename. Same
+        // pattern as `services/rp/src/persistence/document.rs::write_sidecar`.
+        let path = config_path.clone();
+        tokio::task::spawn_blocking(move || write_park_to_config(&path, ra_ticks, dec_ticks))
+            .await
+            .map_err(|e| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    format!("set_park write task join error: {e}"),
+                )
+            })?
+            .map_err(Self::ascom)?;
         // Only mutate the in-memory target after the disk write
         // succeeds — otherwise a failed write would leave the live
         // park target out of sync with what's persisted.
@@ -1477,6 +1509,45 @@ async fn stop_axis_and_wait(
     }
 }
 
+/// Read `mount.park_ra_ticks` / `mount.park_dec_ticks` from the on-disk
+/// config file. Each axis is returned independently — a `None` means
+/// the file did not set that key (or set it to `null`), and the caller
+/// will fall back to the handshake-captured value for that axis.
+///
+/// Failures (file missing, malformed JSON, `mount` key missing or not
+/// an object) are surfaced as `StarAdvError::Config`. Reading the file
+/// only at connect time means an operator can hand-edit the park keys
+/// between connects and have the change take effect on reconnect,
+/// without restarting the driver.
+///
+/// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
+fn read_park_from_config(config_path: &Path) -> crate::error::Result<(Option<i32>, Option<i32>)> {
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| StarAdvError::Config(format!("read config {}: {e}", config_path.display())))?;
+    let root: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+        StarAdvError::Config(format!("parse config {}: {e}", config_path.display()))
+    })?;
+    let mount = root
+        .as_object()
+        .and_then(|o| o.get("mount"))
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| {
+            StarAdvError::Config(format!(
+                "config {} has no `mount` object",
+                config_path.display()
+            ))
+        })?;
+    let ra = mount
+        .get("park_ra_ticks")
+        .and_then(|v| v.as_i64())
+        .and_then(|n| i32::try_from(n).ok());
+    let dec = mount
+        .get("park_dec_ticks")
+        .and_then(|v| v.as_i64())
+        .and_then(|n| i32::try_from(n).ok());
+    Ok((ra, dec))
+}
+
 /// Patch the on-disk JSON config with the supplied park encoder pair.
 ///
 /// Read-as-`Value` + atomic-rename pattern: load the file as
@@ -1484,13 +1555,24 @@ async fn stop_axis_and_wait(
 /// `mount.park_dec_ticks` keys, serialise pretty-printed, write via a
 /// `tempfile::NamedTempFile` in the same directory, `persist` to swap
 /// it in atomically. Every other field of the JSON file — known and
-/// unknown — is preserved verbatim.
+/// unknown — is preserved as a JSON value. Operator-level formatting
+/// (insertion-order of unrelated keys, custom indentation, comments
+/// disguised as fields) is not preserved byte-for-byte because the
+/// round-trip pretty-prints the whole document; the *semantic* content
+/// outside the two park keys is unchanged.
+///
+/// Durability: fsync the staged file before rename (`tempfile::persist`
+/// uses POSIX `rename(2)`), then fsync the parent directory after
+/// rename so the directory entry update is itself durable. Mirrors
+/// `services/rp/src/persistence/document.rs::write_sidecar_sync`.
 ///
 /// The driver never re-serialises its in-memory typed `Config` here:
 /// doing so would round-trip CLI overrides (`--port`, `--baud`, etc.)
 /// back to disk and is structurally avoided. See the design doc's
 /// [§"Park persistence"](../../../docs/services/star-adventurer-gti.md#park-persistence)
 /// for the contract this helper implements.
+///
+/// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
 fn write_park_to_config(
     config_path: &Path,
     park_ra_ticks: i32,
@@ -1541,12 +1623,23 @@ fn write_park_to_config(
         .map_err(|e| StarAdvError::Config(format!("create temp file in {parent:?}: {e}")))?;
     tmp.write_all(pretty.as_bytes())
         .map_err(|e| StarAdvError::Config(format!("write temp file: {e}")))?;
+    // fsync the file data so a crash after rename cannot surface a
+    // renamed-but-zero-length sidecar.
     tmp.as_file()
         .sync_all()
         .map_err(|e| StarAdvError::Config(format!("fsync temp file: {e}")))?;
     tmp.persist(config_path).map_err(|e| {
         StarAdvError::Config(format!("atomic rename to {}: {e}", config_path.display()))
     })?;
+    // fsync the parent directory so the rename itself is durable.
+    // Windows can't open a directory as a regular file handle, so this
+    // is unix-only. Mirrors `services/rp/src/persistence/document.rs`.
+    #[cfg(unix)]
+    {
+        std::fs::File::open(parent)
+            .and_then(|f| f.sync_all())
+            .map_err(|e| StarAdvError::Config(format!("fsync parent dir {parent:?}: {e}")))?;
+    }
     Ok(())
 }
 
@@ -2930,5 +3023,105 @@ mod tests {
         let s = d.state.read().await;
         assert_eq!(s.park_ra_ticks, Some(5000));
         assert_eq!(s.park_dec_ticks, Some(-7000));
+    }
+
+    #[tokio::test]
+    async fn reconnect_after_set_park_picks_up_persisted_values() {
+        // Regression test for the Copilot review feedback on PR #221:
+        // SetPark persists the new park target to disk and updates the
+        // in-memory state, but the in-memory `MountConfig` does not
+        // change. A subsequent disconnect/reconnect within the same
+        // process must therefore re-read the config file rather than
+        // re-loading from the (stale) in-memory config — otherwise the
+        // SetPark target silently reverts to whatever was in
+        // `MountConfig` at process start (or the handshake fallback).
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        seed_default_config(&path);
+        let d = device_with_path(path.clone());
+        d.set_connected(true).await.unwrap();
+        d.transport.seed_ra_position(8000).await;
+        d.transport.seed_dec_position(-3000).await;
+        d.set_park().await.unwrap();
+
+        // Disconnect: in-memory park state is cleared.
+        d.set_connected(false).await.unwrap();
+        assert_eq!(d.state.read().await.park_ra_ticks, None);
+        assert_eq!(d.state.read().await.park_dec_ticks, None);
+
+        // Reset the mock encoders so reconnect's handshake fallback
+        // would be (0, 0) — proves the re-read picked up SetPark's
+        // values rather than just re-reading handshake.
+        d.transport.seed_ra_position(0).await;
+        d.transport.seed_dec_position(0).await;
+
+        d.set_connected(true).await.unwrap();
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(8000));
+        assert_eq!(s.park_dec_ticks, Some(-3000));
+    }
+
+    #[tokio::test]
+    async fn reconnect_with_partial_config_uses_handshake_for_missing_axis() {
+        // Per-axis fallback: if the config sets only park_ra_ticks,
+        // RA comes from the file and Dec comes from the handshake.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        // Hand-craft a JSON config that sets only park_ra_ticks
+        // (park_dec_ticks absent, which `read_park_from_config`
+        // must read as `None`).
+        let mut cfg = Config::default();
+        cfg.mount.park_ra_ticks = Some(1234);
+        // park_dec_ticks deliberately left as None.
+        std::fs::write(&path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+        let d = device_with_path(path);
+        d.set_connected(true).await.unwrap();
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(1234));
+        // Mock handshake reports Dec at 0.
+        assert_eq!(s.park_dec_ticks, Some(0));
+    }
+
+    #[test]
+    fn read_park_from_config_returns_none_for_each_missing_key() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "name": "Test",
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let (ra, dec) = read_park_from_config(&path).unwrap();
+        assert_eq!(ra, None);
+        assert_eq!(dec, None);
+    }
+
+    #[test]
+    fn read_park_from_config_parses_both_keys() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "park_ra_ticks": 1234,
+                "park_dec_ticks": -5678,
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let (ra, dec) = read_park_from_config(&path).unwrap();
+        assert_eq!(ra, Some(1234));
+        assert_eq!(dec, Some(-5678));
+    }
+
+    #[test]
+    fn read_park_from_config_fails_when_mount_object_is_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+        let err = read_park_from_config(&path).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => assert!(msg.contains("mount"), "{msg}"),
+            other => panic!("expected Config, got {other:?}"),
+        }
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1848,6 +1848,49 @@ pub fn probe_park_file_writability(config_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Canonicalise the operator-supplied config path so `SetPark` writes
+/// to a stable absolute location even if the process later `chdir`s
+/// away (also resolves symlinks, which the atomic-rename pattern
+/// needs — the temp file goes in the *physical* parent directory).
+/// On canonicalisation failure (path doesn't yet exist, symlink loop,
+/// permission denied on a path component) the original path is
+/// returned and a `warn!` is logged — `SetPark` will still attempt the
+/// write against the path as given, surfacing the real error there.
+///
+/// Extracted from `main.rs` so the warn-on-failure branch is unit
+/// testable; the binary calls this from `main()`.
+pub fn canonicalise_config_path(config_path: Option<&PathBuf>) -> Option<PathBuf> {
+    config_path.map(|p| {
+        std::fs::canonicalize(p).unwrap_or_else(|e| {
+            tracing::warn!(
+                "could not canonicalise config path {:?}: {e}; SetPark will write to the path as given",
+                p
+            );
+            p.clone()
+        })
+    })
+}
+
+/// Early-warning probe wrapper: run [`probe_park_file_writability`] on
+/// the supplied path and log a `warn!` on failure. Used by `main.rs`
+/// at startup — operators get a heads-up at boot if `SetPark` will
+/// fail at runtime due to filesystem permissions, rather than only
+/// discovering it on the first `SetPark` call. `CanSetPark` is not
+/// affected; the capability still advertises support and the actual
+/// `SetPark` will surface a structured error if the probe was correct.
+///
+/// Extracted from `main.rs` so the warn-on-failure branch is unit
+/// testable.
+pub fn warn_if_park_path_unwritable(config_path: &Path) {
+    if let Err(e) = probe_park_file_writability(config_path) {
+        tracing::warn!(
+            "SetPark writes to {:?} will fail at runtime: {e}. \
+             Check permissions on the containing directory if SetPark support is required.",
+            config_path
+        );
+    }
+}
+
 /// Read `mount.park_ra_ticks` / `mount.park_dec_ticks` from the on-disk
 /// config file. Each axis is returned independently — a `None` means
 /// the file did not set that key (or set it to JSON `null`), and the
@@ -3388,6 +3431,74 @@ mod tests {
         }
     }
 
+    #[test]
+    fn write_park_to_config_fails_on_malformed_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        // Unclosed bracket — `serde_json::from_str` rejects it.
+        std::fs::write(&path, "{ not valid json").unwrap();
+        let err = write_park_to_config(&path, 0, 0).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => assert!(msg.contains("parse config"), "{msg}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_park_from_config_fails_on_malformed_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+        let err = read_park_from_config(&path).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => assert!(msg.contains("parse config"), "{msg}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn park_returns_invariant_violation_when_in_memory_target_is_missing() {
+        // The `park_*_ticks` invariant is: populated by
+        // `load_park_target_after_connect` before `*requested_connection`
+        // flips true, so any code path that's reached
+        // `ensure_connected()` Ok should see Some on both axes. This
+        // test deliberately violates the invariant by clearing the
+        // values after connect, then calls `park()`. The graceful
+        // failure path (return ASCOMError, do not panic) is the
+        // contract we want to pin — see the comment block on
+        // `MountDevice::park` for the panic-vs-error rationale.
+        let d = connected_device().await;
+        d.state.write().await.park_ra_ticks = None;
+        let err = d.park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+        assert!(
+            err.message.contains("park_ra_ticks"),
+            "message should name the missing axis: {}",
+            err.message
+        );
+
+        // Symmetric for the Dec axis.
+        let d = connected_device().await;
+        d.state.write().await.park_dec_ticks = None;
+        let err = d.park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+        assert!(err.message.contains("park_dec_ticks"), "{}", err.message);
+    }
+
+    #[tokio::test]
+    async fn debug_impl_includes_config_file_path() {
+        // Pins the manual `fmt::Debug` impl — adding a new field
+        // requires updating the closure. The path field landed in
+        // PR #221; the smoke test catches a future refactor that
+        // forgets to extend the Debug closure.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let d = device_with_path(path.clone());
+        let s = format!("{d:?}");
+        assert!(s.contains("MountDevice"), "{s}");
+        assert!(s.contains("config_file_path"), "{s}");
+    }
+
     #[tokio::test]
     async fn can_set_park_is_false_when_no_config_path_was_provided() {
         let d = device();
@@ -3786,6 +3897,63 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("config.json");
         probe_park_file_writability(&path).unwrap();
+    }
+
+    #[test]
+    fn canonicalise_config_path_returns_none_when_no_path_given() {
+        assert!(canonicalise_config_path(None).is_none());
+    }
+
+    #[test]
+    fn canonicalise_config_path_returns_resolved_path_when_file_exists() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+        let got = canonicalise_config_path(Some(&path)).expect("Some");
+        // Result is canonicalised — must exist and resolve to the same
+        // file. On macOS the temp dir lives under /private/var/..., so
+        // an exact string match is fragile; just check it resolves.
+        assert!(got.exists(), "canonical path must exist: {got:?}");
+    }
+
+    #[test]
+    fn canonicalise_config_path_falls_back_to_input_on_failure() {
+        // Path doesn't exist → canonicalize errors → fallback to the
+        // original path. The warn! is logged but the function returns
+        // the path unchanged so SetPark can still surface a real error
+        // at write time.
+        let nonexistent = PathBuf::from("/does/not/exist/config.json");
+        let got = canonicalise_config_path(Some(&nonexistent)).expect("Some");
+        assert_eq!(got, nonexistent);
+    }
+
+    #[test]
+    fn warn_if_park_path_unwritable_returns_quietly_on_writable_directory() {
+        // Smoke test: helper returns `()` on success. The warn! body
+        // is exercised by `warn_if_park_path_unwritable_logs_on_failure`
+        // below (unix-only).
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        warn_if_park_path_unwritable(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn warn_if_park_path_unwritable_logs_on_failure() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let mut perms = std::fs::metadata(dir.path()).unwrap().permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(dir.path(), perms).unwrap();
+        // Helper returns `()` even on probe failure — the test passes
+        // as long as the call doesn't panic. The internal warn! body
+        // is what we're measuring for coverage.
+        warn_if_park_path_unwritable(&path);
+        // Restore so TempDir's Drop can clean up.
+        let mut restored = std::fs::metadata(dir.path()).unwrap().permissions();
+        restored.set_mode(0o755);
+        std::fs::set_permissions(dir.path(), restored).unwrap();
     }
 
     #[cfg(unix)]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 use std::ops::RangeInclusive;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -47,10 +48,22 @@ struct DriverState {
     /// flags so callers see "still slewing" until the watcher signals
     /// otherwise.
     slew_in_progress: bool,
+    /// In-memory park-target encoder pair. Populated on the 0→1 connect
+    /// transition from `MountConfig::park_*_ticks` if `Some`, otherwise
+    /// from the handshake-captured positions. `None` here means "not
+    /// loaded yet" — `Park` reads through `expect()` after
+    /// `ensure_connected()` so an unset value would indicate a logic
+    /// error, not a user-visible state.
+    park_ra_ticks: Option<i32>,
+    park_dec_ticks: Option<i32>,
 }
 
 pub struct MountDevice {
     config: MountConfig,
+    /// Optional config-file path. `Some` when the driver was started
+    /// with `--config <path>`; `None` for `Config::default()` runs. Drives
+    /// `CanSetPark` and is the destination for `SetPark` writes.
+    config_file_path: Option<PathBuf>,
     requested_connection: Arc<RwLock<bool>>,
     state: Arc<RwLock<DriverState>>,
     transport: Arc<TransportManager>,
@@ -60,6 +73,7 @@ impl fmt::Debug for MountDevice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MountDevice")
             .field("config", &self.config)
+            .field("config_file_path", &self.config_file_path)
             .field("requested_connection", &self.requested_connection)
             .field("state", &self.state)
             .finish_non_exhaustive()
@@ -68,8 +82,20 @@ impl fmt::Debug for MountDevice {
 
 impl MountDevice {
     pub fn new(config: MountConfig, transport: Arc<TransportManager>) -> Self {
+        Self::with_config_file_path(config, transport, None)
+    }
+
+    /// Construct with an optional config-file path. `Some(path)` enables
+    /// `CanSetPark` / `SetPark` persistence; `None` leaves
+    /// `CanSetPark = false` and `SetPark = NOT_IMPLEMENTED`.
+    pub fn with_config_file_path(
+        config: MountConfig,
+        transport: Arc<TransportManager>,
+        config_file_path: Option<PathBuf>,
+    ) -> Self {
         Self {
             config,
+            config_file_path,
             requested_connection: Arc::new(RwLock::new(false)),
             state: Arc::new(RwLock::new(DriverState::default())),
             transport,
@@ -374,6 +400,35 @@ impl Device for MountDevice {
         }
         if connected {
             self.transport.connect().await.map_err(Self::ascom)?;
+            // Load the park target now that the handshake has populated
+            // `MountParameters`: prefer config values, fall back to the
+            // encoder positions captured during the handshake. See the
+            // design doc's §"Park lifecycle" for the resolution rules.
+            let params = self
+                .transport
+                .parameters()
+                .await
+                .ok_or(ASCOMError::NOT_CONNECTED)?;
+            let ra_target = self
+                .config
+                .park_ra_ticks
+                .unwrap_or(params.ra_at_handshake_ticks);
+            let dec_target = self
+                .config
+                .park_dec_ticks
+                .unwrap_or(params.dec_at_handshake_ticks);
+            {
+                let mut s = self.state.write().await;
+                s.park_ra_ticks = Some(ra_target);
+                s.park_dec_ticks = Some(dec_target);
+            }
+            debug!(
+                ra_target,
+                dec_target,
+                from_config_ra = self.config.park_ra_ticks.is_some(),
+                from_config_dec = self.config.park_dec_ticks.is_some(),
+                "park target loaded"
+            );
             *req = true;
         } else {
             self.transport.disconnect().await.map_err(Self::ascom)?;
@@ -391,6 +446,11 @@ impl Device for MountDevice {
             //     watcher has nothing left to observe; clearing the
             //     flag also tells any in-flight watcher iteration to
             //     bail out (see watcher loops below).
+            //   - `park_ra_ticks` / `park_dec_ticks` — re-loaded on next
+            //     connect from config / handshake. Clearing here means a
+            //     mid-session edit to `MountConfig::park_*_ticks` (a
+            //     future hot-reload feature) would take effect on
+            //     reconnect.
             //
             // Keep `at_park` — Phase 4 may persist it across sessions
             // by reading the encoder; for now leaving it as-is matches
@@ -400,6 +460,8 @@ impl Device for MountDevice {
             s.target_dec_degrees = None;
             s.tracking_requested = false;
             s.slew_in_progress = false;
+            s.park_ra_ticks = None;
+            s.park_dec_ticks = None;
         }
         debug!(connected, "set_connected");
         Ok(())
@@ -443,6 +505,15 @@ impl Telescope for MountDevice {
     }
     async fn can_unpark(&self) -> ASCOMResult<bool> {
         Ok(true)
+    }
+    async fn can_set_park(&self) -> ASCOMResult<bool> {
+        // SetPark requires a config-file path to persist to. Without
+        // one (i.e. the driver was started on `Config::default()`),
+        // `SetPark` would have nowhere to write — see the design doc's
+        // §"Park persistence" for the rationale. ASCOM permits
+        // `CanSetPark` to vary with driver state, so this is a runtime
+        // check rather than a compile-time constant.
+        Ok(self.config_file_path.is_some())
     }
     async fn does_refraction(&self) -> ASCOMResult<bool> {
         Ok(false)
@@ -886,19 +957,31 @@ impl Telescope for MountDevice {
                 .map_err(Self::ascom)?;
             self.state.write().await.tracking_requested = false;
         }
-        // Slew both axes to encoder 0. Same wire sequence as
-        // `slew_to_coordinates_async`: `:K`-and-wait, `:G` with
-        // direction chosen from `sign(0 - current)`, `:S 0`, `:J`.
+        // Slew both axes to the loaded park target. `set_connected(true)`
+        // populated these from config / handshake; we assert their
+        // presence here because the only way they could be `None` after
+        // `ensure_connected()` returned Ok is a logic bug worth surfacing
+        // loudly.
+        let (target_ra_ticks, target_dec_ticks) = {
+            let s = self.state.read().await;
+            (
+                s.park_ra_ticks.expect("park_ra_ticks loaded on connect"),
+                s.park_dec_ticks.expect("park_dec_ticks loaded on connect"),
+            )
+        };
+        // Same wire sequence as `slew_to_coordinates_async`:
+        // `:K`-and-wait, `:G` with direction chosen from
+        // `sign(target - current)`, `:S target`, `:J`.
         let snap = self.transport.snapshot().await;
-        for (axis, current_ticks) in [
-            (Axis::Ra, snap.ra.position_ticks),
-            (Axis::Dec, snap.dec.position_ticks),
+        for (axis, current_ticks, target_ticks) in [
+            (Axis::Ra, snap.ra.position_ticks, target_ra_ticks),
+            (Axis::Dec, snap.dec.position_ticks, target_dec_ticks),
         ] {
             self.stop_and_wait(axis).await?;
             let mode = MotionMode {
                 kind: skywatcher_motor_protocol::command::ModeKind::Goto,
                 speed: skywatcher_motor_protocol::command::Speed::Fast,
-                ccw: current_ticks > 0,
+                ccw: current_ticks > target_ticks,
             };
             self.transport
                 .send(Command::SetMotionMode { axis, mode })
@@ -908,7 +991,10 @@ impl Telescope for MountDevice {
             // internally. See the matching note in
             // `slew_to_coordinates_async`.
             self.transport
-                .send(Command::SetGotoTarget { axis, ticks: 0 })
+                .send(Command::SetGotoTarget {
+                    axis,
+                    ticks: target_ticks,
+                })
                 .await
                 .map_err(Self::ascom)?;
             self.transport
@@ -935,6 +1021,46 @@ impl Telescope for MountDevice {
     async fn unpark(&self) -> ASCOMResult<()> {
         // Unpark does NOT auto-enable tracking.
         self.state.write().await.at_park = false;
+        Ok(())
+    }
+
+    async fn set_park(&self) -> ASCOMResult<()> {
+        // Capability gate: without a config-file path we have nowhere
+        // to persist to. `CanSetPark` advertises `false` in this case,
+        // but ASCOM clients are allowed to call setters whose
+        // capability is `false` and expect `NOT_IMPLEMENTED`.
+        let config_path = self.config_file_path.as_ref().ok_or_else(|| {
+            ASCOMError::new(
+                ASCOMErrorCode::NOT_IMPLEMENTED,
+                "SetPark requires the driver to be started with --config <path>",
+            )
+        })?;
+        self.ensure_connected().await?;
+        // Refuse mid-slew: the "current encoder pair" wouldn't be
+        // stable while the motors are still moving. Also catches
+        // mid-park: AtPark hasn't been set yet but slew_in_progress is.
+        if self.state.read().await.slew_in_progress {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "SetPark refused while slew or park is in progress",
+            ));
+        }
+        let snap = self.transport.snapshot().await;
+        let ra_ticks = snap.ra.position_ticks;
+        let dec_ticks = snap.dec.position_ticks;
+        write_park_to_config(config_path, ra_ticks, dec_ticks).map_err(Self::ascom)?;
+        // Only mutate the in-memory target after the disk write
+        // succeeds — otherwise a failed write would leave the live
+        // park target out of sync with what's persisted.
+        let mut s = self.state.write().await;
+        s.park_ra_ticks = Some(ra_ticks);
+        s.park_dec_ticks = Some(dec_ticks);
+        debug!(
+            ra_ticks,
+            dec_ticks,
+            path = ?config_path,
+            "set_park persisted to config file"
+        );
         Ok(())
     }
 
@@ -1313,6 +1439,79 @@ async fn stop_axis_and_wait(
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// Patch the on-disk JSON config with the supplied park encoder pair.
+///
+/// Read-as-`Value` + atomic-rename pattern: load the file as
+/// `serde_json::Value`, mutate **only** the `mount.park_ra_ticks` and
+/// `mount.park_dec_ticks` keys, serialise pretty-printed, write via a
+/// `tempfile::NamedTempFile` in the same directory, `persist` to swap
+/// it in atomically. Every other field of the JSON file — known and
+/// unknown — is preserved verbatim.
+///
+/// The driver never re-serialises its in-memory typed `Config` here:
+/// doing so would round-trip CLI overrides (`--port`, `--baud`, etc.)
+/// back to disk and is structurally avoided. See the design doc's
+/// [§"Park persistence"](../../../docs/services/star-adventurer-gti.md#park-persistence)
+/// for the contract this helper implements.
+fn write_park_to_config(
+    config_path: &Path,
+    park_ra_ticks: i32,
+    park_dec_ticks: i32,
+) -> crate::error::Result<()> {
+    use std::io::Write;
+
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| StarAdvError::Config(format!("read config {}: {e}", config_path.display())))?;
+    let mut root: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+        StarAdvError::Config(format!("parse config {}: {e}", config_path.display()))
+    })?;
+    let mount = root
+        .as_object_mut()
+        .and_then(|o| o.get_mut("mount"))
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| {
+            StarAdvError::Config(format!(
+                "config {} has no `mount` object",
+                config_path.display()
+            ))
+        })?;
+    mount.insert(
+        "park_ra_ticks".to_string(),
+        serde_json::Value::from(park_ra_ticks),
+    );
+    mount.insert(
+        "park_dec_ticks".to_string(),
+        serde_json::Value::from(park_dec_ticks),
+    );
+    let mut pretty = serde_json::to_string_pretty(&root)
+        .map_err(|e| StarAdvError::Config(format!("serialise config: {e}")))?;
+    // serde_json's pretty-printer omits a trailing newline; add one so
+    // operators editing the file later don't trip POSIX "no newline at
+    // end of file" warnings in diffs.
+    pretty.push('\n');
+
+    // Temp file must live in the **same directory** as the destination
+    // so `persist` can use POSIX `rename` (atomic on the same
+    // filesystem) rather than copy-and-delete. Fall back to the
+    // current dir if the path has no parent (e.g. a bare filename),
+    // which is what Path::parent returns Some("") for — coerce to ".".
+    let parent = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| StarAdvError::Config(format!("create temp file in {parent:?}: {e}")))?;
+    tmp.write_all(pretty.as_bytes())
+        .map_err(|e| StarAdvError::Config(format!("write temp file: {e}")))?;
+    tmp.as_file()
+        .sync_all()
+        .map_err(|e| StarAdvError::Config(format!("fsync temp file: {e}")))?;
+    tmp.persist(config_path).map_err(|e| {
+        StarAdvError::Config(format!("atomic rename to {}: {e}", config_path.display()))
+    })?;
+    Ok(())
 }
 
 /// Spawn the park-completion watcher.
@@ -2470,5 +2669,230 @@ mod tests {
         // here we never reach it because `stop_axis_and_wait` fails
         // first. Still useful to verify no panic.
         pickup_reslew_axis(&manager, Axis::Dec, -1_000_000).await;
+    }
+
+    // ---- SetPark / Park persistence ----
+
+    fn device_with_path(path: PathBuf) -> MountDevice {
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        let manager = Arc::new(TransportManager::new(
+            cfg.clone(),
+            Arc::new(MockTransportFactory),
+        ));
+        MountDevice::with_config_file_path(cfg.mount, manager, Some(path))
+    }
+
+    /// Helper: write a default `Config` to `path` as pretty JSON. Used as
+    /// the seed file for SetPark round-trip tests.
+    fn seed_default_config(path: &Path) {
+        let cfg = Config::default();
+        let json = serde_json::to_string_pretty(&cfg).unwrap();
+        std::fs::write(path, json).unwrap();
+    }
+
+    #[test]
+    fn write_park_to_config_round_trips_through_typed_config() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let mut cfg = Config::default();
+        cfg.server.port = 12345;
+        std::fs::write(&path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+
+        write_park_to_config(&path, 8000, -3000).unwrap();
+
+        let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.mount.park_ra_ticks, Some(8000));
+        assert_eq!(back.mount.park_dec_ticks, Some(-3000));
+        // Unrelated fields survive the round-trip.
+        assert_eq!(back.server.port, 12345);
+    }
+
+    #[test]
+    fn write_park_to_config_overwrites_existing_park_keys() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let mut cfg = Config::default();
+        cfg.mount.park_ra_ticks = Some(100);
+        cfg.mount.park_dec_ticks = Some(200);
+        std::fs::write(&path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+
+        write_park_to_config(&path, 999, -1000).unwrap();
+
+        let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.mount.park_ra_ticks, Some(999));
+        assert_eq!(back.mount.park_dec_ticks, Some(-1000));
+    }
+
+    #[test]
+    fn write_park_to_config_preserves_unknown_keys() {
+        // The driver promises to touch only `mount.park_*_ticks`. Any
+        // other key — including fields the typed `Config` doesn't model
+        // (future schema additions, operator-added scratch values) —
+        // must survive the round-trip. Tested at the raw JSON layer so
+        // the typed `Config`'s field set isn't accidentally what we're
+        // measuring.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "transport": {
+                "kind": "usb",
+                "port": "/dev/ttyACM0",
+                "baud_rate": 115200,
+                "command_timeout": "2s",
+                "polling_interval": "200ms"
+            },
+            "server": {
+                "port": 11117,
+                "discovery_port": null,
+                "tls": null,
+                "auth": null
+            },
+            "mount": {
+                "name": "Test",
+                "unique_id": "test-001",
+                "description": "Test",
+                "site_latitude_deg": 0.0,
+                "site_longitude_deg": 0.0,
+                "future_field": "preserve me"
+            },
+            "top_level_future_field": [1, 2, 3]
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+        write_park_to_config(&path, 5, 10).unwrap();
+
+        let raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(raw["mount"]["park_ra_ticks"], serde_json::json!(5));
+        assert_eq!(raw["mount"]["park_dec_ticks"], serde_json::json!(10));
+        assert_eq!(
+            raw["mount"]["future_field"],
+            serde_json::json!("preserve me")
+        );
+        assert_eq!(raw["top_level_future_field"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn write_park_to_config_fails_when_file_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("does_not_exist.json");
+        let err = write_park_to_config(&path, 0, 0).unwrap_err();
+        assert!(matches!(err, StarAdvError::Config(_)));
+    }
+
+    #[test]
+    fn write_park_to_config_fails_when_mount_object_is_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("malformed.json");
+        std::fs::write(&path, "{}").unwrap();
+        let err = write_park_to_config(&path, 0, 0).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => assert!(msg.contains("mount"), "{msg}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn can_set_park_is_false_when_no_config_path_was_provided() {
+        let d = device();
+        assert!(!d.can_set_park().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_set_park_is_true_when_started_with_a_config_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let d = device_with_path(dir.path().join("config.json"));
+        assert!(d.can_set_park().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn set_park_returns_not_implemented_without_a_config_path() {
+        let d = device();
+        let err = d.set_park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn set_park_returns_not_connected_when_disconnected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        seed_default_config(&path);
+        let d = device_with_path(path);
+        let err = d.set_park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::NOT_CONNECTED);
+    }
+
+    #[tokio::test]
+    async fn set_park_refuses_while_slew_in_progress() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        seed_default_config(&path);
+        let d = device_with_path(path);
+        d.set_connected(true).await.unwrap();
+        d.state.write().await.slew_in_progress = true;
+        let err = d.set_park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    }
+
+    #[tokio::test]
+    async fn set_park_persists_current_snapshot_and_updates_in_memory_target() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        seed_default_config(&path);
+        let d = device_with_path(path.clone());
+        d.set_connected(true).await.unwrap();
+        // Seed the snapshot directly — the polling loop won't overwrite
+        // a stationary mock axis (`advance_one_step` bails on
+        // `!running`), so these values stick.
+        d.transport.seed_ra_position(8000).await;
+        d.transport.seed_dec_position(-3000).await;
+
+        d.set_park().await.unwrap();
+
+        // In-memory target updated.
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(8000));
+        assert_eq!(s.park_dec_ticks, Some(-3000));
+        drop(s);
+
+        // On-disk config updated.
+        let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.mount.park_ra_ticks, Some(8000));
+        assert_eq!(back.mount.park_dec_ticks, Some(-3000));
+    }
+
+    #[tokio::test]
+    async fn park_target_defaults_to_handshake_capture_when_config_has_no_values() {
+        // No config park values → driver should fall back to the
+        // encoder positions captured during the handshake. The mock
+        // starts both axes at 0, so park_ra_ticks / park_dec_ticks
+        // should be Some(0) after connect.
+        let d = device();
+        d.set_connected(true).await.unwrap();
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(0));
+        assert_eq!(s.park_dec_ticks, Some(0));
+    }
+
+    #[tokio::test]
+    async fn park_target_prefers_config_values_over_handshake_capture() {
+        // Config carries park values → driver should use them, not the
+        // (zeroed) handshake fallback.
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        cfg.mount.park_ra_ticks = Some(5000);
+        cfg.mount.park_dec_ticks = Some(-7000);
+        let manager = Arc::new(TransportManager::new(
+            cfg.clone(),
+            Arc::new(MockTransportFactory),
+        ));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(5000));
+        assert_eq!(s.park_dec_ticks, Some(-7000));
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1850,14 +1850,20 @@ pub fn probe_park_file_writability(config_path: &Path) -> std::io::Result<()> {
 
 /// Read `mount.park_ra_ticks` / `mount.park_dec_ticks` from the on-disk
 /// config file. Each axis is returned independently — a `None` means
-/// the file did not set that key (or set it to `null`), and the caller
-/// will fall back to the handshake-captured value for that axis.
+/// the file did not set that key (or set it to JSON `null`), and the
+/// caller will fall back to the handshake-captured value for that axis.
 ///
-/// Failures (file missing, malformed JSON, `mount` key missing or not
-/// an object) are surfaced as `StarAdvError::Config`. Reading the file
-/// only at connect time means an operator can hand-edit the park keys
-/// between connects and have the change take effect on reconnect,
-/// without restarting the driver.
+/// A key that **is** present but holds something other than an integer
+/// inside `i32`'s range is surfaced as a `StarAdvError::Config` rather
+/// than silently treated as `None`. Operator typos (a string,
+/// an i64 too large to be encoder ticks, a float) should fail loudly so
+/// the misconfiguration is visible rather than masked by the handshake
+/// fallback. Other failures (file missing, malformed JSON, `mount` key
+/// missing or not an object) are also surfaced as `StarAdvError::Config`.
+///
+/// Reading the file only at connect time means an operator can
+/// hand-edit the park keys between connects and have the change take
+/// effect on reconnect, without restarting the driver.
 ///
 /// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
 fn read_park_from_config(config_path: &Path) -> crate::error::Result<(Option<i32>, Option<i32>)> {
@@ -1876,15 +1882,39 @@ fn read_park_from_config(config_path: &Path) -> crate::error::Result<(Option<i32
                 config_path.display()
             ))
         })?;
-    let ra = mount
-        .get("park_ra_ticks")
-        .and_then(|v| v.as_i64())
-        .and_then(|n| i32::try_from(n).ok());
-    let dec = mount
-        .get("park_dec_ticks")
-        .and_then(|v| v.as_i64())
-        .and_then(|n| i32::try_from(n).ok());
+    let ra = extract_park_tick(mount.get("park_ra_ticks"), "mount.park_ra_ticks")?;
+    let dec = extract_park_tick(mount.get("park_dec_ticks"), "mount.park_dec_ticks")?;
     Ok((ra, dec))
+}
+
+/// Decode an optional park-tick JSON value:
+///
+/// - Absent (`None`) or explicit `Value::Null` → `Ok(None)` (caller
+///   falls back to the handshake-captured value).
+/// - A JSON integer in the `i32` range → `Ok(Some(n))`.
+/// - Anything else (string, float, boolean, array/object, i64 outside
+///   `i32` range) → `Err(StarAdvError::Config)`. Loud failure on
+///   operator typo is the whole reason this helper exists — silently
+///   falling back to handshake would mask the misconfiguration.
+fn extract_park_tick(
+    value: Option<&serde_json::Value>,
+    key: &'static str,
+) -> crate::error::Result<Option<i32>> {
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(v) => {
+            let n = v.as_i64().ok_or_else(|| {
+                StarAdvError::Config(format!(
+                    "`{key}` must be an integer (encoder ticks), got {v}"
+                ))
+            })?;
+            i32::try_from(n).map(Some).map_err(|_| {
+                StarAdvError::Config(format!(
+                    "`{key}` value {n} is outside the i32 encoder-tick range"
+                ))
+            })
+        }
+    }
 }
 
 /// Patch the on-disk JSON config with the supplied park encoder pair.
@@ -3680,6 +3710,75 @@ mod tests {
         let (ra, dec) = read_park_from_config(&path).unwrap();
         assert_eq!(ra, Some(1234));
         assert_eq!(dec, None);
+    }
+
+    #[test]
+    fn read_park_from_config_errors_on_wrong_type() {
+        // Operator typo: park_ra_ticks declared as a string. Used to
+        // be silently treated as None (fell back to handshake);
+        // current contract is to surface the misconfiguration. Per
+        // Copilot review on PR #221 (comment 3238774050).
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "park_ra_ticks": "not-an-integer",
+                "park_dec_ticks": 0,
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let err = read_park_from_config(&path).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => {
+                assert!(msg.contains("park_ra_ticks"), "{msg}");
+                assert!(msg.contains("integer"), "{msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_park_from_config_errors_on_float_value() {
+        // serde_json::Value::Number for 1.5 isn't representable as
+        // i64; `as_i64()` returns None and we surface a Config error
+        // rather than silently dropping the value.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "park_ra_ticks": 1.5,
+                "park_dec_ticks": 0,
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let err = read_park_from_config(&path).unwrap_err();
+        assert!(matches!(err, StarAdvError::Config(_)));
+    }
+
+    #[test]
+    fn read_park_from_config_errors_on_out_of_i32_range() {
+        // A value that fits in i64 but not i32 — e.g. someone copied
+        // a large encoder count from a higher-resolution mount, or
+        // a typo added a digit. Either way we should fail loudly so
+        // the operator sees the bad value rather than silently
+        // falling back to handshake.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "park_ra_ticks": i64::from(i32::MAX) + 1_i64,
+                "park_dec_ticks": 0,
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let err = read_park_from_config(&path).unwrap_err();
+        match err {
+            StarAdvError::Config(msg) => {
+                assert!(msg.contains("park_ra_ticks"), "{msg}");
+                assert!(msg.contains("i32"), "{msg}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -997,25 +997,6 @@ impl Telescope for MountDevice {
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
 
-        // Latch the target + capture the tracking flag so the
-        // completion watcher knows whether to auto-restore. Also
-        // cancel any in-flight pulse-guide on either axis (the slew
-        // takes ownership of both axes from this point). We do NOT
-        // clear `tracking_requested` here: if any of the StopMotion /
-        // SetMotionMode / ... sends below fail, the in-memory state
-        // would falsely report tracking-off while the wire is still
-        // tracking. The flag is cleared only after the RA :K actually
-        // hits the wire (see the inline write below).
-        let tracking_was_on;
-        {
-            let mut s = self.state.write().await;
-            s.target_ra_hours = Some(ra);
-            s.target_dec_degrees = Some(dec);
-            tracking_was_on = s.tracking_requested;
-            s.pulse_guiding_ra = false;
-            s.pulse_guiding_dec = false;
-        }
-
         // Compute target encoder ticks for the *current* LST. INDI's
         // EQMOD-style post-stop pickup loop (issue #205) handles the
         // residual that arises because RA drifts during the goto: when
@@ -1041,37 +1022,73 @@ impl Telescope for MountDevice {
         // stalling the motor against a hard stop.
         self.check_within_safe_envelope(ra_ticks, dec_ticks, params.cpr_ra, params.cpr_dec)?;
 
-        let snap = self.transport.snapshot().await;
-        let ra_delta = ra_ticks - snap.ra.position_ticks;
-        let dec_delta = dec_ticks - snap.dec.position_ticks;
-        // Both axes use the INDI wire sequence: `:K` + poll `:f`
-        // (decelerate stop — the spec's "motor must be at full stop
-        // before setting the motion mode" requirement) → `:G goto+fast`
-        // → `:I 6` → `:H |delta|` → `:M breaks` → `:J`. The RA-axis
-        // `:K` is also the wire event that halts any in-progress
-        // sidereal tracking; mirror that into the in-memory
-        // `tracking_requested` flag once the stop has actually
-        // succeeded so the state never gets ahead of the wire on
-        // transport failures.
-        self.stop_and_wait(Axis::Ra).await?;
-        self.state.write().await.tracking_requested = false;
-        issue_slew_axis(&self.transport, Axis::Ra, ra_delta)
-            .await
-            .map_err(Self::ascom)?;
-        self.stop_and_wait(Axis::Dec).await?;
-        issue_slew_axis(&self.transport, Axis::Dec, dec_delta)
-            .await
-            .map_err(Self::ascom)?;
-
-        // Mark slew in progress and spawn the completion watcher. The
-        // watcher polls until both axes report stopped, runs the
-        // EQMOD-style pickup loop (up to 5 iterations) to nudge any
-        // residual under 5", optionally re-issues sidereal tracking
-        // on RA (only if it was on before the slew), applies the
-        // settle delay, then clears `slew_in_progress`.
-        let settle = {
+        // Atomically reserve the in-progress slot **before** issuing
+        // any motion. Latch the target + capture the tracking flag in
+        // the same write. We do NOT clear `tracking_requested` here:
+        // if any of the StopMotion / SetMotionMode / ... sends below
+        // fail, the in-memory state would falsely report tracking-off
+        // while the wire is still tracking. The flag is cleared only
+        // after the RA :K actually hits the wire (see the inline
+        // write below).
+        let tracking_was_on;
+        {
             let mut s = self.state.write().await;
+            if s.slew_in_progress {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "slew refused: slew already in progress",
+                ));
+            }
+            s.target_ra_hours = Some(ra);
+            s.target_dec_degrees = Some(dec);
+            tracking_was_on = s.tracking_requested;
             s.slew_in_progress = true;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
+        }
+
+        // From here on, any error path must clear `slew_in_progress`
+        // — otherwise the driver gets stuck reporting Slewing forever.
+        // Wrap motion-issue in an inner future so a single rollback
+        // covers every `?` failure.
+        let result: ASCOMResult<()> = async {
+            let snap = self.transport.snapshot().await;
+            let ra_delta = ra_ticks - snap.ra.position_ticks;
+            let dec_delta = dec_ticks - snap.dec.position_ticks;
+            // Both axes use the INDI wire sequence: `:K` + poll `:f`
+            // (decelerate stop — the spec's "motor must be at full stop
+            // before setting the motion mode" requirement) → `:G goto+fast`
+            // → `:I 6` → `:H |delta|` → `:M breaks` → `:J`. The RA-axis
+            // `:K` is also the wire event that halts any in-progress
+            // sidereal tracking; mirror that into the in-memory
+            // `tracking_requested` flag once the stop has actually
+            // succeeded so the state never gets ahead of the wire on
+            // transport failures.
+            self.stop_and_wait(Axis::Ra).await?;
+            self.state.write().await.tracking_requested = false;
+            issue_slew_axis(&self.transport, Axis::Ra, ra_delta)
+                .await
+                .map_err(Self::ascom)?;
+            self.stop_and_wait(Axis::Dec).await?;
+            issue_slew_axis(&self.transport, Axis::Dec, dec_delta)
+                .await
+                .map_err(Self::ascom)?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            self.state.write().await.slew_in_progress = false;
+            return Err(e);
+        }
+
+        // Hand off to the completion watcher. The watcher polls
+        // until both axes report stopped, runs the EQMOD-style
+        // pickup loop (up to 5 iterations) to nudge any residual
+        // under 5", optionally re-issues sidereal tracking on RA
+        // (only if it was on before the slew), applies the settle
+        // delay, then clears `slew_in_progress`.
+        let settle = {
+            let s = self.state.read().await;
             s.slew_settle_time.unwrap_or(self.config.settle_after_slew)
         };
         spawn_slew_completion_watcher(
@@ -1118,89 +1135,110 @@ impl Telescope for MountDevice {
         if self.state.read().await.at_park {
             return Ok(());
         }
-        // Cancel any in-flight pulse-guide — park takes ownership of
-        // both axes. Watchers see the cleared flags on post-sleep and
-        // bail out without restoring.
+        // Atomically reserve the in-progress slot **before** issuing
+        // any motion. Doing the flag-set after `:J` (the old layout)
+        // left a TOCTOU window where a concurrent `SetPark` could
+        // read mid-slew encoder positions. Cancel any in-flight
+        // pulse-guide in the same write — park takes ownership of
+        // both axes from this point.
         {
             let mut s = self.state.write().await;
+            if s.slew_in_progress {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "park refused: slew already in progress",
+                ));
+            }
+            s.slew_in_progress = true;
             s.pulse_guiding_ra = false;
             s.pulse_guiding_dec = false;
         }
-        // Stop tracking before slewing home (per ASCOM, tracking remains
-        // off after Park). The wire `:K1` is issued first so the in-memory
-        // flag flip only follows a successful stop.
-        if self.state.read().await.tracking_requested {
-            self.transport
-                .send(Command::StopMotion(Axis::Ra))
-                .await
-                .map_err(Self::ascom)?;
-            self.state.write().await.tracking_requested = false;
-        }
-        // Slew both axes to the loaded park target. `set_connected(true)`
-        // populated these from config / handshake; if either is `None`
-        // here it's an internal invariant violation (only path to reach
-        // this code requires `ensure_connected()` to have observed
-        // `requested_connection = true`, which is only set after
-        // `load_park_target_after_connect` populated both). Surface as
-        // a structured ASCOMError rather than a panic — panicking
-        // inside a tokio task aborts it and leaves the Alpaca client
-        // with a connection-reset rather than a recoverable error code.
-        let (target_ra_ticks, target_dec_ticks) = {
-            let s = self.state.read().await;
-            let ra = s.park_ra_ticks.ok_or_else(|| {
-                ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "park_ra_ticks not loaded — internal invariant violation",
-                )
-            })?;
-            let dec = s.park_dec_ticks.ok_or_else(|| {
-                ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "park_dec_ticks not loaded — internal invariant violation",
-                )
-            })?;
-            (ra, dec)
-        };
-        // Same wire sequence as `slew_to_coordinates_async`:
-        // `:K`-and-wait, `:G` with direction chosen from
-        // `sign(target - current)`, `:S target`, `:J`.
-        let snap = self.transport.snapshot().await;
-        for (axis, current_ticks, target_ticks) in [
-            (Axis::Ra, snap.ra.position_ticks, target_ra_ticks),
-            (Axis::Dec, snap.dec.position_ticks, target_dec_ticks),
-        ] {
-            self.stop_and_wait(axis).await?;
-            let mode = MotionMode {
-                kind: skywatcher_motor_protocol::command::ModeKind::Goto,
-                speed: skywatcher_motor_protocol::command::Speed::Fast,
-                ccw: current_ticks > target_ticks,
+        // From here on, any error path must clear `slew_in_progress`
+        // — otherwise the driver gets stuck reporting Slewing forever.
+        // Wrap motion-issue in an inner future so a single rollback
+        // covers every `?` failure.
+        let result: ASCOMResult<()> = async {
+            // Stop tracking before slewing home (per ASCOM, tracking
+            // remains off after Park). The wire `:K1` is issued first
+            // so the in-memory flag flip only follows a successful stop.
+            if self.state.read().await.tracking_requested {
+                self.transport
+                    .send(Command::StopMotion(Axis::Ra))
+                    .await
+                    .map_err(Self::ascom)?;
+                self.state.write().await.tracking_requested = false;
+            }
+            // Slew both axes to the loaded park target.
+            // `set_connected(true)` populated these from config /
+            // handshake; if either is `None` here it's an internal
+            // invariant violation. Surface as a structured ASCOMError
+            // rather than a panic — panicking inside a tokio task
+            // aborts it and leaves the Alpaca client with a
+            // connection-reset.
+            let (target_ra_ticks, target_dec_ticks) = {
+                let s = self.state.read().await;
+                let ra = s.park_ra_ticks.ok_or_else(|| {
+                    ASCOMError::new(
+                        ASCOMErrorCode::INVALID_OPERATION,
+                        "park_ra_ticks not loaded — internal invariant violation",
+                    )
+                })?;
+                let dec = s.park_dec_ticks.ok_or_else(|| {
+                    ASCOMError::new(
+                        ASCOMErrorCode::INVALID_OPERATION,
+                        "park_dec_ticks not loaded — internal invariant violation",
+                    )
+                })?;
+                (ra, dec)
             };
-            self.transport
-                .send(Command::SetMotionMode { axis, mode })
-                .await
-                .map_err(Self::ascom)?;
-            // No `:I` in Goto mode — the firmware computes slew speed
-            // internally. See the matching note in
-            // `slew_to_coordinates_async`.
-            self.transport
-                .send(Command::SetGotoTarget {
-                    axis,
-                    ticks: target_ticks,
-                })
-                .await
-                .map_err(Self::ascom)?;
-            self.transport
-                .send(Command::StartMotion(axis))
-                .await
-                .map_err(Self::ascom)?;
+            // Same wire sequence as `slew_to_coordinates_async`:
+            // `:K`-and-wait, `:G` with direction chosen from
+            // `sign(target - current)`, `:S target`, `:J`.
+            let snap = self.transport.snapshot().await;
+            for (axis, current_ticks, target_ticks) in [
+                (Axis::Ra, snap.ra.position_ticks, target_ra_ticks),
+                (Axis::Dec, snap.dec.position_ticks, target_dec_ticks),
+            ] {
+                self.stop_and_wait(axis).await?;
+                let mode = MotionMode {
+                    kind: skywatcher_motor_protocol::command::ModeKind::Goto,
+                    speed: skywatcher_motor_protocol::command::Speed::Fast,
+                    ccw: current_ticks > target_ticks,
+                };
+                self.transport
+                    .send(Command::SetMotionMode { axis, mode })
+                    .await
+                    .map_err(Self::ascom)?;
+                // No `:I` in Goto mode — the firmware computes slew speed
+                // internally. See the matching note in
+                // `slew_to_coordinates_async`.
+                self.transport
+                    .send(Command::SetGotoTarget {
+                        axis,
+                        ticks: target_ticks,
+                    })
+                    .await
+                    .map_err(Self::ascom)?;
+                self.transport
+                    .send(Command::StartMotion(axis))
+                    .await
+                    .map_err(Self::ascom)?;
+            }
+            Ok(())
         }
-        // Mark slew in progress and spawn the park watcher (sets at_park
-        // = true on completion instead of re-enabling tracking).
-        let settle = {
-            let mut s = self.state.write().await;
-            s.slew_in_progress = true;
-            s.slew_settle_time.unwrap_or(self.config.settle_after_slew)
-        };
+        .await;
+        if let Err(e) = result {
+            self.state.write().await.slew_in_progress = false;
+            return Err(e);
+        }
+        // Hand off to the park watcher; it owns `slew_in_progress`
+        // from here and will clear it on completion.
+        let settle = self
+            .state
+            .read()
+            .await
+            .slew_settle_time
+            .unwrap_or(self.config.settle_after_slew);
         spawn_park_completion_watcher(
             Arc::clone(&self.state),
             Arc::clone(&self.transport),
@@ -1231,6 +1269,21 @@ impl Telescope for MountDevice {
         // Refuse mid-slew: the "current encoder pair" wouldn't be
         // stable while the motors are still moving. Also catches
         // mid-park: AtPark hasn't been set yet but slew_in_progress is.
+        //
+        // Two layers of defense for the concurrent-motion case (per
+        // Copilot review on PR #221, comment 3242621736):
+        //   1. The in-memory `slew_in_progress` flag: park() and
+        //      slew_to_coordinates_async() now set this *before*
+        //      issuing motion (with rollback-on-error), so the
+        //      flag observation here is reliable.
+        //   2. The latest wire snapshot's `running` flag: defense
+        //      in depth against an axis that's running for any
+        //      reason the in-memory flag wouldn't capture (a
+        //      tracking pulse, an external `:J` from a future
+        //      out-of-band path, a flag-set racing the wire send).
+        //      The snapshot is updated by the background poller at
+        //      `polling_interval`; the window where snapshot lags
+        //      reality is bounded by that interval.
         if self.state.read().await.slew_in_progress {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_OPERATION,
@@ -1238,6 +1291,12 @@ impl Telescope for MountDevice {
             ));
         }
         let snap = self.transport.snapshot().await;
+        if snap.ra.running || snap.dec.running {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "SetPark refused while an axis is running per the wire snapshot",
+            ));
+        }
         let ra_ticks = snap.ra.position_ticks;
         let dec_ticks = snap.dec.position_ticks;
         // Disk I/O runs on the blocking pool so the async runtime
@@ -3650,6 +3709,70 @@ mod tests {
         d.state.write().await.slew_in_progress = true;
         let err = d.set_park().await.unwrap_err();
         assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    }
+
+    #[tokio::test]
+    async fn set_park_refuses_when_wire_snapshot_reports_axis_running() {
+        // Defence-in-depth (per Copilot review on PR #221, comment
+        // 3242621736): even if `slew_in_progress` is false — e.g. an
+        // axis is running for a reason the in-memory flag wouldn't
+        // capture — the wire snapshot's `running` flag must still
+        // gate `SetPark` to avoid persisting mid-motion encoder
+        // ticks.
+        //
+        // To exercise this path independently of the
+        // `slew_in_progress` flag, we connect with a
+        // `CapturingMockFactory`, force `ra.running = true` directly
+        // on the mock state (bypassing the slew_to_*_async flag-set
+        // path), wait for the next background poll so the snapshot
+        // reflects the wire, then call SetPark.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let mut cfg = Config::default();
+        if let crate::config::TransportConfig::Usb(usb) = &mut cfg.transport {
+            usb.polling_interval = Duration::from_millis(20);
+        }
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        seed_default_config(&path);
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::with_config_file_path(cfg.mount, manager, Some(path));
+        d.set_connected(true).await.unwrap();
+
+        // Force the wire-side running flag without going through
+        // `slew_to_coordinates_async` (which would set
+        // `slew_in_progress` and trip the other guard).
+        {
+            let mut s = mock.state.lock().await;
+            s.ra.running = true;
+            s.ra.initialized = true;
+        }
+        // Wait for the background poll to ingest the new wire state.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if d.transport.snapshot().await.ra.running {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            d.transport.snapshot().await.ra.running,
+            "precondition: snapshot must reflect RA running=true"
+        );
+        // slew_in_progress flag is still false — only the wire
+        // snapshot is reporting motion. The new defence layer must
+        // still refuse.
+        assert!(!d.state.read().await.slew_in_progress);
+        let err = d.set_park().await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+        assert!(
+            err.message.contains("snapshot"),
+            "error should reference the wire snapshot: {}",
+            err.message
+        );
     }
 
     #[tokio::test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -3114,6 +3114,29 @@ mod tests {
     }
 
     #[test]
+    fn read_park_from_config_treats_explicit_null_as_none_per_axis() {
+        // Pins the doc-comment guarantee: a `None` return value means
+        // the file did not set that key OR set it to `null`, and the
+        // two axes are returned independently. Here `park_ra_ticks`
+        // is set to a real value while `park_dec_ticks` is explicitly
+        // JSON `null`; the helper must return `(Some(1234), None)`,
+        // and the caller (`set_connected`) will then fall back to the
+        // handshake-captured value for the Dec axis only.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let json = serde_json::json!({
+            "mount": {
+                "park_ra_ticks": 1234,
+                "park_dec_ticks": null,
+            }
+        });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+        let (ra, dec) = read_park_from_config(&path).unwrap();
+        assert_eq!(ra, Some(1234));
+        assert_eq!(dec, None);
+    }
+
+    #[test]
     fn read_park_from_config_fails_when_mount_object_is_missing() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("config.json");

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -239,6 +239,60 @@ impl MountDevice {
             "synchronous slew timed out waiting for completion",
         ))
     }
+
+    /// Post-connect park-target load. Source priority, per axis:
+    ///
+    /// 1. `mount.park_*_ticks` from the **on-disk** config file when one
+    ///    was supplied via `--config`. Reading fresh from disk on every
+    ///    connect means a successful `SetPark` followed by
+    ///    disconnect/reconnect picks up the new target, and an operator
+    ///    hand-edit between connects takes effect.
+    /// 2. `self.config.park_*_ticks` for `Config::default()` runs (no
+    ///    config file) — these never change in-process because
+    ///    `SetPark` is unreachable in that mode.
+    /// 3. The encoder positions captured during the init handshake
+    ///    (`:j1` / `:j2`) when neither of the above provided a value.
+    ///
+    /// Extracted from [`set_connected`] so a failure here (file missing,
+    /// malformed JSON, lost transport mid-load) can be rolled back by the
+    /// caller without leaking the connection ref-count. See the design
+    /// doc's §"Park lifecycle" for the resolution rules.
+    async fn load_park_target_after_connect(&self) -> ASCOMResult<()> {
+        let (config_ra, config_dec) = if let Some(path) = self.config_file_path.clone() {
+            let result = tokio::task::spawn_blocking(move || read_park_from_config(&path))
+                .await
+                .map_err(|e| {
+                    ASCOMError::new(
+                        ASCOMErrorCode::INVALID_OPERATION,
+                        format!("park-config read task join error: {e}"),
+                    )
+                })?;
+            result.map_err(Self::ascom)?
+        } else {
+            (self.config.park_ra_ticks, self.config.park_dec_ticks)
+        };
+        let params = self
+            .transport
+            .parameters()
+            .await
+            .ok_or(ASCOMError::NOT_CONNECTED)?;
+        let ra_target = config_ra.unwrap_or(params.ra_at_handshake_ticks);
+        let dec_target = config_dec.unwrap_or(params.dec_at_handshake_ticks);
+        {
+            let mut s = self.state.write().await;
+            s.park_ra_ticks = Some(ra_target);
+            s.park_dec_ticks = Some(dec_target);
+        }
+        debug!(
+            ra_target,
+            dec_target,
+            from_config_ra = config_ra.is_some(),
+            from_config_dec = config_dec.is_some(),
+            from_file = self.config_file_path.is_some(),
+            "park target loaded"
+        );
+        Ok(())
+    }
 }
 
 /// Upper bound on how long the synchronous `SlewToCoordinates` /
@@ -400,55 +454,18 @@ impl Device for MountDevice {
         }
         if connected {
             self.transport.connect().await.map_err(Self::ascom)?;
-            // Load the park target now that the handshake has populated
-            // `MountParameters`. Source priority, per axis:
-            //   1. `mount.park_*_ticks` from the **on-disk** config file
-            //      when one was supplied via `--config`. Reading fresh
-            //      from disk every connect means a successful `SetPark`
-            //      followed by disconnect/reconnect picks up the new
-            //      target, and an operator hand-edit between connects
-            //      takes effect.
-            //   2. `self.config.park_*_ticks` for `Config::default()`
-            //      runs (no config file) — these never change in-process
-            //      because `SetPark` is unreachable in that mode.
-            //   3. The encoder positions captured during the init
-            //      handshake (`:j1` / `:j2`) when neither of the above
-            //      provided a value.
-            // See the design doc's §"Park lifecycle" for the resolution
-            // rules.
-            let (config_ra, config_dec) = if let Some(path) = self.config_file_path.clone() {
-                let result = tokio::task::spawn_blocking(move || read_park_from_config(&path))
-                    .await
-                    .map_err(|e| {
-                        ASCOMError::new(
-                            ASCOMErrorCode::INVALID_OPERATION,
-                            format!("park-config read task join error: {e}"),
-                        )
-                    })?;
-                result.map_err(Self::ascom)?
-            } else {
-                (self.config.park_ra_ticks, self.config.park_dec_ticks)
-            };
-            let params = self
-                .transport
-                .parameters()
-                .await
-                .ok_or(ASCOMError::NOT_CONNECTED)?;
-            let ra_target = config_ra.unwrap_or(params.ra_at_handshake_ticks);
-            let dec_target = config_dec.unwrap_or(params.dec_at_handshake_ticks);
-            {
-                let mut s = self.state.write().await;
-                s.park_ra_ticks = Some(ra_target);
-                s.park_dec_ticks = Some(dec_target);
+            // Post-connect work that can fail (config-file read, parameter
+            // cache lookup) runs inside `load_park_target_after_connect`
+            // so we can roll the connect back on any error — otherwise the
+            // transport ref-count would stay incremented while `*req`
+            // remained false, leaking a connection. Per the Copilot review
+            // on PR #221 (comment 3238682044).
+            if let Err(e) = self.load_park_target_after_connect().await {
+                if let Err(disc_err) = self.transport.disconnect().await {
+                    tracing::warn!("disconnect during set_connected rollback failed: {disc_err}");
+                }
+                return Err(e);
             }
-            debug!(
-                ra_target,
-                dec_target,
-                from_config_ra = config_ra.is_some(),
-                from_config_dec = config_dec.is_some(),
-                from_file = self.config_file_path.is_some(),
-                "park target loaded"
-            );
             *req = true;
         } else {
             self.transport.disconnect().await.map_err(Self::ascom)?;
@@ -2951,6 +2968,42 @@ mod tests {
         let d = device_with_path(path);
         let err = d.set_park().await.unwrap_err();
         assert_eq!(err.code, ASCOMErrorCode::NOT_CONNECTED);
+    }
+
+    #[tokio::test]
+    async fn set_connected_rolls_back_transport_when_park_load_fails() {
+        // Regression test for the Copilot review on PR #221
+        // (comment 3238682044): if `transport.connect()` succeeds but
+        // the post-connect park-target load fails, the transport
+        // ref-count was being left incremented (the underlying
+        // transport open) while `requested_connection` stayed `false`
+        // — effectively leaking a connection. The fix runs the
+        // post-connect work through `load_park_target_after_connect`
+        // and calls `transport.disconnect()` on any failure before
+        // surfacing the error.
+        //
+        // We trigger the failure path by handing `MountDevice` a
+        // `config_file_path` that points to a non-existent file:
+        // the handshake will succeed (mock transport is happy), but
+        // `read_park_from_config` will fail with a missing-file error.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("does_not_exist.json");
+        let d = device_with_path(path);
+
+        let err = d.set_connected(true).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+
+        // The transport must have been disconnected on rollback.
+        // `is_available()` is the underlying TransportManager flag,
+        // which would be `true` if connect succeeded and no rollback
+        // ran. Asserting it false here proves we balanced the
+        // connect ref-count.
+        assert!(
+            !d.transport.is_available(),
+            "transport should be torn down after rollback"
+        );
+        // And the user-visible `connected()` getter agrees.
+        assert!(!d.connected().await.unwrap());
     }
 
     #[tokio::test]

--- a/services/star-adventurer-gti/src/transport/mock.rs
+++ b/services/star-adventurer-gti/src/transport/mock.rs
@@ -125,18 +125,31 @@ impl AxisSimState {
             } else {
                 chunk * dir
             };
-            self.position_ticks += step;
+            self.position_ticks = clamp_to_wire_range(self.position_ticks + step);
             if toward_target && self.position_ticks == self.goto_target_ticks {
                 self.running = false;
             }
         } else {
             // Tracking mode: free-run in the configured direction at
             // a sidereal-ish chunk per poll. Never auto-stop — only
-            // `:K` / `:L` should clear `running`.
+            // `:K` / `:L` should clear `running`. Real GTi firmware
+            // saturates at the 24-bit encoder limit too, so a
+            // long-running tracking mock matches hardware behaviour.
             const SIDEREAL_CHUNK_PER_POLL: i32 = 8;
-            self.position_ticks += SIDEREAL_CHUNK_PER_POLL * dir;
+            self.position_ticks =
+                clamp_to_wire_range(self.position_ticks + SIDEREAL_CHUNK_PER_POLL * dir);
         }
     }
+}
+
+/// Saturating-clamp an encoder-tick value to the wire-representable
+/// signed-24-bit range. Used by [`AxisSimState::advance_one_step`] so
+/// a long-running tracking mock can't drift past `POSITION_MAX` and
+/// panic the next `:j` handler when `encode_position` rejects the
+/// out-of-range value. Real GTi firmware saturates here too.
+fn clamp_to_wire_range(ticks: i32) -> i32 {
+    use skywatcher_motor_protocol::codec::{POSITION_MAX, POSITION_MIN};
+    ticks.clamp(POSITION_MIN, POSITION_MAX)
 }
 
 fn nibble_to_hex(n: u8) -> u8 {
@@ -549,6 +562,46 @@ mod tests {
 
     fn d() -> Duration {
         Duration::from_millis(100)
+    }
+
+    #[test]
+    fn advance_one_step_clamps_at_wire_range_in_tracking_mode() {
+        // Regression test: a long-running tracking mock used to panic
+        // on the next `:j` poll once `position_ticks` drifted past
+        // `POSITION_MAX`, because `encode_position` rejects
+        // out-of-range values. The fix saturates the position at the
+        // 24-bit signed encoder boundary inside `advance_one_step`
+        // itself, matching how real GTi firmware behaves.
+        use skywatcher_motor_protocol::codec::{POSITION_MAX, POSITION_MIN};
+        let mut s = AxisSimState {
+            running: true,
+            goto: false, // tracking
+            ccw: false,
+            // Start one step shy of the upper boundary.
+            position_ticks: POSITION_MAX - 4,
+            ..Default::default()
+        };
+        // Tracking-mode chunk is +8 ticks per step; after one call
+        // we'd be at POSITION_MAX + 4 without clamping.
+        s.advance_one_step();
+        assert_eq!(s.position_ticks, POSITION_MAX);
+        // Further steps stay clamped.
+        s.advance_one_step();
+        s.advance_one_step();
+        assert_eq!(s.position_ticks, POSITION_MAX);
+
+        // Symmetric: CCW direction clamps at the lower boundary.
+        let mut s = AxisSimState {
+            running: true,
+            goto: false,
+            ccw: true,
+            position_ticks: POSITION_MIN + 4,
+            ..Default::default()
+        };
+        s.advance_one_step();
+        assert_eq!(s.position_ticks, POSITION_MIN);
+        s.advance_one_step();
+        assert_eq!(s.position_ticks, POSITION_MIN);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -23,12 +23,18 @@ use crate::config::{Config, TransportConfig};
 use crate::error::{Result, StarAdvError};
 use crate::transport::{Transport, TransportFactory};
 
-/// Snapshot of the values the mount reports during the init handshake. All
-/// 24-bit unsigned wire values; meaningful units are in the design doc.
+/// Snapshot of the values the mount reports during the init handshake.
+/// Meaningful units are in the design doc.
 ///
-/// `ra_at_handshake_ticks` and `dec_at_handshake_ticks` are signed encoder
-/// positions latched at connect time. They serve as the fallback park
-/// target when the config file does not carry explicit `park_ra_ticks` /
+/// The first six fields (`cpr_*`, `tmr_freq`, `high_speed_ratio_*`,
+/// `motor_board_version`) are 24-bit unsigned values decoded straight
+/// from the wire and stored as `u32` for ergonomics.
+///
+/// `ra_at_handshake_ticks` and `dec_at_handshake_ticks` are signed
+/// encoder positions: the wire reports them as 24-bit unsigned with a
+/// `0x800000` bias, which the codec decodes into signed `i32` before
+/// they reach this struct. They serve as the fallback park target when
+/// the config file does not carry explicit `park_ra_ticks` /
 /// `park_dec_ticks` values — see the design doc's
 /// [§"Park lifecycle"](../../../docs/services/star-adventurer-gti.md#park-lifecycle).
 #[derive(Debug, Clone, Copy, Default)]

--- a/services/star-adventurer-gti/src/transport_manager.rs
+++ b/services/star-adventurer-gti/src/transport_manager.rs
@@ -25,6 +25,12 @@ use crate::transport::{Transport, TransportFactory};
 
 /// Snapshot of the values the mount reports during the init handshake. All
 /// 24-bit unsigned wire values; meaningful units are in the design doc.
+///
+/// `ra_at_handshake_ticks` and `dec_at_handshake_ticks` are signed encoder
+/// positions latched at connect time. They serve as the fallback park
+/// target when the config file does not carry explicit `park_ra_ticks` /
+/// `park_dec_ticks` values — see the design doc's
+/// [§"Park lifecycle"](../../../docs/services/star-adventurer-gti.md#park-lifecycle).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MountParameters {
     pub cpr_ra: u32,
@@ -33,6 +39,8 @@ pub struct MountParameters {
     pub high_speed_ratio_ra: u32,
     pub high_speed_ratio_dec: u32,
     pub motor_board_version: u32,
+    pub ra_at_handshake_ticks: i32,
+    pub dec_at_handshake_ticks: i32,
 }
 
 /// Latest poll-loop snapshot. Updated by the background task at
@@ -483,6 +491,8 @@ impl TransportManager {
             high_speed_ratio_ra: hsr_ra,
             high_speed_ratio_dec: hsr_dec,
             motor_board_version: board,
+            ra_at_handshake_ticks: pos_ra,
+            dec_at_handshake_ticks: pos_dec,
         });
         let mut snap = self.snapshot.write().await;
         snap.ra.position_ticks = pos_ra;

--- a/services/star-adventurer-gti/tests/bdd/steps/park_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/park_steps.rs
@@ -1,8 +1,18 @@
 //! Steps for park.feature.
 
 use crate::world::StarAdventurerWorld;
-use cucumber::{then, when};
+use cucumber::{given, then, when};
+use skywatcher_motor_protocol::codec::encode_position;
 use std::time::Duration;
+
+#[given(
+    expr = "a star-adventurer service configured with park_ra_ticks {int} and park_dec_ticks {int}"
+)]
+async fn configured_with_park_ticks(world: &mut StarAdventurerWorld, park_ra: i32, park_dec: i32) {
+    world.config_mut().mount.park_ra_ticks = Some(park_ra);
+    world.config_mut().mount.park_dec_ticks = Some(park_dec);
+    world.start_service().await;
+}
 
 #[when("I park the mount")]
 async fn park_mount(world: &mut StarAdventurerWorld) {
@@ -20,6 +30,11 @@ async fn try_park_mount(world: &mut StarAdventurerWorld) {
 #[when("I unpark the mount")]
 async fn unpark_mount(world: &mut StarAdventurerWorld) {
     world.mount().unpark().await.unwrap();
+}
+
+#[when("I set the park position")]
+async fn set_park_position(world: &mut StarAdventurerWorld) {
+    world.mount().set_park().await.unwrap();
 }
 
 #[when("I try to set the park position")]
@@ -98,24 +113,24 @@ async fn k1_before_s1(world: &mut StarAdventurerWorld) {
     }
 }
 
-#[then("the mount should have received a :S1 command targeting encoder 0")]
-async fn s1_targeting_zero(world: &mut StarAdventurerWorld) {
-    // `:S1<6-byte-bias-encoded-i32>\r`. Encoder 0 = bias 0x800000 →
-    // low-byte-first hex "000080".
+#[then(expr = "the mount should have received a :S1 command targeting encoder {int}")]
+async fn s1_targeting_encoder(world: &mut StarAdventurerWorld, ticks: i32) {
     let log = world.command_log().await;
-    let want = ":S1000080\r";
+    let bytes = encode_position(ticks).expect("encode_position");
+    let want = format!(":S1{}\r", std::str::from_utf8(&bytes).unwrap());
     assert!(
-        log.iter().any(|c| c == want),
+        log.iter().any(|c| c == &want),
         "expected {want:?} in log {log:?}"
     );
 }
 
-#[then("the mount should have received a :S2 command targeting encoder 0")]
-async fn s2_targeting_zero(world: &mut StarAdventurerWorld) {
+#[then(expr = "the mount should have received a :S2 command targeting encoder {int}")]
+async fn s2_targeting_encoder(world: &mut StarAdventurerWorld, ticks: i32) {
     let log = world.command_log().await;
-    let want = ":S2000080\r";
+    let bytes = encode_position(ticks).expect("encode_position");
+    let want = format!(":S2{}\r", std::str::from_utf8(&bytes).unwrap());
     assert!(
-        log.iter().any(|c| c == want),
+        log.iter().any(|c| c == &want),
         "expected {want:?} in log {log:?}"
     );
 }
@@ -125,4 +140,23 @@ async fn no_second_s1(world: &mut StarAdventurerWorld) {
     let log = world.command_log().await;
     let s1_count = log.iter().filter(|c| c.starts_with(":S1")).count();
     assert!(s1_count <= 1, ":S1 issued {s1_count} times; log {log:?}");
+}
+
+#[then(expr = "the persisted config should have park_ra_ticks {int} and park_dec_ticks {int}")]
+async fn persisted_config_has_park_values(
+    world: &mut StarAdventurerWorld,
+    want_ra: i32,
+    want_dec: i32,
+) {
+    let cfg = world.read_persisted_config();
+    assert_eq!(
+        cfg.mount.park_ra_ticks,
+        Some(want_ra),
+        "park_ra_ticks mismatch"
+    );
+    assert_eq!(
+        cfg.mount.park_dec_ticks,
+        Some(want_dec),
+        "park_dec_ticks mismatch"
+    );
 }

--- a/services/star-adventurer-gti/tests/bdd/world.rs
+++ b/services/star-adventurer-gti/tests/bdd/world.rs
@@ -171,6 +171,19 @@ impl StarAdventurerWorld {
         self.last_error_code = Some(e.code.raw());
         self.last_error = Some(e.message.to_string());
     }
+
+    /// Re-read the config file the running service was started with and
+    /// parse it back into a [`Config`]. Used by SetPark scenarios to
+    /// assert the file was rewritten in-place.
+    pub fn read_persisted_config(&self) -> Config {
+        let dir = self
+            .temp_dir
+            .as_ref()
+            .expect("temp_dir not initialised — call start_service first");
+        let path = dir.path().join("config.json");
+        let content = std::fs::read_to_string(&path).expect("read persisted config");
+        serde_json::from_str(&content).expect("parse persisted config")
+    }
 }
 
 /// Reasonable defaults for BDD scenarios: USB transport with a mock

--- a/services/star-adventurer-gti/tests/features/device_metadata.feature
+++ b/services/star-adventurer-gti/tests/features/device_metadata.feature
@@ -2,7 +2,10 @@ Feature: Device metadata
   The mount device reports its identity, capability flags, and static
   properties via the ASCOM Alpaca HTTP API. Capability values reflect the
   MVP scope: GermanPolar alignment, Topocentric coordinates, sidereal-only
-  tracking, no PulseGuide / MoveAxis / SetPark / FindHome / Alt-Az.
+  tracking, no PulseGuide / MoveAxis / FindHome / Alt-Az. CanSetPark is
+  runtime-determined — `true` when the driver was started with `--config`
+  (the BDD harness always provides one), `false` for `Config::default()`
+  runs.
 
   Scenario: Device reports configured name
     Given a star-adventurer service configured with name "Test Mount"
@@ -48,7 +51,7 @@ Feature: Device metadata
       | CanFindHome                 | false        |
       | CanPark                     | true         |
       | CanUnpark                   | true         |
-      | CanSetPark                  | false        |
+      | CanSetPark                  | true         |
       | CanSetPierSide              | false        |
       | DoesRefraction              | false        |
 

--- a/services/star-adventurer-gti/tests/features/park.feature
+++ b/services/star-adventurer-gti/tests/features/park.feature
@@ -1,8 +1,13 @@
-Feature: Park and unpark
-  Park stops tracking, slews both axes to encoder position 0 (the mount's
-  natural power-up state), and sets AtPark when both axes report stopped.
-  Tracking remains disabled after Park (per ASCOM). Unpark clears AtPark
-  but does not auto-enable tracking. SetPark is not supported in MVP.
+Feature: Park, unpark, and SetPark
+  Park stops tracking, slews both axes to the in-memory park-target
+  encoder pair, and sets AtPark when both axes report stopped. The park
+  target is loaded on connect from `mount.park_ra_ticks` /
+  `mount.park_dec_ticks` in the config, falling back to the encoder
+  positions captured during the init handshake when those values are
+  absent. Tracking remains disabled after Park (per ASCOM). Unpark clears
+  AtPark but does not auto-enable tracking. SetPark captures the current
+  encoder pair and writes it back into the running config file via
+  atomic rename.
 
   Scenario: AtPark is false on first connect
     Given a running star-adventurer service
@@ -17,12 +22,28 @@ Feature: Park and unpark
     Then the mount should have received command :K1 before any :S1
     And Tracking should be false
 
-  Scenario: Park targets encoder zero on both axes
+  Scenario: Park targets the handshake-captured encoder pair when the config has no park values
     Given a running star-adventurer service
+    And the RA-axis encoder reads 0 ticks
+    And the Dec-axis encoder reads 0 ticks
     When I connect the device
     And I park the mount
     Then the mount should have received a :S1 command targeting encoder 0
     And the mount should have received a :S2 command targeting encoder 0
+
+  Scenario: Park targets the Dec encoder position captured at handshake
+    Given a running star-adventurer service
+    And the Dec-axis encoder reads 12000 ticks
+    When I connect the device
+    And I park the mount
+    Then the mount should have received a :S2 command targeting encoder 12000
+
+  Scenario: Park targets the configured park_ra_ticks when present
+    Given a star-adventurer service configured with park_ra_ticks 5000 and park_dec_ticks -7000
+    When I connect the device
+    And I park the mount
+    Then the mount should have received a :S1 command targeting encoder 5000
+    And the mount should have received a :S2 command targeting encoder -7000
 
   Scenario: Park is idempotent
     Given a running star-adventurer service
@@ -32,7 +53,7 @@ Feature: Park and unpark
     And I park the mount
     Then the mount should not have received a second :S1 command
 
-  Scenario: AtPark becomes true once both axes settle at encoder 0
+  Scenario: AtPark becomes true once both axes settle at the park target
     Given a running star-adventurer service
     When I connect the device
     And I park the mount
@@ -51,11 +72,18 @@ Feature: Park and unpark
     When I unpark the mount
     Then Tracking should be false
 
-  Scenario: SetPark is not implemented in MVP
+  Scenario: SetPark writes the current encoder ticks back to the config file
     Given a running star-adventurer service
+    And the RA-axis encoder reads 8000 ticks
+    And the Dec-axis encoder reads -3000 ticks
     When I connect the device
-    And I try to set the park position
-    Then the operation should fail with not-implemented
+    And I set the park position
+    Then the persisted config should have park_ra_ticks 8000 and park_dec_ticks -3000
+
+  Scenario: SetPark fails when disconnected
+    Given a running star-adventurer service
+    When I try to set the park position
+    Then the operation should fail with not-connected
 
   Scenario: Park fails while disconnected
     Given a running star-adventurer service


### PR DESCRIPTION
## Summary

Closes #203. Phase 5 of the `star-adventurer-gti` MVP: park now slews to a configurable encoder pair (config or handshake fallback) rather than the hardcoded `(0, 0)`, and `SetPark` persists the current encoder pair back into the running config file via atomic rename.

- **Park lifecycle.** `set_connected(true)` loads the in-memory park target from `mount.park_ra_ticks` / `mount.park_dec_ticks` if present in the on-disk config (re-read every connect); otherwise falls back to the encoder positions captured during the init handshake (`:j1` / `:j2`). Per-axis fallback. `park()` slews to the loaded target with `ccw` chosen from `sign(target − current)` per axis.
- **SetPark persistence.** Reads the on-disk JSON as `serde_json::Value`, mutates *only* `mount.park_ra_ticks` and `mount.park_dec_ticks`, atomic-renames via `tempfile::NamedTempFile::persist` followed by a parent-dir `fsync` on unix. The typed `Config` is never re-serialised, so CLI overrides (`--port`, `--baud`, etc.) cannot leak back into the file. Other fields are preserved as JSON values — note that this is JSON-value preservation, not byte-for-byte: `serde_json::to_string_pretty` rewrites whitespace and `serde_json::Map` is alphabetical by default, so operator formatting and key order are not retained. The *content* outside the two park keys is unchanged. I/O runs on `tokio::task::spawn_blocking`.
- **CanSetPark runtime-determined.** `true` only when the driver was started with `--config <path>`. `Config::default()` runs (no `--config`) advertise `CanSetPark = false` and return `NOT_IMPLEMENTED` from `SetPark` — ASCOM permits this, and silently dropping persistence would violate the capability contract.
- **Refusal cases.** `SetPark` also refuses when disconnected (`NOT_CONNECTED`), while `slew_in_progress` is set, or while the wire snapshot reports either axis `running` (defence in depth — covers the window between `:J` and the in-memory flag-set). `park()` and `slew_to_coordinates_async()` set `slew_in_progress = true` before issuing motion commands and roll the flag back on any error, eliminating the TOCTOU window itself.
- **Startup writability probe.** `main.rs` runs `probe_park_file_writability` on the canonicalised config path and logs `warn!` at boot if the parent directory isn't writable. Operators see misconfigured permissions early.
- **Invariant violations surface as ASCOMError, not panic.** `park()`'s read of in-memory `park_*_ticks` uses `ok_or_else` rather than `expect()` so a future logic bug surfaces a recoverable error code instead of aborting the tokio task.

## Test plan

- [x] `cargo nextest run` — 200 unit tests pass
- [x] `cargo test --test bdd` — 114 BDD scenarios pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --all --all-features --all-targets --locked` — full workspace builds

## Design doc

Updated `docs/services/star-adventurer-gti.md`:
- Capability flags table (CanSetPark is runtime-dependent)
- Writes/methods table (SetPark row no longer NOT_IMPLEMENTED)
- Park lifecycle (per-axis target resolution rules; config-file re-read each connect)
- New §"Park persistence" subsection (atomicity, blast radius, read-as-Value rationale, JSON-value preservation caveat, spawn_blocking placement, parent-dir fsync)
- Configuration JSON example + field notes
- MVP Phase status (Phase 5 added)
- Deferred table (`SetPark, CanSetPark` row removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)