### PR TITLE
docs(pa-falcon-rotator): design doc + implementation plan

### DIFF
--- a/docs/plans/pa-falcon-rotator-implementation.md
+++ b/docs/plans/pa-falcon-rotator-implementation.md
@@ -218,9 +218,8 @@ Implementation in `rotator_device.rs`:
 * `Rotator::position` — `serial_manager.read_status().await.map(|s| normalise(s.position_deg + serial_manager.sync_offset()))`.
 * `Rotator::mechanical_position` — `serial_manager.read_status().await.map(|s| normalise(s.position_deg))`.
 * `Rotator::target_position`:
-    - If `serial_manager.target_position().await.is_some()` → return that value.
-    - Else → return current `position()`.
-    - `is_moving` check: on every read, if `target_position` is `Some` and `read_status().is_moving == false`, clear it before returning the fallback `position`.
+    - If `serial_manager.target_position().await.is_some()` → return that value. The stored target survives a successful move; it is cleared only by `Halt` or by the next `Move*`. This lets clients compare `Position` against `TargetPosition` post-move to verify they landed where they asked.
+    - Else → return current `position()` (one fresh `FA`).
 * `Rotator::reverse` (get) — `serial_manager.read_status().await.map(|s| s.motor_reverse)`.
 * `Rotator::set_reverse(b)` — validate input not-NaN (n/a — `bool`), call `serial_manager.set_reverse(b)`.
 * `Rotator::step_size → Ok(0.01155)`.
@@ -237,8 +236,8 @@ Implementation in `rotator_device.rs`:
     - `set_target_position(normalise(sky_deg))`, `move_mechanical(normalise(sky_deg - sync_offset))`.
 * `Rotator::move_mechanical(mech_deg)`:
     - Validate finite.
-    - `target_sky = normalise(mech_deg + sync_offset)` (so `TargetPosition` reads still report a sky value).
-    - `set_target_position(target_sky)`, `move_mechanical(normalise(mech_deg))`.
+    - The wire command is `MD:<normalise(mech_deg)>` directly (no offset applied to the wire value — matches the design-doc mapping table).
+    - However the driver-side cache is kept in sky coordinates for consistency across `Move*` variants: `target_sky = normalise(mech_deg + sync_offset)`. So `set_target_position(target_sky)` followed by `move_mechanical(normalise(mech_deg))`.
 * `Rotator::sync(sky_deg)`:
     - Validate finite.
     - `serial_manager.sync(sky_deg)`.
@@ -326,7 +325,7 @@ Implementation in `services/pa-falcon-rotator/tests/conformu_integration.rs`:
 Implementation:
 
 * `README.md` Services table — add a `pa-falcon-rotator` row between `star-adventurer-gti` and the `[cov-*]` block. Update `[cov-pa-falcon-rotator]` markdown reference links at the bottom. Add a short `### pa-falcon-rotator` paragraph under the Services list.
-* `docs/workspace.md` Services table — flip the phase note on the `pa-falcon-rotator` row from "Phase 1 — design landed; implementation in flight" (added in PR #1) to its production form (drop the parenthetical).
+* `docs/workspace.md` Services table — flip the phase note on the `pa-falcon-rotator` row from `(Phase 1 — design landed; implementation tracked in [`docs/plans/pa-falcon-rotator-implementation.md`](plans/pa-falcon-rotator-implementation.md))` (added in PR #1) to its production form (drop the parenthetical entirely).
 * `docs/workspace.md` Plans table — flip the entry on this plan from "active" to "archived 2026-MM-DD" and move the file to `docs/plans/archive/`.
 * If we adopt sentinel integration: add a sentinel monitor for the rotator port (deferred — outside this plan).
 

--- a/docs/plans/pa-falcon-rotator-implementation.md
+++ b/docs/plans/pa-falcon-rotator-implementation.md
@@ -1,0 +1,385 @@
+# pa-falcon-rotator — Implementation Plan
+
+## Status
+
+**Active.** Phase 1 (design doc, `docs/services/falcon-rotator.md`) lands alongside this plan. Phases 2 (BDD scaffold + service skeleton) and 3 (implementation) follow per the sub-phase breakdown below.
+
+## Outcomes (definition of done)
+
+* `cargo run -p pa-falcon-rotator -- -c services/pa-falcon-rotator/examples/config-linux.json` boots, opens the serial port, runs the handshake, registers the Rotator and Status Switch devices on port 11118, and survives a NINA / SGPro connect → `Sync` → `MoveAbsolute` → `IsMoving`-poll → `Halt` → disconnect cycle against a real Falcon v1.
+* Every `unimplemented!()` body landed in Phase 2 is removed and replaced by a real implementation with at least one test exercising it.
+* All `tests/features/*.feature` files have their `@wip` tags removed; `cargo test -p pa-falcon-rotator --features mock --test bdd` runs every scenario green.
+* `tests/conformu_integration.rs` exists and is `#[ignore]`; `cargo test -p pa-falcon-rotator --features conformu --test conformu_integration -- --ignored --nocapture` passes for both the Rotator and the Switch interfaces against the binary running under `MockSerialPortFactory`.
+* `[package.metadata.conformu]` block in `services/pa-falcon-rotator/Cargo.toml` registers the service for the nightly ConformU rotation.
+* `docs/workspace.md` Services row reflects the final phase status; `README.md` service table includes a `pa-falcon-rotator` row.
+* `cargo rail run --profile commit -q` and `cargo fmt --check` are clean for every commit in the chain.
+
+## Branching strategy
+
+Sub-phases land as commits on dedicated PR branches:
+
+* **PR #1** (this PR) — `feature/falcon-rotator-driver`: design doc + this plan.
+* **PR #2** — `feature/pa-falcon-rotator-phase2`: BDD scaffold + service skeleton in one commit (the qhy/star precedent). Based on `main` after PR #1 merges.
+* **PR #3** — `feature/pa-falcon-rotator-protocol`: Phase 3a (`protocol.rs` + unit tests). No `@wip` removed.
+* **PR #4** — `feature/pa-falcon-rotator-plumbing`: Phase 3b–3c (`config`, `error`, `io`, `serial`, `mock`, `serial_manager`). No `@wip` removed.
+* **PR #5** — `feature/pa-falcon-rotator-rotator-device`: Phase 3d (Rotator trait impl). Removes `@wip` from `connection_lifecycle`, `metadata`, `position_reads`, `movement`, `halt`, `reverse`, `sync_offset`.
+* **PR #6** — `feature/pa-falcon-rotator-switch-device`: Phase 3e (Switch trait impl). Removes `@wip` from `status_switch`.
+* **PR #7** — `feature/pa-falcon-rotator-conformu`: Phase 3f–3h (`test_lib`, ConformU, README + workspace.md final-state updates).
+
+Each PR rebases onto `main` after the previous merges; ordering is strict — every PR depends on the previous one compiling.
+
+## Sub-phases
+
+Each sub-phase ends in a single commit. The `@wip` tags listed under "Removes" are the ones taken off in that sub-phase.
+
+### 2a — Crate skeleton + workspace integration (single commit, ships with 2b)
+
+Files created:
+
+* `services/pa-falcon-rotator/Cargo.toml` — package metadata, feature flags (`mock`, `conformu`), dependencies (`ascom-alpaca` with `server,rotator,switch`, `tokio`, `tokio-serial`, `serde`, `serde_json`, `humantime-serde`, `clap`, `async-trait`, `tracing`, `tracing-subscriber`, `thiserror`, `rp-tls`, `rp-auth`, `axum`), dev-deps (`bdd-infra`, `tokio-test`, `mockall`, `proptest`, `reqwest`, `cucumber`, `cargo-husky`, `tempfile`), `[[test]] name = "bdd" harness = false`. **No** `i18n` / `rust-embed` (see design doc E4).
+* `services/pa-falcon-rotator/src/lib.rs` — module declarations, `ServerBuilder` + `BoundServer` stubs (signatures only, `unimplemented!()` bodies, `#[cfg_attr(coverage_nightly, coverage(off))]` on each).
+* `services/pa-falcon-rotator/src/main.rs` — `clap` `Args` struct, `tokio::main`, `ServerBuilder::new(...).build().await?.start().await` body. No i18n.
+* `services/pa-falcon-rotator/src/config.rs` — `Config`, `SerialConfig`, `ServerConfig`, `RotatorConfig`, `SwitchConfig` types with `Default` impls per the design doc's defaults table. `load_config(path)`. Inline `#[cfg(test)]` tests for defaults + JSON round-trip.
+* `services/pa-falcon-rotator/src/error.rs` — `FalconRotatorError` enum (`NotConnected`, `ConnectionFailed`, `SerialPort`, `Timeout`, `Io`, `InvalidResponse`, `ParseError`, `InvalidValue`, `Communication`), `Result<T>` alias, `to_ascom_error` mapping per design-doc Error Model table. Inline `#[cfg(test)]` Display + mapping tests.
+* `services/pa-falcon-rotator/src/io.rs` — `SerialReader`, `SerialWriter`, `SerialPortFactory` traits with `#[cfg_attr(test, mockall::automock)]`. `SerialPair` struct.
+* `services/pa-falcon-rotator/src/serial.rs` — `TokioSerialPortFactory` implementing `SerialPortFactory` via `tokio-serial`. Stubbed (`unimplemented!()`).
+* `services/pa-falcon-rotator/src/mock.rs` — `#[cfg(feature = "mock")] pub struct MockSerialPortFactory` with a small deterministic state machine: stored mechanical position, is-moving flag, motor-reverse flag, derotation flag, voltage_raw. Returns canned `FR_OK` for `F#`, `FV:1.3` for `FV`, etc. Stubbed body for now.
+* `services/pa-falcon-rotator/src/protocol.rs` — `Command` enum (variants for `Ping`, `FullStatus`, `FirmwareVersion`, `PositionDeg`, `PositionSteps`, `Voltage`, `DerotationOff` / `DerotationRate(u32)`, `SyncDeg(f64)`, `MoveDeg(f64)`, `MoveSteps(u32)`, `Halt`, `IsRunning`, `SetReverse(bool)`). `to_command_string()` method. `FalconStatus` parsed struct (steps, deg, is_moving, limit_detect, do_derotation, motor_reverse). Stubbed parsers.
+* `services/pa-falcon-rotator/src/serial_manager.rs` — `SerialManager` struct: `config`, `connection_count` (`AtomicU32`), `serial_available` (`AtomicBool`), `reader`/`writer` (`Mutex<Option<Box<dyn ...>>>`), `command_lock` (`Mutex<()>`), `sync_offset` (`Mutex<f64>`), `target_position` (`Mutex<Option<f64>>`), `last_limit_detected` (`Mutex<Option<bool>>`), `serial_factory`. Stubbed methods: `connect`, `disconnect`, `is_available`, `send_command`, `read_status` (issues `FA` + edge-checks `limit_detect`), `read_voltage`, `move_to`, `halt`, `sync`, `get_sync_offset`, `target_position`, `get_target_position`.
+* `services/pa-falcon-rotator/src/rotator_device.rs` — `FalconRotatorDevice` impl skeleton. `Device` trait stub. `Rotator` trait stub.
+* `services/pa-falcon-rotator/src/switch_device.rs` — `FalconStatusSwitchDevice` impl skeleton. `Device` trait stub. `Switch` trait stub.
+* `services/pa-falcon-rotator/examples/config-linux.json`, `config-macos.json`, `config-windows.json` — copy the ppba-driver pattern adjusted for port `11118`, serial paths per OS.
+* Root `Cargo.toml`: add `services/pa-falcon-rotator` to `[workspace] members`.
+
+Tests in this sub-phase:
+
+* Only the inline `#[cfg(test)]` defaults / Display tests in `config.rs` and `error.rs`.
+
+Verification:
+
+* `cargo build -p pa-falcon-rotator --all-features --all-targets --locked` compiles.
+* `cargo nextest run -p pa-falcon-rotator --all-features --locked` runs the inline tests green.
+
+Removes:
+
+* Nothing (no `@wip` exists yet).
+
+### 2b — BDD infrastructure (same commit as 2a)
+
+Files created:
+
+* `services/pa-falcon-rotator/tests/bdd.rs` — entry point. Uses `bdd_infra::bdd_main!` macro. Filters out scenarios tagged `@wip` via `.filter_run_and_exit("tests/features", |feat, _rule, sc| { !is_wip(feat, sc) })`. **Must use `_and_exit`**, per `docs/skills/testing.md` §2.7 (issue #171 precedent). `after` hook calls `world.service_handle.stop()`.
+* `services/pa-falcon-rotator/tests/bdd/world.rs` — `FalconWorld` struct with `service_handle: Option<bdd_infra::ServiceHandle>`, `temp_dir: Option<tempfile::TempDir>`, helpers for writing a config file, building a connected device handle, etc.
+* `services/pa-falcon-rotator/tests/bdd/steps/mod.rs` — re-exports of step files.
+* `services/pa-falcon-rotator/tests/bdd/steps/connection_steps.rs` — `Given a configured pa-falcon-rotator service`, `When the client connects`, `Then connection is established`. Stubbed bodies.
+* `services/pa-falcon-rotator/tests/bdd/steps/metadata_steps.rs` — `Then the rotator's CanReverse is true`, `Then the StepSize is 0.01155`, etc.
+* `services/pa-falcon-rotator/tests/bdd/steps/position_steps.rs` — `When the client reads MechanicalPosition`, `Then Position is X.XX`.
+* `services/pa-falcon-rotator/tests/bdd/steps/movement_steps.rs` — `When the client calls MoveAbsolute X.X`, `Then the device received MD:X.X`, `Then IsMoving is true / false`.
+* `services/pa-falcon-rotator/tests/bdd/steps/halt_steps.rs` — `When the client calls Halt`, `Then TargetPosition is current Position`.
+* `services/pa-falcon-rotator/tests/bdd/steps/reverse_steps.rs` — `Given the mock reports motor_reverse = true`, `When the client calls SetReverse(true)`, `Then no FN command was sent` (read-before-write).
+* `services/pa-falcon-rotator/tests/bdd/steps/sync_steps.rs` — `When the client calls Sync(37.5)`, `Then Position reports 37.5`, `Then MechanicalPosition is unchanged`.
+* `services/pa-falcon-rotator/tests/bdd/steps/status_switch_steps.rs` — Switch device steps: `Then MaxSwitch is 2`, `Then GetSwitchValue(0) is X`, `Then GetSwitch(1) is true` (after a limit hit), etc.
+* Eight `tests/features/*.feature` files per the design-doc Module Structure section. Every scenario tagged `@wip`. Feature descriptions written as specifications (per `docs/skills/testing.md` §2.2); scenario titles state outcomes (§2.3); contract constants explicit in step text (§2.5).
+
+Verification:
+
+* `cargo test -p pa-falcon-rotator --features mock --test bdd` exits 0 (all scenarios skipped because `@wip`).
+
+Removes:
+
+* Nothing.
+
+### 3a — Protocol layer
+
+Implementation:
+
+* `Command::to_command_string` per the design-doc Command Table.
+* `parse_full_status(&str) -> Result<FalconStatus>` — splits on `:`, validates `FR_OK` prefix, parses each field. Trims trailing `\n` / whitespace per the ppba pattern.
+* `parse_firmware_version(&str)`, `parse_position_deg(&str)`, `parse_position_steps(&str)`, `parse_voltage_raw(&str)`, `parse_is_running(&str)`, `parse_reverse(&str)` — one for every response shape.
+* `validate_ping_response(&str) -> Result<()>` — accepts `FR_OK` ± trailing whitespace.
+* `validate_echo(command, response)` — generic echo validator for `MD:`, `SD:`, `DR:`, `FH`, `FN:` shapes.
+
+Tests:
+
+* Inline `#[cfg(test)] mod tests` covering:
+    - `parse_full_status` happy path: `FR_OK:4332:50.00:0:0:0:0` → expected `FalconStatus`.
+    - Every failure mode: wrong prefix, too-few-fields, bad float, bad bool. Each as a separate test fn.
+    - `parse_full_status` with trailing `\n`.
+    - `parse_full_status` with `limit_detect = 1`.
+    - Each command's `to_command_string()` exact-string check.
+    - `validate_ping_response`: `FR_OK`, `FR_OK\n`, reject `INVALID`, reject empty.
+    - `validate_echo` for representative commands.
+* `tests/property_tests.rs`: serialize → parse round-trip on `FalconStatus` for random valid field values.
+
+Removes:
+
+* Nothing from `@wip` yet — protocol alone can't drive BDD scenarios.
+
+### 3b — Config + error + IO + serial + mock
+
+Implementation:
+
+* `config::load_config` — `std::fs::read_to_string` + `serde_json::from_str`.
+* `error::FalconRotatorError::to_ascom_error` — `NotConnected → NOT_CONNECTED`, `InvalidValue → INVALID_VALUE`, all others → `ASCOMError::invalid_operation(self.to_string())`. Mirrors qhy-focuser exactly.
+* `serial::TokioSerialPortFactory::open` — `tokio_serial::new(port, baud_rate).timeout(timeout).open_native_async()` → wrap in `TokioSerialReader` (`BufReader<ReadHalf>::read_line`) and `TokioSerialWriter` (`WriteHalf::write_all` + `flush`).
+* `serial::TokioSerialPortFactory::port_exists` — `tokio_serial::available_ports()` lookup.
+* `mock::MockSerialPortFactory` — full implementation. State:
+    - `mech_position_deg: Arc<Mutex<f64>>` (default 0.0)
+    - `is_moving: Arc<Mutex<bool>>` (default false; flipped by `MD:`, cleared on next `FA` after each move — best-effort simulation enough for BDD)
+    - `motor_reverse: Arc<Mutex<bool>>` (default false)
+    - `do_derotation: Arc<Mutex<bool>>` (default false; reset by `DR:0`)
+    - `limit_detect: Arc<Mutex<bool>>` (default false; settable from a test hook)
+    - `voltage_raw: Arc<Mutex<u32>>` (default 800)
+    - `firmware_version: &'static str` (default `"1.3"`)
+    - `command_log: Arc<Mutex<Vec<String>>>` — every command written, in order. Tests inspect.
+* The mock reader's `read_line()` returns the queued response for the most recent command. The mock writer's `write_message()` appends to `command_log` and computes the canned response.
+* The mock honours every command in the design-doc command table including `FF` (which we don't issue, but the mock should reject it if it ever shows up — fail loud rather than silently accept).
+
+Tests:
+
+* `config::tests` — defaults match design doc, JSON round-trip works, partial JSON fills in defaults.
+* `error::tests` — Display strings, `to_ascom_error` mapping per the design-doc table.
+* `io::tests` — `SerialPair` construction with `MockSerialReader` + `MockSerialWriter`.
+* `mock::tests` (under `#[cfg(test)] mod tests` inside `src/mock.rs`) — `F#` → `FR_OK`, `MD:50.00` → echo + state update, `FH` → `FH:1` + `is_moving=false`, `FN:1` → echo + state, `FA` after `MD` returns updated position.
+
+Removes:
+
+* Nothing.
+
+### 3c — SerialManager (handshake + command lock + driver-side state)
+
+Implementation:
+
+* `SerialManager::connect`:
+    1. `connection_count.fetch_add(1, SeqCst)`. If `> 0`, return `Ok(())` (subsequent device connecting).
+    2. `factory.open(...)` → store reader+writer.
+    3. Handshake (sequential, each failure → `ConnectionFailed`):
+        - `send_command_internal(Ping)` → `validate_ping_response`
+        - `send_command_internal(FirmwareVersion)` → `parse_firmware_version` → `info!("Falcon firmware v{}", version)`
+        - `send_command_internal(DerotationOff)` → echo validation
+        - `send_command_internal(FullStatus)` → `parse_full_status` — drop the result, the read is just a smoke test
+        - `send_command_internal(Voltage)` → `parse_voltage_raw` — same
+    4. `serial_available.store(true, SeqCst)`.
+* `SerialManager::disconnect`:
+    1. Atomically decrement; if was already 0, no-op (underflow protection).
+    2. If now 0: `serial_available.store(false, SeqCst)`, drop reader/writer, reset `sync_offset` to 0.0, reset `target_position` to None, reset `last_limit_detected` to None.
+* `SerialManager::send_command_internal(cmd)`:
+    1. `let _g = command_lock.lock().await;`
+    2. `writer.write_message(&cmd.to_command_string()).await?;`
+    3. `let resp = reader.read_line().await?.ok_or(Communication("closed"))?;`
+    4. Return raw response — parsing is the caller's job.
+* `SerialManager::read_status()` → `Result<FalconStatus>`:
+    1. `send_command_internal(FullStatus)` → `parse_full_status`.
+    2. Edge-check `limit_detect`: lock `last_limit_detected`, compare; on `Some(false) → true` transition or `None → true`, `warn!("Falcon reported limit_detect after move toward {:?}", *target_position.lock().await)`.
+    3. Return parsed status.
+* `SerialManager::read_voltage_raw()` → `Result<u32>`: `send_command_internal(Voltage)` → `parse_voltage_raw`.
+* `SerialManager::move_mechanical(target_mech_deg)`:
+    1. Connection check.
+    2. `send_command_internal(MoveDeg(normalise(target_mech_deg)))` → echo validate.
+* `SerialManager::halt()`:
+    1. Connection check.
+    2. `send_command_internal(Halt)` → echo validate.
+    3. Clear `target_position` (`Mutex<Option<f64>>` ← `None`).
+* `SerialManager::set_reverse(want: bool)`:
+    1. Read `FA`, compare `motor_reverse`. If equal, return `Ok(())`.
+    2. Else `send_command_internal(SetReverse(want))` → echo validate.
+* `SerialManager::sync(sky_deg)`:
+    1. Read `FA` to get current mechanical position.
+    2. Compute `offset = (sky_deg - mech) mod 360`.
+    3. Write `sync_offset.lock().await.write(offset)`.
+* `SerialManager::sync_offset()` → `f64` getter.
+* `SerialManager::set_target_position(sky_deg)`, `clear_target_position`, `target_position()` — accessor trio for `Mutex<Option<f64>>`.
+* `normalise(deg) -> f64` — `((deg % 360.0) + 360.0) % 360.0`. Private helper.
+
+Tests:
+
+* `serial_manager::tests` (under `#[cfg(test)] mod tests` inside `src/serial_manager.rs`):
+    - `test_connect_increments_refcount` — connect twice, disconnect once, still available.
+    - `test_disconnect_underflow_protection` — disconnect without connect, no panic.
+    - `test_connect_factory_error` — `MockSerialPortFactory` variant that returns `ConnectionFailed`.
+    - `test_connect_handshake_ping_failure` — mock returns `BAD` for `F#`, expect `InvalidResponse`.
+    - `test_set_reverse_skips_write_when_equal` — mock starts with reverse=true, call `set_reverse(true)`, assert only `FA` in `command_log` (no `FN`).
+    - `test_set_reverse_writes_when_different` — mock starts with reverse=false, call `set_reverse(true)`, assert `FA` + `FN:1` in `command_log`.
+    - `test_sync_offset_arithmetic` — mock at mech=120°, `sync(30°)` → offset = -90° (mod 360 = 270°).
+    - `test_limit_detect_edge_log` — drive `read_status` twice with mock-state `limit_detect = false` then `true`, capture `tracing` output via `tracing-subscriber::fmt::TestWriter`, assert one `warn!` line.
+
+Removes:
+
+* Nothing (Rotator + Switch traits not implemented yet).
+
+### 3d — Rotator device (Phase 3 first BDD-greening sub-phase)
+
+Implementation in `rotator_device.rs`:
+
+* `FalconRotatorDevice::new(config, serial_manager)`.
+* `Device::static_name`, `unique_id`, `description`, `driver_info`, `driver_version`, `connected`, `set_connected` — exact qhy-focuser shape.
+* `Rotator::can_reverse → Ok(true)`.
+* `Rotator::is_moving` — `serial_manager.read_status().await.map(|s| s.is_moving)`.
+* `Rotator::position` — `serial_manager.read_status().await.map(|s| normalise(s.position_deg + serial_manager.sync_offset()))`.
+* `Rotator::mechanical_position` — `serial_manager.read_status().await.map(|s| normalise(s.position_deg))`.
+* `Rotator::target_position`:
+    - If `serial_manager.target_position().await.is_some()` → return that value.
+    - Else → return current `position()`.
+    - `is_moving` check: on every read, if `target_position` is `Some` and `read_status().is_moving == false`, clear it before returning the fallback `position`.
+* `Rotator::reverse` (get) — `serial_manager.read_status().await.map(|s| s.motor_reverse)`.
+* `Rotator::set_reverse(b)` — validate input not-NaN (n/a — `bool`), call `serial_manager.set_reverse(b)`.
+* `Rotator::step_size → Ok(0.01155)`.
+* `Rotator::halt`:
+    - Connection check.
+    - `serial_manager.halt().await`.
+* `Rotator::move_(delta)`:
+    - Validate finite (`delta.is_finite()`); else `InvalidValue`.
+    - `current_sky = read_status().position_deg + sync_offset`.
+    - `target_sky = normalise(current_sky + delta)`.
+    - `set_target_position(target_sky)`, `move_mechanical(normalise(target_sky - sync_offset))`.
+* `Rotator::move_absolute(sky_deg)`:
+    - Validate finite.
+    - `set_target_position(normalise(sky_deg))`, `move_mechanical(normalise(sky_deg - sync_offset))`.
+* `Rotator::move_mechanical(mech_deg)`:
+    - Validate finite.
+    - `target_sky = normalise(mech_deg + sync_offset)` (so `TargetPosition` reads still report a sky value).
+    - `set_target_position(target_sky)`, `move_mechanical(normalise(mech_deg))`.
+* `Rotator::sync(sky_deg)`:
+    - Validate finite.
+    - `serial_manager.sync(sky_deg)`.
+
+`lib.rs::ServerBuilder::build`:
+
+* Register `FalconRotatorDevice` if `config.rotator.enabled`.
+* Register `FalconStatusSwitchDevice` if `config.switch.enabled` (3e fills in the trait body).
+* Standard `rp-tls` + `rp-auth` wiring per ppba/qhy.
+
+Tests:
+
+* `rotator_device::tests` — `to_ascom_error` mapping for each error variant; `Rotator::can_reverse`, `step_size`, `target_position` fallback.
+
+BDD step bodies (in `tests/bdd/steps/`):
+
+* `connection_steps.rs` — `Given a service with config X`, `When client PUT /connected?Connected=true`, `Then status is Ok`, `Then F# was the first command sent`.
+* `metadata_steps.rs` — `Then CanReverse is true`, `Then StepSize is 0.01155`, `Then Name is "Pegasus Falcon Rotator"`.
+* `position_steps.rs` — `Given the mock reports mechanical 142.30°`, `When client reads MechanicalPosition`, `Then value is 142.30`. `Given sync offset = -104.80°`, `Then Position is 37.50`.
+* `movement_steps.rs` — `When client calls MoveAbsolute(180.0)`, `Then MD:284.80 was sent`. `When is_moving polled`, `Then FA was issued`.
+* `halt_steps.rs` — `When client calls Halt`, `Then FH was sent`, `Then TargetPosition equals current Position`.
+* `reverse_steps.rs` — read-before-write scenarios; assert `command_log` contains `FA` but no `FN` when value already matches.
+* `sync_offset_steps.rs` — `When Sync(37.5)`, `Then MechanicalPosition unchanged`, `Then Position is 37.50`, `Then SD was NOT sent`.
+
+Removes:
+
+* `@wip` from `connection_lifecycle.feature`, `metadata.feature`, `position_reads.feature`, `movement.feature`, `halt.feature`, `reverse.feature`, `sync_offset.feature`.
+
+### 3e — Status Switch device
+
+Implementation in `switch_device.rs`:
+
+* `FalconStatusSwitchDevice::new(config, serial_manager)`.
+* `Device` trait — same shape as Rotator's.
+* `Switch::max_switch → Ok(2)`.
+* `Switch::get_switch_name(0) → Ok("Input Voltage (raw)")`, `(1) → Ok("Limit Hit")`, others → `InvalidValue`.
+* `Switch::get_switch_description(0) → Ok("Raw ADC count from the Falcon's VS command; scale not yet calibrated")`, `(1) → Ok("Mirrors FA.limit_detect for the most recent status read")`.
+* `Switch::can_write(_) → Ok(false)`.
+* `Switch::set_switch / set_switch_value → INVALID_OPERATION` (no writable switches).
+* `Switch::min_switch_value(0) → 0.0`, `(1) → 0.0`.
+* `Switch::max_switch_value(0) → 1023.0`, `(1) → 1.0`.
+* `Switch::switch_step(0) → 1.0`, `(1) → 1.0`.
+* `Switch::get_switch_value(0)` — `serial_manager.read_voltage_raw().await.map(f64::from)`.
+* `Switch::get_switch_value(1)` — `serial_manager.read_status().await.map(|s| if s.limit_detect { 1.0 } else { 0.0 })`.
+* `Switch::get_switch(0)` — `get_switch_value(0).await.map(|v| v > 0.0)`.
+* `Switch::get_switch(1)` — `get_switch_value(1).await.map(|v| v > 0.5)`.
+* `Switch::can_async / set_async_value / state_change_complete / cancel_async` — `NOT_IMPLEMENTED` (Switch V3 async ops are optional for read-only devices).
+
+BDD step bodies in `status_switch_steps.rs`:
+
+* `Then MaxSwitch is 2`, `Then CanWrite(0) is false`, `Then GetSwitchValue(0) issued VS to the device`, `Given the mock voltage is 812`, `Then GetSwitchValue(0) returns 812`, `Given the mock limit_detect is 1`, `Then GetSwitch(1) is true`, `Then GetSwitchValue(1) returns 1.0`, `Then SetSwitch(0, true) returns INVALID_OPERATION`.
+
+Tests:
+
+* `switch_device::tests` — metadata strings, range bounds, write-rejection.
+
+Removes:
+
+* `@wip` from `status_switch.feature`.
+
+### 3f — `tests/test_lib.rs` server-startup tests
+
+Implementation in `services/pa-falcon-rotator/tests/test_lib.rs` (gated on `feature = "mock"`):
+
+* `static SERVER_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());` (same pattern as qhy-focuser).
+* `test_server_starts_with_mock_factory` — build `ServerBuilder::new(test_config()).with_factory(MockSerialPortFactory::default()).build()`, bind to port `0`, hit `/management/v1/description`, assert HTTP 200.
+* `test_server_registers_both_devices` — hit `/management/v1/configureddevices`, assert two entries (rotator + switch).
+* `test_rotator_only_when_switch_disabled` — config with `switch.enabled = false`, assert one entry.
+
+### 3g — ConformU integration
+
+Implementation in `services/pa-falcon-rotator/tests/conformu_integration.rs`:
+
+* `#[ignore]` everywhere. Spawn the binary with `--features mock`, parse `bound_addr=`, run two ConformU passes:
+    - `cargo test ... -- --ignored --nocapture` invokes `conformu conformance http://127.0.0.1:<port>/api/v1/rotator/0` then `.../switch/0`.
+* Re-uses `bdd_infra::parse_bound_port` per `docs/skills/testing.md` §5.1.
+
+`Cargo.toml`:
+
+* `[features] conformu = ["mock", "ascom-alpaca/test"]` already in 2a; add `[package.metadata.conformu] command = "cargo test -p pa-falcon-rotator --features conformu --test conformu_integration -- --ignored --nocapture"`.
+* `.github/workflows/conformu.yml` discovers new entries dynamically via `cargo metadata` (per `docs/skills/pre-push.md`) — no workflow edit needed.
+
+### 3h — README + workspace.md final updates
+
+Implementation:
+
+* `README.md` Services table — add a `pa-falcon-rotator` row between `star-adventurer-gti` and the `[cov-*]` block. Update `[cov-pa-falcon-rotator]` markdown reference links at the bottom. Add a short `### pa-falcon-rotator` paragraph under the Services list.
+* `docs/workspace.md` Services table — flip the phase note on the `pa-falcon-rotator` row from "Phase 1 — design landed; implementation in flight" (added in PR #1) to its production form (drop the parenthetical).
+* `docs/workspace.md` Plans table — flip the entry on this plan from "active" to "archived 2026-MM-DD" and move the file to `docs/plans/archive/`.
+* If we adopt sentinel integration: add a sentinel monitor for the rotator port (deferred — outside this plan).
+
+Removes:
+
+* Nothing in code; this is the documentation closing-out commit.
+
+## Order of execution
+
+`2a + 2b → 3a → 3b → 3c → 3d → 3e → 3f → 3g → 3h`.
+
+The only inter-PR gate is that each rebases onto the previous's `main`-merged state. Within Phase 3, sub-phases 3a–3c can technically land in one PR (no `@wip` removed, no behavioural diff visible to ASCOM clients) — splitting them is a reviewer ergonomics call, not a correctness one.
+
+## Hardware validation
+
+After PR #6 (Switch device) merges, run the binary against the actual Falcon v1:
+
+1. Plug the Falcon into a Linux box.
+2. `cargo run -p pa-falcon-rotator -- -c examples/config-linux.json`.
+3. From another shell, exercise the Alpaca API via `curl`:
+    - `curl -X PUT http://127.0.0.1:11118/api/v1/rotator/0/connected -d "Connected=true"`
+    - `curl http://127.0.0.1:11118/api/v1/rotator/0/mechanicalposition`
+    - `curl -X PUT http://127.0.0.1:11118/api/v1/rotator/0/sync -d "Position=0.0"`
+    - `curl -X PUT http://127.0.0.1:11118/api/v1/rotator/0/moveabsolute -d "Position=90.0"`
+    - `curl http://127.0.0.1:11118/api/v1/rotator/0/ismoving` (poll until `false`)
+    - `curl http://127.0.0.1:11118/api/v1/rotator/0/position`
+    - `curl http://127.0.0.1:11118/api/v1/switch/0/getswitchvalue?Id=0` (raw voltage)
+    - `curl http://127.0.0.1:11118/api/v1/rotator/0/connected -d "Connected=false" -X PUT`
+4. Then run ConformU against real hardware: `conformu conformance http://127.0.0.1:11118/api/v1/rotator/0` and same against `/switch/0`. Both should pass with zero errors.
+
+This validation surfaces any discrepancies between the design doc's behavioural assumptions and real hardware. Capture findings as follow-up issues against the design doc rather than blocking PR #6 — the design is allowed to evolve once hardware truth is in.
+
+## Follow-ups (post-MVP)
+
+Tracked in the design doc's [`Follow-ups`](../services/falcon-rotator.md#follow-ups) section:
+
+1. Voltage scale calibration (raw ADC → volts).
+2. ADC width verification.
+3. Sync offset persistence (if operators ask).
+4. De-rotation surface (Custom Action / extra Switch / extra device).
+5. Falcon v2 protocol support.
+
+None of these block this implementation plan from being considered complete.
+
+## References
+
+* [`docs/services/falcon-rotator.md`](../services/falcon-rotator.md) — the design contract this plan implements.
+* [`docs/skills/development-workflow.md`](../skills/development-workflow.md) — Phase 1/2/3 ordering.
+* [`docs/skills/testing.md`](../skills/testing.md) — BDD conventions (`@wip` usage §2.7, contract constants §2.5, `bdd_main!` §5.2).
+* [`docs/skills/pre-push.md`](../skills/pre-push.md) — quality-gate commands run between each sub-phase.
+* `services/qhy-focuser/src/serial_manager.rs` — closest template for `SerialManager`.
+* `services/qhy-focuser/src/focuser_device.rs` — closest template for the ASCOM device trait wrapper pattern.
+* `services/ppba-driver/src/switch_device.rs` and `switches.rs` — template for `FalconStatusSwitchDevice`.
+* `services/ppba-driver/src/lib.rs` and `services/qhy-focuser/src/lib.rs` — `ServerBuilder` template.
+* [Pegasus Astro Falcon Rotator product page](https://pegasusastro.com/products/falcon-rotator/) — source of the 86.6 steps/° and 220° CW soft-limit figures.
+* [Falcon Serial Command Table (firmware ≥ v1.3)](https://pegasusastro.com/wp-content/uploads/2022/05/Falcon_Serial_Command_Table.pdf) — wire-protocol reference.

--- a/docs/services/falcon-rotator.md
+++ b/docs/services/falcon-rotator.md
@@ -1,0 +1,414 @@
+# pa-falcon-rotator Driver
+
+ASCOM Alpaca Rotator driver for the Pegasus Astro Falcon Rotator.
+
+## Overview
+
+The `pa-falcon-rotator` service exposes the Pegasus Astro Falcon Rotator (firmware ≥ v1.3) as **two** ASCOM Alpaca devices on a single server:
+
+1. An ASCOM **Rotator** device implementing the standard `IRotatorV4` surface: `Position`, `MechanicalPosition`, `TargetPosition`, `IsMoving`, `Reverse`, `Move` / `MoveAbsolute` / `MoveMechanical` / `Sync` / `Halt`.
+2. An ASCOM **Switch** device with two read-only switches: `0` = input-voltage reading from `VS` (raw ADC count — scale factor deferred), `1` = limit-hit indicator from `FA.limit_detect`. See [Status Switch Device](#status-switch-device).
+
+The service borrows the **layering** from `ppba-driver` / `qhy-focuser` but deliberately **omits the cached / background-polled state machine** those services carry. Every ASCOM property read maps to a serial command. See [Why no cache](#why-no-cache) for the trade-offs.
+
+- **Serial abstraction** (`io.rs`, `serial.rs`, `mock.rs`) — trait-based I/O so unit tests and BDD scenarios run without hardware.
+- **Protocol layer** (`protocol.rs`) — command serialisation and response parsing (Falcon ASCII).
+- **Serial manager** (`serial_manager.rs`) — ref-counted shared connection + per-command serialisation lock + two pieces of driver-side state (`sync_offset`, `target_position`). No background poller. No cached device state.
+- **ASCOM devices** (`rotator_device.rs`, `switch_device.rs`) — `Device` + `Rotator` / `Device` + `Switch` trait implementations, both issuing serial commands through the shared `SerialManager`.
+- **Server builder** (`lib.rs`) — binds the ASCOM Alpaca server and registers both devices.
+
+## Architecture
+
+```
++-------------------+        FH/FA/MD/SD/...        +----------------------+
+|                   |  ASCII over 9600-8N1 serial   |                      |
+| pa-falcon-rotator |  ───────────────────────────► |  Falcon Rotator      |
+|  (Alpaca server)  |  ◄─────────────────────────── |  (firmware ≥ 1.3)    |
+|                   |   FR_OK / FD:.. / FR:.. etc.  |                      |
++--------▲----------+                               +----------------------+
+         │ HTTP (port 11118)
+         │ /api/v1/rotator/0/...
++--------┴----------+
+|  Alpaca client    |
+|  (NINA, SGPro,…)  |
++-------------------+
+```
+
+A single serial connection is shared by both registered devices and all of their clients. The `SerialManager` ref-counts `set_connected(true)` so the port is opened on the first connect and closed when the last device disconnects. A `command_lock` serialises every device-bound write/read pair so concurrent property reads queue cleanly on the one physical port. The `SerialManager` also holds three small pieces of driver-side state: `sync_offset` (sky-vs-mechanical correction), `target_position` (the last commanded `MD` target), and `last_limit_detected` (used for `limit_detect` edge logging — see [`limit_detect` handling](#limit_detect-handling)).
+
+### Why no cache
+
+Every other serial service in this repo (`ppba-driver`, `qhy-focuser`, `star-adventurer-gti`) caches device state behind a `RwLock<CachedState>` updated by a background poller. `pa-falcon-rotator` does not, by design.
+
+The benefit a cache would add — sub-millisecond property reads — matters when many concurrent ASCOM clients hit the same server. We don't expect that here: observatory rotators are typically driven by exactly one session at a time. The costs are real: a polling task with its own lifecycle, a state-completion detector, an "active refresh" patch for `is_moving()` to defeat staleness during moves, and a second source of truth that drifts when the device is mutated out of band by the Pegasus Unity app.
+
+A no-cache design pays one ~10–30 ms serial roundtrip per property read in exchange for always-fresh reads, drift-free state, and a `SerialManager` that's roughly a third the line count of its cached cousins. The trade-off is reversible: if production load shows contention, we can layer a TTL cache on top later — and the device-trait implementations need not change, because every property reads through the same `SerialManager::send_command` API.
+
+## Hardware Constraints
+
+| Property | Value | Source |
+|---|---|---|
+| Transport | USB-CDC virtual serial port | vendor |
+| Baud rate | 9600 | PDF |
+| Framing | 8N1 | PDF |
+| Line terminator | LF (`\n`) on both directions | PDF (literal "/n" read as typo) |
+| Command-set firmware | Falcon v1, firmware ≥ v1.3 (Sep 2020 review) | PDF |
+| Angular unit (driver-facing) | degrees, two decimal places (`MD:nn.nn`) | PDF |
+| Angular unit (internal device) | steps (integer); `FA` reports both | PDF |
+| Steps per degree | 86.6 | <https://pegasusastro.com/products/falcon-rotator/> |
+| Steps per revolution | 31,192 | <https://pegasusastro.com/products/falcon-rotator/> |
+| Angular resolution | ~0.01155° per motor step | derived from `1.0 / 86.6` |
+| Soft rotation limit | Clockwise rotation refused beyond 220°; the device automatically takes the anti-clockwise path | <https://pegasusastro.com/products/falcon-rotator/> |
+
+Note: the vendor's "86.6 steps/°" and "31,192 steps/revolution" are mutually inconsistent by ~16 steps (`86.6 × 360 = 31,176`). The 0.011541° value (`360 / 31192`) is closer to the truth; 0.01155° is a clean published figure and is what the driver reports. The difference is irrelevant at ASCOM client UI precision.
+
+The Falcon is a **finite-rotation device with mechanical end stops** and an additional firmware-enforced soft limit at 220° CW. Drivers issuing `MD:<deg>` with any value in `[0, 360)` are safe: the Falcon picks the path itself. The `FA.limit_detect` flag fires only on a physical limit hit (mechanical jam or end-stop) — not as part of normal direction selection.
+
+## Protocol Reference
+
+All commands are ASCII, newline-terminated. The PDF's footer literally reads "/n", which we treat as a typo for `\n` (LF). All responses are line-terminated by the device.
+
+### Command Table
+
+| Command | Description | Response |
+|---|---|---|
+| `F#` | Ping / status check | `FR_OK` |
+| `FA` | Full status (see below) | `FR_OK:steps:deg:moving:limit:derot:reverse` |
+| `FV` | Firmware version | `FV:n.n` |
+| `FD` | Current position in degrees | `FD:nn.nn` |
+| `FP` | Current position in steps | `FP:n..` |
+| `VS` | Input voltage (raw / unscaled) | `VS:n..` |
+| `DR:<ms>` | Enable de-rotation at `<ms>` ms/step; `DR:0` disables | `DR:<ms>` |
+| `SD:<deg>` | **Device-side** sync: rewrite the Falcon's stored position counter to `<deg>` *without moving* | `SD:<deg>` |
+| `MD:<deg>` | Move to absolute degrees | `MD:<deg>` |
+| `MS:<steps>` | Move to absolute steps | `MS:<steps>` |
+| `FH` | Halt | `FH:1` |
+| `FR` | Is running (`1` = moving, `0` = idle) | `FR:1` or `FR:0` |
+| `FN:<b>` | Set motor reverse (1 reverse / 0 normal). **Persisted in EEPROM.** | `FN:1` or `FN:0` |
+| `FF` | Reload firmware | *(no response)* |
+
+### `FA` response format
+
+```
+FR_OK:position_in_steps:position_in_deg:is_moving:limit_detect:do_derotation:motor_reverse
+```
+
+Example: `FR_OK:4332:50.00:0:0:0:0` → 4332 steps, 50.00°, idle, no limit, derotation off, reverse off.
+
+Field types:
+
+| Field | Type | Notes |
+|---|---|---|
+| `position_in_steps` | unsigned integer | Internal step counter |
+| `position_in_deg` | `f64`, two decimals | Authoritative for `MechanicalPosition` |
+| `is_moving` | `0` / `1` | Drives `IsMoving` |
+| `limit_detect` | `0` / `1` | Driver logs `warn!` on edge transitions, does not raise |
+| `do_derotation` | `0` / `1` | MVP keeps this `0` (see [De-rotation](#de-rotation)) |
+| `motor_reverse` | `0` / `1` | Drives `Reverse` |
+
+### Commands the driver does **not** send
+
+- **`FF`** — firmware reload is a maintenance operation with no response and unknown post-conditions. The driver never issues it. Operators perform firmware updates via the vendor tool.
+- **`FF`** is also excluded from `SupportedActions` for the same reason.
+
+## ASCOM Rotator Mapping
+
+The Falcon has a single physical-angle concept. ASCOM's `IRotatorV3+` separates *mechanical* angle from *sky* angle joined by a `Sync` offset. The driver implements that separation in software.
+
+| ASCOM Property/Method | Implementation |
+|---|---|
+| `CanReverse` | `true` (always) |
+| `IsMoving` | Issues `FA`, returns `FA.is_moving == 1`. Always fresh from the device. |
+| `Position` | Issues `FA`, returns `(FA.position_in_deg + sync_offset) mod 360`. |
+| `MechanicalPosition` | Issues `FA`, returns `FA.position_in_deg` normalised to `[0, 360)`. |
+| `TargetPosition` | If a `Move*` is outstanding, returns the sky-coordinate target stored in `SerialManager::target_position: Mutex<Option<f64>>`. Otherwise (no move ever requested, or last move was halted, or the device is idle after a completed move) returns the current `Position`. Treating "where I am" as the implicit target when nothing else is in flight keeps ConformU happy and matches the dominant convention among ASCOM rotator drivers. |
+| `Reverse` (get) | Issues `FA`, returns `FA.motor_reverse`. |
+| `Reverse` (set) | EEPROM-wear-aware: issues `FA` first, only writes `FN:b` if the requested value differs from the device's current value. See [Reverse semantics](#reverse-semantics--eeprom-persistence). |
+| `StepSize` | `0.01155` (constant). Per the vendor product page, the Falcon does 86.6 steps per degree → `1.0 / 86.6 ≈ 0.01155 °/step`. Reported as `f64` even though the `MD:nn.nn` wire format limits commandable values to 0.01° precision; ASCOM clients that round move targets to `StepSize` will land within one motor step of the requested angle. |
+| `Halt()` | `FH`. Clears `TargetPosition` and `is_moving` on success. |
+| `Move(delta)` | Relative move: `target = (MechanicalPosition + delta - sync_offset) mod 360`, then `MD:<target>`. ASCOM defines `Move` in **sky** coordinates, so the same `sync_offset` is applied. |
+| `MoveAbsolute(skyDeg)` | `target_mechanical = (skyDeg - sync_offset) mod 360`, then `MD:<target_mechanical>`. |
+| `MoveMechanical(mechDeg)` | `MD:<mechDeg mod 360>` directly — no offset applied. |
+| `Sync(skyDeg)` | `sync_offset = (skyDeg - MechanicalPosition) mod 360`. **Driver-side only.** The Falcon's `SD` command is *not* used here: ASCOM Sync must leave `MechanicalPosition` unchanged, but `SD` rewrites the device's stored counter. |
+
+### Sync semantics — why driver-side, not `SD`
+
+ASCOM's `Sync(skyAngle)` is specified as: *the value reported by `Position` becomes `skyAngle`, the value reported by `MechanicalPosition` is unchanged*. The Falcon's `SD:<deg>` command rewrites the device's stored counter, which would change `MechanicalPosition` on the next `FA` poll and break the ASCOM contract. The driver therefore tracks the offset in software (an `f64` in `CachedState`, initialised to `0.0` on connect) and never issues `SD`.
+
+A side-effect of this choice: the sync offset is **not** persisted across driver restarts. If a deployment needs persistent sync, that is a follow-up — see [Open questions](#open-questions).
+
+### Move target storage
+
+`SerialManager` holds `target_position: Mutex<Option<f64>>` storing the **sky-coordinate** target (so `TargetPosition` reads don't need to re-apply the offset). Lifecycle:
+
+1. `Move(delta)` / `MoveAbsolute(skyDeg)` / `MoveMechanical(mechDeg)` each compute the sky target, write `target_position = Some(sky_target)`, convert to mechanical, then issue `MD:<mech>`.
+2. While the move is in progress, `is_moving()` reads `FA.is_moving` directly from the device on every call. There is no driver-side "is the move done?" flag — the device is the authoritative source.
+3. `TargetPosition` reads return the stored sky target if `Some`; otherwise they return the current `Position` (one fresh `FA` read).
+4. `target_position` is cleared (`None`) in three places: on `Halt`, on the *next* `Move*` (the new target overwrites; this is a momentary transition not a clear-then-set), and when `FA.is_moving == 0` is observed by an `is_moving()` call that finds `target_position = Some(...)` — at that point the move has completed and the stored target is no longer "in flight."
+
+The Falcon's `is_moving` flag is the authoritative completion signal. We deliberately do **not** compare `FA.position_in_deg` to `target_position` for completion — angular comparison would have to handle backlash, overshoot, and wraparound, and the device already tells us the answer.
+
+> **Note on storage frame.** Storing the **sky** target (not mechanical) means `TargetPosition` reads are stable across mid-flight syncs (rare in practice, but possible if a client misbehaves). The driver applies the `sync_offset` once at write time to compute the mechanical `MD:` argument. Reads don't re-apply the offset, so the value the client gets back is the same value it asked for.
+
+### Reverse semantics — EEPROM persistence
+
+`FN:b` is documented as "One off setting — stored in EEPROM". The driver therefore protects the EEPROM by reading before writing:
+
+1. `Reverse` get → single `FA`, returns `motor_reverse`. Operator changes via the Pegasus Unity app are visible on the very next get.
+2. `Reverse` set → `FA` first; if the device already reports the requested value, the driver returns success without writing. Only if the values differ does the driver issue `FN:b` and validate the echo.
+
+The extra `FA` per set is a one-roundtrip cost (~30 ms), paid only when an ASCOM client calls `setreverse`, which is rare.
+
+### Position normalisation
+
+All angles exposed to ASCOM clients are normalised to `[0.0, 360.0)`. The normalisation rule is the standard `((x % 360.0) + 360.0) % 360.0` to handle negative deltas from `Move(delta < 0)`.
+
+### `limit_detect` handling
+
+`FA.limit_detect == 1` indicates the rotator hit a mechanical end stop on the most recent move. The driver surfaces this two ways:
+
+1. **`warn!` log on the rising edge.** `SerialManager` holds `last_limit_detected: Mutex<Option<bool>>`. Every `FA` response is parsed; on a `false → true` transition the driver logs `warn!("Falcon reported limit_detect after move toward {:?}", target_position)`. The state is initialised to `None` on connect so the first observation after a fresh connection always logs.
+2. **Read-only Switch ID `1`.** The Status Switch device exposes `limit_detect` as a boolean switch (`MinSwitchValue = 0`, `MaxSwitchValue = 1`, `SwitchStep = 1`). `GetSwitch(1)` and `GetSwitchValue(1)` each issue a fresh `FA` and return the value verbatim. Operator dashboards (sentinel, custom monitors) can poll this switch to alert on limit hits.
+
+The driver does **not**:
+
+- Raise an ASCOM error from `Move*` when a limit was hit (the call returned `Ok` long before the device stopped).
+- Pre-validate move targets against any soft range — the Falcon owns its own travel limits.
+- Latch `limit_detect` itself — we mirror whatever the device currently reports. If the Falcon clears the flag on the next successful move, the Switch clears too.
+
+## De-rotation
+
+The Falcon's `DR:<ms>` enables a free-running rotation intended for alt-az field derotation. ASCOM's `IRotator` has no derotation concept and assumes discrete moves to a target.
+
+**MVP behaviour:** the driver issues `DR:0` once during the connect handshake to guarantee a known idle state. The driver does **not** expose any way to *enable* derotation. The `FA` field is parsed and logged but not surfaced over Alpaca.
+
+Adding derotation later is tracked in [Open questions](#open-questions).
+
+## Status Switch Device
+
+The Falcon reports two non-rotator state values that fall outside the ASCOM Rotator surface: an input-voltage reading (`VS`, "raw format" per the PDF) and a limit-detect flag (`FA.limit_detect`). Both are exposed as read-only switches on a second ASCOM device registered on the same Alpaca server.
+
+ASCOM `IObservingConditions` was considered for voltage and rejected: its standard properties are strictly weather data (`Temperature`, `Humidity`, `Pressure`, `DewPoint`, `CloudCover`, etc.) and voltage is not in that set. ConformU would flag an `ObservingConditions` device that exposed only voltage. `ppba-driver` reaches the same conclusion — its `Switch` device carries voltage (switch `10`), and its `ObservingConditions` device carries only the temp/humidity/dewpoint trio.
+
+### Switch layout
+
+| ID | Name | Type | Min | Max | Step | Source | Notes |
+|---|---|---|---|---|---|---|---|
+| 0 | Input Voltage (raw) | Numeric | 0 | 1023 | 1 | `VS` | Raw ADC count. Scale factor is **not** applied — see [Scale calibration](#scale-calibration). |
+| 1 | Limit Hit | Boolean | 0 | 1 | 1 | `FA.limit_detect` | Mirrors the device's current limit-detect flag. See [`limit_detect` handling](#limit_detect-handling). |
+
+`MaxSwitch = 2`. `CanWrite(0) = false`, `CanWrite(1) = false`.
+
+- `GetSwitch(0)` returns `true` if `voltage_raw > 0` (per ASCOM's "false at MinSwitchValue, true otherwise" rule).
+- `GetSwitch(1)` returns `true` iff a limit is currently detected.
+- `GetSwitchValue(0)` issues `VS` and returns the parsed raw ADC count as `f64`.
+- `GetSwitchValue(1)` issues `FA` and returns `0.0` or `1.0`.
+
+`Min = 0`, `Max = 1023` for switch 0 assumes a 10-bit ADC on the Falcon's MCU. If hardware characterisation reveals a wider range (12-bit / 16-bit) the `Max` value is widened in a follow-up; the field is hard-coded rather than configurable to keep the ASCOM metadata stable across deployments.
+
+### Scale calibration
+
+The voltage raw-to-volts conversion is **deliberately deferred**. The PDF gives no scale factor, and we have no schematic for the input divider. Two follow-up paths once hardware characterisation is in hand:
+
+1. Replace the raw-ADC switch with a calibrated `Input Voltage (V)` switch using a hard-coded scale derived from the bench measurement. Simplest if the conversion is firmware-stable.
+2. Add `voltage_scale: f64` and `voltage_offset: f64` to the rotator config and report `volts = raw * scale + offset`. Lets the operator re-calibrate without a code change.
+
+Either path is a follow-up PR. The MVP just exposes the raw count.
+
+### Reads
+
+`VS` is issued on demand inside `GetSwitchValue(0)`. `FA` is issued on demand inside `GetSwitch(1)` / `GetSwitchValue(1)` and shares its parse path with `Rotator.IsMoving` — both routes through `SerialManager::read_status()`, and the `last_limit_detected` edge tracker fires from there regardless of which device initiated the read.
+
+## Configuration
+
+```json
+{
+  "serial": {
+    "port": "/dev/ttyUSB0",
+    "baud_rate": 9600,
+    "timeout": "2s"
+  },
+  "server": {
+    "port": 11118,
+    "auth": {
+      "username": "observatory",
+      "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
+    }
+  },
+  "rotator": {
+    "name": "Pegasus Falcon Rotator",
+    "unique_id": "pa-falcon-rotator-001",
+    "description": "Pegasus Astro Falcon Rotator (firmware >= 1.3)",
+    "enabled": true
+  },
+  "switch": {
+    "name": "Pegasus Falcon Status",
+    "unique_id": "pa-falcon-rotator-status-001",
+    "description": "Pegasus Falcon Rotator status sensors (voltage + limit-hit)",
+    "enabled": true
+  }
+}
+```
+
+| Section | Field | Description | Default |
+|---|---|---|---|
+| `serial` | `port` | Serial port path | `"/dev/ttyUSB0"` |
+| `serial` | `baud_rate` | Baud rate | `9600` |
+| `serial` | `timeout` | Serial read/write timeout (`humantime`) | `"2s"` |
+| `server` | `port` | HTTP server port | `11118` |
+| `server` | `discovery_port` | Alpaca discovery port | `32227` |
+| `server` | `tls` | Optional `rp-tls` block | none |
+| `server` | `auth` | Optional `rp-auth` block | none |
+| `rotator` | `name` | ASCOM device name | `"Pegasus Falcon Rotator"` |
+| `rotator` | `unique_id` | Unique identifier | `"pa-falcon-rotator-001"` |
+| `rotator` | `description` | Device description | `"Pegasus Astro Falcon Rotator (firmware >= 1.3)"` |
+| `rotator` | `enabled` | Whether to register the Rotator device | `true` |
+| `switch` | `name` | ASCOM device name for the Switch | `"Pegasus Falcon Status"` |
+| `switch` | `unique_id` | Unique identifier for the Switch | `"pa-falcon-rotator-status-001"` |
+| `switch` | `description` | Switch description | `"Pegasus Falcon Rotator status sensors (voltage + limit-hit)"` |
+| `switch` | `enabled` | Whether to register the Switch device | `true` |
+
+### CLI Arguments
+
+| Argument | Description |
+|---|---|
+| `-c, --config` | Path to configuration file |
+| `--port` | Serial port path (overrides config) |
+| `--server-port` | Server port (overrides config) |
+| `-l, --log-level` | Log level: `trace`, `debug`, `info`, `warn`, `error` |
+
+## Module Structure
+
+```
+services/pa-falcon-rotator/
+├── src/
+│   ├── lib.rs              # ServerBuilder, BoundServer
+│   ├── main.rs             # CLI entry point
+│   ├── config.rs           # Config types + JSON loading
+│   ├── error.rs            # FalconRotatorError enum (thiserror)
+│   ├── rotator_device.rs   # ASCOM Device + Rotator trait impl
+│   ├── switch_device.rs    # ASCOM Device + Switch trait impl (voltage)
+│   ├── io.rs               # SerialReader / SerialWriter / SerialPortFactory traits
+│   ├── serial.rs           # tokio-serial implementation
+│   ├── mock.rs             # MockSerialPortFactory (feature = "mock")
+│   ├── protocol.rs         # Command enum + response parsers
+│   └── serial_manager.rs   # Ref-counted connection + command lock + sync_offset / target_position
+├── tests/
+│   ├── bdd.rs              # cucumber entry point (harness = false)
+│   ├── bdd/
+│   │   ├── world.rs        # FalconWorld
+│   │   └── steps/
+│   │       ├── mod.rs
+│   │       ├── connection_steps.rs
+│   │       ├── metadata_steps.rs
+│   │       ├── position_steps.rs
+│   │       ├── movement_steps.rs
+│   │       ├── halt_steps.rs
+│   │       ├── reverse_steps.rs
+│   │       ├── sync_steps.rs
+│   │       └── status_switch_steps.rs
+│   ├── features/
+│   │   ├── connection_lifecycle.feature
+│   │   ├── metadata.feature
+│   │   ├── position_reads.feature
+│   │   ├── movement.feature
+│   │   ├── halt.feature
+│   │   ├── reverse.feature
+│   │   ├── sync_offset.feature
+│   │   └── status_switch.feature
+│   └── conformu_integration.rs   # ASCOM Rotator + Switch conformance (#[ignore])
+└── examples/
+    ├── config-linux.json
+    ├── config-macos.json
+    └── config-windows.json
+```
+
+## Connection Lifecycle
+
+1. Client `PUT /connected?Connected=true` on either device.
+2. The device's `set_connected(true)` calls `SerialManager::connect()`.
+3. First connect opens the port via `SerialPortFactory::open`.
+4. Handshake (sequential, each step propagates errors as `ConnectionFailed`):
+   - `F#` → expect `FR_OK` — proves we are talking to a Falcon.
+   - `FV` → log firmware version at `info!`.
+   - `DR:0` → force derotation off (known state regardless of how the device was last left).
+   - `FA` → smoke-test the response shape (parsed but not stored anywhere — there is no cache).
+   - `VS` → smoke-test the voltage response shape.
+5. `serial_available` flips to `true`.
+6. Subsequent `set_connected(true)` calls increment the ref count without re-running the handshake.
+7. `set_connected(false)` decrements; when the last device disconnects, the port closes.
+8. The driver-side `sync_offset` is reset to `0.0` and `target_position` is cleared whenever the ref count returns to zero. Neither is persisted across reconnects.
+
+## Move Lifecycle
+
+For each of `Move(delta)`, `MoveAbsolute(skyDeg)`, `MoveMechanical(mechDeg)`:
+
+1. Reject with `NOT_CONNECTED` if `connected() == false`.
+2. For `Move(delta)`, the driver issues `FA` first to read the current `position_in_deg` so the relative move can be computed against the live mechanical angle. `MoveAbsolute` / `MoveMechanical` need no read.
+3. Compute the mechanical target (per the [mapping table](#ascom-rotator-mapping)).
+4. Normalise into `[0.0, 360.0)`.
+5. Store the target: `target_position = Some(mechanical_target)`.
+6. Under the command lock, write `MD:<target>\n` to the device and validate the echo response (`MD:<target>` ± `\n`).
+7. Return `Ok(())` to the client (ASCOM `Move*` returns immediately; the move is asynchronous).
+8. Move completion is reported by `IsMoving` reads — each one issues a fresh `FA`. `target_position` survives completion so `TargetPosition` reads stay populated until either `Halt` or the next `Move*`.
+
+`Halt()` writes `FH\n`, validates `FH:1`, then clears `target_position`.
+
+## Error Model
+
+Matches the qhy-focuser / ppba-driver precedent for cross-driver consistency: only the two error variants ASCOM clients actually distinguish on get their own codes; everything else collapses to `INVALID_OPERATION`.
+
+| Driver error variant | ASCOM error code | Triggering conditions |
+|---|---|---|
+| `NotConnected` | `NOT_CONNECTED` (`0x407`) | Any property/method called while `connected() == false` |
+| `InvalidValue(msg)` | `INVALID_VALUE` (`0x401`) | Client supplied `NaN` / non-finite angle to `Move*` / `Sync` |
+| All others | `INVALID_OPERATION` (`0x40B`) | `ConnectionFailed` (handshake failure), `SerialPort`, `Timeout`, `Io`, `InvalidResponse`, `ParseError`, `Communication` |
+
+## MVP Scope
+
+In scope for the first iteration:
+
+- Connect / disconnect with handshake (`F# → FV → DR:0 → FA → VS`).
+- `Position`, `MechanicalPosition`, `IsMoving`, `Reverse`, `TargetPosition` reads on the Rotator device — each backed by a live serial command.
+- `MoveAbsolute`, `Move`, `MoveMechanical`, `Halt`.
+- `Sync` as a driver-side offset.
+- `Reverse` writes via `FN:b` with EEPROM-wear protection (read-then-write-if-different).
+- Status Switch device: two read-only switches (voltage raw ADC + limit-hit boolean), each read on demand.
+- ConformU compliance for both `IRotatorV4` and `ISwitchV3`.
+- BDD scenarios mirroring each feature area listed in [Module Structure](#module-structure).
+
+Deferred:
+
+- De-rotation (no ASCOM mapping; design out a Custom Action or a derotator-flavoured device).
+- Voltage raw-to-volts scale calibration (Switch currently reports raw ADC; scale factor or config-driven calibration is a follow-up).
+- `SD`-based persistent sync (only if `Sync` offset persistence becomes a real requirement).
+- Internationalisation of the CLI (`ppba-driver` style) — skip for MVP; reuse the spike outcome later.
+
+## Testing
+
+Per [`docs/skills/testing.md`](../skills/testing.md):
+
+- **BDD** (cucumber-rs, primary): one feature file per concern in `tests/features/`. Scenarios drive the binary via Alpaca HTTP, using `MockSerialPortFactory` for stable responses. Use `@wip` on every scenario until Phase 3 makes them green.
+- **Unit tests** (`#[cfg(test)]` in `src/`): protocol serialisation, `FA` response parsing (happy path + every failure mode in the [error table](#error-model)), config defaults, sync-offset arithmetic, normalisation rules.
+- **Property tests** (`proptest`): position normalisation is idempotent; round-trip `Move(delta)` → `Move(-delta)` returns to the original sky angle modulo floating-point error.
+- **Server tests** (`#[cfg(feature = "mock")]`): bootstrap a server on `127.0.0.1:0` and confirm the bound address parses correctly (the `bound_addr=` contract).
+- **ConformU** (`tests/conformu_integration.rs`, `#[ignore]`): run against the binary with the `mock` feature, mirroring `ppba-driver` / `qhy-focuser`. Registered under `[package.metadata.conformu]`.
+
+## Follow-ups
+
+These are explicit deferrals — not open design questions, but work the MVP intentionally leaves to a later iteration.
+
+1. **Voltage scale calibration.** Switch `0` currently exposes the raw ADC count. Once the Falcon has been bench-measured against a known supply rail, replace the raw-count switch with a calibrated `Input Voltage (V)` switch using either a hard-coded scale or `voltage_scale` / `voltage_offset` config fields.
+2. **ADC width.** Switch `0`'s `MaxSwitchValue = 1023` assumes a 10-bit ADC. If hardware characterisation finds a wider range (12-bit / 16-bit), widen the metadata in a follow-up PR.
+3. **Sync offset persistence.** Driver-side `sync_offset` resets on every reconnect. If observatories ever ask for it to survive driver restarts (rare — the standard workflow is to re-plate-solve and re-sync each session), add a small JSON state file next to the config.
+4. **De-rotation surface.** `DR` is forced off on connect and never exposed. If a real demand emerges, the natural designs are a Custom ASCOM `Action` ("StartDerotation"/"StopDerotation"), an additional read/write Switch, or a separate device alongside the existing two.
+5. **Falcon Rotator v2.** This design targets the discontinued v1 hardware. If a v2 ever lands on this codebase, expect a fresh PDF + a partial protocol divergence.
+6. **TLS-cert hot-reload.** Inherited from `ppba-driver` / `qhy-focuser`: the service requires a restart to pick up new TLS certs. Not a Falcon-specific issue.
+
+## References
+
+- **Pegasus Astro Falcon Serial Command Table** (firmware ≥ v1.3, Sep 2020): `https://pegasusastro.com/wp-content/uploads/2022/05/Falcon_Serial_Command_Table.pdf`
+- **Falcon Rotator product page**: `https://pegasusastro.com/products/falcon-rotator/`
+- **ASCOM IRotatorV4 spec**: <https://ascom-standards.org/newdocs/rotator.html>
+- **`ppba-driver` design doc**: [`ppba-driver.md`](ppba-driver.md) — the architectural template.
+- **`qhy-focuser` design doc**: [`qhy-focuser.md`](qhy-focuser.md) — the closest behavioural analogue (single moving device with `IsMoving` + `Position`).

--- a/docs/services/falcon-rotator.md
+++ b/docs/services/falcon-rotator.md
@@ -34,7 +34,7 @@ The service borrows the **layering** from `ppba-driver` / `qhy-focuser` but deli
 +-------------------+
 ```
 
-A single serial connection is shared by both registered devices and all of their clients. The `SerialManager` ref-counts `set_connected(true)` so the port is opened on the first connect and closed when the last device disconnects. A `command_lock` serialises every device-bound write/read pair so concurrent property reads queue cleanly on the one physical port. The `SerialManager` also holds three small pieces of driver-side state: `sync_offset` (sky-vs-mechanical correction), `target_position` (the last commanded `MD` target), and `last_limit_detected` (used for `limit_detect` edge logging — see [`limit_detect` handling](#limit_detect-handling)).
+A single serial connection is shared by both registered devices and all of their clients. The `SerialManager` ref-counts `set_connected(true)` so the port is opened on the first connect and closed when the last device disconnects. A `command_lock` serialises every device-bound write/read pair so concurrent property reads queue cleanly on the one physical port. The `SerialManager` also holds three small pieces of driver-side state: `sync_offset` (sky-vs-mechanical correction), `target_position` (the last requested target in **sky** coordinates), and `last_limit_detected` (used for `limit_detect` edge logging — see [`limit_detect` handling](#limit_detect-handling)).
 
 ### Why no cache
 
@@ -108,8 +108,7 @@ Field types:
 
 ### Commands the driver does **not** send
 
-- **`FF`** — firmware reload is a maintenance operation with no response and unknown post-conditions. The driver never issues it. Operators perform firmware updates via the vendor tool.
-- **`FF`** is also excluded from `SupportedActions` for the same reason.
+- **`FF`** — firmware reload is a maintenance operation with no response and unknown post-conditions. The driver never issues it, and excludes it from `SupportedActions` so ASCOM clients cannot trigger it via the `Action` endpoint either. Operators perform firmware updates via the vendor tool.
 
 ## ASCOM Rotator Mapping
 
@@ -128,12 +127,12 @@ The Falcon has a single physical-angle concept. ASCOM's `IRotatorV3+` separates 
 | `Halt()` | `FH`. Clears `TargetPosition` and `is_moving` on success. |
 | `Move(delta)` | Relative move: `target = (MechanicalPosition + delta - sync_offset) mod 360`, then `MD:<target>`. ASCOM defines `Move` in **sky** coordinates, so the same `sync_offset` is applied. |
 | `MoveAbsolute(skyDeg)` | `target_mechanical = (skyDeg - sync_offset) mod 360`, then `MD:<target_mechanical>`. |
-| `MoveMechanical(mechDeg)` | `MD:<mechDeg mod 360>` directly — no offset applied. |
+| `MoveMechanical(mechDeg)` | Wire command: `MD:<mechDeg mod 360>` directly — `sync_offset` is **not** applied to the wire value. Internal `target_position` is still stored in sky coordinates (`mechDeg + sync_offset`) so subsequent `TargetPosition` reads stay in the same frame regardless of which `Move*` variant set them. |
 | `Sync(skyDeg)` | `sync_offset = (skyDeg - MechanicalPosition) mod 360`. **Driver-side only.** The Falcon's `SD` command is *not* used here: ASCOM Sync must leave `MechanicalPosition` unchanged, but `SD` rewrites the device's stored counter. |
 
 ### Sync semantics — why driver-side, not `SD`
 
-ASCOM's `Sync(skyAngle)` is specified as: *the value reported by `Position` becomes `skyAngle`, the value reported by `MechanicalPosition` is unchanged*. The Falcon's `SD:<deg>` command rewrites the device's stored counter, which would change `MechanicalPosition` on the next `FA` poll and break the ASCOM contract. The driver therefore tracks the offset in software (an `f64` in `CachedState`, initialised to `0.0` on connect) and never issues `SD`.
+ASCOM's `Sync(skyAngle)` is specified as: *the value reported by `Position` becomes `skyAngle`, the value reported by `MechanicalPosition` is unchanged*. The Falcon's `SD:<deg>` command rewrites the device's stored counter, which would change `MechanicalPosition` on the next `FA` read and break the ASCOM contract. The driver therefore tracks the offset in software as `SerialManager::sync_offset: Mutex<f64>` (initialised to `0.0` on connect) and never issues `SD`.
 
 A side-effect of this choice: the sync offset is **not** persisted across driver restarts. If a deployment needs persistent sync, that is a follow-up — see [Open questions](#open-questions).
 
@@ -144,7 +143,7 @@ A side-effect of this choice: the sync offset is **not** persisted across driver
 1. `Move(delta)` / `MoveAbsolute(skyDeg)` / `MoveMechanical(mechDeg)` each compute the sky target, write `target_position = Some(sky_target)`, convert to mechanical, then issue `MD:<mech>`.
 2. While the move is in progress, `is_moving()` reads `FA.is_moving` directly from the device on every call. There is no driver-side "is the move done?" flag — the device is the authoritative source.
 3. `TargetPosition` reads return the stored sky target if `Some`; otherwise they return the current `Position` (one fresh `FA` read).
-4. `target_position` is cleared (`None`) in three places: on `Halt`, on the *next* `Move*` (the new target overwrites; this is a momentary transition not a clear-then-set), and when `FA.is_moving == 0` is observed by an `is_moving()` call that finds `target_position = Some(...)` — at that point the move has completed and the stored target is no longer "in flight."
+4. `target_position` is cleared (`None`) in exactly two places: on `Halt`, and on the *next* `Move*` (the new target overwrites; this is a momentary transition, not a clear-then-set). A **successful move does not clear `target_position`** — the stored target remains readable so clients can verify "did I land where I asked?" by comparing `Position` to `TargetPosition` after `IsMoving` falls false.
 
 The Falcon's `is_moving` flag is the authoritative completion signal. We deliberately do **not** compare `FA.position_in_deg` to `target_position` for completion — angular comparison would have to handle backlash, overshoot, and wraparound, and the device already tells us the answer.
 
@@ -230,6 +229,7 @@ Either path is a follow-up PR. The MVP just exposes the raw count.
   },
   "server": {
     "port": 11118,
+    "discovery_port": 32227,
     "auth": {
       "username": "observatory",
       "password_hash": "$argon2id$v=19$m=19456,t=2,p=1$..."
@@ -348,7 +348,7 @@ For each of `Move(delta)`, `MoveAbsolute(skyDeg)`, `MoveMechanical(mechDeg)`:
 3. Compute the mechanical target (per the [mapping table](#ascom-rotator-mapping)).
 4. Normalise into `[0.0, 360.0)`.
 5. Store the target: `target_position = Some(mechanical_target)`.
-6. Under the command lock, write `MD:<target>\n` to the device and validate the echo response (`MD:<target>` ± `\n`).
+6. Under the command lock, write `MD:<target>\n` to the device and validate the echo response (`MD:<target>`, optionally with a trailing `\n`).
 7. Return `Ok(())` to the client (ASCOM `Move*` returns immediately; the move is asynchronous).
 8. Move completion is reported by `IsMoving` reads — each one issues a fresh `FA`. `target_position` survives completion so `TargetPosition` reads stay populated until either `Halt` or the next `Move*`.
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -18,6 +18,7 @@ belong in any single service design doc.
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
 | [star-adventurer-gti](services/star-adventurer-gti.md) | Telescope | 11117 | `docs/services/star-adventurer-gti.md` (Phase 2 — BDD scaffold landed; all scenarios `@wip` pending Phase 3 implementation) |
+| [pa-falcon-rotator](services/falcon-rotator.md) | Rotator + Switch (status) | 11118 | `docs/services/falcon-rotator.md` (Phase 1 — design landed; implementation tracked in [`docs/plans/pa-falcon-rotator-implementation.md`](plans/pa-falcon-rotator-implementation.md)) |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |
 
 ## Documentation Index
@@ -45,6 +46,7 @@ belong in any single service design doc.
 | [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
 | [i18n-cli-spike.md](plans/i18n-cli-spike.md) | Tech spike landing Fluent + `i18n-embed` behind `ppba-driver`'s clap CLI (en + de) |
 | [plate-solver.md](plans/archive/plate-solver.md) | plate-solver rp-managed service implementation (ADR-005 sequencing, archived 2026-05-15) |
+| [pa-falcon-rotator-implementation.md](plans/pa-falcon-rotator-implementation.md) | pa-falcon-rotator Phase 2 (BDD scaffold) + Phase 3 (Rotator + Status Switch implementation) breakdown |
 
 ## Shared Crates
 


### PR DESCRIPTION
## Summary

- Phase 1 design doc (`docs/services/falcon-rotator.md`) for a new ASCOM Alpaca Rotator service targeting the **Pegasus Astro Falcon Rotator v1** (firmware ≥ 1.3, 9600 8N1 serial). Two devices register on one Alpaca server (port 11118): a Rotator (`IRotatorV4`) and a 2-switch Status Switch (voltage raw ADC + limit-hit).
- Implementation plan (`docs/plans/pa-falcon-rotator-implementation.md`) with the multi-PR breakdown: Phase 2 (BDD scaffold) → Phase 3a–3h (protocol → plumbing → SerialManager → Rotator device → Switch device → test_lib → ConformU → README/workspace finalisation).
- `docs/workspace.md` updated with the new service row and plan entry.

## Notable design decisions

- **No cache / no polling.** Diverges from the qhy/ppba template: every ASCOM property read maps to a direct serial command. Trade-off favours code simplicity and always-fresh reads over multi-client contention (rare for observatory rotators).
- **`Sync(skyAngle)` is a driver-side `f64` offset.** The Falcon's `SD` command is never issued — it would rewrite the device's stored mechanical counter and violate ASCOM's "MechanicalPosition unchanged after Sync" contract.
- **Two devices, one server.** Rotator + Status Switch (voltage on switch 0 as raw ADC since scale calibration is deferred until hardware bench-measurement; limit-hit on switch 1 mirrors `FA.limit_detect`).
- **`StepSize = 0.01155`** — derived from the vendor product page's published 86.6 steps/° figure.
- **`FF` firmware-reload excluded** from the command set entirely.
- **EEPROM-wear protection on `Reverse`:** read `FA` first, only issue `FN:b` if the value actually changes.
- **Error mapping mirrors qhy/ppba precedent:** `NotConnected → NOT_CONNECTED`, `InvalidValue → INVALID_VALUE`, everything else → `INVALID_OPERATION`.
- **No i18n** in MVP (skip the spike pattern until the spike concludes).
- **Deferred** (in the plan's Follow-ups): voltage scale calibration, ADC width verification, sync persistence, de-rotation surface, Falcon v2 protocol.

## Out of scope for this PR

- No code yet. The service crate (`services/pa-falcon-rotator/`) lands in Phase 2 (next PR).
- README.md update deferred to Phase 3h (when the service actually exists).

## Test plan

- [x] `cargo rail plan --merge-base` confirms scope is `empty` (docs-only change, no Rust packages affected).
- [x] `cargo fmt --check` passes.
- [x] Pre-commit hook (clippy `-D warnings` + fmt) runs green on commit.
- [ ] Reviewer reads `docs/services/falcon-rotator.md` end-to-end and pushes back on any decision that feels wrong before Phase 2 starts.
- [ ] Reviewer skims `docs/plans/pa-falcon-rotator-implementation.md` and flags any sub-phase that's mis-scoped (too big / too small / wrong ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)