### PR TITLE
docs: archive plate-solver + sky-survey-camera plans, file forward-work issues

### DIFF
--- a/docs/plans/archive/image-evaluation-tools.md
+++ b/docs/plans/archive/image-evaluation-tools.md
@@ -797,10 +797,10 @@ its size (subprocess supervision, ASTAP CLI argument layout, `.wcs`
 parsing, per-platform install verification) and because ADR-005
 already called for "a separate plan to sequence the plate-solver
 rp-managed-service implementation." Tracked end-to-end in
-[`docs/plans/plate-solver.md`](plate-solver.md), where all eight
+[`docs/plans/archive/plate-solver.md`](plate-solver.md), where all eight
 phases (Phase 1 design doc through Phase 8 LGPL §4/§6 review) landed.
 
-- [x] **`docs/plans/plate-solver.md`** sequenced the service itself:
+- [x] **`docs/plans/archive/plate-solver.md`** sequenced the service itself:
       workspace member skeleton, ASTAP subprocess wrapper, HTTP API,
       BDD scenarios, supervision integration with sentinel, and the
       per-platform end-to-end solve passes that retired ADR-005 Open

--- a/docs/plans/archive/plate-solver.md
+++ b/docs/plans/archive/plate-solver.md
@@ -1,9 +1,30 @@
 # Plan: `plate-solver` service
 
+**Status: COMPLETE (archived 2026-05-15).** All eight phases shipped;
+ADR-005 open questions 1–6 retired (item 4 partially — solve-time
+trending now tracked under forward-work issues below). The service
+lives at [`services/plate-solver/`](../../../services/plate-solver/);
+the design contract is [`docs/services/plate-solver.md`](../../services/plate-solver.md).
+
+Forward-work items called out by this plan are tracked as standalone
+issues:
+
+- #232 — Sentinel HTTP service supervision (Phase 5 deferred)
+- #233 — Committable m31 happy-path FITS fixture (Phase 6 deferred)
+- #234 — Solve-time budget assertion in nightly (Phase 6 deferred)
+- #235 — Windows ARM64 verification (ADR-005 OQ 3, out of scope for v1)
+- #236 — Automated nightly hinted-vs-blind perf trending (Phase 7 deferred)
+
+The rp-side `plate_solve` MCP tool — listed by this plan's Phase 7 as
+forward work in the parent plan's Phase 6c-2 — has since landed
+([`services/rp/src/mcp/built_in/plate_solve.rs`](../../../services/rp/src/mcp/built_in/plate_solve.rs)
++ [`crates/rp-plate-solver/`](../../../crates/rp-plate-solver/)). No
+follow-up issue needed for it.
+
 **Date:** 2026-05-02
 **Branch:** `worktree-astap`
-**ADR:** [005-plate-solver](../decisions/005-plate-solver.md)
-**Parent plan:** [archive/image-evaluation-tools.md Phase 6c-1](archive/image-evaluation-tools.md#phase-6c-1--plate-solver-rp-managed-service)
+**ADR:** [005-plate-solver](../../decisions/005-plate-solver.md)
+**Parent plan:** [image-evaluation-tools.md Phase 6c-1](image-evaluation-tools.md#phase-6c-1--plate-solver-rp-managed-service)
 
 ## Background
 
@@ -699,7 +720,7 @@ Status: **complete.**
 The plan's original framing assumed a Sentinel "configured
 restart-command per service" feature the existing Sentinel doesn't
 have — Sentinel today is an Alpaca SafetyMonitor poller and notifier
-([`docs/services/sentinel.md`](../services/sentinel.md)), not a
+([`docs/services/sentinel.md`](../../services/sentinel.md)), not a
 generic HTTP service supervisor. The honest answer for v1: the
 operator's OS process supervisor (systemd / launchd / NSSM) is the
 recovery mechanism; future Sentinel work can layer on the `/health`

--- a/docs/plans/archive/rp-planning-tools.md
+++ b/docs/plans/archive/rp-planning-tools.md
@@ -7,7 +7,7 @@ tools"). See **Outcomes** below.
 **Date:** 2026-05-03
 **Branch:** `worktree-planning-tools`
 **Parent design doc:** [`docs/services/rp.md`](../../services/rp.md)
-**Closest precedent:** [`docs/plans/plate-solver.md`](../plate-solver.md) (eight-phase, design-first plan)
+**Closest precedent:** [`docs/plans/archive/plate-solver.md`](plate-solver.md) (eight-phase, design-first plan)
 
 ## Outcomes (2026-05-09)
 
@@ -736,7 +736,7 @@ Within that fixed scope, dependencies are mostly linear:
   — design-first, test-first phasing
 - [`docs/skills/testing.md`](../../skills/testing.md) — BDD and unit
   test conventions; `@wip` filter (§2.7)
-- [`docs/plans/plate-solver.md`](../plate-solver.md) — closest
+- [`docs/plans/archive/plate-solver.md`](plate-solver.md) — closest
   precedent for an eight-phase, design-first plan in this workspace
 - [`docs/plans/archive/image-evaluation-tools.md`](image-evaluation-tools.md)
   §"Phase 6c-prep — Telescope (mount) primitives" — prerequisite for

--- a/docs/plans/archive/sky-survey-camera-mount-following.md
+++ b/docs/plans/archive/sky-survey-camera-mount-following.md
@@ -1,9 +1,36 @@
 # Plan: sky-survey-camera mount-following + simulated pointing offset
 
+**Status: COMPLETE (archived 2026-05-15).** All four phases shipped.
+Phases 1–3 landed via PR #142 (squash commit `f2e1086`); Phase 4
+landed via PR #187 (squash commit `7b924aa`, with subsequent
+Copilot-round follow-up commits). The canonical behavioral contracts
+live in [`docs/services/sky-survey-camera.md`](../../services/sky-survey-camera.md);
+the service itself is at [`services/sky-survey-camera/`](../../../services/sky-survey-camera/).
+
+Forward-work items called out by this plan are tracked as a standalone
+issue (the others were explicitly skipped — see notes):
+
+- #237 — Optional ASCOM Rotator support for follow mode (Future work item 1)
+- Non-linear pointing models (Future work item 2) — not tracked; no consumer pulling on it.
+- Sidereal drift during exposure (Future work item 3) — not tracked; no consumer pulling on it.
+- OmniSim PR upstream (Future work item 4) — not tracked; community contribution that benefits other consumers more than us.
+
+**Design-to-implementation divergence to flag for future readers:** the
+design decision §"`POST /sky-survey/position` returns 409 in follow-mode"
+was **reversed during Phase 4**. The shipped F6 behavior is that `POST`
+in follow mode arms a *one-shot pointing override* (consumed by the next
+light exposure), and a new contract **F7** was added to specify that
+override's semantics. This change was necessary to make the closed-loop
+centering scenario converge — a persistent offset would never let the
+loop reach zero residual. The plan body below preserves the original
+"returns 409" framing as a historical artifact; consult the canonical
+F1–F7 contracts in [`docs/services/sky-survey-camera.md`](../../services/sky-survey-camera.md)
+§"Behavioral Contracts" for the actual shipped behavior.
+
 **Date:** 2026-05-03
 **Branch:** `worktree-trail-mount`
-**Parent service:** [`docs/services/sky-survey-camera.md`](../services/sky-survey-camera.md) — retires the *Telescope-following mode* item under Future Work.
-**Consumer plan:** [`docs/plans/archive/image-evaluation-tools.md` Phase 6c-3](archive/image-evaluation-tools.md#phase-6c-3--center_on_target-design--bdd--impl) — `center_on_target` BDD currently has to fake convergence via a synthetic `PlateSolveOps` adapter ("OmniSim does not model pointing"). This plan removes that caveat for the end-to-end path.
+**Parent service:** [`docs/services/sky-survey-camera.md`](../../services/sky-survey-camera.md) — retires the *Telescope-following mode* item under Future Work.
+**Consumer plan:** [`docs/plans/archive/image-evaluation-tools.md` Phase 6c-3](image-evaluation-tools.md#phase-6c-3--center_on_target-design--bdd--impl) — `center_on_target` BDD currently has to fake convergence via a synthetic `PlateSolveOps` adapter ("OmniSim does not model pointing"). This plan removes that caveat for the end-to-end path.
 
 ## Background
 
@@ -166,7 +193,7 @@ Each phase is its own PR. All four phases land on this branch (`worktree-trail-m
 
 ### Phase 1 — Service design doc update
 
-Status: **done** — landed in `4e7691d`.
+Status: **done** — landed in PR #142 (squash commit `f2e1086`).
 
 - [ ] Update `docs/services/sky-survey-camera.md`:
   - "Configuration" — add the `pointing.telescope` schema block with field-by-field description.
@@ -181,7 +208,7 @@ Status: **done** — landed in `4e7691d`.
 
 ### Phase 2 — `PointingSource` refactor + telescope-follow mode (no offset yet)
 
-Status: **done** — landed in `6ce90ae`.
+Status: **done** — landed in PR #142 (squash commit `f2e1086`).
 
 - [ ] `services/sky-survey-camera/src/pointing.rs` — introduce `PointingSource` enum. `Static(SharedPointing)` is the existing path, no behaviour change. `Telescope(TelescopeFollow)` is a new struct holding `Arc<dyn Telescope>` + its config; `snapshot()` reads RA/Dec from the mount, returns a `PointingState`. **Offset stays at zero in this phase** so the diff is bounded.
 - [ ] `services/sky-survey-camera/src/config.rs` — extend `PointingConfig` with the optional `telescope: Option<TelescopeFollowConfig>`. Wire `humantime_serde` for `request_timeout`. Reuse `rp_auth::config::ClientAuthConfig` (already a workspace dep transitively via `rp`; if not, add the workspace dep — no new crates.io download).
@@ -193,7 +220,7 @@ Status: **done** — landed in `6ce90ae`.
 
 ### Phase 3 — Pointing offset injection + F5/F6 BDD
 
-Status: **done** — landed in `9d4f518`. The mount stub stayed in-crate
+Status: **done** — landed in PR #142 (squash commit `f2e1086`). The mount stub stayed in-crate
 (`tests/bdd/world.rs`) rather than landing in `bdd-infra`, since no
 other service-level BDD currently needs an ASCOM Telescope mock. If a
 second crate eventually needs one, the `MountStubBehavior` /
@@ -210,8 +237,18 @@ second crate eventually needs one, the `MountStubBehavior` /
 
 ### Phase 4 — Closed-loop centering BDD
 
-Status: **ready to start.** Both consumer-side phases have landed on
-`main`:
+Status: **done** — landed in PR #187 (squash commit `7b924aa`, plus
+Copilot-round follow-ups `d5dd83d`, `878ad55`, `e346761`, `b1f97b9`,
+`8e736a7`). The shipped implementation diverged from the plan in one
+load-bearing way: F6 was changed from "return 409" to "arm a one-shot
+pointing override", and F7 was added to specify that override's
+semantics. Without that change, a persistent offset would never let the
+centering loop converge to zero residual. See the archive banner at the
+top of this file for the divergence summary, and
+[`docs/services/sky-survey-camera.md`](../../services/sky-survey-camera.md)
+§"Behavioral Contracts" for the canonical F1–F7 contracts.
+
+Both consumer-side phases have landed on `main`:
 
 - **6c-2** (`plate_solve` MCP tool in `rp`) — shipped in #156
   (`415c934`). `services/rp/src/mcp/built_in/plate_solve.rs` and

--- a/docs/services/plate-solver.md
+++ b/docs/services/plate-solver.md
@@ -63,7 +63,7 @@ Accessibility").
   ASTAP SIGSEGV, hang, or deadlock cannot threaten `rp`'s session
   state. This rationale is the load-bearing argument for choosing
   rp-managed-service over plugin shape; see
-  `docs/plans/plate-solver.md` §"Stability and supervision" for
+  `docs/plans/archive/plate-solver.md` §"Stability and supervision" for
   the full discriminator.
 - **Tenet 4 — Remote interfaces only.** HTTP between rp and the
   service. The service-to-ASTAP boundary is a CLI subprocess, not an
@@ -78,7 +78,7 @@ Accessibility").
 ### HTTP API
 
 The service exposes exactly two endpoints. The contract is frozen by
-`docs/plans/plate-solver.md` §"HTTP contract"; this section
+`docs/plans/archive/plate-solver.md` §"HTTP contract"; this section
 states the behavior, not the wire format details.
 
 #### `POST /api/v1/solve`
@@ -419,7 +419,7 @@ the real ASTAP binary, gated by a runtime check on the
 `ASTAP_BINARY` environment variable. Scenarios skip silently when
 the env var is unset (the PR-required path). They fire when the env
 var is set, which is the dedicated nightly cross-platform smoke
-workflow's job. See `docs/plans/plate-solver.md` §"Real-ASTAP
+workflow's job. See `docs/plans/archive/plate-solver.md` §"Real-ASTAP
 coverage: cadence and gating" for the rationale and the `bdd.rs`
 filter snippet.
 
@@ -493,7 +493,7 @@ operational tooling (Prometheus blackbox exporter, Nagios, etc.).
 ## References
 
 - ADR-005 — `docs/decisions/005-plate-solver.md`
-- Implementation plan — `docs/plans/plate-solver.md`
+- Implementation plan — `docs/plans/archive/plate-solver.md`
 - rp design doc, §"Plate Solver" — `docs/services/rp.md`
 - rp design doc, §"Sentinel Watchdog Integration" — `docs/services/rp.md`
 - rp design doc, §"File Accessibility" — `docs/services/rp.md`

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1686,7 +1686,7 @@ The choice of solver and the supervision posture are settled by
 doc — HTTP contract, supervision contract, configuration, mock test
 double — lives at [`docs/services/plate-solver.md`](plate-solver.md).
 Implementation sequencing is in
-[`docs/plans/plate-solver.md`](../plans/plate-solver.md).
+[`docs/plans/archive/plate-solver.md`](../plans/archive/plate-solver.md).
 
 ### File Accessibility
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -44,7 +44,7 @@ belong in any single service design doc.
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
 | [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
 | [i18n-cli-spike.md](plans/i18n-cli-spike.md) | Tech spike landing Fluent + `i18n-embed` behind `ppba-driver`'s clap CLI (en + de) |
-| [plate-solver.md](plans/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing) |
+| [plate-solver.md](plans/archive/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing, archived 2026-05-15) |
 
 ## Shared Crates
 

--- a/services/plate-solver/README.md
+++ b/services/plate-solver/README.md
@@ -5,12 +5,12 @@ solve API to `rp`. Operator installs ASTAP separately (BYO per ADR-005);
 `plate-solver` ships no ASTAP binary or index database.
 
 See [`docs/services/plate-solver.md`](../../docs/services/plate-solver.md)
-for the design contract and [`docs/plans/plate-solver.md`](../../docs/plans/plate-solver.md)
-for implementation sequencing.
+for the design contract and [`docs/plans/archive/plate-solver.md`](../../docs/plans/archive/plate-solver.md)
+for implementation sequencing (archived 2026-05-15).
 
 ## Status
 
-All eight phases of the [implementation plan](../../docs/plans/plate-solver.md#phases)
+All eight phases of the [implementation plan](../../docs/plans/archive/plate-solver.md#phases)
 have shipped: design doc, crate scaffolding + `AstapRunner` trait +
 `.wcs` parser, BDD scenarios, HTTP server + supervision,
 process-supervisor recipes, nightly cross-platform real-ASTAP smoke,
@@ -211,5 +211,5 @@ top of the same `/health` endpoint this service already exposes.
 - `pixel_scale_arcsec`: arcseconds per pixel.
 - `rotation_deg`: degrees.
 
-Full HTTP contract in [`docs/plans/plate-solver.md`](../../docs/plans/plate-solver.md)
+Full HTTP contract in [`docs/plans/archive/plate-solver.md`](../../docs/plans/archive/plate-solver.md)
 §"HTTP contract".

--- a/services/plate-solver/src/api.rs
+++ b/services/plate-solver/src/api.rs
@@ -2,7 +2,7 @@
 //! `GET /health`.
 //!
 //! Frozen contract details live in
-//! `docs/plans/plate-solver.md` §"HTTP contract" and the
+//! `docs/plans/archive/plate-solver.md` §"HTTP contract" and the
 //! behavior contract is in `docs/services/plate-solver.md`.
 
 use crate::error::AppError;

--- a/services/plate-solver/src/lib.rs
+++ b/services/plate-solver/src/lib.rs
@@ -1,7 +1,7 @@
 //! plate-solver — rp-managed service wrapping the ASTAP CLI.
 //!
 //! See `docs/services/plate-solver.md` for the design contract and
-//! `docs/plans/plate-solver.md` for sequencing.
+//! `docs/plans/archive/plate-solver.md` for sequencing.
 
 pub mod api;
 pub mod config;

--- a/services/plate-solver/tests/bdd.rs
+++ b/services/plate-solver/tests/bdd.rs
@@ -10,8 +10,8 @@
 //! - `@requires-astap` — gates a small cross-platform real-ASTAP
 //!   smoke that fires only when `ASTAP_BINARY` is set in the
 //!   environment. PR jobs do not set it; the dedicated nightly
-//!   workflow does. See `docs/plans/plate-solver.md` §"Real-ASTAP
-//!   coverage: cadence and gating".
+//!   workflow does. See `docs/plans/archive/plate-solver.md`
+//!   §"Real-ASTAP coverage: cadence and gating".
 //!
 //! Both filter forms accept the tag with or without a leading `@`,
 //! matching `services/rp/tests/bdd.rs`'s pattern (cucumber-rs may

--- a/services/plate-solver/tests/features/real_astap_smoke.feature
+++ b/services/plate-solver/tests/features/real_astap_smoke.feature
@@ -7,8 +7,8 @@ Feature: Real-ASTAP smoke (mock-honesty backstop)
   cross-platform workflow sets that var via the `install-astap` action;
   PR jobs do not, so these scenarios are skipped on every PR.
 
-  See `docs/plans/plate-solver.md` §"Real-ASTAP coverage: cadence
-  and gating" for the rationale and the bdd.rs filter snippet.
+  See `docs/plans/archive/plate-solver.md` §"Real-ASTAP coverage:
+  cadence and gating" for the rationale and the bdd.rs filter snippet.
 
   Note: the `@wip` tag is removed by Phase 4 along with all other
   feature files'. The `@requires-astap` tag stays — it's the permanent

--- a/services/plate-solver/tests/features/solve_request.feature
+++ b/services/plate-solver/tests/features/solve_request.feature
@@ -5,7 +5,7 @@ Feature: POST /api/v1/solve — request handling and error surface
   returns the parsed WCS solution or one of the five frozen error codes.
 
   The complete HTTP contract — request fields, response fields, error
-  code table — lives in `docs/plans/plate-solver.md` §"HTTP contract".
+  code table — lives in `docs/plans/archive/plate-solver.md` §"HTTP contract".
   Each scenario below exercises that contract one branch at a time.
 
   Background:

--- a/services/rp/tests/bdd/steps/sky_survey_camera_steps.rs
+++ b/services/rp/tests/bdd/steps/sky_survey_camera_steps.rs
@@ -1,7 +1,7 @@
 //! BDD step definitions for the closed-loop centering scenario.
 //!
 //! Phase-4 integration path from
-//! `docs/plans/sky-survey-camera-mount-following.md`: the camera is a
+//! `docs/plans/archive/sky-survey-camera-mount-following.md`: the camera is a
 //! real `sky-survey-camera` process configured to follow OmniSim's
 //! Telescope. The scenario primes a one-shot pointing override on
 //! the camera (F7) before invoking `center_on_target`, so iter 0

--- a/services/rp/tests/features/center_on_target.feature
+++ b/services/rp/tests/features/center_on_target.feature
@@ -235,7 +235,7 @@ Feature: Center on target compound tool
       | dec              | 91    |
 
   # Closed-loop scenarios (Phase 4 of
-  # docs/plans/sky-survey-camera-mount-following.md): the camera is a
+  # docs/plans/archive/sky-survey-camera-mount-following.md): the camera is a
   # real `sky-survey-camera` process following OmniSim's Telescope.
   # Before invoking `center_on_target`, the scenario `POST`s to the
   # camera's `/sky-survey/position` endpoint, which in follow mode


### PR DESCRIPTION
## Summary

Two completed plans audited and moved to `docs/plans/archive/`, with their explicit forward-work items filed as standalone issues so they can be picked up independently.

### plate-solver (8 phases, all shipped)

- Plan archived with a status banner pointing at #232–#236 (five forward-work items) and noting that the sixth item — rp-side `plate_solve` MCP tool — has already landed.
- Filed:
  - #232 — Sentinel HTTP service supervision via `/health` + restart command
  - #233 — Committable m31 happy-path FITS fixture
  - #234 — Solve-time budget assertion in nightly
  - #235 — Windows ARM64 verification
  - #236 — Automated nightly hinted-vs-blind perf trending

### sky-survey-camera-mount-following (4 phases, all shipped)

- Plan archived with a status banner documenting actual PR refs (#142 for Phases 1–3, #187 for Phase 4) and replacing three non-resolving pre-rebase commit hashes.
- Phase 4 status line corrected from "ready to start" to "done".
- Design-to-implementation divergence flagged in the banner: the plan's "POST /sky-survey/position returns 409 in follow mode" decision was reversed during Phase 4 — F6 now arms a one-shot pointing override and F7 was added. Without that change the closed-loop centering scenario could not converge. Canonical contracts are in the design doc.
- Filed:
  - #237 — Optional ASCOM Rotator support for follow mode (one of four "Future work" items; the other three are not tracked by explicit decision because no consumer is pulling on them).

### Mechanics

- 15 files total: 2 `git mv` renames + 11 inbound link/comment updates + 2 archive-banner edits (in the moved files).
- Inbound link sweep covered `docs/workspace.md`, `docs/services/rp.md`, `docs/services/plate-solver.md`, the two sibling archive plans (`rp-planning-tools`, `image-evaluation-tools`), the plate-solver README, four source-comment references, and three feature-file references.
- Relative paths inside the moved plans adjusted so their outbound links resolve from the archive directory.
- Final `grep` for stale plan paths returns zero hits.

## Test plan

- [x] `cargo rail run --profile commit -q` — clean (456 tests passed; rail exercised `plate-solver` and `rp` per merge-base analysis).
- [x] `cargo fmt --check` — clean.
- [x] Pre-commit hooks (clippy + fmt) passed for both commits.
- [x] `grep` for stale `docs/plans/plate-solver.md` and `docs/plans/sky-survey-camera-mount-following.md` paths returns zero non-archive hits.
- [x] All five filed issues (#232–#236) and #237 verified to exist before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)