### PR TITLE
chore(star-adventurer-gti): remove from nightly ConformU rotation (#201)

### DIFF
--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -797,7 +797,7 @@ ConformU verifies ASCOM compliance.
 | Service unit tests (`#[cfg(test)]` per module) | `coordinates`: encoder ↔ RA/Dec across edge cases (poles, meridian, hemisphere flip); `config`: defaults, JSON round-trips, CLI overrides; `error`: ASCOM mapping |
 | Service BDD (cucumber) | every behaviour table-row above as a scenario, with the mock transport |
 | Service `test_lib.rs` (gated on `mock`) | server starts, binds the configured port, exposes the configured device |
-| `conformu_integration.rs` (gated on `conformu`) | ASCOM Telescope compliance via `ConformUTestBuilder::run()` — runs both `alpacaprotocol` and `conformance` phases. Wired into the nightly `conformu` workflow via `[package.metadata.conformu]` in `Cargo.toml`. See [§"Expected ConformU report"](#expected-conformu-report) for the known deferred-by-design / upstream issues. |
+| `conformu_integration.rs` (gated on `conformu`) | ASCOM Telescope compliance via `ConformUTestBuilder::run()` — runs both `alpacaprotocol` and `conformance` phases. **Currently NOT wired into the nightly `conformu` workflow** (issue #201): three independent conformance-phase failures need driver work first. See [§"Running ConformU manually"](#running-conformu-manually) and [§"Expected ConformU report"](#expected-conformu-report). |
 
 The mock transport is a feature-gated in-memory state machine that
 simulates the motor controller — it accepts the same `:cmd<axis>...\r`
@@ -811,70 +811,96 @@ walks toward `goto_target_ticks` and clears `running` on arrival. BDD
 tests use the mock by default; ConformU and `test_lib.rs` use the
 feature-gated mock so the binary itself runs against a fake mount.
 
+### Running ConformU manually
+
+This service is deliberately **not** in the nightly `conformu`
+workflow rotation (issue #201). `ConformUTestBuilder::run()` (which
+the in-tree integration test uses) runs `alpacaprotocol` then
+`conformance`. With PulseGuide landed (PR #206), the
+`alpacaprotocol` phase now completes — but the `conformance` phase
+surfaces three independent failures that need driver work before
+re-adding `[package.metadata.conformu]` to the package's
+`Cargo.toml`:
+
+1. **`SideOfPierTests` aborts CheckMethods.** ConformU
+   (`TelescopeTester.cs::SopPierTest`) slews to mechanical-HA
+   ±9 h to verify pier-side reporting on both sides of the
+   meridian. The `[-6, +6]` h safety envelope correctly rejects
+   those slews on real hardware, but the
+   `InvalidValueException` is caught by ConformU's
+   "Exception when testing device" handler at CheckMethods scope
+   and the rest of the suite is abandoned — so the CI test exits
+   with one ISSUE and no further diagnostics. Widening the
+   envelope just for the mock test config (e.g.
+   `ra_min_hours = -12`, `ra_max_hours = 12`) lets CheckMethods
+   complete and exposes the other two failures below.
+2. **`SideOfPier` returns `pierWest` for every in-envelope
+   target.** `coordinates::side_of_pier` keys on
+   `|dec_ticks| > cpr_dec/4` (the Dec-encoder-past-pole
+   "physical flip" convention). Inside the safety envelope the
+   Dec encoder never crosses that threshold, so the driver
+   reports `West` regardless of which side of the meridian the
+   mount is observing. ConformU asserts the ASCOM pointing-state
+   convention (`pierWest` for HA ∈ [-6, 0), `pierEast` for
+   HA ∈ (0, +6]) and records ISSUEs for every HA > 0 case in
+   both `SideofPier` and `DestinationSideofPier`.
+3. **PulseGuide Dec moves at full sidereal rate.** ConformU's
+   PulseGuide tolerance check expects
+   `guide_rate_dec_fraction × sidereal × duration` of declination
+   change (37.6″ for a 5 s pulse at the default 0.5× rate);
+   the driver actually moves ~71.4″ (~ 2×). The same factor-of-2
+   shows up at every HA test point in both North/South pulses,
+   so it is an axis-rate calculation bug in the rate-shifted
+   tracking burst introduced by PR #206, not a Dec-vs-encoder
+   coordinate issue.
+
+To run ConformU's `conformance` phase by hand against the running
+service (no nightly opt-in needed):
+
+```bash
+# Terminal 1: start the service in mock mode on a fixed port.
+cargo run -p star-adventurer-gti --features mock -- \
+    --transport mock --server-port 11117
+
+# Terminal 2: point ConformU at it.
+conformu conformance http://localhost:11117/api/v1/telescope/0
+```
+
 ### Expected ConformU report
 
-A clean nightly ConformU run against this driver reports:
+These are the conformance-phase findings against the current
+driver (PR #206). They are *not* a green run — fixing (2) and (3)
+above is on the roadmap before the package is re-added to the
+nightly workflow.
+
+After (1) is worked around by widening the mock test envelope:
 
 - **0 errors** — anything here is a real driver regression.
-- **7 issues**, all of which are cosmetic / inherent to a
-  non-flipping GEM:
-  - `SOPPierTest` ×4 — the safety envelope correctly rejects
-    cross-meridian slews that would land at `RA mech-HA = ±9h`
-    (well outside the default ±6h counterweight-horizontal
-    envelope). `SOPPierTest` exercises the pier-flip code paths
-    by commanding such slews. The driver returns
-    `InvalidValueException` from both `SlewToCoordinatesAsync`
-    and `DestinationSideOfPier` (the two go through the same
-    `check_within_safe_envelope` gate) for each of the two
-    ±9 h test points, so ConformU records four exception
-    entries per run. This is the same envelope-rejection
-    mechanism Phase 4 added — see
-    [§Phase 4 driver-logic changes].
-  - `SideofPier` ×1 and `DestinationSideofPier` ×1 —
-    "`pierWest` is returned when the mount is observing at an
-    hour angle between 0.0 and +6.0". ConformU's
-    `SideofPier` test assumes the mount flips at the meridian
-    (the EQMOD / Sky-Watcher Synscan / ASCOM-driver-pattern
-    behaviour) and therefore expects `pierEast` for any target
-    west of the meridian. The Star Adventurer GTi driver does
-    not initiate flips — the safety envelope keeps the
-    encoder within `[-CPR/4, +CPR/4]` of the home position,
-    which the Dec-encoder side-of-pier convention correctly
-    classifies as `pierWest` regardless of whether the target
-    is east or west of the meridian. The ASCOM spec is
-    explicit that `SideOfPier` reports the OTA's mechanical
-    position, not the target's sky position, so the driver's
-    answer is correct for this mount; ConformU's
-    flip-assumption check just doesn't apply.
-  - `DestinationSideOfPier` ×1 — "Same value for
-    DestinationSideOfPier received on both sides of the
-    meridian". Same root cause: the driver never plans a
-    flip, so every in-envelope target lands in the same
-    pointing state.
+- **~58 issues**, dominated by:
+  - PulseGuide North/South/East/West tolerance failures at
+    HA ±3 and ±9 (×24 entries) — driver bug (3).
+  - `SideofPier` and `DestinationSideofPier` "`pierWest` is
+    returned when the mount is observing at an hour angle
+    between 0.0 and +6.0" (×8 entries) — driver bug (2).
+  - `SideofPier` / `DestinationSideofPier`
+    "reports physical pier side rather than pointing state"
+    and "Same value … on both sides of the meridian"
+    (×4 entries) — manifestation of bug (2).
 
-Issue counts shift on convention changes:
+Historical baselines (`alpacaprotocol`-only or partial
+`conformance` runs):
 
 - Pre-#202 baseline (HA-meridian split, `DestinationSideOfPier`
-  unimplemented): **9 issues** — `DestinationSideOfPier` ×1
+  unimplemented): 9 issues — `DestinationSideOfPier` ×1
   (NotImplemented), `SOPPierTest` ×4 (inherited from
   NotImplemented), `SOPPierTest` ×2 (safety envelope),
   `TrackingRate Write` ×2 (upstream `ascom-alpaca-rs`
   framework bug — Alpaca enum rejection at the axum/serde
   layer before reaching the driver).
 - Post-#202 baseline (Dec-encoder split, `DestinationSideOfPier`
-  implemented): **7 issues** as listed above. The
-  `TrackingRate Write` ×2 entries disappeared after an
-  unrelated upstream fix; the four `DestinationSideOfPier`
-  "consistency" / "Exception" entries got reclassified by the
-  Dec-encoder switch (the four inherited-from-NotImplemented
-  ones became three of the new-cause ones plus the two
-  `SideofPier` / `DestinationSideofPier` consistency
-  entries).
-
-Any issue or error outside that list — and in particular any
-`SlewTo*` / `SyncTo*` row reporting a tolerance exceedance
-("`Actual RA: ..., Target RA: ...`" with > 10″ delta) — is a
-real regression. Fix the driver, then refresh this section.
+  implemented, PulseGuide not yet landed, conformance never
+  reached SideOfPierTests because alpacaprotocol failed on
+  `IsPulseGuiding`): 7 issues as previously documented.
 
 ## Connection Lifecycle
 
@@ -928,7 +954,8 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase 4 — Real-hardware bringup** | partially landed — first hardware connect surfaced several protocol-decoding gaps that the mock had hidden. Details below. |
 | **Phase A5 — `:I`/`:M` on slew + EQMOD pickup** | landed (issue #205) — reinstates `:I` on the slew path, switches goto to `:H` (delta target) + `:M` (break-point), and adds an iterative post-stop pickup loop to close the residual RA drift the Phase 4 ConformU run flagged. |
 | **Phase A6 — Dec-encoder `SideOfPier` + `DestinationSideOfPier`** | landed (issue #202) — switches `SideOfPier` from the RA mech-HA split at `HA = 0` to the canonical INDI eqmod Dec-encoder convention (`East` when `\|dec_encoder\| > cpr_dec/4`), and lands `DestinationSideOfPier` reusing the same coordinate-math pipeline as `SlewToCoordinatesAsync`. ConformU expected-issues count moves from 9 to 7: the `DestinationSideOfPier` NotImplemented entry and the four inherited `SOPPierTest` entries clear, the two upstream `TrackingRate Write` entries disappear (unrelated framework fix), and three new "non-flipping mount" entries appear that reflect ConformU's flip-aware-GEM assumption rather than driver bugs. See [§Expected ConformU report](#expected-conformu-report). |
-| **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`, and re-enables `[package.metadata.conformu]` so the full two-phase ConformU integration runs again. |
+| **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`. Re-enabled `[package.metadata.conformu]` so the full two-phase ConformU integration ran again — but the `conformance` phase, which `alpacaprotocol`-only manual runs hadn't exercised, surfaced three failures that PR #206's review hadn't caught; see Phase A8. |
+| **Phase A8 — Nightly ConformU opt-out (#201)** | landed (issue #201) — removed `[package.metadata.conformu]` again. ConformU's `conformance` phase fails for three independent reasons that need driver work first: (a) `SideOfPierTests` slews to mech-HA ±9 h, which the safety envelope correctly rejects on hardware but which ConformU treats as a fatal CheckMethods-level exception that abandons the rest of the suite; (b) `SideOfPier` always returns `pierWest` for in-envelope targets (Dec-encoder convention) where ConformU asserts the ASCOM pointing-state convention; (c) PulseGuide Dec moves at full sidereal rate instead of `guide_rate_dec_fraction × sidereal`. See [§Running ConformU manually](#running-conformu-manually) and [§Expected ConformU report](#expected-conformu-report) for the failure details and reproduction steps. |
 | **Phase 5 — user-defined `SetPark` + persistence** | landed (issue #203) — park target now sourced from `mount.park_ra_ticks` / `mount.park_dec_ticks` in the config (fallback: encoder positions captured at handshake), `SetPark` writes the current encoder pair back into the running config file via atomic rename, `CanSetPark` flips on when `--config` is provided. See [§Park lifecycle](#park-lifecycle) and [§Park persistence](#park-persistence). |
 
 #### Phase 4 findings (hardware bringup)

--- a/services/star-adventurer-gti/Cargo.toml
+++ b/services/star-adventurer-gti/Cargo.toml
@@ -36,8 +36,32 @@ erfars = { workspace = true }
 chrono = { workspace = true }
 tempfile = { workspace = true }
 
-[package.metadata.conformu]
-command = "cargo test -p star-adventurer-gti --features conformu --test conformu_integration -- --ignored --nocapture"
+# Intentionally NOT opting in to the nightly ConformU workflow via
+# `[package.metadata.conformu]` (issue #201). When PR #206
+# re-enabled it after PulseGuide landed, the conformance phase
+# surfaced three independent failures that the alpacaprotocol-only
+# manual runs hadn't exercised:
+#
+# 1. `SideOfPierTests` slews to mechanical-HA ±9 h to verify
+#    pier-side reporting on both sides of the meridian. The
+#    `[-6, +6]` h safety envelope (`MountConfig::ra_{min,max}_hours`)
+#    correctly rejects those slews for real hardware, but ConformU
+#    treats the resulting `InvalidValueException` as a fatal
+#    exception and abandons `CheckMethods` entirely — so the rest
+#    of the suite never runs in CI.
+# 2. `SideOfPier` returns `pierWest` for every in-envelope target
+#    because `coordinates::side_of_pier` keys on
+#    `|dec_ticks| > cpr_dec/4` (the Dec-encoder-past-pole "physical
+#    flip" convention). ConformU asserts the ASCOM pointing-state
+#    convention (`pierWest` for HA ∈ [-6, 0), `pierEast` for
+#    HA ∈ (0, +6]) and records ISSUEs for the HA > 0 cases.
+# 3. PulseGuide North / South tolerance checks fail by ~2× — Dec
+#    moves at full sidereal rate instead of
+#    `guide_rate_dec_fraction × sidereal`.
+#
+# Re-add `[package.metadata.conformu]` once those land. Until then,
+# run ConformU manually — see
+# `docs/services/star-adventurer-gti.md` §"Running ConformU manually".
 
 [dev-dependencies]
 bdd-infra = { workspace = true }


### PR DESCRIPTION
## Summary

- Drops `[package.metadata.conformu]` from `services/star-adventurer-gti/Cargo.toml`, so the nightly `conformu` workflow's `cargo metadata` discovery no longer matrix-spawns star-adventurer-gti jobs (verified: 4 services remain — `filemonitor`, `ppba-driver`, `qhy-focuser`, `sky-survey-camera`).
- Documents three deferred driver bugs the conformance phase exposed once PR #206 re-enabled the opt-in: (a) safety envelope rejects ConformU's mech-HA ±9 h pier-flip slews and ConformU treats the `InvalidValueException` as a fatal CheckMethods exception; (b) `SideOfPier` keys on the Dec-encoder-past-pole convention and always returns `pierWest` for in-envelope targets where ConformU asserts the ASCOM pointing-state convention; (c) PulseGuide Dec moves at ~2× the expected rate.
- Restores "Running ConformU manually" + adds Phase A8 + rewrites "Expected ConformU report" in `docs/services/star-adventurer-gti.md` so the deferred work is discoverable; integration test (`conformu_integration.rs`) stays in-tree for manual runs.

Closes #201.

## Test plan

- [x] `cargo metadata --format-version 1 --no-deps | jq '[.packages[] | select(.metadata.conformu.command) | .name]'` returns the 4 remaining services and excludes `star-adventurer-gti`.
- [x] `cargo rail run --profile commit -q` — 216 tests pass.
- [x] `cargo fmt --check` clean.
- [x] Pre-commit hook (`cargo clippy --all --all-targets --all-features -- -D warnings` + `cargo fmt --all -- --check`) clean.
- [ ] Next scheduled nightly `conformu` workflow run goes green.

## Follow-ups (separate issues)

- Driver bug: PulseGuide Dec rate is 2× expected — likely a sign or reciprocal in the rate-shifted-tracking step-period math from PR #206.
- Driver bug: `SideOfPier` returns `pierWest` for every in-envelope target — switch the primary discriminator from "Dec encoder past pole" to mech-HA sign (or combine both) to match the ASCOM pointing-state convention.
- macOS `Pre-build workspace` step intermittently invoked `rustup-init` instead of `cargo` on 2026-05-15 (Swatinem/rust-cache@v2 restored a `~/.cargo/bin` where `cargo` is a copy of `rustup-init`). Unrelated to issue #201; track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)