### PR TITLE
ci: add Raspberry Pi 5 ARM64 nightly self-hosted runner

### DIFF
--- a/.github/workflows/pi-nightly.yml
+++ b/.github/workflows/pi-nightly.yml
@@ -1,0 +1,187 @@
+# Nightly verification on a Raspberry Pi 5 self-hosted runner (Linux/ARM64).
+#
+# Coverage rationale: the workflows in this directory all target x86_64
+# GitHub-hosted runners (ubuntu/macos/windows). The Pi 5 is ARM64, so this
+# nightly catches arch-specific regressions (atomics, alignment, vendored C
+# deps such as cfitsio) that scheduled.yml cannot. See
+# docs/skills/raspberry-pi-runner.md for runner setup and security posture.
+#
+# === Security model — DO NOT WEAKEN ===
+#
+# This is the only workflow that runs on a self-hosted runner, and the repo is
+# public. Self-hosted runners on public repos are dangerous specifically
+# because a malicious PR can edit the workflow YAML and run arbitrary code on
+# the runner during PR validation. The safety property here is that this
+# workflow has NO `pull_request` and NO `push` trigger. Scheduled runs always
+# execute the workflow file from the default branch (main), and only the
+# repo owner can write to main, so PRs literally cannot influence what
+# executes on the Pi.
+#
+# Belt-and-suspenders:
+#   * `if: github.ref == 'refs/heads/main'` on the build job
+#   * `ref: main` pinned on `actions/checkout`
+#   * Workflow-level `permissions: contents: read` (the issue-writer job
+#     elevates only what it needs, scoped to that job)
+#
+# If you ever feel tempted to add `pull_request:` to this file, do not — see
+# docs/skills/raspberry-pi-runner.md §"Why no pull_request trigger".
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Daily at 04:00 UTC. Slots between plate-solver-smoke (03:30 UTC) and
+    # install-astap (04:30 UTC) so a Pi observer of the Actions tab sees them
+    # in a clean sequence; neither of those workflows runs on this runner,
+    # so the only real coordination cost is human readability.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+# Don't cancel an in-flight nightly if a manual dispatch fires — losing a
+# scheduled run is worse than running two back-to-back.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+name: pi-nightly
+
+jobs:
+  arm64-stable:
+    # Hard gate against accidental non-main execution. `schedule` already
+    # implies main; this keeps that property explicit and survives any future
+    # trigger change.
+    if: github.ref == 'refs/heads/main'
+    name: raspberry-pi / linux / arm64 / stable
+    # `raspberry-pi` is the custom label applied during runner registration;
+    # the other three are standard self-hosted labels GitHub injects
+    # automatically. Match in the same shape used during `config.sh
+    # --labels raspberry-pi` — see docs/skills/raspberry-pi-runner.md.
+    runs-on: [self-hosted, Linux, ARM64, raspberry-pi]
+    # First run with a cold cache can build the full workspace from scratch on
+    # ARM, which is slow on a Pi 5. 6h is generous; warmed-cache runs should
+    # finish in ~60-90 min.
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Install ASCOM OmniSim
+        uses: ./.github/actions/install-omnisim
+
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Separate cache namespace from the existing linux-stable (x86)
+          # cache so the two architectures don't evict each other.
+          shared-key: linux-arm64-stable
+
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+
+      # Pre-build all targets so nextest and BDD tests find cached binaries
+      # without recompilation. Mirrors scheduled.yml's nightly job.
+      - name: cargo build --workspace
+        run: cargo build --locked --workspace --all-features --all-targets
+
+      - name: cargo nextest run
+        run: cargo nextest run --locked --all-features --all-targets
+
+      # BDD tests use a custom harness (bdd_main!) incompatible with nextest.
+      - name: cargo test --test bdd
+        run: cargo test --locked --all-features --test bdd
+
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: cargo test --doc
+        run: cargo test --locked --all-features --doc
+
+      # Preserve OmniSim logs on failure for off-runner analysis (matches the
+      # pattern in test.yml). Without this, the only copy lives inside the
+      # runner's _work directory and is overwritten next run.
+      - name: Upload OmniSim logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: omnisim-logs-pi-nightly
+          path: '**/bdd-infra-omnisim-logs/**'
+          if-no-files-found: ignore
+          retention-days: 14
+
+  notify-on-failure:
+    # Open or update a tracking issue when the scheduled nightly fails so a
+    # red ARM build does not sit unnoticed in the Actions tab. Skipped on
+    # workflow_dispatch so manual debugging runs do not churn the issue.
+    # Runs on a hosted runner — if the Pi runner itself is offline or broken,
+    # this still fires and reports.
+    needs: arm64-stable
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = `nightly: pi-nightly ARM64 build failing`;
+            const body = [
+              `The nightly Raspberry Pi 5 ARM64 verification workflow failed.`,
+              ``,
+              `Likely causes: an arch-specific regression (atomics, alignment,`,
+              `endian, SIMD intrinsics, vendored C deps such as cfitsio), a`,
+              `change that breaks cross-arch feature unification, the Pi runner`,
+              `being offline or low on disk, or an OmniSim/BDD flake. See the`,
+              `failed job for the per-step log and the uploaded OmniSim logs`,
+              `artifact (if the failure was in cargo test --test bdd).`,
+              ``,
+              `Runner setup and decommissioning: docs/skills/raspberry-pi-runner.md`,
+              ``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `This issue is opened automatically when the workflow fails on`,
+              `schedule. It will be updated (rather than re-opened) on subsequent`,
+              `failures so the notification cadence stays low. Close it once the`,
+              `underlying issue is resolved; the next failure will reopen.`,
+            ].join("\n");
+            // Search both open AND closed so the body's "the next failure
+            // will reopen" promise is honored. Mirrors the conformu.yml and
+            // install-astap.yml patterns.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              labels: "pi-nightly",
+            });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              if (match.state === "closed") {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  state: "open",
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: run ${context.runId}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["pi-nightly", "ci-flake"],
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ rusty-photon/
 | [docs/skills/development-workflow.md](docs/skills/development-workflow.md) | Skill: design-first, test-first development workflow |
 | [docs/skills/testing.md](docs/skills/testing.md) | Skill: writing and organizing tests |
 | [docs/skills/pre-push.md](docs/skills/pre-push.md) | Skill: running CI quality gates before pushing |
+| [docs/skills/raspberry-pi-runner.md](docs/skills/raspberry-pi-runner.md) | Skill: setting up the Pi 5 ARM64 nightly self-hosted runner |
 | [docs/references/ascom-alpaca.md](docs/references/ascom-alpaca.md) | ASCOM Alpaca protocol reference |
 | [docs/decisions/](docs/decisions/) | Architecture Decision Records |
 

--- a/docs/skills/pre-push.md
+++ b/docs/skills/pre-push.md
@@ -207,6 +207,24 @@ Current services and their commands:
 - **qhy-focuser**: `cargo test -p qhy-focuser --features conformu --test conformu_integration -- --ignored --nocapture`
 - **sky-survey-camera**: `cargo test -p sky-survey-camera --features conformu --test conformu_integration -- --ignored --nocapture`
 
+### pi-nightly.yml (rolling, self-hosted ARM64)
+
+Runs the workspace build + tests on a Raspberry Pi 5 self-hosted runner
+(Linux/ARM64) once per night. The only CI surface that exercises ARM64;
+catches arch-specific regressions (atomics, alignment, vendored C deps
+like `cfitsio`, cross-arch feature unification) that the x86 GitHub-hosted
+runners cannot. **Triggers are deliberately limited to `schedule` and
+`workflow_dispatch`** — never `pull_request` or `push` — because the repo
+is public and a self-hosted runner accepting PR triggers would let forks
+execute arbitrary code on the Pi. See
+[docs/skills/raspberry-pi-runner.md](raspberry-pi-runner.md) for the full
+security model, setup steps, and decommissioning procedure.
+
+| CI Job | Local Command | Prerequisites | Required? |
+|--------|---------------|---------------|-----------|
+| **arm64-stable** | Same as scheduled `nightly` but on ARM64 stable: `cargo build --locked --workspace --all-features --all-targets` + `cargo nextest run --locked --all-features --all-targets` + `cargo test --locked --all-features --test bdd` + `cargo test --locked --all-features --doc` | self-hosted ARM64 runner, stable, cargo-nextest | Optional |
+| **notify-on-failure** | N/A (CI-only — opens/updates a `pi-nightly` labelled issue when `arm64-stable` fails on a scheduled run) | -- | CI-only |
+
 ### scheduled.yml (rolling)
 
 These jobs only run on push to main, on schedule, or manually -- **not on PRs**.

--- a/docs/skills/raspberry-pi-runner.md
+++ b/docs/skills/raspberry-pi-runner.md
@@ -168,12 +168,15 @@ deregistration in the UI — useful if the Pi is reimaged.
 
 ### 5. Install as a systemd service
 
-GitHub ships an installer for this:
+GitHub ships an installer for this. Note the `sudo bash -c '...'` wrapping:
+`svc.sh` writes to `/etc/systemd/system/` (root-only) and reads template
+files from its own directory, but Ubuntu Server 24.04 creates
+`/home/gh-runner` with mode `0750` so your regular sudo user can't `cd`
+into it. Running the whole compound under `sudo` lets root do both the
+directory entry and the install:
 
 ```bash
-cd ~gh-runner/actions-runner
-sudo ./svc.sh install gh-runner
-sudo ./svc.sh start
+sudo bash -c 'cd /home/gh-runner/actions-runner && ./svc.sh install gh-runner && ./svc.sh start'
 ```
 
 The service is named `actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service`
@@ -243,18 +246,20 @@ the Pi):
    stale entry).
 2. Generate a fresh token from the "New self-hosted runner" UI on that same
    page.
-3. On the Pi:
+3. On the Pi (the `sudo -u gh-runner bash -c '...'` wrapping is for the
+   same `0750` home-directory reason as §5 — `config.sh` expects to run
+   from inside its own directory):
    ```bash
    sudo systemctl stop actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
-   sudo -u gh-runner ~gh-runner/actions-runner/config.sh remove --token <REMOVAL_TOKEN>
-   sudo -u gh-runner ~gh-runner/actions-runner/config.sh \
+   sudo -u gh-runner bash -c 'cd /home/gh-runner/actions-runner && ./config.sh remove --token <REMOVAL_TOKEN>'
+   sudo -u gh-runner bash -c 'cd /home/gh-runner/actions-runner && ./config.sh \
      --url https://github.com/ivonnyssen/rusty-photon \
      --token <FRESH_REGISTRATION_TOKEN> \
      --name pi5-nightly \
      --labels raspberry-pi \
      --work _work \
      --unattended \
-     --replace
+     --replace'
    sudo systemctl start actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
    ```
 
@@ -267,10 +272,8 @@ If the Pi is going away or the workflow is being retired:
 
 1. On the Pi:
    ```bash
-   cd ~gh-runner/actions-runner
-   sudo ./svc.sh stop
-   sudo ./svc.sh uninstall
-   sudo -u gh-runner ./config.sh remove --token <REMOVAL_TOKEN>
+   sudo bash -c 'cd /home/gh-runner/actions-runner && ./svc.sh stop && ./svc.sh uninstall'
+   sudo -u gh-runner bash -c 'cd /home/gh-runner/actions-runner && ./config.sh remove --token <REMOVAL_TOKEN>'
    sudo userdel -r gh-runner
    ```
 2. On GitHub: confirm the runner is gone from

--- a/docs/skills/raspberry-pi-runner.md
+++ b/docs/skills/raspberry-pi-runner.md
@@ -129,7 +129,7 @@ latest ARM64 Linux runner from
 sudo -u gh-runner bash -c '
   mkdir -p $HOME/actions-runner
   cd $HOME/actions-runner
-  RUNNER_VERSION=2.319.1   # check releases page for current
+  RUNNER_VERSION=2.334.0   # check releases page for current
   curl -fsSL -o actions-runner.tar.gz \
     https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz
   tar xzf actions-runner.tar.gz

--- a/docs/skills/raspberry-pi-runner.md
+++ b/docs/skills/raspberry-pi-runner.md
@@ -1,0 +1,338 @@
+# Skill: Raspberry Pi 5 Self-Hosted Nightly Runner
+
+## When to Read This
+
+- Setting up the Raspberry Pi 5 self-hosted runner for the first time
+- Re-registering the runner after a token expiry or factory reset
+- Debugging a red `pi-nightly` workflow run
+- Decommissioning the runner (removing from GitHub + the Pi itself)
+- Auditing the security posture of self-hosted runners on this repo
+
+## Prerequisites
+
+- A Raspberry Pi 5 (Linux/ARM64) running Ubuntu 24.04 LTS or newer
+- SSH access to the Pi as a sudo-capable user
+- Owner or admin access to the `ivonnyssen/rusty-photon` GitHub repo
+- A network position that lets the Pi reach `github.com` and `*.actions.githubusercontent.com` over HTTPS
+
+## Why a Self-Hosted Runner (and Why It Is Safe Here)
+
+GitHub-hosted runners only cover x86_64 (`ubuntu-latest`, `macos-latest`,
+`windows-latest`). The Pi 5 is ARM64, so a Pi nightly catches arch-specific
+regressions the rest of CI cannot: atomics, alignment, vendored C
+dependencies such as `cfitsio` / `fitsio-sys`, cross-arch feature
+unification breaks, and BDD scenarios that exercise endian-sensitive
+serialisation paths.
+
+This repo is **public**, which is the case GitHub's own docs warn against:
+"We recommend that you only use self-hosted runners with private
+repositories. This is because forks of your public repository can
+potentially run dangerous code on your self-hosted runner machine by
+creating a pull request that executes the code in a workflow."
+
+The threat is concrete: a malicious PR can edit the workflow YAML, and on
+`pull_request` events GitHub Actions runs the **PR's version** of that
+YAML, not main's. So if any workflow on a self-hosted runner triggers on
+`pull_request`, a fork can execute arbitrary commands on the Pi during PR
+validation.
+
+`pi-nightly.yml` neutralises this by triggering **only** on `schedule` and
+`workflow_dispatch`. Scheduled runs always use the workflow file from the
+default branch (main), and only the repo owner can push to main, so PRs
+cannot influence what executes on the Pi. The job adds two more belts:
+`ref: main` on `actions/checkout` and `if: github.ref == 'refs/heads/main'`
+at the job level.
+
+### Why no `pull_request` trigger
+
+The "I'd like ARM coverage on PRs too" temptation must be resisted on a
+public repo until either (a) the runner is moved to a private mirror, or
+(b) a Just-In-Time (JIT) ephemeral runner pool with PR-approval gating is
+set up. Both are substantial changes. For now, the rule is binary: this
+file gets `schedule:` and `workflow_dispatch:` only.
+
+If you ever need ARM-on-PR coverage, prefer GitHub's free `ubuntu-24.04-arm`
+runner (free for public repos) — see
+[github.com/actions/runner-images](https://github.com/actions/runner-images).
+
+## One-Time Setup
+
+The setup script `scripts/setup-pi-runner.sh` is the canonical, idempotent
+path. The sections below explain what the script does so an operator can
+audit or reproduce it manually.
+
+### 1. System dependencies
+
+The Pi needs a small set of packages that GitHub-hosted runners pre-install
+but Ubuntu Server does not:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  pkg-config \
+  curl \
+  git \
+  jq \
+  libssl-dev \
+  libcfitsio-dev \
+  unzip \
+  ca-certificates
+```
+
+`libcfitsio-dev` is required by the `fitsio-sys` build script. Without it
+the `rp-fits`, `filemonitor`, and `sky-survey-camera` packages fail to
+compile (this is the "use `-p <package>`" caveat that the user-level
+`MEMORY.md` references). `libssl-dev` is required by transitive C-FFI
+crates in the workspace.
+
+### 2. Dedicated unprivileged user
+
+The runner must not run as root. Create a dedicated user with no sudo
+rights, no shell login (only the runner's `actions-runner` directory
+matters), and a fresh home dir:
+
+```bash
+sudo useradd -m -s /usr/sbin/nologin -U gh-runner
+```
+
+The `nologin` shell prevents interactive logins; the runner's `run.sh` is
+invoked by systemd, which doesn't need a login shell.
+
+If the runner needs `rustup` (which it does — `dtolnay/rust-toolchain@stable`
+calls it), the toolchain lives under `~gh-runner/.rustup` and
+`~gh-runner/.cargo`. That's fine — both are inside the dedicated user's
+home and isolated from any other user on the Pi.
+
+### 3. Rustup + stable toolchain
+
+`dtolnay/rust-toolchain@stable` installs rustup on first call if missing,
+but it's faster to pre-install:
+
+```bash
+sudo -u gh-runner bash -c '
+  curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+  echo "source $HOME/.cargo/env" >> $HOME/.bashrc
+'
+```
+
+`cargo-nextest` is installed by the workflow via `taiki-e/install-action`,
+so no pre-install needed.
+
+### 4. Download and register the runner
+
+GitHub's runner ships as a single tarball per OS/arch combo. Get the
+latest ARM64 Linux runner from
+[github.com/actions/runner/releases](https://github.com/actions/runner/releases).
+
+```bash
+sudo -u gh-runner bash -c '
+  mkdir -p $HOME/actions-runner
+  cd $HOME/actions-runner
+  RUNNER_VERSION=2.319.1   # check releases page for current
+  curl -fsSL -o actions-runner.tar.gz \
+    https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz
+  tar xzf actions-runner.tar.gz
+  rm actions-runner.tar.gz
+'
+```
+
+Registration requires a **runner registration token**, which is
+short-lived (expires in ~1 hour) and must be fetched from GitHub:
+
+> Repo → Settings → Actions → Runners → New self-hosted runner → copy the
+> token shown in the `./config.sh ...` snippet
+
+Then on the Pi:
+
+```bash
+sudo -u gh-runner bash -c '
+  cd $HOME/actions-runner
+  ./config.sh \
+    --url https://github.com/ivonnyssen/rusty-photon \
+    --token <TOKEN_FROM_GITHUB_UI> \
+    --name pi5-nightly \
+    --labels raspberry-pi \
+    --work _work \
+    --unattended \
+    --replace
+'
+```
+
+The `--labels raspberry-pi` value must match the workflow's
+`runs-on: [self-hosted, Linux, ARM64, raspberry-pi]` (the first three
+labels are auto-applied by GitHub based on the runner's environment).
+
+`--replace` lets re-registration overwrite a stale entry without manual
+deregistration in the UI — useful if the Pi is reimaged.
+
+### 5. Install as a systemd service
+
+GitHub ships an installer for this:
+
+```bash
+cd ~gh-runner/actions-runner
+sudo ./svc.sh install gh-runner
+sudo ./svc.sh start
+```
+
+The service is named `actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service`
+(or similar). Verify:
+
+```bash
+systemctl status actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
+sudo journalctl -u actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service -f
+```
+
+From GitHub: Repo → Settings → Actions → Runners — the runner should show
+as **Idle** within a few seconds.
+
+## Operational Notes
+
+### Triggering a run manually
+
+`pi-nightly.yml` exposes `workflow_dispatch`. From the Actions tab:
+
+> Actions → pi-nightly → Run workflow → Branch: main → Run workflow
+
+`workflow_dispatch` enforces the same `if: github.ref == 'refs/heads/main'`
+gate as the scheduled trigger, so this can only run against main.
+
+### Reading logs
+
+Live job logs appear in the Actions tab as usual. The runner-side daemon
+log (start/stop, job pickup, deregistration events) is in journald:
+
+```bash
+sudo journalctl -u actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service -f
+```
+
+The job's working tree lives under `~gh-runner/actions-runner/_work/rusty-photon/rusty-photon`
+between runs. The runner's default behaviour is to wipe the workspace
+between jobs but preserve cached toolchains (`.rustup`, `.cargo`) in the
+user's home dir.
+
+### Disk usage
+
+Cargo's `target/` directory under `_work/` can grow to 5-10 GB across a
+mixed workspace + all-features build. The Swatinem cache only restores
+incremental state, so the active `target/` is unavoidable. Plan for at
+least 32 GB of free disk on the Pi (an external SSD is strongly
+recommended over an SD card for write durability).
+
+### Notifications
+
+`pi-nightly.yml` includes a `notify-on-failure` job that opens or updates
+a `pi-nightly`-labelled issue in the repo on every scheduled failure.
+This runs on a GitHub-hosted runner, so it still fires when the Pi itself
+is offline (the `arm64-stable` job will fail with "runner offline" and
+`notify-on-failure` reports it).
+
+GitHub also sends an email by default to the workflow author when a
+scheduled run fails — controlled at
+github.com → Settings → Notifications → Actions.
+
+## Re-Registering the Runner
+
+The runner registration token GitHub gave you at setup time was one-time;
+it cannot be re-used. To re-register (typically after a reimage or moving
+the Pi):
+
+1. On GitHub: Repo → Settings → Actions → Runners → click the runner row →
+   "Remove runner" (or do nothing — `--replace` at config time handles a
+   stale entry).
+2. Generate a fresh token from the "New self-hosted runner" UI on that same
+   page.
+3. On the Pi:
+   ```bash
+   sudo systemctl stop actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
+   sudo -u gh-runner ~gh-runner/actions-runner/config.sh remove --token <REMOVAL_TOKEN>
+   sudo -u gh-runner ~gh-runner/actions-runner/config.sh \
+     --url https://github.com/ivonnyssen/rusty-photon \
+     --token <FRESH_REGISTRATION_TOKEN> \
+     --name pi5-nightly \
+     --labels raspberry-pi \
+     --work _work \
+     --unattended \
+     --replace
+   sudo systemctl start actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
+   ```
+
+The removal token and registration token are different and are both shown
+in the GitHub UI when needed.
+
+## Decommissioning
+
+If the Pi is going away or the workflow is being retired:
+
+1. On the Pi:
+   ```bash
+   cd ~gh-runner/actions-runner
+   sudo ./svc.sh stop
+   sudo ./svc.sh uninstall
+   sudo -u gh-runner ./config.sh remove --token <REMOVAL_TOKEN>
+   sudo userdel -r gh-runner
+   ```
+2. On GitHub: confirm the runner is gone from
+   Settings → Actions → Runners.
+3. Delete `.github/workflows/pi-nightly.yml`, this runbook, and
+   `scripts/setup-pi-runner.sh`. Update `README.md` and `.github/DOCS.md`
+   to drop the references.
+
+## Troubleshooting
+
+### Runner shows as "Offline" in the GitHub UI
+
+Most common cause: systemd service stopped or network outage. Check:
+
+```bash
+systemctl status actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service
+sudo journalctl -u actions.runner.ivonnyssen-rusty-photon.pi5-nightly.service -n 200
+ping -c 3 github.com
+```
+
+If the service is `failed`, look for "Token has expired" — that means the
+registration was revoked from the UI side. Re-register (see above).
+
+### `cargo build` fails with "could not find pkg-config" or "openssl-sys"
+
+System deps were not installed for the `gh-runner` user's PATH. Re-run the
+apt-get block from §"System dependencies". Confirm `pkg-config --version`
+works as the `gh-runner` user:
+
+```bash
+sudo -u gh-runner pkg-config --version
+```
+
+### `fitsio-sys` build script fails
+
+`libcfitsio-dev` missing. Install it; no rebuild flags needed.
+
+### nextest runs but BDD hangs / OmniSim crashes
+
+The Pi may be hitting one of the same intermittent OmniSim issues
+addressed in `test.yml`. The workflow uploads OmniSim logs on failure to
+the `omnisim-logs-pi-nightly` artifact — download it from the failed run
+and investigate per `crates/bdd-infra/src/rp_harness/omnisim.rs`.
+
+### Cache misses every night
+
+Confirm the `shared-key` in `pi-nightly.yml` matches across runs
+(`linux-arm64-stable`). GitHub's Actions cache has a 10 GB cap per repo,
+so a very full cache namespace can also evict ARM entries — check repo
+Settings → Actions → Caches.
+
+## References
+
+- [CLAUDE.md / AGENTS.md](../../CLAUDE.md) — operating rules (rules 4–6 govern
+  pre-push gates and commit format)
+- [docs/skills/pre-push.md](pre-push.md) — quality-gate suite this nightly
+  approximates
+- [.github/workflows/pi-nightly.yml](../../.github/workflows/pi-nightly.yml) —
+  the workflow itself (read the header comment for the security model)
+- [scripts/setup-pi-runner.sh](../../scripts/setup-pi-runner.sh) — idempotent
+  setup script
+- [GitHub: Self-hosted runners — security](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
+  — the upstream warning this skill mitigates
+- [GitHub Actions runner releases](https://github.com/actions/runner/releases)
+  — current `linux-arm64` tarballs and changelogs

--- a/scripts/setup-pi-runner.sh
+++ b/scripts/setup-pi-runner.sh
@@ -32,9 +32,11 @@ set -euo pipefail
 # === Defaults ===
 
 # Bump RUNNER_VERSION + refresh RUNNER_SHA256 in tandem when upgrading.
-# Find current releases at https://github.com/actions/runner/releases.
-RUNNER_VERSION="${RUNNER_VERSION:-2.319.1}"
-RUNNER_SHA256="${RUNNER_SHA256:-}"
+# Find current releases at https://github.com/actions/runner/releases — the
+# release body includes a per-arch SHA-256 table. The pinned values below
+# were captured on 2026-05-14 against the v2.334.0 release.
+RUNNER_VERSION="${RUNNER_VERSION:-2.334.0}"
+RUNNER_SHA256="${RUNNER_SHA256:-f44255bd3e80160eb25f71bc83d06ea025f6908748807a584687b3184759f7e4}"
 RUNNER_NAME="${RUNNER_NAME:-pi5-nightly}"
 RUNNER_LABEL="${RUNNER_LABEL:-raspberry-pi}"
 RUNNER_USER="${RUNNER_USER:-gh-runner}"

--- a/scripts/setup-pi-runner.sh
+++ b/scripts/setup-pi-runner.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Provision a Raspberry Pi 5 (Linux/ARM64) as the rusty-photon `pi-nightly`
+# self-hosted runner. Idempotent: safe to re-run after a partial setup or
+# when bumping RUNNER_VERSION.
+#
+# Operator-facing runbook (security model, decommissioning, troubleshooting):
+#   docs/skills/raspberry-pi-runner.md
+#
+# Usage:
+#   RUNNER_TOKEN=<token-from-github> ./scripts/setup-pi-runner.sh
+#
+#   Optional env vars:
+#     RUNNER_VERSION   Runner release tag (default below, pinned at script edit time)
+#     RUNNER_SHA256    Expected SHA-256 of the runner tarball. If unset, the
+#                      script downloads without integrity verification; if set,
+#                      mismatch aborts the install.
+#     RUNNER_NAME      Display name in the GitHub UI (default: pi5-nightly)
+#     RUNNER_LABEL     Custom label matched by .github/workflows/pi-nightly.yml
+#                      (default: raspberry-pi — must match the workflow's
+#                      runs-on list or jobs will never schedule)
+#     RUNNER_USER      System user that owns the runner (default: gh-runner)
+#     REPO_URL         Repository URL (default: ivonnyssen/rusty-photon)
+#
+# To obtain RUNNER_TOKEN:
+#   GitHub → Repo Settings → Actions → Runners → "New self-hosted runner"
+#   The token is shown in the displayed `./config.sh` snippet. It expires in
+#   ~1 hour, so generate it just before running this script.
+
+set -euo pipefail
+
+# === Defaults ===
+
+# Bump RUNNER_VERSION + refresh RUNNER_SHA256 in tandem when upgrading.
+# Find current releases at https://github.com/actions/runner/releases.
+RUNNER_VERSION="${RUNNER_VERSION:-2.319.1}"
+RUNNER_SHA256="${RUNNER_SHA256:-}"
+RUNNER_NAME="${RUNNER_NAME:-pi5-nightly}"
+RUNNER_LABEL="${RUNNER_LABEL:-raspberry-pi}"
+RUNNER_USER="${RUNNER_USER:-gh-runner}"
+REPO_URL="${REPO_URL:-https://github.com/ivonnyssen/rusty-photon}"
+
+ARCH_TAG="linux-arm64"
+RUNNER_TARBALL="actions-runner-${ARCH_TAG}-${RUNNER_VERSION}.tar.gz"
+RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_TARBALL}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+# === Pre-flight ===
+
+[[ $EUID -ne 0 ]] || die "Do not run this script as root. It will use sudo for the parts that need it."
+
+case "$(uname -sm)" in
+  "Linux aarch64") ;;
+  *) die "Expected Linux aarch64 (Pi 5 64-bit OS). Got: $(uname -sm)" ;;
+esac
+
+command -v sudo >/dev/null || die "sudo is required but not installed."
+command -v curl >/dev/null || sudo apt-get install -y curl
+command -v jq >/dev/null   || true   # jq is installed below if missing
+
+# === 1. System dependencies ===
+
+log "Installing system dependencies (apt-get)..."
+sudo apt-get update -qq
+sudo apt-get install -y \
+  build-essential \
+  pkg-config \
+  curl \
+  git \
+  jq \
+  libssl-dev \
+  libcfitsio-dev \
+  unzip \
+  ca-certificates
+
+# === 2. Dedicated unprivileged user ===
+
+if id -u "$RUNNER_USER" >/dev/null 2>&1; then
+  log "User $RUNNER_USER already exists; skipping creation."
+else
+  log "Creating user $RUNNER_USER (nologin shell, no sudo)..."
+  sudo useradd -m -s /usr/sbin/nologin -U "$RUNNER_USER"
+fi
+
+RUNNER_HOME=$(getent passwd "$RUNNER_USER" | cut -d: -f6)
+[[ -n "$RUNNER_HOME" && -d "$RUNNER_HOME" ]] || die "Could not resolve $RUNNER_USER home directory."
+
+# === 3. Rustup + stable toolchain (as RUNNER_USER) ===
+
+if sudo -u "$RUNNER_USER" test -x "$RUNNER_HOME/.cargo/bin/cargo"; then
+  log "rustup already installed for $RUNNER_USER; running rustup update stable."
+  sudo -u "$RUNNER_USER" bash -lc '. $HOME/.cargo/env && rustup update stable'
+else
+  log "Installing rustup + stable toolchain for $RUNNER_USER..."
+  sudo -u "$RUNNER_USER" bash -lc '
+    curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable --profile minimal
+  '
+fi
+
+# === 4. Download + extract the runner tarball ===
+
+RUNNER_DIR="$RUNNER_HOME/actions-runner"
+
+if sudo -u "$RUNNER_USER" test -f "$RUNNER_DIR/config.sh"; then
+  log "Runner files already present at $RUNNER_DIR; skipping download/extract."
+else
+  log "Downloading runner $RUNNER_VERSION ($ARCH_TAG)..."
+  sudo -u "$RUNNER_USER" mkdir -p "$RUNNER_DIR"
+  sudo -u "$RUNNER_USER" bash -lc "
+    set -euo pipefail
+    cd '$RUNNER_DIR'
+    curl -fsSL --retry 3 --retry-delay 2 -o '$RUNNER_TARBALL' '$RUNNER_URL'
+  "
+
+  if [[ -n "$RUNNER_SHA256" ]]; then
+    log "Verifying SHA-256 of $RUNNER_TARBALL..."
+    ACTUAL=$(sudo -u "$RUNNER_USER" sha256sum "$RUNNER_DIR/$RUNNER_TARBALL" | awk '{print $1}')
+    if [[ "$ACTUAL" != "$RUNNER_SHA256" ]]; then
+      die "SHA-256 mismatch.
+  expected: $RUNNER_SHA256
+  actual:   $ACTUAL
+Refusing to extract. Verify RUNNER_VERSION + RUNNER_SHA256 against the GitHub releases page."
+    fi
+    log "SHA-256 match."
+  else
+    warn "RUNNER_SHA256 not set — skipping integrity check. Set it on production setup."
+  fi
+
+  sudo -u "$RUNNER_USER" bash -lc "
+    set -euo pipefail
+    cd '$RUNNER_DIR'
+    tar xzf '$RUNNER_TARBALL'
+    rm '$RUNNER_TARBALL'
+  "
+fi
+
+# === 5. Register the runner with GitHub ===
+
+if [[ -z "${RUNNER_TOKEN:-}" ]]; then
+  cat >&2 <<EOF
+
+RUNNER_TOKEN is not set. To register the runner, generate a registration
+token at:
+
+  ${REPO_URL}/settings/actions/runners/new
+
+(scroll to the \`./config.sh\` snippet; copy the value after \`--token\`).
+
+Then re-run:
+
+  RUNNER_TOKEN=<token> $0
+
+System packages, the $RUNNER_USER user, rustup, and the runner binaries are
+already in place — re-running with RUNNER_TOKEN set will skip them and only
+register + install the service.
+
+EOF
+  exit 1
+fi
+
+# If a previous registration exists, --replace lets config.sh overwrite it
+# without us having to call `config.sh remove` first.
+log "Configuring runner $RUNNER_NAME (label: $RUNNER_LABEL)..."
+sudo -u "$RUNNER_USER" bash -lc "
+  set -euo pipefail
+  cd '$RUNNER_DIR'
+  ./config.sh \
+    --url '$REPO_URL' \
+    --token '$RUNNER_TOKEN' \
+    --name '$RUNNER_NAME' \
+    --labels '$RUNNER_LABEL' \
+    --work _work \
+    --unattended \
+    --replace
+"
+
+# === 6. Install + start the systemd service ===
+
+log "Installing systemd service..."
+( cd "$RUNNER_DIR" && sudo ./svc.sh install "$RUNNER_USER" )
+
+log "Starting service..."
+( cd "$RUNNER_DIR" && sudo ./svc.sh start )
+
+# svc.sh names the unit something like
+# actions.runner.<owner>-<repo>.<runner-name>.service. Derive it for status.
+REPO_SLUG="$(echo "$REPO_URL" | sed -E 's|https?://github.com/||; s|/|-|')"
+UNIT="actions.runner.${REPO_SLUG}.${RUNNER_NAME}.service"
+
+log "Service status:"
+sudo systemctl --no-pager status "$UNIT" || true
+
+cat <<EOF
+
+Runner setup complete. The runner should appear as "Idle" within seconds at:
+
+  ${REPO_URL}/settings/actions/runners
+
+Follow live logs with:
+
+  sudo journalctl -u $UNIT -f
+
+Trigger an immediate verification run from the Actions tab:
+
+  ${REPO_URL}/actions/workflows/pi-nightly.yml  ->  "Run workflow"
+
+EOF

--- a/scripts/setup-pi-runner.sh
+++ b/scripts/setup-pi-runner.sh
@@ -181,12 +181,18 @@ sudo -u "$RUNNER_USER" bash -lc "
 "
 
 # === 6. Install + start the systemd service ===
+#
+# svc.sh writes to /etc/systemd/system/ (root-only) AND reads template files
+# from its own directory (under $RUNNER_DIR). Ubuntu Server 24.04 creates
+# $RUNNER_HOME with mode 0750 by default, so the calling sudo-capable user
+# typically cannot `cd` into $RUNNER_DIR; the cd must happen *inside* the
+# sudo invocation so root does both the directory entry and the install.
 
 log "Installing systemd service..."
-( cd "$RUNNER_DIR" && sudo ./svc.sh install "$RUNNER_USER" )
+sudo bash -c "cd '$RUNNER_DIR' && ./svc.sh install '$RUNNER_USER'"
 
 log "Starting service..."
-( cd "$RUNNER_DIR" && sudo ./svc.sh start )
+sudo bash -c "cd '$RUNNER_DIR' && ./svc.sh start"
 
 # svc.sh names the unit something like
 # actions.runner.<owner>-<repo>.<runner-name>.service. Derive it for status.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pi-nightly.yml`: a `schedule`+`workflow_dispatch`-only workflow that runs the full workspace build, `cargo nextest`, BDD, and doc tests on a Raspberry Pi 5 self-hosted runner (Linux/ARM64). Gives CI an ARM64 surface — atomics, alignment, vendored C deps like `cfitsio` / `fitsio-sys`, cross-arch feature unification — that the existing x86-only matrix can't cover.
- Add `docs/skills/raspberry-pi-runner.md` (security model, setup, re-registration, decommissioning, troubleshooting) and `scripts/setup-pi-runner.sh` (idempotent provisioning: system deps, dedicated `gh-runner` user, rustup, runner download with SHA-256 verification, systemd service).
- Update `README.md` doc index and `docs/skills/pre-push.md` workflow-breakdown table to point at the new runbook.

## Security model

The repo is public, which is the case GitHub itself warns against for self-hosted runners (a malicious PR can edit workflow YAML and have it execute on the runner). The workflow neutralises this by triggering **only** on `schedule` and `workflow_dispatch` — never `pull_request` or `push`. Scheduled runs always use the workflow file from the default branch (main), and only the owner can write to main, so PRs cannot influence what executes on the Pi.

Belt-and-suspenders:
- `ref: main` pinned on `actions/checkout`
- `if: github.ref == '"'"'refs/heads/main'"'"'` at the build job
- Workflow-level `permissions: contents: read`
- `permissions: issues: write` scoped only to the `notify-on-failure` job (which runs on `ubuntu-latest` so it still fires when the Pi itself is offline)

The runbook documents the threat model so future maintainers can see why `pull_request:` must never be added to this file.

## Operational notes

- Schedule slot: 04:00 UTC daily (between plate-solver-smoke at 03:30 and install-astap at 04:30, for readability — none of those workflows share the Pi runner).
- `notify-on-failure` opens or updates a `pi-nightly`-labelled issue on scheduled failures, same pattern as `conformu.yml` and `plate-solver-smoke.yml`.
- First cold-cache build on the Pi 5 takes ~60–90 min; warmed-cache runs via `Swatinem/rust-cache` are much faster.

## Test plan
- [ ] Merge this PR so the workflow file lands on main.
- [ ] Run `scripts/setup-pi-runner.sh` on the Pi with a fresh registration token from Settings → Actions → Runners → New self-hosted runner.
- [ ] Verify the runner shows **Idle** in Settings → Actions → Runners and `actions.runner.*.service` is `active (running)` on the Pi.
- [ ] Trigger `pi-nightly` manually via Actions → pi-nightly → Run workflow → main; confirm `arm64-stable` picks up the job, builds, tests, and goes green.
- [ ] Let the next scheduled run (04:00 UTC) fire end-to-end and confirm warmed-cache behaviour.
- [ ] (Negative) Optionally remove the runner from Settings → Actions → Runners and confirm `notify-on-failure` opens an issue on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)