### PR TITLE
feat(star-adventurer-gti): PulseGuide as rate-shifted tracking (#206)

### DIFF
--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -10,10 +10,10 @@ mount as an ASCOM Telescope for any Alpaca-compatible client (NINA, SGPro,
 `rp`, etc.).
 
 The driver implements the subset of `ITelescopeV3` that the rusty-photon
-ecosystem actually needs (slew, sync, track, park, abort, side-of-pier),
-plus the standard device metadata. PulseGuide, MoveAxis, custom tracking
-rates, and polar-alignment helpers are explicitly deferred (see [§MVP
-Scope](#mvp-scope)).
+ecosystem actually needs (slew, sync, track, park, abort, side-of-pier,
+PulseGuide), plus the standard device metadata. MoveAxis, custom
+tracking rates, and polar-alignment helpers are explicitly deferred
+(see [§MVP Scope](#mvp-scope)).
 
 [Sky-Watcher motor-controller command set]: https://inter-static.skywatcher.com/downloads/skywatcher_motor_controller_command_set.pdf
 
@@ -275,8 +275,8 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `CanSetTrackingRate` | `false` | sidereal only in MVP |
 | `CanSetRightAscensionRate` | `false` | custom rates deferred |
 | `CanSetDeclinationRate` | `false` | custom rates deferred |
-| `CanSetGuideRates` | `false` | PulseGuide deferred |
-| `CanPulseGuide` | `false` | PulseGuide deferred |
+| `CanSetGuideRates` | `true` | implemented (`GuideRateRightAscension` / `GuideRateDeclination` are independently settable in deg/sec, defaulting to `0.5 × sidereal`) |
+| `CanPulseGuide` | `true` | implemented as rate-shifted tracking (see [§PulseGuide lifecycle](#pulseguide-lifecycle)) |
 | `CanMoveAxis(any)` | `false` | manual slew deferred |
 | `CanFindHome` | `false` | no hardware home position |
 | `CanPark` | `true` | implemented (software park) |
@@ -300,6 +300,9 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `Slewing` | `true` while either axis status (`:f`) reports running in Goto mode; cleared when both stop |
 | `Tracking` | driver-state mirror of last `Tracking` setter |
 | `TrackingRate` | always `Sidereal` in MVP |
+| `GuideRateRightAscension` | RA guide rate (deg/sec). In-memory mirror of the last `SetGuideRateRightAscension` write, default `0.5 × SIDEREAL_DEG_PER_SEC ≈ 0.00209` (i.e. fraction = 0.5 of sidereal). Re-initialised to the default on each `Connected = true`. |
+| `GuideRateDeclination` | Dec guide rate (deg/sec). Same shape as RA; settable independently per ASCOM. |
+| `IsPulseGuiding` | `true` if either axis has an in-flight pulse (`pulse_guiding_ra || pulse_guiding_dec`); see [§PulseGuide lifecycle](#pulseguide-lifecycle) for the per-axis flag semantics. |
 | `AtPark` | driver-state flag; set by `Park`, cleared by `Unpark` and by any motion command |
 | `AtHome` | `false` (no hardware home concept) |
 | `SideOfPier` | derived from Dec-axis encoder + Dec-axis CPR + site latitude — canonical INDI eqmod convention (`PierSide::East` when `\|dec_encoder\| > cpr_dec/4`, i.e. Dec rotated past either celestial pole). Southern hemisphere inverts. See [§Side-of-pier](#side-of-pier) |
@@ -331,7 +334,9 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `Tracking = false` | issue `:K<RA>` (decelerate to stop). Allowed while parked — Park already left tracking off and a caller re-asserting that should not error |
 | `FindHome()` | `NOT_IMPLEMENTED` |
 | `MoveAxis(*)` | `NOT_IMPLEMENTED` |
-| `PulseGuide(*)` | `NOT_IMPLEMENTED` |
+| `PulseGuide(direction, duration)` | rate-shifted tracking pulse on the targeted axis; returns immediately after spawning the watcher task. Refuses when parked / disconnected / slewing / same-axis pulse already in flight. `duration = 0` is a no-op success. See [§PulseGuide lifecycle](#pulseguide-lifecycle) for the wire path. |
+| `SetGuideRateRightAscension(deg_per_sec)` | validate `(0, SIDEREAL_DEG_PER_SEC)` exclusive; store as fraction = `deg_per_sec / SIDEREAL_DEG_PER_SEC`. Out-of-range → `INVALID_VALUE`. |
+| `SetGuideRateDeclination(deg_per_sec)` | same shape as RA. |
 | `Action(name, parameters)` | `ACTION_NOT_IMPLEMENTED` for all action names in MVP |
 
 ### Slew lifecycle
@@ -398,6 +403,90 @@ Park()
    ├─ AtPark = true
    └─ Tracking remains false
 ```
+
+### PulseGuide lifecycle
+
+A guide pulse is a temporary rate shift on the targeted axis,
+implemented from the existing `:K` / `:G` / `:I` / `:J` tracking
+primitives — no `:P` (that's the ST4 hardware-jack rate setter, not a
+host-driven pulse command). This matches what `indi-eqmod`'s
+`GuideNorth` / `GuideSouth` / `GuideEast` / `GuideWest` do.
+
+```
+PulseGuide(direction, duration)
+   │
+   ├─ validate: !AtPark, !disconnected, !slew_in_progress,
+   │            !pulse_guiding_<targeted_axis>; duration = 0 → return Ok
+   ├─ resolve direction → (axis, ccw, rate_factor):
+   │     East  → (RA,  ccw=false, 1 - guide_rate_ra_fraction)
+   │     West  → (RA,  ccw=false, 1 + guide_rate_ra_fraction)
+   │     North → (Dec, ccw=false, guide_rate_dec_fraction)
+   │     South → (Dec, ccw=true,  guide_rate_dec_fraction)
+   ├─ compute shifted period:
+   │     period = round(sidereal_step_period(tmr_freq, cpr_ra) / rate_factor)
+   ├─ capture tracking_was_on = state.tracking_requested (RA pulses only)
+   ├─ set pulse_guiding_<axis> = true                ; synchronous, pre-spawn
+   │
+   ├─ on the wire (in PulseGuide call thread):
+   │     :K<axis>           stop and wait for running flag clear
+   │     :G<axis> TRACKING + ccw
+   │     :I<axis> period
+   │     :J<axis>
+   │
+   ├─ spawn watcher task:
+   │     tokio::sleep(duration)
+   │     if !pulse_guiding_<axis>      → bail (external cancellation)
+   │     if !transport.is_available()  → clear flag, bail
+   │     if state.at_park || slew_in_progress → clear flag, bail
+   │     ── otherwise restore prior state:
+   │     RA  pulse: :K1 + stop-and-wait, then
+   │                if tracking_was_on:
+   │                    :G1 TRACKING (ccw=false)
+   │                    :I1 sidereal_period
+   │                    :J1
+   │     Dec pulse: :K2 + stop-and-wait (Dec is normally idle; no restore)
+   │     clear pulse_guiding_<axis>
+   │
+   └─ return immediately to the Alpaca caller
+```
+
+`IsPulseGuiding` returns `pulse_guiding_ra || pulse_guiding_dec` —
+perpendicular pulses (one RA + one Dec) run concurrently; a same-axis
+re-pulse while one is in flight is rejected with `INVALID_OPERATION`.
+
+**Cross-cutting cancellation rule.** Any operation that mutates a given
+axis — `set_tracking`, `slew_to_coordinates_async`, `park`,
+`abort_slew`, `sync_to_coordinates`, `set_connected(false)` — clears
+the corresponding `pulse_guiding_<axis>` flag *before* issuing its own
+wire commands. The watcher's post-sleep restore step checks the flag
+and bails out if cleared, so the new operation owns the axis without
+racing the watcher. Without this, `set_tracking(false)` during an East
+pulse would be silently undone when the watcher re-issued sidereal
+tracking on restore.
+
+**Dec sign convention.** `+Dec` always maps to `ccw=false`, regardless
+of side-of-pier. The driver does not invert Dec direction after a
+meridian flip — the existing slew/sync pipeline doesn't either; it
+assumes a stable encoder-to-celestial-Dec mapping and requires the
+user to `SyncToCoordinates` after a manual flip to recalibrate. A
+PulseGuide call after a flip with no re-sync will guide in the wrong
+celestial direction; this is consistent with the rest of the driver
+and is the autoguider's responsibility to detect (via guide
+calibration).
+
+**Step-period unit reuse.** `sidereal_step_period(tmr_freq, cpr_ra)`
+is also used for the Dec rate computation. The protocol's step-period
+units are timer-counter ticks per motor step on both axes, and
+`cpr_ra` ≈ `cpr_dec` on the GTi, so reusing the helper avoids a near-
+duplicate `sidereal_step_period_dec`. INDI takes the same shortcut.
+
+**Guide-rate fraction validation.** Internal storage is two fractions
+in `(0.0, 1.0)` open interval (RA and Dec independently). The
+exclusive upper bound matters: `fraction = 1.0` makes East's
+`rate_factor = 0`, which divides by zero in the period formula. INDI
+clamps at 0.9 for the same reason. ASCOM clients see deg/sec through
+`GuideRateRightAscension` / `GuideRateDeclination`; the setter
+validates `(0, SIDEREAL_DEG_PER_SEC)` and converts to fraction.
 
 ### Side-of-pier
 
@@ -593,7 +682,7 @@ ConformU verifies ASCOM compliance.
 | Service unit tests (`#[cfg(test)]` per module) | `coordinates`: encoder ↔ RA/Dec across edge cases (poles, meridian, hemisphere flip); `config`: defaults, JSON round-trips, CLI overrides; `error`: ASCOM mapping |
 | Service BDD (cucumber) | every behaviour table-row above as a scenario, with the mock transport |
 | Service `test_lib.rs` (gated on `mock`) | server starts, binds the configured port, exposes the configured device |
-| `conformu_integration.rs` (gated on `conformu`) | ASCOM Telescope compliance via `ConformUTestBuilder::run()` — same shape as `qhy-focuser`. Currently **not wired into the nightly `conformu` workflow** (no `[package.metadata.conformu]` opt-in); see [§"Running ConformU manually"](#running-conformu-manually) for why and how to drive it by hand until `PulseGuide` is implemented |
+| `conformu_integration.rs` (gated on `conformu`) | ASCOM Telescope compliance via `ConformUTestBuilder::run()` — runs both `alpacaprotocol` and `conformance` phases. Wired into the nightly `conformu` workflow via `[package.metadata.conformu]` in `Cargo.toml`. See [§"Expected ConformU report"](#expected-conformu-report) for the known deferred-by-design / upstream issues. |
 
 The mock transport is a feature-gated in-memory state machine that
 simulates the motor controller — it accepts the same `:cmd<axis>...\r`
@@ -607,39 +696,9 @@ walks toward `goto_target_ticks` and clears `running` on arrival. BDD
 tests use the mock by default; ConformU and `test_lib.rs` use the
 feature-gated mock so the binary itself runs against a fake mount.
 
-### Running ConformU manually
+### Expected ConformU report
 
-This service is deliberately **not** in the nightly `conformu`
-workflow rotation. `ConformUTestBuilder::run()` (which the
-in-tree integration test uses, matching `qhy-focuser`) runs two
-phases in sequence: `alpacaprotocol` then `conformance`. The
-`alpacaprotocol` phase polls `IsPulseGuiding` while exercising
-`PulseGuide` PUT-parameter-order tests *even when
-`CanPulseGuide=false`*, and treats the spec-mandated
-`NotImplementedException` from `IsPulseGuiding` as a fatal
-protocol-test failure. The right structural fix is implementing
-`PulseGuide` so `CanPulseGuide` flips to `true` and the polling
-stops being a problem; until then the integration test cannot
-be wired in without either deviating the driver from the ASCOM
-spec or carrying a non-standard test harness that diverges from
-the other services. Neither is wanted. Re-add
-`[package.metadata.conformu]` in `services/star-adventurer-gti/Cargo.toml`
-once PulseGuide lands.
-
-In the meantime, run ConformU's `conformance` phase by hand:
-
-```bash
-# Terminal 1: start the service in mock mode on a fixed port.
-cargo run -p star-adventurer-gti --features mock -- \
-    --config services/star-adventurer-gti/conformu-test-config.json \
-    -l info
-
-# Terminal 2: drive ConformU against it.
-conformu conformance \
-    http://localhost:11117/api/v1/telescope/0
-```
-
-Expect the conformance run to report:
+A clean nightly ConformU run against this driver reports:
 
 - **0 errors** — anything here is a real driver regression.
 - **7 issues**, all of which are cosmetic / inherent to a
@@ -702,11 +761,6 @@ Any issue or error outside that list — and in particular any
 ("`Actual RA: ..., Target RA: ...`" with > 10″ delta) — is a
 real regression. Fix the driver, then refresh this section.
 
-> Note: `conformu alpacaprotocol …` against this service will
-> abort with a fatal `IsPulseGuiding` `NotImplementedException`
-> until `PulseGuide` is implemented. That is the upstream
-> ConformU bug above and is expected.
-
 ## Connection Lifecycle
 
 ```
@@ -758,7 +812,8 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase 3 — Implementation** | ✓ landed: codec, transports (USB+UDP), `MountDevice`, ConformU integration (PR #188); BDD step bodies + `@wip` removal (PR #189). All 9 feature files / 77 scenarios green on Linux/Windows/macOS CI. |
 | **Phase 4 — Real-hardware bringup** | partially landed — first hardware connect surfaced several protocol-decoding gaps that the mock had hidden. Details below. |
 | **Phase A5 — `:I`/`:M` on slew + EQMOD pickup** | landed (issue #205) — reinstates `:I` on the slew path, switches goto to `:H` (delta target) + `:M` (break-point), and adds an iterative post-stop pickup loop to close the residual RA drift the Phase 4 ConformU run flagged. |
-| **Phase A6 — Dec-encoder `SideOfPier` + `DestinationSideOfPier`** | landed (issue #202) — switches `SideOfPier` from the RA mech-HA split at `HA = 0` to the canonical INDI eqmod Dec-encoder convention (`East` when `\|dec_encoder\| > cpr_dec/4`), and lands `DestinationSideOfPier` reusing the same coordinate-math pipeline as `SlewToCoordinatesAsync`. ConformU expected-issues count moves from 9 to 7: the `DestinationSideOfPier` NotImplemented entry and the four inherited `SOPPierTest` entries clear, the two upstream `TrackingRate Write` entries disappear (unrelated framework fix), and three new "non-flipping mount" entries appear that reflect ConformU's flip-aware-GEM assumption rather than driver bugs. See §"Running ConformU manually". |
+| **Phase A6 — Dec-encoder `SideOfPier` + `DestinationSideOfPier`** | landed (issue #202) — switches `SideOfPier` from the RA mech-HA split at `HA = 0` to the canonical INDI eqmod Dec-encoder convention (`East` when `\|dec_encoder\| > cpr_dec/4`), and lands `DestinationSideOfPier` reusing the same coordinate-math pipeline as `SlewToCoordinatesAsync`. ConformU expected-issues count moves from 9 to 7: the `DestinationSideOfPier` NotImplemented entry and the four inherited `SOPPierTest` entries clear, the two upstream `TrackingRate Write` entries disappear (unrelated framework fix), and three new "non-flipping mount" entries appear that reflect ConformU's flip-aware-GEM assumption rather than driver bugs. See [§Expected ConformU report](#expected-conformu-report). |
+| **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`, and re-enables `[package.metadata.conformu]` so the full two-phase ConformU integration runs again. |
 
 #### Phase 4 findings (hardware bringup)
 
@@ -978,7 +1033,6 @@ What's still outstanding from Phase 4:
 
 | Capability | Why deferred |
 |---|---|
-| `PulseGuide`, `CanPulseGuide`, `GuideRate*` | autoguiding via the mount's ST4-equivalent — protocol command exists (`P`) but driver-side rate calibration plus BDD coverage is a substantial extension; PHD2 already drives guide pulses through `phd2-guider`'s direct-mount path, so no rp-side dependency |
 | `MoveAxis`, `CanMoveAxis(*)` | manual hand-paddle-style slew rates; not needed by `rp`; deferred along with custom tracking rates |
 | `SlewToAltAz*`, `SyncToAltAz`, `CanSlewAltAz*` | RA/Dec coverage is sufficient for `rp`'s tools; Alt/Az slew is a separate path through the coordinate module |
 | `RightAscensionRate`, `DeclinationRate` setters | custom-rate tracking; not needed for sidereal-only MVP |

--- a/services/star-adventurer-gti/Cargo.toml
+++ b/services/star-adventurer-gti/Cargo.toml
@@ -35,18 +35,8 @@ axum = { workspace = true }
 erfars = { workspace = true }
 chrono = { workspace = true }
 
-# Intentionally NOT opting in to the nightly ConformU workflow via
-# `[package.metadata.conformu]`: ConformU's `alpacaprotocol` phase
-# polls `IsPulseGuiding` while exercising `PulseGuide` PUT-parameter
-# tests *even when `CanPulseGuide=false`*, and treats the
-# spec-mandated `NotImplementedException` from `IsPulseGuiding` as a
-# fatal protocol-test failure. Working around it would require
-# either a driver-side spec deviation (returning `Ok(false)` from
-# `IsPulseGuiding`, which other services don't do) or a non-standard
-# custom test harness. Neither is wanted. Re-add the
-# `[package.metadata.conformu]` entry when PulseGuide is implemented
-# and `CanPulseGuide=true`. Until then, run ConformU manually — see
-# `docs/services/star-adventurer-gti.md` §"Running ConformU manually".
+[package.metadata.conformu]
+command = "cargo test -p star-adventurer-gti --features conformu --test conformu_integration -- --ignored --nocapture"
 
 [dev-dependencies]
 bdd-infra = { workspace = true }

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -255,6 +255,38 @@ pub fn sidereal_step_period(tmr_freq: u32, cpr_ra: u32) -> u32 {
     ((tmr_freq as f64) * sidereal_seconds / (cpr_ra as f64)).round() as u32
 }
 
+/// Sidereal rate in degrees per second.
+///
+/// `360° / 86164.0905 s ≈ 4.17807e-3 deg/sec ≈ 15.04108″/sec`. ASCOM
+/// `GuideRateRightAscension` / `GuideRateDeclination` are expressed in
+/// these units; internally the driver uses a fraction of sidereal in
+/// `(0, 1)` for the rate-shift math.
+pub const SIDEREAL_DEG_PER_SEC: f64 = 360.0 / 86164.0905;
+
+/// Rate-shifted step period for a PulseGuide burst, in timer-counter
+/// units (the same units `:I` takes).
+///
+/// `rate_factor` is the target rate as a multiple of sidereal:
+///   - East  → `1.0 - ra_fraction` (RA tracking slowed)
+///   - West  → `1.0 + ra_fraction` (RA tracking sped up)
+///   - North → `dec_fraction`      (Dec spun from zero)
+///   - South → `dec_fraction`
+///
+/// Step period scales inversely with rate
+/// (`period = sidereal_period / rate_factor`).
+///
+/// The caller is responsible for keeping `rate_factor` strictly
+/// positive — `pulse_guide`'s upstream validation rejects a guide-rate
+/// fraction outside `(0, 1)`, so the East formula `1 - fraction`
+/// stays in `(0, 1)` and never zeroes the divisor.
+pub fn pulse_guide_step_period(sidereal_period: u32, rate_factor: f64) -> u32 {
+    debug_assert!(
+        rate_factor > 0.0,
+        "rate_factor must be positive (got {rate_factor})"
+    );
+    ((sidereal_period as f64) / rate_factor).round() as u32
+}
+
 /// Fold a value into `[-period/2, +period/2)`. Used by both the RA and
 /// Dec encoder mappings.
 fn fold_to_signed(value: f64, period: f64) -> f64 {
@@ -529,6 +561,54 @@ mod tests {
         assert!(
             (d2 - 2 * d1).abs() <= 1,
             "expected ~2× scaling: 200ms→{d1}, 400ms→{d2}"
+        );
+    }
+
+    #[test]
+    fn pulse_guide_step_period_identity_at_unit_rate_factor() {
+        // Rate factor = 1.0 reproduces the sidereal period exactly
+        // (modulo rounding to integer).
+        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        assert_eq!(pulse_guide_step_period(p_sid, 1.0), p_sid);
+    }
+
+    #[test]
+    fn pulse_guide_step_period_halves_rate_doubles_period() {
+        // Rate factor = 0.5 (Dec North/South at fraction = 0.5, or East
+        // at fraction = 0.5) doubles the step period.
+        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let shifted = pulse_guide_step_period(p_sid, 0.5);
+        assert_eq!(shifted, 2 * p_sid);
+    }
+
+    #[test]
+    fn pulse_guide_step_period_west_at_fraction_half_uses_one_and_a_half_rate() {
+        // West at fraction = 0.5 → rate_factor = 1.5 → period = P_sid / 1.5.
+        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let shifted = pulse_guide_step_period(p_sid, 1.5);
+        let expected = ((p_sid as f64) / 1.5).round() as u32;
+        assert_eq!(shifted, expected);
+        // Sanity: must be smaller than sidereal (faster rate ⇒ shorter
+        // period).
+        assert!(shifted < p_sid);
+    }
+
+    #[test]
+    fn pulse_guide_step_period_small_fraction_grows_period_proportionally() {
+        // fraction = 0.1 on Dec → rate_factor = 0.1 → period = 10 × sidereal.
+        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let shifted = pulse_guide_step_period(p_sid, 0.1);
+        assert_eq!(shifted, 10 * p_sid);
+    }
+
+    #[test]
+    fn sidereal_deg_per_sec_is_about_fifteen_arcseconds_per_second() {
+        // Cross-check the constant against the textbook value: sidereal
+        // rate ≈ 15.04108″/sec.
+        let arcsec_per_sec = SIDEREAL_DEG_PER_SEC * 3600.0;
+        assert!(
+            (arcsec_per_sec - 15.04108).abs() < 1e-4,
+            "expected ~15.04108″/sec, got {arcsec_per_sec}"
         );
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -12,12 +12,13 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use ascom_alpaca::api::telescope::{
-    AlignmentMode, DriveRate, EquatorialCoordinateType, PierSide, Telescope, TelescopeAxis,
+    AlignmentMode, DriveRate, EquatorialCoordinateType, GuideDirection, PierSide, Telescope,
+    TelescopeAxis,
 };
 use ascom_alpaca::api::Device;
 use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
 use async_trait::async_trait;
-use skywatcher_motor_protocol::command::MotionMode;
+use skywatcher_motor_protocol::command::{ModeKind, MotionMode, Speed};
 use skywatcher_motor_protocol::{Axis, Command};
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -25,16 +26,22 @@ use tracing::debug;
 use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, dec_ticks_to_degrees, local_sidereal_time_hours, mechanical_ha_to_ra,
-    mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, ra_dec_to_alt_az, ra_ticks_to_mechanical_ha,
-    ra_to_mechanical_ha, side_of_pier as side_of_pier_calc, sidereal_step_period,
+    mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
+    ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, side_of_pier as side_of_pier_calc,
+    sidereal_step_period, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::TransportManager;
 
+/// Default guide rate as a fraction of sidereal. ASCOM clients see
+/// this multiplied by `SIDEREAL_DEG_PER_SEC` through
+/// `GuideRateRightAscension` / `GuideRateDeclination`.
+const DEFAULT_GUIDE_RATE_FRACTION: f64 = 0.5;
+
 /// In-memory mirror of latched-from-the-client state (Tracking enabled,
 /// AtPark flag, last target). The values that come from the wire (current
 /// RA/Dec, Slewing) are read through [`TransportManager`].
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct DriverState {
     tracking_requested: bool,
     at_park: bool,
@@ -47,6 +54,36 @@ struct DriverState {
     /// flags so callers see "still slewing" until the watcher signals
     /// otherwise.
     slew_in_progress: bool,
+    /// PulseGuide rate on the RA axis as a fraction of sidereal in
+    /// `(0, 1)`. `GuideRateRightAscension` is this × `SIDEREAL_DEG_PER_SEC`.
+    /// Resets to [`DEFAULT_GUIDE_RATE_FRACTION`] on each disconnect.
+    guide_rate_ra_fraction: f64,
+    guide_rate_dec_fraction: f64,
+    /// `true` between issuing a PulseGuide on this axis and the
+    /// watcher clearing the flag after the pulse `duration` has
+    /// elapsed (or earlier, via the cancellation rule — any
+    /// axis-mutating operation clears the flag before issuing its own
+    /// wire commands so the watcher's post-sleep restore bails out).
+    /// See §"PulseGuide lifecycle" in the design doc.
+    pulse_guiding_ra: bool,
+    pulse_guiding_dec: bool,
+}
+
+impl Default for DriverState {
+    fn default() -> Self {
+        Self {
+            tracking_requested: false,
+            at_park: false,
+            target_ra_hours: None,
+            target_dec_degrees: None,
+            slew_settle_time: None,
+            slew_in_progress: false,
+            guide_rate_ra_fraction: DEFAULT_GUIDE_RATE_FRACTION,
+            guide_rate_dec_fraction: DEFAULT_GUIDE_RATE_FRACTION,
+            pulse_guiding_ra: false,
+            pulse_guiding_dec: false,
+        }
+    }
 }
 
 pub struct MountDevice {
@@ -348,6 +385,30 @@ async fn pickup_reslew_axis(transport: &TransportManager, axis: Axis, delta: i32
     }
 }
 
+/// Validate an ASCOM `GuideRate*` setter value (deg/sec) and return
+/// the equivalent fraction of sidereal. Rejects values outside the
+/// open interval `(0, SIDEREAL_DEG_PER_SEC)`:
+///
+/// - `≤ 0` is non-physical (zero rate = no motion; negative = wrong
+///   direction).
+/// - `≥ SIDEREAL_DEG_PER_SEC` would push East's `rate_factor = 1 -
+///   fraction` to zero or negative, which divides by zero in the
+///   step-period formula. INDI's eqmod driver imposes the same upper
+///   bound for the same reason.
+fn validate_guide_rate(deg_per_sec: f64) -> ASCOMResult<f64> {
+    let fraction = deg_per_sec / SIDEREAL_DEG_PER_SEC;
+    if !fraction.is_finite() || fraction <= 0.0 || fraction >= 1.0 {
+        return Err(ASCOMError::new(
+            ASCOMErrorCode::INVALID_VALUE,
+            format!(
+                "guide rate {deg_per_sec} deg/sec is outside the supported \
+                 range (0, {SIDEREAL_DEG_PER_SEC})"
+            ),
+        ));
+    }
+    Ok(fraction)
+}
+
 #[async_trait]
 impl Device for MountDevice {
     fn static_name(&self) -> &str {
@@ -395,11 +456,21 @@ impl Device for MountDevice {
             // Keep `at_park` — Phase 4 may persist it across sessions
             // by reading the encoder; for now leaving it as-is matches
             // ASCOM's "AtPark reflects mechanical state" intent.
+            //
+            // Reset guide rates to the default — the design doc says
+            // they re-initialise on each `Connected = true`, matching
+            // INDI's behaviour. Doing the reset on disconnect (instead
+            // of on the next connect) is symmetric with the other
+            // per-session clears here.
             let mut s = self.state.write().await;
             s.target_ra_hours = None;
             s.target_dec_degrees = None;
             s.tracking_requested = false;
             s.slew_in_progress = false;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
+            s.guide_rate_ra_fraction = DEFAULT_GUIDE_RATE_FRACTION;
+            s.guide_rate_dec_fraction = DEFAULT_GUIDE_RATE_FRACTION;
         }
         debug!(connected, "set_connected");
         Ok(())
@@ -442,6 +513,12 @@ impl Telescope for MountDevice {
         Ok(true)
     }
     async fn can_unpark(&self) -> ASCOMResult<bool> {
+        Ok(true)
+    }
+    async fn can_pulse_guide(&self) -> ASCOMResult<bool> {
+        Ok(true)
+    }
+    async fn can_set_guide_rates(&self) -> ASCOMResult<bool> {
         Ok(true)
     }
     async fn does_refraction(&self) -> ASCOMResult<bool> {
@@ -543,6 +620,13 @@ impl Telescope for MountDevice {
 
     async fn set_tracking(&self, tracking: bool) -> ASCOMResult<()> {
         self.ensure_connected().await?;
+        // Cancel any in-flight RA pulse before mutating the RA axis.
+        // The pulse-guide watcher's post-sleep restore step checks
+        // `pulse_guiding_ra` and bails if cleared. Without this,
+        // `set_tracking(false)` during an East/West pulse would be
+        // silently undone when the watcher re-issued sidereal tracking
+        // on restore.
+        self.state.write().await.pulse_guiding_ra = false;
         if tracking {
             // Enabling tracking while parked is invalid per ASCOM
             // ITelescopeV3. Disabling tracking while parked stays
@@ -725,6 +809,14 @@ impl Telescope for MountDevice {
         self.ensure_connected().await?;
         Self::validate_coordinates(ra, dec)?;
         self.ensure_unparked().await?;
+        // Cancel any in-flight pulse-guide on either axis — sync is
+        // an axis-position mutation and we don't want the watcher
+        // restoring tracking against the freshly-set encoder position.
+        {
+            let mut s = self.state.write().await;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
+        }
         let params = self
             .transport
             .parameters()
@@ -796,7 +888,9 @@ impl Telescope for MountDevice {
             .ok_or(ASCOMError::NOT_CONNECTED)?;
 
         // Latch the target + capture the tracking flag so the
-        // completion watcher knows whether to auto-restore. We do NOT
+        // completion watcher knows whether to auto-restore. Also
+        // cancel any in-flight pulse-guide on either axis (the slew
+        // takes ownership of both axes from this point). We do NOT
         // clear `tracking_requested` here: if any of the StopMotion /
         // SetMotionMode / ... sends below fail, the in-memory state
         // would falsely report tracking-off while the wire is still
@@ -808,6 +902,8 @@ impl Telescope for MountDevice {
             s.target_ra_hours = Some(ra);
             s.target_dec_degrees = Some(dec);
             tracking_was_on = s.tracking_requested;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
         }
 
         // Compute target encoder ticks for the *current* LST. INDI's
@@ -912,6 +1008,14 @@ impl Telescope for MountDevice {
         if self.state.read().await.at_park {
             return Ok(());
         }
+        // Cancel any in-flight pulse-guide — park takes ownership of
+        // both axes. Watchers see the cleared flags on post-sleep and
+        // bail out without restoring.
+        {
+            let mut s = self.state.write().await;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
+        }
         // Stop tracking before slewing home (per ASCOM, tracking remains
         // off after Park). The wire `:K1` is issued first so the in-memory
         // flag flip only follows a successful stop.
@@ -992,6 +1096,13 @@ impl Telescope for MountDevice {
             let mut s = self.state.write().await;
             s.slew_in_progress = false;
             s.tracking_requested = false;
+            // Cancel any in-flight pulse-guide on either axis. The
+            // watcher's post-sleep restore step bails when it sees the
+            // flag cleared; `:L1`/`:L2` below already halt any
+            // rate-shifted motion, so there's nothing for the watcher
+            // to restore.
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
         }
         // Issue :L on both axes (instant stop). Log the underlying
         // transport error if either send fails — silent failure here
@@ -1020,6 +1131,133 @@ impl Telescope for MountDevice {
 
     async fn set_slew_settle_time(&self, slew_settle_time: Duration) -> ASCOMResult<()> {
         self.state.write().await.slew_settle_time = Some(slew_settle_time);
+        Ok(())
+    }
+
+    // ---- PulseGuide ----
+
+    async fn is_pulse_guiding(&self) -> ASCOMResult<bool> {
+        let s = self.state.read().await;
+        Ok(s.pulse_guiding_ra || s.pulse_guiding_dec)
+    }
+
+    async fn guide_rate_right_ascension(&self) -> ASCOMResult<f64> {
+        let f = self.state.read().await.guide_rate_ra_fraction;
+        Ok(f * SIDEREAL_DEG_PER_SEC)
+    }
+
+    async fn set_guide_rate_right_ascension(
+        &self,
+        guide_rate_right_ascension: f64,
+    ) -> ASCOMResult<()> {
+        let fraction = validate_guide_rate(guide_rate_right_ascension)?;
+        self.state.write().await.guide_rate_ra_fraction = fraction;
+        Ok(())
+    }
+
+    async fn guide_rate_declination(&self) -> ASCOMResult<f64> {
+        let f = self.state.read().await.guide_rate_dec_fraction;
+        Ok(f * SIDEREAL_DEG_PER_SEC)
+    }
+
+    async fn set_guide_rate_declination(&self, guide_rate_declination: f64) -> ASCOMResult<()> {
+        let fraction = validate_guide_rate(guide_rate_declination)?;
+        self.state.write().await.guide_rate_dec_fraction = fraction;
+        Ok(())
+    }
+
+    async fn pulse_guide(&self, direction: GuideDirection, duration: Duration) -> ASCOMResult<()> {
+        self.ensure_connected().await?;
+        self.ensure_unparked().await?;
+        if self.slewing().await? {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "PulseGuide refused while slewing",
+            ));
+        }
+        // Duration zero is a no-op success per ASCOM convention. Skip
+        // before resolving direction / acquiring locks to keep the
+        // hot-path predictable.
+        if duration.is_zero() {
+            return Ok(());
+        }
+        // Resolve direction → (axis, ccw, rate_factor) and capture the
+        // `tracking_was_on` snapshot under a single read lock. Same
+        // read also catches a same-axis pulse already in flight.
+        let (axis, ccw, rate_factor, tracking_was_on) = {
+            let s = self.state.read().await;
+            let (axis, ccw, rate_factor) = match direction {
+                GuideDirection::East => (Axis::Ra, false, 1.0 - s.guide_rate_ra_fraction),
+                GuideDirection::West => (Axis::Ra, false, 1.0 + s.guide_rate_ra_fraction),
+                GuideDirection::North => (Axis::Dec, false, s.guide_rate_dec_fraction),
+                GuideDirection::South => (Axis::Dec, true, s.guide_rate_dec_fraction),
+            };
+            let in_flight = match axis {
+                Axis::Ra => s.pulse_guiding_ra,
+                Axis::Dec => s.pulse_guiding_dec,
+                Axis::Both => false,
+            };
+            if in_flight {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "PulseGuide refused while a same-axis pulse is in flight",
+                ));
+            }
+            let tracking_was_on = axis == Axis::Ra && s.tracking_requested;
+            (axis, ccw, rate_factor, tracking_was_on)
+        };
+        // Compute the shifted step period from the cached
+        // sidereal-period helper and the rate factor.
+        let params = self
+            .transport
+            .parameters()
+            .await
+            .ok_or(ASCOMError::NOT_CONNECTED)?;
+        let sidereal_period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
+        let shifted_period = pulse_guide_step_period(sidereal_period, rate_factor);
+        // Wire path: `:K<axis>` (and wait for the running flag to clear
+        // so `:G` doesn't return `!2 MotorNotStopped`), `:G<axis>`
+        // (Tracking + ccw), `:I<axis>` (shifted period), `:J<axis>`.
+        self.stop_and_wait(axis).await?;
+        let mode = MotionMode {
+            kind: ModeKind::Tracking,
+            speed: Speed::Slow,
+            ccw,
+        };
+        self.transport
+            .send(Command::SetMotionMode { axis, mode })
+            .await
+            .map_err(Self::ascom)?;
+        self.transport
+            .send(Command::SetStepPeriod {
+                axis,
+                period: shifted_period,
+            })
+            .await
+            .map_err(Self::ascom)?;
+        self.transport
+            .send(Command::StartMotion(axis))
+            .await
+            .map_err(Self::ascom)?;
+        // Set the in-flight flag synchronously before spawning so a
+        // client that polls `IsPulseGuiding` immediately after
+        // `PulseGuide` returns sees `true` even for sub-poll durations.
+        {
+            let mut s = self.state.write().await;
+            match axis {
+                Axis::Ra => s.pulse_guiding_ra = true,
+                Axis::Dec => s.pulse_guiding_dec = true,
+                Axis::Both => {}
+            }
+        }
+        spawn_pulse_guide_watcher(
+            Arc::clone(&self.state),
+            Arc::clone(&self.transport),
+            axis,
+            duration,
+            tracking_was_on,
+        );
+        debug!(?direction, ?duration, axis = ?axis, "pulse_guide spawned");
         Ok(())
     }
 }
@@ -1421,6 +1659,98 @@ fn spawn_park_completion_watcher(
             return;
         }
     });
+}
+
+/// Spawn the PulseGuide watcher.
+///
+/// Sleeps for `duration`, then restores prior state on the targeted
+/// axis:
+/// - **RA pulse**: stop-and-wait, then if `tracking_was_on_for_restore`
+///   re-issue `:G1 TRACKING` + `:I1 sidereal_period` + `:J1` so the
+///   user-observable `Tracking` state survives the pulse.
+/// - **Dec pulse**: stop-and-wait (Dec is normally idle; no restore).
+///
+/// The watcher checks the per-axis `pulse_guiding_<axis>` flag before
+/// the restore step and bails out if cleared (the cancellation rule:
+/// any axis-mutating call clears the flag before its own wire commands
+/// so the watcher steps aside). Errors during the restore are logged
+/// at `warn` and swallowed — matches [`pickup_reslew_axis`].
+fn spawn_pulse_guide_watcher(
+    state: Arc<RwLock<DriverState>>,
+    transport: Arc<TransportManager>,
+    axis: Axis,
+    duration: Duration,
+    tracking_was_on_for_restore: bool,
+) {
+    tokio::spawn(async move {
+        tokio::time::sleep(duration).await;
+        // Bail if the pulse was cancelled externally (another op
+        // cleared the flag), the transport dropped, or the mount
+        // entered a state that takes ownership of the axis
+        // (slew/park).
+        let still_active = {
+            let s = state.read().await;
+            let active = match axis {
+                Axis::Ra => s.pulse_guiding_ra,
+                Axis::Dec => s.pulse_guiding_dec,
+                Axis::Both => false,
+            };
+            active && !s.at_park && !s.slew_in_progress
+        };
+        if !still_active || !transport.is_available() {
+            clear_pulse_flag(&state, axis).await;
+            return;
+        }
+        // Stop the axis. Any failure here means we can't safely restore
+        // either, so log and bail.
+        if let Err(e) = stop_axis_and_wait(&transport, axis, AXIS_STOP_TIMEOUT).await {
+            tracing::warn!("pulse-guide restore stop {axis:?} failed: {e}");
+            clear_pulse_flag(&state, axis).await;
+            return;
+        }
+        // RA-only: re-issue sidereal tracking iff the user had it on
+        // at issue time. Dec just stays stopped (Dec is normally idle).
+        if axis == Axis::Ra && tracking_was_on_for_restore {
+            // Re-check the cancellation flag before issuing the restore
+            // commands — a concurrent set_tracking(false) between the
+            // stop above and here would otherwise be silently undone.
+            let still_want_restore = state.read().await.pulse_guiding_ra;
+            if still_want_restore {
+                if let Some(params) = transport.parameters().await {
+                    let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
+                    if let Err(e) = transport
+                        .send(Command::SetMotionMode {
+                            axis: Axis::Ra,
+                            mode: MotionMode::TRACKING,
+                        })
+                        .await
+                    {
+                        tracing::warn!("pulse-guide restore :G1 failed: {e}");
+                    } else if let Err(e) = transport
+                        .send(Command::SetStepPeriod {
+                            axis: Axis::Ra,
+                            period,
+                        })
+                        .await
+                    {
+                        tracing::warn!("pulse-guide restore :I1 failed: {e}");
+                    } else if let Err(e) = transport.send(Command::StartMotion(Axis::Ra)).await {
+                        tracing::warn!("pulse-guide restore :J1 failed: {e}");
+                    }
+                }
+            }
+        }
+        clear_pulse_flag(&state, axis).await;
+    });
+}
+
+async fn clear_pulse_flag(state: &Arc<RwLock<DriverState>>, axis: Axis) {
+    let mut s = state.write().await;
+    match axis {
+        Axis::Ra => s.pulse_guiding_ra = false,
+        Axis::Dec => s.pulse_guiding_dec = false,
+        Axis::Both => {}
+    }
 }
 
 #[cfg(all(test, feature = "mock"))]
@@ -2506,5 +2836,333 @@ mod tests {
         // here we never reach it because `stop_axis_and_wait` fails
         // first. Still useful to verify no panic.
         pickup_reslew_axis(&manager, Axis::Dec, -1_000_000).await;
+    }
+
+    // ---- PulseGuide tests ----
+
+    #[tokio::test]
+    async fn pulse_guide_capability_flags_are_true() {
+        let d = device();
+        assert!(d.can_pulse_guide().await.unwrap());
+        assert!(d.can_set_guide_rates().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_pulse_guiding_defaults_to_false_after_connect() {
+        let d = connected_device().await;
+        assert!(!d.is_pulse_guiding().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn default_guide_rates_are_half_sidereal() {
+        let d = connected_device().await;
+        let ra = d.guide_rate_right_ascension().await.unwrap();
+        let dec = d.guide_rate_declination().await.unwrap();
+        // 0.5 × SIDEREAL_DEG_PER_SEC ≈ 0.00208904
+        let expected = 0.5 * SIDEREAL_DEG_PER_SEC;
+        assert!((ra - expected).abs() < 1e-9, "RA: {ra}");
+        assert!((dec - expected).abs() < 1e-9, "Dec: {dec}");
+    }
+
+    #[tokio::test]
+    async fn set_guide_rate_ra_round_trips_through_fraction() {
+        let d = connected_device().await;
+        let target = 0.001_f64;
+        d.set_guide_rate_right_ascension(target).await.unwrap();
+        let got = d.guide_rate_right_ascension().await.unwrap();
+        assert!(
+            (got - target).abs() < 1e-9,
+            "round-trip: set {target}, got {got}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_guide_rate_rejects_zero_and_negative() {
+        let d = connected_device().await;
+        let err = d.set_guide_rate_right_ascension(0.0).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+        let err = d.set_guide_rate_declination(-0.001).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+    }
+
+    #[tokio::test]
+    async fn set_guide_rate_rejects_at_or_above_sidereal() {
+        // Upper bound is exclusive — fraction = 1.0 zeroes East's
+        // rate factor (`1 - fraction`) and divides by zero in the
+        // step-period formula.
+        let d = connected_device().await;
+        let err = d
+            .set_guide_rate_right_ascension(SIDEREAL_DEG_PER_SEC)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+        let err = d
+            .set_guide_rate_right_ascension(SIDEREAL_DEG_PER_SEC * 2.0)
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_refuses_while_disconnected() {
+        let d = device();
+        let err = d
+            .pulse_guide(GuideDirection::North, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::NOT_CONNECTED);
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_zero_duration_is_no_op() {
+        // Asserting "no wire activity" via the capturing mock: the
+        // pulse_guide returns Ok and no `:K2` / `:G2` / `:I2` / `:J2`
+        // setter frames are emitted on the Dec axis.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+
+        let baseline_len = mock.state.lock().await.command_log.len();
+        d.pulse_guide(GuideDirection::North, Duration::ZERO)
+            .await
+            .unwrap();
+        let log = mock.state.lock().await.command_log.clone();
+        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
+        let dec_setters: Vec<&&[u8]> = new_frames
+            .iter()
+            .filter(|f| {
+                f.len() >= 3
+                    && f[0] == b':'
+                    && f[2] == b'2'
+                    && matches!(f[1], b'G' | b'I' | b'J' | b'K' | b'L')
+            })
+            .collect();
+        assert!(
+            dec_setters.is_empty(),
+            "expected no Dec setter frames, got {dec_setters:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_north_issues_tracking_cw_on_dec_axis() {
+        // North → Dec axis, ccw=false → `:G210` (Tracking-Slow-CW).
+        // Step period is sidereal / 0.5 = 2 × sidereal.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+
+        let baseline_len = mock.state.lock().await.command_log.len();
+        // Long enough duration that the watcher's post-sleep restore
+        // doesn't fire during this test — we want to inspect the
+        // pulse-start wire frames only.
+        d.pulse_guide(GuideDirection::North, Duration::from_secs(30))
+            .await
+            .unwrap();
+        // Immediately read the log; the watcher is asleep.
+        let log = mock.state.lock().await.command_log.clone();
+        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
+        let dec_setters: Vec<&&[u8]> = new_frames
+            .iter()
+            .filter(|f| {
+                f.len() >= 3
+                    && f[0] == b':'
+                    && f[2] == b'2'
+                    && matches!(f[1], b'G' | b'I' | b'J' | b'K' | b'L')
+            })
+            .collect();
+        assert_eq!(
+            dec_setters.len(),
+            4,
+            "expected exactly 4 Dec setter frames (:K2 :G2 :I2 :J2), got {dec_setters:?}"
+        );
+        assert_eq!(*dec_setters[0], b":K2\r", "1st Dec setter should be :K2");
+        assert_eq!(
+            *dec_setters[1], b":G210\r",
+            "2nd Dec setter should be :G210 (Tracking-Slow-CW)"
+        );
+        assert_eq!(&dec_setters[2][..3], b":I2", "3rd Dec setter should be :I2");
+        assert_eq!(*dec_setters[3], b":J2\r", "4th Dec setter should be :J2");
+        // IsPulseGuiding flipped synchronously.
+        assert!(d.is_pulse_guiding().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_south_issues_tracking_ccw_on_dec_axis() {
+        // South → Dec axis, ccw=true → `:G211` (Tracking-Slow-CCW).
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+
+        let baseline_len = mock.state.lock().await.command_log.len();
+        d.pulse_guide(GuideDirection::South, Duration::from_secs(30))
+            .await
+            .unwrap();
+        let log = mock.state.lock().await.command_log.clone();
+        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
+        let g2 = new_frames
+            .iter()
+            .find(|f| f.starts_with(b":G2"))
+            .expect("expected a :G2 frame");
+        assert_eq!(*g2, b":G211\r", "South → :G211");
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_east_uses_rate_factor_one_minus_fraction() {
+        // East at default fraction (0.5) → rate factor = 0.5 → step
+        // period = sidereal_period / 0.5 = 2 × sidereal. Decode the
+        // `:I1` payload and compare against the expected shifted
+        // period.
+        use crate::transport::mock::CapturingMockFactory;
+        use skywatcher_motor_protocol::codec::decode_u24;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        d.set_tracking(true).await.unwrap();
+
+        let baseline_len = mock.state.lock().await.command_log.len();
+        d.pulse_guide(GuideDirection::East, Duration::from_secs(30))
+            .await
+            .unwrap();
+        let log = mock.state.lock().await.command_log.clone();
+        let new_frames: Vec<&[u8]> = log[baseline_len..].iter().map(|v| v.as_slice()).collect();
+        // First `:I1` after pulse_guide start: payload should be
+        // 2 × P_sid (rate factor = 0.5 → period doubles).
+        let i1 = new_frames
+            .iter()
+            .find(|f| f.starts_with(b":I1") && f.len() == 10)
+            .expect("expected :I1 frame with 6-hex payload");
+        let payload: &[u8; 6] = (&i1[3..9]).try_into().unwrap();
+        let actual_period = decode_u24(payload).unwrap();
+        let mock_state = mock.state.lock().await;
+        let p_sid =
+            crate::coordinates::sidereal_step_period(mock_state.tmr_freq, mock_state.cpr_ra);
+        let expected = 2 * p_sid;
+        drop(mock_state);
+        assert_eq!(
+            actual_period, expected,
+            "East at default 0.5 fraction → period must be 2× sidereal ({p_sid} → {expected}), got {actual_period}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_sets_is_pulse_guiding_synchronously() {
+        // The flag must be true before pulse_guide returns. Use a
+        // very short duration so the watcher could in principle clear
+        // the flag before our read — the synchronous-before-spawn
+        // ordering guarantees we still observe `true`.
+        let d = connected_device().await;
+        // Long enough duration that the watcher is still asleep.
+        d.pulse_guide(GuideDirection::North, Duration::from_secs(30))
+            .await
+            .unwrap();
+        assert!(d.is_pulse_guiding().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_watcher_clears_flag_after_duration() {
+        // Short pulse: the watcher should clear `is_pulse_guiding`
+        // within a small multiple of the duration. Poll for up to
+        // 2 seconds.
+        let d = connected_device().await;
+        d.pulse_guide(GuideDirection::North, Duration::from_millis(100))
+            .await
+            .unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if !d.is_pulse_guiding().await.unwrap() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("watcher did not clear is_pulse_guiding within 2s of a 100ms pulse");
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_rejects_same_axis_while_one_in_flight() {
+        let d = connected_device().await;
+        // Long-running first pulse — watcher is asleep.
+        d.pulse_guide(GuideDirection::North, Duration::from_secs(30))
+            .await
+            .unwrap();
+        let err = d
+            .pulse_guide(GuideDirection::South, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_refuses_while_parked() {
+        let d = connected_device().await;
+        d.park().await.unwrap();
+        // Wait for AtPark = true (park watcher).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if d.at_park().await.unwrap() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let err = d
+            .pulse_guide(GuideDirection::North, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_WHILE_PARKED);
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_ra_with_tracking_off_does_not_restore_tracking() {
+        // Issue an East pulse while tracking is OFF. After the pulse
+        // completes, tracking_requested should still be false and the
+        // watcher should not have emitted a second `:G110` (restore)
+        // frame.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        let mock = factory.mock.clone();
+        let cfg = Config::default();
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        assert!(!d.tracking().await.unwrap(), "precondition: tracking off");
+
+        d.pulse_guide(GuideDirection::East, Duration::from_millis(100))
+            .await
+            .unwrap();
+        // Wait for the watcher to finish.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if !d.is_pulse_guiding().await.unwrap() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!d.is_pulse_guiding().await.unwrap());
+        // Tracking still off.
+        assert!(!d.tracking().await.unwrap());
+        // Exactly one `:G110\r` in the log (the pulse-start; no
+        // restore). `:G110` is RA Tracking-Slow-CW; the watcher would
+        // only emit a second one on the restore branch if
+        // `tracking_was_on` was true at issue.
+        let log = mock.state.lock().await.command_log.clone();
+        let g110_count = log.iter().filter(|f| f.as_slice() == b":G110\r").count();
+        assert_eq!(
+            g110_count, 1,
+            "expected 1 :G110 frame (pulse-start only, no restore), got {g110_count}; log {log:?}"
+        );
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1232,13 +1232,16 @@ impl Telescope for MountDevice {
         // or acquires it later (and sees our flag). Without the
         // atomic set, the previous flow let a concurrent caller pass
         // the in-flight check while we were still awaiting the
-        // `:K`/`:G`/`:I`/`:J` sends.
+        // `:K`/`:G`/`:I`/`:J` sends. `axis` is always `Ra` or `Dec`
+        // here — `GuideDirection` only resolves to those two — so the
+        // boolean dispatch is exhaustive without a third branch.
+        let is_ra = axis == Axis::Ra;
         {
             let mut s = self.state.write().await;
-            let already_in_flight = match axis {
-                Axis::Ra => s.pulse_guiding_ra,
-                Axis::Dec => s.pulse_guiding_dec,
-                Axis::Both => false,
+            let already_in_flight = if is_ra {
+                s.pulse_guiding_ra
+            } else {
+                s.pulse_guiding_dec
             };
             if already_in_flight {
                 return Err(ASCOMError::new(
@@ -1246,10 +1249,10 @@ impl Telescope for MountDevice {
                     "PulseGuide refused while a same-axis pulse is in flight",
                 ));
             }
-            match axis {
-                Axis::Ra => s.pulse_guiding_ra = true,
-                Axis::Dec => s.pulse_guiding_dec = true,
-                Axis::Both => {}
+            if is_ra {
+                s.pulse_guiding_ra = true;
+            } else {
+                s.pulse_guiding_dec = true;
             }
         }
         // Wire path: `:K<axis>` (decelerate and wait for the running
@@ -1728,10 +1731,10 @@ fn spawn_pulse_guide_watcher(
         // (slew/park).
         let still_active = {
             let s = state.read().await;
-            let active = match axis {
-                Axis::Ra => s.pulse_guiding_ra,
-                Axis::Dec => s.pulse_guiding_dec,
-                Axis::Both => false,
+            let active = if axis == Axis::Ra {
+                s.pulse_guiding_ra
+            } else {
+                s.pulse_guiding_dec
             };
             active && !s.at_park && !s.slew_in_progress
         };
@@ -1783,11 +1786,15 @@ fn spawn_pulse_guide_watcher(
 }
 
 async fn clear_pulse_flag(state: &Arc<RwLock<DriverState>>, axis: Axis) {
+    // `GuideDirection` only resolves to `Ra` or `Dec` (see the
+    // direction-to-axis match in `MountDevice::pulse_guide`), so this
+    // helper never sees `Axis::Both`. Using a boolean dispatch keeps
+    // the code exhaustive without an unreachable arm.
     let mut s = state.write().await;
-    match axis {
-        Axis::Ra => s.pulse_guiding_ra = false,
-        Axis::Dec => s.pulse_guiding_dec = false,
-        Axis::Both => {}
+    if axis == Axis::Ra {
+        s.pulse_guiding_ra = false;
+    } else {
+        s.pulse_guiding_dec = false;
     }
 }
 
@@ -3130,6 +3137,36 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         panic!("watcher did not clear is_pulse_guiding within 2s of a 100ms pulse");
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_rolls_back_flag_on_wire_failure() {
+        // `StuckAxisFactory` returns `running=true` on every `:f` poll
+        // so `stop_and_wait` times out after `AXIS_STOP_TIMEOUT` (2 s),
+        // surfacing as a `StarAdvError::Transport` →
+        // `ASCOMErrorCode::INVALID_OPERATION`. The pulse-guide
+        // rollback path must clear `pulse_guiding_<axis>` so a
+        // subsequent caller isn't blocked by the half-applied pulse
+        // and `IsPulseGuiding` reports `false` consistent with the
+        // lack of actual motion.
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        let manager = Arc::new(TransportManager::new(
+            cfg.clone(),
+            Arc::new(StuckAxisFactory),
+        ));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        let err = d
+            .pulse_guide(GuideDirection::North, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+        assert!(
+            !d.is_pulse_guiding().await.unwrap(),
+            "flag must be cleared after a wire-failure rollback"
+        );
     }
 
     #[tokio::test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -1181,9 +1181,13 @@ impl Telescope for MountDevice {
         if duration.is_zero() {
             return Ok(());
         }
-        // Resolve direction → (axis, ccw, rate_factor) and capture the
-        // `tracking_was_on` snapshot under a single read lock. Same
-        // read also catches a same-axis pulse already in flight.
+        // Resolve direction → (axis, ccw, rate_factor) under a read
+        // lock. The in-flight check + flag-set happens later under a
+        // write lock so it's atomic against concurrent same-axis
+        // calls (the rate_factor / tracking_was_on snapshots taken
+        // here are stable: rates can be updated concurrently, but
+        // the worst case is a one-tick-late read which ASCOM
+        // tolerates).
         let (axis, ccw, rate_factor, tracking_was_on) = {
             let s = self.state.read().await;
             let (axis, ccw, rate_factor) = match direction {
@@ -1192,22 +1196,17 @@ impl Telescope for MountDevice {
                 GuideDirection::North => (Axis::Dec, false, s.guide_rate_dec_fraction),
                 GuideDirection::South => (Axis::Dec, true, s.guide_rate_dec_fraction),
             };
-            let in_flight = match axis {
-                Axis::Ra => s.pulse_guiding_ra,
-                Axis::Dec => s.pulse_guiding_dec,
-                Axis::Both => false,
-            };
-            if in_flight {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "PulseGuide refused while a same-axis pulse is in flight",
-                ));
-            }
             let tracking_was_on = axis == Axis::Ra && s.tracking_requested;
             (axis, ccw, rate_factor, tracking_was_on)
         };
         // Compute the shifted step period from the cached
-        // sidereal-period helper and the rate factor.
+        // sidereal-period helper and the rate factor. Validate against
+        // the protocol's 24-bit `:I` payload range before sending —
+        // `encode_u24` silently truncates above `0x00FF_FFFF`, so an
+        // un-validated period would wrap to an unintended speed.
+        // For sidereal_period ≈ 380K on the GTi, the floor is
+        // `rate_factor ≥ sidereal_period / 0xFFFFFF ≈ 0.023`. Tiny
+        // guide-rate fractions trip this; clients see `INVALID_VALUE`.
         let params = self
             .transport
             .parameters()
@@ -1215,40 +1214,79 @@ impl Telescope for MountDevice {
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         let sidereal_period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
         let shifted_period = pulse_guide_step_period(sidereal_period, rate_factor);
-        // Wire path: `:K<axis>` (and wait for the running flag to clear
-        // so `:G` doesn't return `!2 MotorNotStopped`), `:G<axis>`
-        // (Tracking + ccw), `:I<axis>` (shifted period), `:J<axis>`.
-        self.stop_and_wait(axis).await?;
-        let mode = MotionMode {
-            kind: ModeKind::Tracking,
-            speed: Speed::Slow,
-            ccw,
-        };
-        self.transport
-            .send(Command::SetMotionMode { axis, mode })
-            .await
-            .map_err(Self::ascom)?;
-        self.transport
-            .send(Command::SetStepPeriod {
-                axis,
-                period: shifted_period,
-            })
-            .await
-            .map_err(Self::ascom)?;
-        self.transport
-            .send(Command::StartMotion(axis))
-            .await
-            .map_err(Self::ascom)?;
-        // Set the in-flight flag synchronously before spawning so a
-        // client that polls `IsPulseGuiding` immediately after
-        // `PulseGuide` returns sees `true` even for sub-poll durations.
+        const MAX_STEP_PERIOD: u32 = 0x00FF_FFFF;
+        if shifted_period == 0 || shifted_period > MAX_STEP_PERIOD {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_VALUE,
+                format!(
+                    "PulseGuide step period {shifted_period} (rate_factor {rate_factor:.4} × \
+                     sidereal_period {sidereal_period}) is outside the protocol's 24-bit \
+                     range; pick a guide rate closer to sidereal"
+                ),
+            ));
+        }
+        // Atomically check `pulse_guiding_<axis>` and set it to true
+        // under a single write lock. This closes the TOCTOU window: a
+        // concurrent same-axis `pulse_guide` either acquires the
+        // write lock first (and we see the flag set on the next read),
+        // or acquires it later (and sees our flag). Without the
+        // atomic set, the previous flow let a concurrent caller pass
+        // the in-flight check while we were still awaiting the
+        // `:K`/`:G`/`:I`/`:J` sends.
         {
             let mut s = self.state.write().await;
+            let already_in_flight = match axis {
+                Axis::Ra => s.pulse_guiding_ra,
+                Axis::Dec => s.pulse_guiding_dec,
+                Axis::Both => false,
+            };
+            if already_in_flight {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "PulseGuide refused while a same-axis pulse is in flight",
+                ));
+            }
             match axis {
                 Axis::Ra => s.pulse_guiding_ra = true,
                 Axis::Dec => s.pulse_guiding_dec = true,
                 Axis::Both => {}
             }
+        }
+        // Wire path: `:K<axis>` (decelerate and wait for the running
+        // flag to clear so `:G` doesn't return `!2 MotorNotStopped`),
+        // `:G<axis>` (Tracking + ccw), `:I<axis>` (shifted period),
+        // `:J<axis>`. Any failure on the wire rolls back the
+        // `pulse_guiding_<axis>` flag so the next caller isn't blocked
+        // by a half-applied pulse, and so `IsPulseGuiding` reports
+        // false consistent with the lack of actual motion.
+        let mode = MotionMode {
+            kind: ModeKind::Tracking,
+            speed: Speed::Slow,
+            ccw,
+        };
+        let wire_result: ASCOMResult<()> = async {
+            self.stop_and_wait(axis).await?;
+            self.transport
+                .send(Command::SetMotionMode { axis, mode })
+                .await
+                .map_err(Self::ascom)?;
+            self.transport
+                .send(Command::SetStepPeriod {
+                    axis,
+                    period: shifted_period,
+                })
+                .await
+                .map_err(Self::ascom)?;
+            self.transport
+                .send(Command::StartMotion(axis))
+                .await
+                .map_err(Self::ascom)?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = wire_result {
+            clear_pulse_flag(&self.state, axis).await;
+            return Err(e);
         }
         spawn_pulse_guide_watcher(
             Arc::clone(&self.state),
@@ -3061,12 +3099,14 @@ mod tests {
 
     #[tokio::test]
     async fn pulse_guide_sets_is_pulse_guiding_synchronously() {
-        // The flag must be true before pulse_guide returns. Use a
-        // very short duration so the watcher could in principle clear
-        // the flag before our read — the synchronous-before-spawn
-        // ordering guarantees we still observe `true`.
+        // The flag must flip to true before `pulse_guide` returns —
+        // see the atomic check-and-set under the write lock in
+        // `MountDevice::pulse_guide`. The 30-second duration here is
+        // not a "short pulse" test; it just keeps the watcher's
+        // `tokio::time::sleep` from completing during the assertion
+        // read so the only way `is_pulse_guiding()` can be true is
+        // the synchronous flag-set.
         let d = connected_device().await;
-        // Long enough duration that the watcher is still asleep.
         d.pulse_guide(GuideDirection::North, Duration::from_secs(30))
             .await
             .unwrap();
@@ -3090,6 +3130,29 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         panic!("watcher did not clear is_pulse_guiding within 2s of a 100ms pulse");
+    }
+
+    #[tokio::test]
+    async fn pulse_guide_rejects_step_period_overflow() {
+        // Tiny guide-rate fractions push the shifted step period
+        // above the protocol's 24-bit `:I` payload range. Without
+        // the check, `encode_u24` would silently truncate to a
+        // wrap-around value and run the mount at a wildly wrong
+        // speed. For the GTi mock's defaults (sidereal_period ≈
+        // 380K), the boundary is `rate_factor ≈ 0.023`; fraction
+        // 0.001 is well below.
+        let d = connected_device().await;
+        d.set_guide_rate_declination(SIDEREAL_DEG_PER_SEC * 0.001)
+            .await
+            .unwrap();
+        let err = d
+            .pulse_guide(GuideDirection::North, Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+        // The rollback must clear the flag the period validation
+        // would otherwise have set.
+        assert!(!d.is_pulse_guiding().await.unwrap());
     }
 
     #[tokio::test]

--- a/services/star-adventurer-gti/tests/bdd/steps/mod.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/mod.rs
@@ -3,6 +3,7 @@ pub mod connection_steps;
 pub mod coordinate_steps;
 pub mod metadata_steps;
 pub mod park_steps;
+pub mod pulse_guide_steps;
 pub mod side_of_pier_steps;
 pub mod slew_steps;
 pub mod sync_steps;

--- a/services/star-adventurer-gti/tests/bdd/steps/pulse_guide_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/pulse_guide_steps.rs
@@ -1,0 +1,138 @@
+//! Steps for pulse_guide.feature.
+
+use crate::world::StarAdventurerWorld;
+use cucumber::{then, when};
+use std::time::{Duration, Instant};
+
+fn parse_direction(s: &str) -> ascom_alpaca::api::telescope::GuideDirection {
+    use ascom_alpaca::api::telescope::GuideDirection;
+    match s {
+        "North" => GuideDirection::North,
+        "South" => GuideDirection::South,
+        "East" => GuideDirection::East,
+        "West" => GuideDirection::West,
+        other => panic!("unknown guide direction {other:?}"),
+    }
+}
+
+#[when(expr = "I pulse guide {word} for {int} ms")]
+async fn pulse_guide(world: &mut StarAdventurerWorld, direction: String, ms: u64) {
+    let dir = parse_direction(&direction);
+    world
+        .mount()
+        .pulse_guide(dir, Duration::from_millis(ms))
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I try to pulse guide {word} for {int} ms")]
+async fn try_pulse_guide(world: &mut StarAdventurerWorld, direction: String, ms: u64) {
+    let dir = parse_direction(&direction);
+    match world
+        .mount()
+        .pulse_guide(dir, Duration::from_millis(ms))
+        .await
+    {
+        Ok(()) => world.clear_error(),
+        Err(e) => world.record_error(e),
+    }
+}
+
+#[when(expr = "I set GuideRateRightAscension to {float}")]
+async fn set_guide_rate_ra(world: &mut StarAdventurerWorld, value: f64) {
+    world
+        .mount()
+        .set_guide_rate_right_ascension(value)
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I set GuideRateDeclination to {float}")]
+async fn set_guide_rate_dec(world: &mut StarAdventurerWorld, value: f64) {
+    world
+        .mount()
+        .set_guide_rate_declination(value)
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I try to set GuideRateRightAscension to {float}")]
+async fn try_set_guide_rate_ra(world: &mut StarAdventurerWorld, value: f64) {
+    match world.mount().set_guide_rate_right_ascension(value).await {
+        Ok(()) => world.clear_error(),
+        Err(e) => world.record_error(e),
+    }
+}
+
+#[when(expr = "I try to set GuideRateDeclination to {float}")]
+async fn try_set_guide_rate_dec(world: &mut StarAdventurerWorld, value: f64) {
+    match world.mount().set_guide_rate_declination(value).await {
+        Ok(()) => world.clear_error(),
+        Err(e) => world.record_error(e),
+    }
+}
+
+#[then("CanPulseGuide should be true")]
+async fn can_pulse_guide_true(world: &mut StarAdventurerWorld) {
+    assert!(world.mount().can_pulse_guide().await.unwrap());
+}
+
+#[then("CanSetGuideRates should be true")]
+async fn can_set_guide_rates_true(world: &mut StarAdventurerWorld) {
+    assert!(world.mount().can_set_guide_rates().await.unwrap());
+}
+
+#[then("IsPulseGuiding should be true")]
+async fn is_pulse_guiding_true(world: &mut StarAdventurerWorld) {
+    assert!(world.mount().is_pulse_guiding().await.unwrap());
+}
+
+#[then("IsPulseGuiding should be false")]
+async fn is_pulse_guiding_false(world: &mut StarAdventurerWorld) {
+    assert!(!world.mount().is_pulse_guiding().await.unwrap());
+}
+
+#[then(expr = "IsPulseGuiding should become false within {int} ms")]
+async fn is_pulse_guiding_becomes_false(world: &mut StarAdventurerWorld, ms: u64) {
+    let deadline = Instant::now() + Duration::from_millis(ms);
+    while Instant::now() < deadline {
+        if !world.mount().is_pulse_guiding().await.unwrap() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("IsPulseGuiding did not clear within {ms} ms");
+}
+
+#[then(expr = "GuideRateRightAscension should be approximately {float} within {float}")]
+async fn guide_rate_ra_approx(world: &mut StarAdventurerWorld, expected: f64, tolerance: f64) {
+    let actual = world.mount().guide_rate_right_ascension().await.unwrap();
+    assert!(
+        (actual - expected).abs() < tolerance,
+        "GuideRateRightAscension: got {actual}, expected {expected} ± {tolerance}"
+    );
+}
+
+#[then(expr = "GuideRateDeclination should be approximately {float} within {float}")]
+async fn guide_rate_dec_approx(world: &mut StarAdventurerWorld, expected: f64, tolerance: f64) {
+    let actual = world.mount().guide_rate_declination().await.unwrap();
+    assert!(
+        (actual - expected).abs() < tolerance,
+        "GuideRateDeclination: got {actual}, expected {expected} ± {tolerance}"
+    );
+}
+
+#[then(expr = "the RA tracking-mode :G110 frame count should be exactly {int}")]
+async fn ra_g110_count(world: &mut StarAdventurerWorld, expected: usize) {
+    // Each pulse start emits one `:G110\r`. A restored sidereal-tracking
+    // re-issue (the watcher's post-sleep branch when `tracking_was_on`)
+    // emits a second `:G110\r`. Counting frames in the log lets a
+    // scenario assert whether the restore step fired without trying to
+    // identify which frame came from which call site.
+    let log = world.command_log().await;
+    let count = log.iter().filter(|c| c.as_str() == ":G110\r").count();
+    assert_eq!(
+        count, expected,
+        "expected exactly {expected} :G110 frames, saw {count} in log {log:?}"
+    );
+}

--- a/services/star-adventurer-gti/tests/features/device_metadata.feature
+++ b/services/star-adventurer-gti/tests/features/device_metadata.feature
@@ -43,8 +43,8 @@ Feature: Device metadata
       | CanSetTracking              | true         |
       | CanSetRightAscensionRate    | false        |
       | CanSetDeclinationRate       | false        |
-      | CanSetGuideRates            | false        |
-      | CanPulseGuide               | false        |
+      | CanSetGuideRates            | true         |
+      | CanPulseGuide               | true         |
       | CanFindHome                 | false        |
       | CanPark                     | true         |
       | CanUnpark                   | true         |

--- a/services/star-adventurer-gti/tests/features/device_metadata.feature
+++ b/services/star-adventurer-gti/tests/features/device_metadata.feature
@@ -2,7 +2,8 @@ Feature: Device metadata
   The mount device reports its identity, capability flags, and static
   properties via the ASCOM Alpaca HTTP API. Capability values reflect the
   MVP scope: GermanPolar alignment, Topocentric coordinates, sidereal-only
-  tracking, no PulseGuide / MoveAxis / SetPark / FindHome / Alt-Az.
+  tracking, PulseGuide / SetGuideRates supported (since #206); no
+  MoveAxis / SetPark / FindHome / Alt-Az.
 
   Scenario: Device reports configured name
     Given a star-adventurer service configured with name "Test Mount"

--- a/services/star-adventurer-gti/tests/features/pulse_guide.feature
+++ b/services/star-adventurer-gti/tests/features/pulse_guide.feature
@@ -89,7 +89,7 @@ Feature: PulseGuide as rate-shifted tracking
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide North for 200 ms
+    And I pulse guide North for 2000 ms
     Then IsPulseGuiding should be true
     And the mount should have received commands matching:
       | pattern |
@@ -97,14 +97,14 @@ Feature: PulseGuide as rate-shifted tracking
       | :G210   |
       | :I2.*   |
       | :J2     |
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 5000 ms
     And the mount should have received command :K2
 
   Scenario: PulseGuide South issues Tracking + CCW commands on the Dec axis
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide South for 200 ms
+    And I pulse guide South for 2000 ms
     Then IsPulseGuiding should be true
     And the mount should have received commands matching:
       | pattern |
@@ -112,7 +112,7 @@ Feature: PulseGuide as rate-shifted tracking
       | :G211   |
       | :I2.*   |
       | :J2     |
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 5000 ms
 
   Scenario: PulseGuide East while tracking shifts the rate and restores sidereal
     # East slows tracking (period grows); after the pulse the watcher
@@ -121,9 +121,9 @@ Feature: PulseGuide as rate-shifted tracking
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide East for 200 ms
+    And I pulse guide East for 2000 ms
     Then IsPulseGuiding should be true
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 5000 ms
     And the mount should have received commands matching:
       | pattern |
       | :K1     |
@@ -140,9 +140,9 @@ Feature: PulseGuide as rate-shifted tracking
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide West for 200 ms
+    And I pulse guide West for 2000 ms
     Then IsPulseGuiding should be true
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 5000 ms
     And the mount should have received commands matching:
       | pattern |
       | :K1     |
@@ -171,10 +171,19 @@ Feature: PulseGuide as rate-shifted tracking
     Then the operation should fail with invalid-while-parked
 
   Scenario: PulseGuide fails while slewing
+    # `the mount is slewing` seeds `running=true / goto=true` on both
+    # mock axes, but the driver-side snapshot only reflects that after
+    # the polling task does its first `:f` read post-connect. On a
+    # fast runner the polling can lag the PulseGuide call, leaving
+    # `slewing()` returning false and PulseGuide proceeding. Waiting
+    # for `Slewing` to be visible before issuing the pulse closes
+    # the race deterministically (the existing `Then Slewing should
+    # be true` step polls with a 5 s deadline).
     Given a running star-adventurer service
     And the mount is slewing
     When I connect the device
-    And I try to pulse guide North for 100 ms
+    Then Slewing should be true
+    When I try to pulse guide North for 100 ms
     Then the operation should fail with invalid-operation
 
   Scenario: PulseGuide fails while disconnected
@@ -188,7 +197,7 @@ Feature: PulseGuide as rate-shifted tracking
     And I pulse guide North for 1000 ms
     And I try to pulse guide South for 100 ms
     Then the operation should fail with invalid-operation
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 5000 ms
 
   Scenario: Perpendicular concurrent pulses (N on Dec, E on RA) both succeed
     # Durations are deliberately long (2 seconds each) to survive
@@ -215,12 +224,17 @@ Feature: PulseGuide as rate-shifted tracking
     # start) and one from `pulse guide East` (rate-shifted start).
     # A third :G110 would indicate the watcher restored tracking
     # despite the cancellation.
+    #
+    # Pulse duration of 3 s gives the BDD client's HTTP round-trip
+    # for `I disable tracking` plenty of headroom to clear the flag
+    # before the watcher's sleep elapses on slow CI — a tight
+    # duration here would race the watcher's restore decision.
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide East for 800 ms
+    And I pulse guide East for 3000 ms
     And I disable tracking
-    Then IsPulseGuiding should become false within 2000 ms
+    Then IsPulseGuiding should become false within 5000 ms
     And Tracking should be false
     And the RA tracking-mode :G110 frame count should be exactly 2
 

--- a/services/star-adventurer-gti/tests/features/pulse_guide.feature
+++ b/services/star-adventurer-gti/tests/features/pulse_guide.feature
@@ -1,0 +1,234 @@
+Feature: PulseGuide as rate-shifted tracking
+  PulseGuide implements ASCOM autoguiding as a temporary rate shift on the
+  targeted axis built from the standard tracking primitives — no `:P`
+  command (that's the external ST4-jack rate setter, not a host-driven
+  pulse). For each direction the call emits
+  `:K<axis>` → `:G<axis>` (Tracking + ccw) → `:I<axis>` (shifted period) →
+  `:J<axis>`, sets `IsPulseGuiding`, and spawns a watcher task that
+  restores prior state after the requested duration.
+
+  Direction → (axis, ccw, rate factor of sidereal):
+  | Direction | Axis | ccw   | rate factor      |
+  | East      | RA   | false | 1 - ra_fraction  |
+  | West      | RA   | false | 1 + ra_fraction  |
+  | North     | Dec  | false | dec_fraction     |
+  | South     | Dec  | true  | dec_fraction     |
+
+  Wire mode bytes (Tracking-Slow):
+  | Direction | :G frame |
+  | East/West | :G110    |
+  | North     | :G210    |
+  | South     | :G211    |
+
+  Default `GuideRateRightAscension` / `GuideRateDeclination` is
+  0.5 × sidereal (`SIDEREAL_DEG_PER_SEC ≈ 0.00417807`, so the default
+  rate is approximately `0.00208904 deg/sec`).
+
+  Scenario: CanPulseGuide is true when connected
+    Given a running star-adventurer service
+    When I connect the device
+    Then CanPulseGuide should be true
+
+  Scenario: CanSetGuideRates is true when connected
+    Given a running star-adventurer service
+    When I connect the device
+    Then CanSetGuideRates should be true
+
+  Scenario: IsPulseGuiding defaults to false after connect
+    Given a running star-adventurer service
+    When I connect the device
+    Then IsPulseGuiding should be false
+
+  Scenario: Default GuideRateRightAscension is half sidereal
+    Given a running star-adventurer service
+    When I connect the device
+    Then GuideRateRightAscension should be approximately 0.00208904 within 0.00001
+
+  Scenario: Default GuideRateDeclination is half sidereal
+    Given a running star-adventurer service
+    When I connect the device
+    Then GuideRateDeclination should be approximately 0.00208904 within 0.00001
+
+  Scenario: Setting GuideRateRightAscension within (0, sidereal) succeeds
+    Given a running star-adventurer service
+    When I connect the device
+    And I set GuideRateRightAscension to 0.001
+    Then GuideRateRightAscension should be approximately 0.001 within 0.00001
+
+  Scenario: Setting GuideRateDeclination within (0, sidereal) succeeds
+    Given a running star-adventurer service
+    When I connect the device
+    And I set GuideRateDeclination to 0.003
+    Then GuideRateDeclination should be approximately 0.003 within 0.00001
+
+  Scenario: Setting GuideRateRightAscension to zero fails
+    Given a running star-adventurer service
+    When I connect the device
+    And I try to set GuideRateRightAscension to 0.0
+    Then the operation should fail with invalid-value
+
+  Scenario: Setting GuideRateRightAscension above sidereal fails
+    # Upper bound is exclusive — fraction >= 1.0 would zero East's
+    # rate factor and divide by zero in the step-period formula.
+    # Match INDI's treatment of guide rate as a fraction strictly
+    # less than 1. Using a value clearly above sidereal
+    # (`SIDEREAL_DEG_PER_SEC ≈ 0.00417807`) so the rejection is
+    # unambiguous even with floating-point comparison.
+    Given a running star-adventurer service
+    When I connect the device
+    And I try to set GuideRateRightAscension to 0.01
+    Then the operation should fail with invalid-value
+
+  Scenario: Setting GuideRateDeclination to negative fails
+    Given a running star-adventurer service
+    When I connect the device
+    And I try to set GuideRateDeclination to -0.001
+    Then the operation should fail with invalid-value
+
+  Scenario: PulseGuide North issues Tracking + CW commands on the Dec axis
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide North for 200 ms
+    Then IsPulseGuiding should be true
+    And the mount should have received commands matching:
+      | pattern |
+      | :K2     |
+      | :G210   |
+      | :I2.*   |
+      | :J2     |
+    And IsPulseGuiding should become false within 2000 ms
+    And the mount should have received command :K2
+
+  Scenario: PulseGuide South issues Tracking + CCW commands on the Dec axis
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide South for 200 ms
+    Then IsPulseGuiding should be true
+    And the mount should have received commands matching:
+      | pattern |
+      | :K2     |
+      | :G211   |
+      | :I2.*   |
+      | :J2     |
+    And IsPulseGuiding should become false within 2000 ms
+
+  Scenario: PulseGuide East while tracking shifts the rate and restores sidereal
+    # East slows tracking (period grows); after the pulse the watcher
+    # re-issues sidereal tracking on RA so the user-observable
+    # `Tracking` state is unchanged.
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide East for 200 ms
+    Then IsPulseGuiding should be true
+    And IsPulseGuiding should become false within 2000 ms
+    And the mount should have received commands matching:
+      | pattern |
+      | :K1     |
+      | :G110   |
+      | :I1.*   |
+      | :J1     |
+      | :K1     |
+      | :G110   |
+      | :I1.*   |
+      | :J1     |
+
+  Scenario: PulseGuide West while tracking shifts the rate and restores sidereal
+    # West speeds tracking (period shrinks); same restore shape as East.
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide West for 200 ms
+    Then IsPulseGuiding should be true
+    And IsPulseGuiding should become false within 2000 ms
+    And the mount should have received commands matching:
+      | pattern |
+      | :K1     |
+      | :G110   |
+      | :I1.*   |
+      | :J1     |
+      | :K1     |
+      | :G110   |
+      | :I1.*   |
+      | :J1     |
+
+  Scenario: PulseGuide East while not tracking does not restore tracking
+    # Without prior tracking, the watcher's RA restore branch is skipped
+    # — only a final `:K1` (stop) is emitted. Tracking stays off.
+    Given a running star-adventurer service
+    When I connect the device
+    And I pulse guide East for 200 ms
+    Then IsPulseGuiding should become false within 2000 ms
+    And the RA tracking-mode :G110 frame count should be exactly 1
+    And Tracking should be false
+
+  Scenario: PulseGuide fails while parked
+    Given a running star-adventurer service
+    And the device is parked
+    When I try to pulse guide North for 100 ms
+    Then the operation should fail with invalid-while-parked
+
+  Scenario: PulseGuide fails while slewing
+    Given a running star-adventurer service
+    And the mount is slewing
+    When I connect the device
+    And I try to pulse guide North for 100 ms
+    Then the operation should fail with invalid-operation
+
+  Scenario: PulseGuide fails while disconnected
+    Given a running star-adventurer service
+    When I try to pulse guide North for 100 ms
+    Then the operation should fail with not-connected
+
+  Scenario: A second pulse on the same axis is rejected while one is in flight
+    Given a running star-adventurer service
+    When I connect the device
+    And I pulse guide North for 1000 ms
+    And I try to pulse guide South for 100 ms
+    Then the operation should fail with invalid-operation
+    And IsPulseGuiding should become false within 2000 ms
+
+  Scenario: Perpendicular concurrent pulses (N on Dec, E on RA) both succeed
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide North for 300 ms
+    And I pulse guide East for 300 ms
+    Then IsPulseGuiding should be true
+    And IsPulseGuiding should become false within 2000 ms
+
+  Scenario: set_tracking(false) during an RA pulse cancels the pulse restore
+    # Cancellation rule: any axis-mutating call clears the pulse flag
+    # before issuing its own wire commands, so the watcher's post-sleep
+    # restore step bails out. The user-observable invariant is that
+    # tracking stays off after the pulse — the watcher MUST NOT
+    # re-issue tracking. The on-the-wire :G110 count after this
+    # scenario is exactly 2: one from `enable tracking` (sidereal
+    # start) and one from `pulse guide East` (rate-shifted start).
+    # A third :G110 would indicate the watcher restored tracking
+    # despite the cancellation.
+    Given a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    And I pulse guide East for 800 ms
+    And I disable tracking
+    Then IsPulseGuiding should become false within 2000 ms
+    And Tracking should be false
+    And the RA tracking-mode :G110 frame count should be exactly 2
+
+  Scenario: AbortSlew during an in-flight pulse clears IsPulseGuiding
+    Given a running star-adventurer service
+    When I connect the device
+    And I pulse guide North for 1000 ms
+    And I abort the slew
+    Then IsPulseGuiding should become false within 1000 ms
+
+  Scenario: Duration zero succeeds with no wire activity
+    # ASCOM permits zero-duration pulses; treat as a no-op.
+    Given a running star-adventurer service
+    When I connect the device
+    And I pulse guide North for 0 ms
+    Then IsPulseGuiding should be false
+    And the Dec axis should have received no commands

--- a/services/star-adventurer-gti/tests/features/pulse_guide.feature
+++ b/services/star-adventurer-gti/tests/features/pulse_guide.feature
@@ -191,13 +191,19 @@ Feature: PulseGuide as rate-shifted tracking
     And IsPulseGuiding should become false within 2000 ms
 
   Scenario: Perpendicular concurrent pulses (N on Dec, E on RA) both succeed
+    # Durations are deliberately long (2 seconds each) to survive
+    # slow-CI scheduling: the two `pulse_guide` calls plus the
+    # following `IsPulseGuiding` read each take an HTTP round-trip,
+    # so a short (<500ms) pulse can expire on a heavily-loaded
+    # runner before the assertion fires. The 4s polling deadline
+    # for completion gives both watchers room to wake.
     Given a running star-adventurer service
     When I connect the device
     And I enable tracking
-    And I pulse guide North for 300 ms
-    And I pulse guide East for 300 ms
+    And I pulse guide North for 2000 ms
+    And I pulse guide East for 2000 ms
     Then IsPulseGuiding should be true
-    And IsPulseGuiding should become false within 2000 ms
+    And IsPulseGuiding should become false within 4000 ms
 
   Scenario: set_tracking(false) during an RA pulse cancels the pulse restore
     # Cancellation rule: any axis-mutating call clears the pulse flag


### PR DESCRIPTION
## Summary

Implements `PulseGuide` for the Star Adventurer GTi as a temporary
rate-shifted tracking burst on the targeted axis, built from the
existing `:K` / `:G` / `:I` / `:J` primitives. Matches `indi-eqmod`'s
`StartRATracking(rate ± shift)` / `StartDETracking(rate ± shift)`
approach — no `:P` (that's the ST4 hardware-jack rate setter, not a
host-driven pulse trigger). Closes #206.

**Wire path per direction:**
| Direction | Axis | `ccw` | rate factor              | wire `:G` byte |
|-----------|------|-------|--------------------------|----------------|
| East      | RA   | false | `1 - guide_rate_ra_frac` | `:G110`        |
| West      | RA   | false | `1 + guide_rate_ra_frac` | `:G110`        |
| North     | Dec  | false | `guide_rate_dec_frac`    | `:G210`        |
| South     | Dec  | true  | `guide_rate_dec_frac`    | `:G211`        |

For each pulse: `:K<axis>` (stop and wait) → `:G<axis>` (Tracking +
ccw) → `:I<axis>` (`sidereal_period / rate_factor`) → `:J<axis>`.
After the requested `duration`, a watcher task stops the axis; for
RA pulses, re-issues sidereal tracking iff it was on at issue time.

**Capabilities flipped** `CanPulseGuide` and `CanSetGuideRates` to
`true`. `GuideRateRightAscension` / `GuideRateDeclination` are
exposed in deg/sec; internal storage is the fraction of sidereal in
the open interval `(0, 1)` (matches INDI — `fraction = 1.0` would
zero East's rate factor and divide by zero in the period formula).
Default rates initialise to `0.5 × sidereal` on each connect.

**Cross-cutting cancellation rule**: `set_tracking`,
`slew_to_coordinates_async`, `park`, `abort_slew`,
`sync_to_coordinates`, and `set_connected(false)` each clear the
per-axis pulse flag before issuing wire commands so the watcher's
post-sleep restore step bails out. Without this, e.g.
`set_tracking(false)` during an East pulse would be silently undone
when the watcher re-issued sidereal tracking.

**ConformU re-enabled**: re-adds `[package.metadata.conformu]` in
`Cargo.toml`. The `alpacaprotocol` phase previously refused to
proceed past the `IsPulseGuiding` poll's `NotImplementedException`;
with PulseGuide implemented, both ConformU phases run.

## Test plan
- [x] 15 new unit tests pass (5 in `coordinates.rs`, 10 in `mount_device.rs`)
- [x] 21 new BDD scenarios in `pulse_guide.feature` pass — covers
      capability flags, default rates, rate validation, all four
      directions, restore semantics, parked / disconnected / slewing /
      same-axis-in-flight refusals, perpendicular concurrent pulses,
      `set_tracking` and `AbortSlew` cancellation paths, and
      zero-duration no-ops
- [x] `cargo nextest run -p star-adventurer-gti --all-features` — 159 / 159 pass
- [x] `cargo test -p star-adventurer-gti --features mock --test bdd` — 111 / 111 scenarios pass
- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo rail run --profile commit -q` green
- [ ] ConformU integration `cargo test -p star-adventurer-gti --features conformu --test conformu_integration -- --ignored --nocapture` — runner-only verification expected via nightly workflow
- [ ] Hardware verification (post-merge): 1-second North pulse with `guide_rate_dec = 0.5 × sidereal` should advance Dec encoder by approximately `0.5 × 15.04″ ≈ 7.5″` worth of ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)