### PR TITLE
Phase 6: meridian-flip support (hardware-validated 2026-05-16, lat 32.7°N)

### DIFF
--- a/docs/plans/star-adventurer-gti-meridian-flip.md
+++ b/docs/plans/star-adventurer-gti-meridian-flip.md
@@ -13,18 +13,23 @@
   3 arcmin inside the mechanical limit, ASCOM `SlewToCoordinates`
   LST-roundtrip drift no longer pushes boundary targets over the
   cliff. No CPR-dependent comparator constant needed.
-- **Phase 2 — meridian-flip support: implementation in progress** on
-  branch `worktree-meridian-flip-phase`. Scope landed in this PR:
+- **Phase 2 — meridian-flip support: hardware-validated 2026-05-16**
+  on branch `worktree-meridian-flip-phase`. Scope landed in this PR:
   §§2.1, 2.2, 2.3, 2.4, 2.6, 2.7 — coordinate helpers, per-pier-side
-  envelopes, through-wrap slew routing, `SetSideOfPier`, the `enabled`
+  envelopes, asymmetric counterweight binding-zone envelope,
+  binding-zone-path-aware through-wrap RA routing,
+  visible-pole Dec routing, `SetSideOfPier`, the `enabled`
   + `flip_range_hours` config fields, and BDD coverage.
   §2.5 (auto-flip during tracking) and the
   `auto_flip_during_tracking` / `auto_flip_at_meridian_offset_hours`
   config fields are deferred to a follow-up — hosts (NINA / SGP /
   rp) own flip timing in MVP; explicit `SetSideOfPier` calls drive
-  flips. §2.8 hardware validation is the next milestone: until the
-  first real GTi flip lands, `flip_policy.enabled` defaults `false`
-  and the driver behaves identically to Phase 5.
+  flips. §2.8 hardware validation completed at lat 32.7°N: end-to-end
+  AP Park 1–5 traversal including the through-wrap saddle-east flip
+  and its flip-back. A flip-back regression (sign-blind heuristic in
+  `flip_slew_ra_delta`) was caught mid-session and fixed in commit
+  `072cc72`. `flip_policy.enabled` still defaults `false` — operators
+  opt in once they've replayed the validation locally.
 - **Phase 3 — altitude-based safety floor: planning.** Replaces the
   rectangular Dec envelope (`dec_min_degrees` / `dec_max_degrees`)
   with a single `min_altitude_degrees` floor computed from HA + dec +
@@ -450,6 +455,45 @@ Validation plan, integrated into normal Phase 2 hardware-bringup:
    pickup loop handle the wrap point in their delta computations
    (this is firmware-level behaviour and should already be correct,
    but worth a wire-trace pass).
+
+#### Outcome (2026-05-16, lat 32.7°N)
+
+Both validation items passed. Cable wrap was not exercised destructively
+(the user kept hand-stop authority over the mount throughout). The
+through-wrap saddle-east flip (`SetSideOfPier(East)` from
+`(mech_HA = 0, dec = -57.3°)` pierWest staging) issued RA −1.81 M ticks
+CCW (−180° polar-axis) + Dec +2.38 M ticks CW (+294° through wrap past
+NCP), landing cleanly at Park 4 N (saddle east, OTA south horizon
+level). No motor stall, no audible binding, no transport-layer fallout.
+
+The flip-back from saddle-east (Park 4 N → Park 5 N at
+`(mech_HA = ±12, dec = +57.3°)`) exposed a sign-blind heuristic in
+`flip_slew_ra_delta`. The function's old rule —
+`|current_ticks| > cpr_ra/4 ⇒ "safe direction is positive"` — was
+designed for the `+cpr_ra/2` wrap (where positive direction wraps into
+the safe negative half) and inverted incorrectly at `-cpr_ra/2`. For
+the Park 5 slew, current was `-1,810,272` (just east of the
+saddle-east wrap on the negative side), canonical short delta was
+`-3,798` ticks CCW (a ~0.03° polar-axis nudge that physically just
+crosses the `-12 ↔ +12` wrap, staying in the safe arc). The old rule
+flipped that to `+cpr_ra - 3,798 = +3,625,002` ticks CW, a 359.6°
+polar-axis revolution that swept `mech_HA` through the binding zone
+and slammed the CW shaft into the pier. The operator powered the
+mount off mid-sweep.
+
+Fix landed in commit `072cc72` — the routing now checks whether the
+canonical short delta's mech_HA sweep actually crosses
+`(zone_min, zone_max)`, using the configured binding zone (checked
+modulo 24 h at `k ∈ {-1, 0, +1}` to handle the wrap). Re-run of the
+same Park 5 slew issued RA −3,631 ticks CCW (the canonical safe step)
+and the mount landed at Park 5 N visually confirmed.
+
+A structurally analogous sign-blindness exists in `flip_slew_dec_delta`
+— the dec routing assumes "safe direction in north for post-flip half
+is negative" but inverts at the `-cpr_dec/2` side of the wrap. This
+session's Park 4 → Park 5 dec was on the `+cpr_dec/2` side where the
+old heuristic happens to be correct, so the dec bug wasn't exercised.
+Tracked in a follow-up issue.
 
 ---
 

--- a/docs/plans/star-adventurer-gti-meridian-flip.md
+++ b/docs/plans/star-adventurer-gti-meridian-flip.md
@@ -13,12 +13,18 @@
   3 arcmin inside the mechanical limit, ASCOM `SlewToCoordinates`
   LST-roundtrip drift no longer pushes boundary targets over the
   cliff. No CPR-dependent comparator constant needed.
-- **Phase 2 — meridian-flip support: planning.** The GTi-specific
-  geometric finding below (the flip can be routed to avoid the
-  counterweight-up binding region) shifts this from "blocked on
-  flip-capable hardware" toward "implementable + hardware-validatable
-  on the GTi", subject to one remaining open question — see
-  §"Open questions".
+- **Phase 2 — meridian-flip support: implementation in progress** on
+  branch `worktree-meridian-flip-phase`. Scope landed in this PR:
+  §§2.1, 2.2, 2.3, 2.4, 2.6, 2.7 — coordinate helpers, per-pier-side
+  envelopes, through-wrap slew routing, `SetSideOfPier`, the `enabled`
+  + `flip_range_hours` config fields, and BDD coverage.
+  §2.5 (auto-flip during tracking) and the
+  `auto_flip_during_tracking` / `auto_flip_at_meridian_offset_hours`
+  config fields are deferred to a follow-up — hosts (NINA / SGP /
+  rp) own flip timing in MVP; explicit `SetSideOfPier` calls drive
+  flips. §2.8 hardware validation is the next milestone: until the
+  first real GTi flip lands, `flip_policy.enabled` defaults `false`
+  and the driver behaves identically to Phase 5.
 - **Phase 3 — altitude-based safety floor: planning.** Replaces the
   rectangular Dec envelope (`dec_min_degrees` / `dec_max_degrees`)
   with a single `min_altitude_degrees` floor computed from HA + dec +

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -765,22 +765,59 @@ the new value (the Dec encoder has moved past the pole);
 #### Through-wrap slew routing
 
 When the slew planner decides to flip (either via `SetSideOfPier` or
-because the decision tree picked the opposite side), the RA axis is
-routed through the negative-`mech_HA` half of the encoder range — the
-half where the counterweight stays at or below the local horizon. The
-RA encoder traverses from its current value through `mech_HA = 0`
-("home") and the encoder wrap at `−12 h ≡ +12 h` to the post-flip
-target. The Dec encoder simultaneously rotates through the celestial
-pole to land past `±90°`.
+because the decision tree picked the opposite side), both axes are
+routed through specific safe segments of their encoder ranges. The
+RA axis stays in the counterweight-below-horizon half; the Dec axis
+crosses the *visible* celestial pole rather than the below-horizon
+one.
+
+**RA axis:** routed through the negative-`mech_HA` half of the encoder
+range — the half where the counterweight stays at or below the local
+horizon. The RA encoder traverses from its current value through
+`mech_HA = 0` ("home") and the encoder wrap at `−12 h ≡ +12 h` to the
+post-flip target. The driver enforces this by forcing `:G`'s CCW bit
+to `1` on flip slews and adjusting the `:H` increment to the
+complementary magnitude when the canonical-shortest direction would
+have gone the other way (the GTi's mechanical binding zone at
+`mech_HA ∈ (+6.95, +11.05)` is the same for every observer latitude,
+so the routing rule is hemisphere-independent).
+
+**Dec axis:** routed through the visible celestial pole, NOT the
+below-horizon pole. For a polar-aligned mount, only one of the two
+celestial poles is above the local horizon — NCP at altitude `+lat`
+for Northern observers, SCP at altitude `+|lat|` for Southern. The
+encoder positions are `+cpr_dec/4` (NCP) and `−cpr_dec/4` (SCP). The
+Dec axis must traverse the visible pole during a flip slew; routing
+through the below-horizon pole drives the OTA into the ground
+(altitude `−|lat|` at the dip).
+
+The rule, expressed by encoder side:
+
+- **Northern** observer (safe pole `+cpr_dec/4`):
+  - `current_dec_encoder` in the pre-flip half (`|enc| ≤ cpr_dec/4`):
+    force the Dec slew CW (positive delta). The path crosses
+    `+cpr_dec/4` from below.
+  - `current_dec_encoder` in the post-flip half (`|enc| > cpr_dec/4`):
+    force CCW (negative delta). The path descends back through
+    `+cpr_dec/4`.
+- **Southern** observer: inverted. Safe pole is `−cpr_dec/4` (SCP).
+
+The canonical fold's boundary case at exactly `±cpr_dec/2` (e.g.
+flipping from `dec_encoder = 0` to a celestial target of `dec = 0`
+where the post-flip target is `+180° ≡ −180°`) lands on the negative
+direction by default; for a Northern observer that routes through
+SCP and is the failure mode the first real-hardware validation
+exposed. The fix forces the long way around (`delta − cpr` or
+`delta + cpr`) so the path always crosses the *safe* pole.
 
 The slew lifecycle (see [§Slew lifecycle](#slew-lifecycle)) is
 otherwise unchanged: the same `:K → :G → :I → :H → :M → :J`
 wire sequence per axis, the same EQMOD pickup loop, the same settle
 delay. The flip slew differs from a normal slew only in which
-encoder target the planner computes and which CCW bit `:G` issues for
-the RA axis (forced to the negative-direction sign on a flip slew, so
-the routing goes "under" the polar axis rather than taking the
-shortest encoder path).
+encoder target the planner computes and which CCW bit `:G` issues
+per axis (forced to the safe-direction sign on flip slews, so the
+routing goes "under" the polar axis on RA and through the visible
+pole on Dec rather than taking the shortest-encoder path).
 
 #### Hardware validation
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -828,7 +828,8 @@ fields. The transport block is a tagged enum: `usb` or `udp`.
     "flip_policy": {
       "enabled": false,
       "flip_range_hours": 0.5
-    }
+    },
+    "home_pose": null
   }
 }
 ```
@@ -879,6 +880,49 @@ Notes:
   reachable. Valid range `(0, 0.95]`; the upper bound is the verified
   safe headroom past counterweight-horizontal on the pre-flip side.
   See [§Meridian flip](#meridian-flip).
+- `home_pose` defaults `null` — no encoder seeding on connect, the
+  driver trusts whatever encoder value the firmware reports.
+  Operators powering up the mount at a recognised Astro-Physics park
+  position set it to the matching `ap_park_<n>` string (`"ap_park_1"`
+  through `"ap_park_5"`) and the driver issues `:E1` / `:E2` on
+  connect to seed the firmware encoder to the codebase's convention
+  for that pose. See [§Home pose](#home-pose).
+
+### Home pose
+
+The Sky-Watcher firmware resets its encoder counter to `(0, 0)` on
+every power-up. The codebase's coordinate math interprets that zero
+against the configured `home_pose`, so the operator's physical
+power-up pose lines up with the driver's celestial-coordinate
+readings without an explicit `SyncToCoordinates` step.
+
+The five named poses follow the Astro-Physics
+["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
+document. Each pose is mirror-symmetric between the Northern and
+Southern Hemispheres, and the driver applies the hemisphere case-split
+internally from `site_latitude_deg`. AP Park 4 / Park 5 are
+post-meridian-flip poses (saddle east); the seed step lands the
+encoder past the celestial pole on the Dec axis and at the `±12 h`
+encoder wrap on the RA axis for Park 4.
+
+| `home_pose` | AP description | Codebase `mech_HA` | Codebase `dec_encoder` |
+|---|---|---|---|
+| `null` (default) | No seeding — trust the firmware encoder as-is. Pre-Phase-6 behaviour. | — | — |
+| `ap_park_1` | RA horizontal, saddle west, OTA level facing the polar-side horizon. | `0 h` | `±(90 − \|lat\|)°` (sign matches hemisphere) |
+| `ap_park_2` | OTA level facing the east horizon (target at celestial east-rising equator). Hemisphere-independent. | `−6 h` | `0°` |
+| `ap_park_3` | OTA along polar axis pointing at the visible celestial pole — Sky-Watcher's stock power-up pose. | `0 h` | `±90°` (sign matches hemisphere) |
+| `ap_park_4` | Post-flip mirror of Park 1: saddle east, OTA level facing the anti-polar horizon. | `−12 h` (encoder wrap) | `∓(90 + \|lat\|)°` (sign anti-hemisphere) |
+| `ap_park_5` | Post-flip mirror of Park 1: saddle east, OTA level facing the polar-side horizon. APCC-only in AP's own software. | `0 h` (post-flip wrap) | `±(90 + \|lat\|)°` (sign matches hemisphere) |
+
+The seed step is skipped when the firmware reports a non-zero
+encoder reading on connect — that indicates the mount has already
+been slewed or synced this power cycle, and the driver does not
+clobber the existing position. Reconnecting mid-session after a
+slew is therefore safe.
+
+Documented operator assumption: when `home_pose` is set, the operator
+powers up the mount **at** the configured pose and connects the
+driver before any slew or sync.
 
 ### CLI arguments
 
@@ -1067,6 +1111,11 @@ init handshake:
   :g1, :g2          (high-speed ratio)     → cache
   :e1               (motor board version)  → debug! log
   :j1, :j2          (initial positions)    → cache
+   ↓
+load park target from config / handshake → in-memory park ticks
+   ↓
+if home_pose is set AND firmware encoder is (0, 0):
+  :E1, :E2  (seed encoder to the AP pose's codebase convention)
    ↓
 start background polling task (interval = config.polling_interval)
    ↓
@@ -1373,6 +1422,11 @@ What's still outstanding from Phase 4:
   ambiguous bits of the spec against this driver.
 - [EQMOD project](https://eq-mod.sourceforge.net/) — Windows-side
   reference driver and protocol-decoding documentation.
+- [Astro-Physics "Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
+  — canonical reference for the five named park positions (Park 1
+  through Park 5) the [§Home pose](#home-pose) config exposes,
+  including the per-hemisphere celestial-Dec formulae and the
+  east-side / west-side scope orientations.
 
 ### Misleading and explicitly out-of-scope
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -963,21 +963,28 @@ readings without an explicit `SyncToCoordinates` step.
 
 The five named poses follow the Astro-Physics
 ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
-document. Each pose is mirror-symmetric between the Northern and
-Southern Hemispheres, and the driver applies the hemisphere case-split
-internally from `site_latitude_deg`. AP Park 4 / Park 5 are
-post-meridian-flip poses (saddle east); the seed step lands the
-encoder past the celestial pole on the Dec axis and at the `±12 h`
-encoder wrap on the RA axis for Park 4.
+document. Each AP pose describes a fixed mechanical pier side
+(OTA-on-west-of-mount or OTA-on-east-of-mount) that's the same for
+both hemispheres — but the driver's natural-vs-flipped pier convention
+flips between hemispheres (N natural = pierWest, S natural = pierEast,
+see `pre_flip_side` in `mount_device.rs`). So a pose like Park 1
+(OTA on the west side of the mount) is the **natural pier** in the
+North and the **flipped pier** in the South, and its encoder
+representation differs accordingly:
 
-| `home_pose` | AP description | Codebase `mech_HA` | Codebase `dec_encoder` |
-|---|---|---|---|
-| `null` (default) | No seeding — trust the firmware encoder as-is. Pre-Phase-6 behaviour. | — | — |
-| `ap_park_1` | RA horizontal, saddle west, OTA level facing the polar-side horizon. | `0 h` | `±(90 − \|lat\|)°` (sign matches hemisphere) |
-| `ap_park_2` | OTA level facing the east horizon (target at celestial east-rising equator). Hemisphere-independent. | `−6 h` | `0°` |
-| `ap_park_3` | OTA along polar axis pointing at the visible celestial pole — Sky-Watcher's stock power-up pose. | `0 h` | `±90°` (sign matches hemisphere) |
-| `ap_park_4` | Post-flip mirror of Park 1: saddle east, OTA level facing the anti-polar horizon. | `−12 h` (encoder wrap) | `∓(90 + \|lat\|)°` (sign anti-hemisphere) |
-| `ap_park_5` | Post-flip mirror of Park 1: saddle east, OTA level facing the polar-side horizon. APCC-only in AP's own software. | `0 h` (post-flip wrap) | `±(90 + \|lat\|)°` (sign matches hemisphere) |
+- Natural side: `mech_HA = celestial_HA`, `dec_enc = celestial_dec`.
+- Flipped side: `mech_HA = celestial_HA + 12 h` folded to `[−12, +12)`,
+  `dec_enc = sign(celestial_dec) · (180° − |celestial_dec|)` (past
+  the celestial pole on the encoder).
+
+| `home_pose` | AP description | Mech. pier | N hem (mech_HA, dec_enc) | S hem (mech_HA, dec_enc) |
+|---|---|---|---|---|
+| `null` (default) | No seeding — trust the firmware encoder as-is. Pre-Phase-6 behaviour. | — | — | — |
+| `ap_park_1` | OTA on west, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)`. | West | `(−12 h, +(90 − \|lat\|)°)` (natural) | `(0 h, −(90 + \|lat\|)°)` (flipped past pole) |
+| `ap_park_2` | OTA level facing east horizon, counterweight straight down. Hemisphere-independent celestial coords `(HA=−6, Dec=0)`. | — (CW down) | `(−6 h, 0°)` | `(−6 h, 0°)` |
+| `ap_park_3` | OTA along polar axis at the visible celestial pole. Sky-Watcher's stock power-up pose. | — (CW along polar) | `(−6 h, +90°)` | `(−6 h, −90°)` |
+| `ap_park_4` | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (flipped past pole) | `(0 h, +(90 − \|lat\|)°)` (natural) |
+| `ap_park_5` | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(0 h, +(90 + \|lat\|)°)` (flipped past pole) | `(−12 h, −(90 − \|lat\|)°)` (natural) |
 
 The seed step is skipped when the firmware reports a non-zero
 encoder reading on connect — that indicates the mount has already

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -814,31 +814,42 @@ RA axis stays in the counterweight-below-horizon half; the Dec axis
 crosses the *visible* celestial pole rather than the below-horizon
 one.
 
-**RA axis:** routed through the negative-`mech_HA` half of the encoder
-range (`mech_HA ∈ [−12, 0]`) — the half where the counterweight stays
-at or below the local horizon. The mechanical binding zone at
-`mech_HA ∈ (+6.95, +11.05)` is the same for every observer latitude,
-so the rule is hemisphere-independent.
+**RA axis:** the counterweight binding zone at
+`mech_HA ∈ (+6.95, +11.05)` is one-sided and hemisphere-independent;
+every other arc of the polar-axis circle is safe. The routing rule is
+therefore stated directly in terms of the binding zone rather than as
+a sign proxy:
 
-The safe direction depends on the *current* encoder position:
+- Compute the canonical short delta's mech_HA sweep
+  (`[current_mech_HA, current_mech_HA + canonical_delta_ha]`).
+- If that sweep stays outside `(zone_min, zone_max)` (modulo 24 h —
+  the binding-zone copy at `k ∈ {-1, 0, +1}` is checked, enough to
+  cover any `|canonical_delta_ha| ≤ 12 h` path), use the canonical
+  direction.
+- Otherwise take the long way (`canonical ± cpr_ra`), which lands at
+  the same modular destination via the safe arc on the other side.
 
-- `|current_ticks| ≤ cpr_ra/4` (current in the pre-flip envelope,
-  `mech_HA ∈ [−6, +6]`): force CCW (negative delta). Path decreases
-  through the negative half to the target. This is the forward-flip
-  case (pre-flip → post-flip wrap).
-- `|current_ticks| > cpr_ra/4` (current at or past the wrap,
-  `mech_HA` near `±12`): force CW (positive delta). Path increases
-  *away from the wrap* into the safe negative half. This is the
-  flip-back case (post-flip → pre-flip).
+This handles the forward-flip case (pre-flip near meridian → post-flip
+wrap, canonical CCW already in the safe negative half), the flip-back
+case (post-flip wrap on either side of the `±12` boundary → pre-flip
+near meridian, canonical short path stays in the safe arc), and the
+edge case the prior sign-blind heuristic mis-fired on:
+**hardware validation 2026-05-16, Park 4 N → Park 5 N flip-back.**
+Current `mech_HA ≈ −11.97` (post-flip pierEast just east of the
+saddle-east wrap), target `mech_HA ≈ +11.99` (pre-flip pierWest just
+west of the same wrap). Canonical short delta is a ~4 k-tick CCW
+nudge that physically just crosses the `−12 ↔ +12` wrap; the old
+`|current| > cpr_ra/4 ⇒ "safe is positive"` rule misread that as
+"in the post-flip half, force positive" and issued a `+cpr_ra − 4 k`
+≈ +3.625 M-tick CW full revolution that swept mech_HA through
+`(+6.95, +11.05)` and slammed the CW shaft into the pier. The
+path-aware check preserves the safe canonical step.
 
-A naive "always CCW for flip slews" rule works for forward flips but
-drives the counterweight into the binding zone on flip-back: from
-raw `−cpr/2` going CCW wraps the encoder past `+12` and crosses
-`mech_HA = +6 to +9` (the binding peak). Hardware validation #3 hit
-this exact failure mode on the back-to-Park-3 slew, slamming the CW
-shaft into the pier and dropping the USB-CDC. The current-position-
-aware rule (mirroring the Dec routing) selects the right direction
-in both cases.
+Empty zone (`zone_min ≥ zone_max`) disables the routing — the
+canonical short delta is always used. BDD tests rely on this to keep
+small-distance scenarios from accidentally triggering the long way
+when the wall-clock LST puts a synthetic target inside the default
+zone.
 
 **Dec axis:** routed through the visible celestial pole, NOT the
 below-horizon pole. For a polar-aligned mount, only one of the two
@@ -879,14 +890,33 @@ pole on Dec rather than taking the shortest-encoder path).
 
 #### Hardware validation
 
-`flip_policy.enabled` defaults to `false` until at least one
-successful real-hardware flip on a GTi has been recorded. The
-mechanical symmetry argument (plan §2.8) is strong, but the
-through-wrap traversal is the first time the GTi's negative-`mech_HA`
-half is exercised past the pre-flip safe envelope, and asymmetric
-failure modes like cable wrap will surface there. The first real
-`SetSideOfPier(East)` on hardware is the validation gate; until then
-operators leave `flip_policy.enabled` at its default.
+`flip_policy.enabled` defaults to `false` until the through-wrap
+flip-back path is hardware-verified end-to-end on a GTi.
+
+**2026-05-16, lat 32.7°N (San Diego).** The AP Park 1–5 sequence ran
+end-to-end:
+
+1. `Park 3 → Park 2`: small Dec slew (−90° to celestial equator).
+2. `Park 2 → staging (HA = 0, Dec = −57.3°)`: pre-flip pierWest small
+   slew; no routing change.
+3. `SetSideOfPier(East) → Park 4 N`: through-wrap flip slew — RA
+   −180° (saddle west → east) + Dec +294° CW (through wrap, past
+   NCP, ending past-pole at `dec_encoder ≈ −122.78°`).
+4. `Slew to (LST + 12 h, Dec = +57.3°) → Park 5 N`: flip-back over
+   the saddle-east wrap. Wire issued was RA **−3,631 ticks CCW**
+   (canonical short path, ~0.024° of polar-axis rotation) + Dec
+   −180° CCW via NCP. The earlier sign-blind heuristic issued a
+   +3.625 M-tick CW full revolution instead and the operator
+   powered the mount off mid-sweep — see §"Through-wrap slew
+   routing" above for the path-aware fix.
+5. `Park → Park 3 N`: clean unwind.
+
+All five poses confirmed visually. The dec axis's analogous routing
+helper (`flip_slew_dec_delta`) was not exercised on its
+sign-blind edge case in this session (current dec was on the
+`+cpr_dec/2` side of the wrap where the old heuristic happens to be
+correct); a follow-up issue tracks porting the path-aware fix to that
+function.
 
 ## Configuration
 
@@ -1296,7 +1326,7 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase A6 — Dec-encoder `SideOfPier` + `DestinationSideOfPier`** | landed (issue #202) — switches `SideOfPier` from the RA mech-HA split at `HA = 0` to the canonical INDI eqmod Dec-encoder convention (`East` when `\|dec_encoder\| > cpr_dec/4`), and lands `DestinationSideOfPier` reusing the same coordinate-math pipeline as `SlewToCoordinatesAsync`. ConformU expected-issues count moves from 9 to 7: the `DestinationSideOfPier` NotImplemented entry and the four inherited `SOPPierTest` entries clear, the two upstream `TrackingRate Write` entries disappear (unrelated framework fix), and three new "non-flipping mount" entries appear that reflect ConformU's flip-aware-GEM assumption rather than driver bugs. See [§Expected ConformU report](#expected-conformu-report). |
 | **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`, and re-enables `[package.metadata.conformu]` so the full two-phase ConformU integration runs again. |
 | **Phase 5 — user-defined `SetPark` + persistence** | landed (issue #203) — park target now sourced from `mount.park_ra_ticks` / `mount.park_dec_ticks` in the config (fallback: encoder positions captured at handshake), `SetPark` writes the current encoder pair back into the running config file via atomic rename, `CanSetPark` flips on when `--config` is provided. See [§Park lifecycle](#park-lifecycle) and [§Park persistence](#park-persistence). |
-| **Phase 6 — meridian-flip support** | implementation in progress — adds `MountConfig::flip_policy` (`enabled` + `flip_range_hours`), per-pier-side safe envelopes, through-wrap slew routing for flip slews, `SetSideOfPier`, and flip-aware `DestinationSideOfPier`. `flip_policy.enabled` defaults `false` and awaits a successful first real-hardware flip on a GTi before the default is reconsidered. Auto-flip-during-tracking is intentionally deferred to a Phase 2.5 follow-up — the driver only flips on an explicit `SetSideOfPier` or a slew whose target requires the opposite side. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md). See [§Meridian flip](#meridian-flip). |
+| **Phase 6 — meridian-flip support** | hardware-validated 2026-05-16 (lat 32.7°N) — adds `MountConfig::flip_policy` (`enabled` + `flip_range_hours`), the asymmetric counterweight binding-zone safety envelope, binding-zone-path-aware through-wrap RA routing, visible-pole Dec routing, `SetSideOfPier`, and flip-aware `DestinationSideOfPier`. End-to-end AP Park 1–5 traversal (including the through-wrap saddle-east flip and its flip-back) ran clean; the flip-back from the saddle-east wrap caught a sign-blind heuristic in `flip_slew_ra_delta` that the path-aware check now handles. `flip_policy.enabled` still defaults `false` (operators opt in once they've replayed the validation locally). Auto-flip-during-tracking is intentionally deferred to a Phase 2.5 follow-up — the driver only flips on an explicit `SetSideOfPier` or a slew whose target requires the opposite side. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md). See [§Meridian flip](#meridian-flip). |
 
 #### Phase 4 findings (hardware bringup)
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -986,11 +986,18 @@ representation differs accordingly:
 | `ap_park_4` | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (flipped past pole) | `(0 h, +(90 − \|lat\|)°)` (natural) |
 | `ap_park_5` | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(0 h, +(90 + \|lat\|)°)` (flipped past pole) | `(−12 h, −(90 − \|lat\|)°)` (natural) |
 
-The seed step is skipped when the firmware reports a non-zero
-encoder reading on connect — that indicates the mount has already
-been slewed or synced this power cycle, and the driver does not
-clobber the existing position. Reconnecting mid-session after a
-slew is therefore safe.
+The seed step is skipped when the firmware reports an encoder
+reading beyond a small fresh-power-up tolerance
+(`FRESH_POWER_UP_TICK_TOLERANCE`, currently 100 ticks ≈ 10″ at the
+GTi's CPR). The tolerance exists because the Sky-Watcher firmware
+does not always read exactly `(0, 0)` after a power-cycle —
+empirically the validation GTi reports `dec = −1` on connect, a
+single-tick initialisation artifact (~0.4″) that obviously still
+represents the just-powered-up state. Any genuine post-slew
+encoder is tens of thousands of ticks away from zero, so the
+tolerance comfortably distinguishes "fresh power-up" from
+"already slewed this session". Reconnecting mid-session after a
+slew is therefore still safe.
 
 Documented operator assumption: when `home_pose` is set, the operator
 powers up the mount **at** the configured pose and connects the

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -705,26 +705,50 @@ deferred to Phase 2.5 — see [§Deferred](#deferred-not-in-mvp)):
   verification); a larger value would push the post-flip `mech_HA`
   into the unverified mirror of the binding zone.
 
-#### Per-pier-side safety envelopes
+#### Safety envelope (counterweight binding zone)
 
-The pre-flip safe zone (`MountConfig::ra_min_hours` /
-`ra_max_hours` / `dec_min_degrees` / `dec_max_degrees`, defaults
-`[−6.95, +6.95]` h RA and `[−90, +90]°` Dec) covers `pierWest`
-operation as in Phase 1.1.
+Mechanical safety on a GEM is dominated by one specific hazard:
+when the OTA tracks westward past meridian on the natural pierWest,
+the counterweight swings up to peak altitude at `mech_HA = +6` and
+then back down toward the east horizon at `mech_HA = +12`. There's
+a narrow arc on the way down — `mech_HA ∈ (+6.95, +11.05)` — where
+the CW shaft binds against the pier structure on the east side. The
+binding is **asymmetric** (no symmetric mirror on the negative
+mech_HA side, because the negative half puts the CW into the floor
+beneath the pier, not against pier hardware).
 
-The post-flip (`pierEast`) safe zone mirrors the pre-flip RA zone
-through the encoder wrap at `±12 h`. For a target HA satisfying
-`|target_HA| ≤ flip_range_hours`, the post-flip mech-HA is
-`target_HA + 12 h` (folded signed into `[−12, +12)`), which lands in
-the symmetric band `[+12 − flip_range_hours, +12] ∪ [−12, −12 +
-flip_range_hours]`. The Dec encoder lands past either celestial pole
-— `|dec_encoder| > 90°` (Northern Hemisphere; Southern inverts).
+The driver enforces this as a single interval on the **chosen-side
+encoder mech_HA**, in `MountConfig::binding_zone_min_hours` and
+`binding_zone_max_hours` (defaults `6.95` and `11.05` — the
+hardware-verified GTi values):
 
-A flip-aware slew validates against the envelope for the *chosen*
-side: a flip slew checks the post-flip RA band and the
-past-the-pole Dec mapping; a normal slew checks the pre-flip zone.
-Targets outside the relevant zone are rejected with `INVALID_VALUE`
-before any wire motion.
+- A slew or sync is rejected with `INVALID_VALUE` if its target
+  mech_HA falls inside the binding-zone interval.
+- For natural-side targets, `target_mech_HA = celestial_HA` (folded
+  signed into `[−12, +12)`).
+- For flipped-side targets, `target_mech_HA = celestial_HA + 12 h`
+  (folded).
+- Setting `binding_zone_min ≥ binding_zone_max` (an empty interval)
+  disables the check — used by BDD scenarios that pass hardcoded
+  celestial coords whose computed mech_HA depends on wallclock LST.
+
+The check is **destination-only**, mirroring INDI EQMOD's
+`EncoderTarget` pattern. The slew *path* is not analysed; the slew
+direction is picked by sign-of-delta (or
+[`flip_slew_ra_delta`](#flip_slew_ra_delta) for flip slews) and is
+robust to the asymmetric zone because every reachable encoder
+direction stays on one side of it.
+
+`Park` writes the target encoder ticks directly without consulting
+the binding-zone check — also mirroring EQMOD's privileged-park
+pattern. The operator's `park_ra_ticks` / `park_dec_ticks` are
+assumed to have been validated against the binding zone at the time
+of configuration.
+
+The Dec envelope (`dec_min_degrees` / `dec_max_degrees`, defaults
+`[−90, +90]°`) is independent — it bounds the celestial Dec the
+driver will accept, primarily a sanity check against client-side
+coordinate-math bugs.
 
 #### Pier-side decision tree
 
@@ -733,27 +757,36 @@ dec)` share the same selector:
 
 1. If `flip_policy.enabled = false`, return the current `SideOfPier`.
 2. Compute `target_HA = LST − ra` (signed, folded to `[−12, +12)`).
-3. If the *current* side's safety envelope covers `target_HA`, stay
-   on the current side (no unnecessary flip). The pre-flip side (the
-   "normal" pointing — `pierWest` in the Northern Hemisphere,
-   `pierEast` in the Southern) covers `target_HA ∈ [ra_min_hours,
-   ra_max_hours]`; the post-flip side covers `target_HA ∈
-   [−flip_range_hours, +flip_range_hours]`.
+3. If the *current* side can reach the target without entering the
+   binding zone, stay on the current side (no unnecessary flip):
+   - **Pre-flip side** (`pierWest` in the Northern Hemisphere,
+     `pierEast` in the Southern): "covers" means `target_HA ∉
+     binding_zone`. This is wider than the legacy
+     `[ra_min_hours, ra_max_hours]` window — the whole sky except
+     the binding interval.
+   - **Post-flip side**: "covers" means `|target_HA| ≤
+     flip_range_hours`. This is an *operational* preference (after
+     a flip, the driver expects to flip back to natural side soon),
+     not a hard mechanical constraint. The post-flip side could
+     mechanically be tracked far past `±flip_range_hours`, but the
+     decision tree treats anything outside as "should flip back".
 4. Otherwise return the *opposite* side.
 
-The driver does not pre-emptively flip; it only flips when the target
-can't be reached from the current side or when `SetSideOfPier` forces
-it. The post-flip envelope's reach (`flip_range_hours`) is small —
-`0.5 h` by default — so the practical pattern is: pre-flip side
-covers most of the sky; an explicit or implicit flip rotates the
-mount through the meridian to the post-flip side for tracking a
-target past meridian crossing; the next slew that targets HA outside
-the flip window auto-flips back to the pre-flip side.
+The driver does not pre-emptively flip; it only flips when the
+target can't be reached from the current side (per rule 3) or when
+`SetSideOfPier` forces it. The post-flip operational window
+(`flip_range_hours`) is small — `0.5 h` by default — so the
+practical pattern is: pre-flip side covers most of the sky; an
+explicit or implicit flip rotates the mount through the meridian to
+the post-flip side for tracking a target past meridian crossing;
+the next slew that targets HA outside the flip window auto-flips
+back to the pre-flip side.
 
-When neither side's envelope covers the target (e.g. an
-above-the-pole pointing past `ra_max_hours`), the selector returns
-the *opposite* side; the subsequent envelope validation rejects the
-slew with `INVALID_VALUE` regardless of which side was chosen.
+Park 1 / Park 5 anti-meridian poses are reachable via
+`SlewToCoordinatesAsync` because they live at `target_HA = ±12 h`
+on the natural / flipped pier respectively, and their corresponding
+`mech_HA` (folded `−12` for Park 1 on pierWest, `0` for Park 5 on
+pierEast) is outside the binding zone.
 
 #### `SetSideOfPier(side)`
 
@@ -925,6 +958,20 @@ Notes:
   WGS84 degrees, `+E`. (ASCOM convention.)
 - `tracking_rate` accepts `"sidereal"` only in MVP. Field is reserved
   for future expansion.
+- `binding_zone_min_hours` / `binding_zone_max_hours` define the
+  counterweight-binding interval in encoder `mech_HA` (signed hours
+  folded `[−12, +12)`). Slews / syncs whose chosen-side `mech_HA`
+  falls inside the interval are rejected with `INVALID_VALUE`.
+  Defaults `(6.95, 11.05)` for the GTi — the asymmetric one-sided
+  zone where the CW shaft binds against the pier from the east side
+  as it swings down toward east horizon past the
+  `mech_HA = +6 h` peak altitude. The negative-mech_HA mirror is
+  *not* a binding zone (CW points into the ground beneath the
+  pier). Setting `min ≥ max` disables the check (used by tests and
+  by operators whose binding zone is elsewhere). See
+  [§Safety envelope](#safety-envelope-counterweight-binding-zone).
+- `dec_min_degrees` / `dec_max_degrees` clip the celestial-Dec
+  range the driver will accept on slew / sync. Defaults `[−90, +90]°`.
 - `park_ra_ticks` / `park_dec_ticks` are written by `SetPark` and read
   on every connect; absent (or `null`) at first run, populated once
   `SetPark` is called. Operators may set them by hand to pin a known
@@ -1396,23 +1443,25 @@ In addition to the codec fixes:
   counterweight-up region with ConformU's pier-flip tests stalled
   the motor against a hard stop while the encoder counter kept
   advancing (audible motor noise, OTA stationary). `MountConfig`
-  now carries `ra_min_hours` / `ra_max_hours` /
-  `dec_min_degrees` / `dec_max_degrees`. `SyncToCoordinates`,
-  `SlewToCoordinatesAsync`, and `Park` reject targets outside
-  the envelope with `INVALID_VALUE` before any wire motion.
-  Defaults: `±6.95 h` RA — `0.05 h` (`3 arcmin`) inside the
-  GTi's hardware-verified `±6.99 h` mechanical limit (per the
-  2026-05-13 hardware test) and INDI eqmod's baked-in `±7 h`
-  envelope for every Sky-Watcher mount (`zeroRAEncoder ±
-  (totalRAEncoder/4 + totalRAEncoder/24)` in
-  `eqmodbase.cpp::Goto`). The buffer is deliberate: the ASCOM
-  `SlewToCoordinates(ra, dec)` round-trip means the driver
-  re-reads LST a few tens of ms after the client computed the
-  target, so a target quantised exactly to the mechanical limit
-  would drift past it; and the deferred Phase 2 meridian-flip
-  planner will need headroom between the configured envelope
-  and the mechanical stops to plan multi-stage flip slews —
-  `±90°` Dec.
+  now carries `binding_zone_min_hours` /
+  `binding_zone_max_hours` (the asymmetric mech_HA interval where
+  the CW binds against the pier) plus `dec_min_degrees` /
+  `dec_max_degrees`. `SyncToCoordinates` and
+  `SlewToCoordinatesAsync` reject targets whose chosen-side
+  `mech_HA` falls inside the binding zone with `INVALID_VALUE`
+  before any wire motion; `Park` writes the target encoder ticks
+  directly without the binding-zone check, matching INDI EQMOD's
+  privileged-park pattern. Pre-Phase-6 builds used a symmetric
+  natural-side window (`ra_min_hours` / `ra_max_hours`); that's
+  been replaced by the asymmetric binding-zone interval because
+  the actual GEM hazard is one-sided.
+  Defaults: binding zone `(6.95, 11.05) h` of mech_HA — the
+  hardware-verified GTi binding region (the symmetric
+  `±6.99 h` natural-side bound from the 2026-05-13 test is
+  *subsumed* by the new asymmetric model: tracking past
+  `+6.95 h` would enter the zone and is refused, while reaching
+  `−12 h` for anti-meridian poses like Park 1 is no longer
+  blocked). `±90°` Dec.
 - **Slew watcher abort on `:f` blocked** — both the slew and
   park completion watchers issue `:L` on both axes and clear
   `slew_in_progress` if either axis reports `blocked=true`.

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1015,23 +1015,38 @@ document. Each AP pose describes a fixed mechanical pier side
 both hemispheres — but the driver's natural-vs-flipped pier convention
 flips between hemispheres (N natural = pierWest, S natural = pierEast,
 see `pre_flip_side` in `mount_device.rs`). So a pose like Park 1
-(OTA on the west side of the mount) is the **natural pier** in the
-North and the **flipped pier** in the South, and its encoder
-representation differs accordingly:
+The codebase's `mech_HA` is hemisphere-independent: the saddle east/west
+position is determined by the encoder alone (`|mech_HA| ≤ 6 h` →
+saddle west; `|mech_HA| > 6 h` → saddle east). The dec encoder *is*
+hemisphere-dependent — at fixed `mech_HA`, the dec=0 reference points
+at different celestial coords for N vs S, so the rotation needed to
+reach the AP-described OTA pointing differs in magnitude.
 
-- Natural side: `mech_HA = celestial_HA`, `dec_enc = celestial_dec`.
-- Flipped side: `mech_HA = celestial_HA + 12 h` folded to `[−12, +12)`,
-  `dec_enc = sign(celestial_dec) · (180° − |celestial_dec|)` (past
-  the celestial pole on the encoder).
+The encoder values below were corrected via hardware verification at
+lat 32.7°N on 2026-05-17. The earlier mapping (commit `2725a2f`) had
+Park 1 and Park 5 swapped: it claimed Park 1 N was at
+`(mech_HA=−12, dec_enc=+(90−|lat|)°)`, but that encoder pose
+physically corresponds to AP Park 5 N (saddle east). The corrected
+mapping places each AP pose at the encoder values that physically
+match it.
 
 | `home_pose` | AP description | Mech. pier | N hem (mech_HA, dec_enc) | S hem (mech_HA, dec_enc) |
 |---|---|---|---|---|
 | `null` (default) | No seeding — trust the firmware encoder as-is. Pre-Phase-6 behaviour. | — | — | — |
-| `ap_park_1` | OTA on west, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)`. | West | `(−12 h, +(90 − \|lat\|)°)` (natural) | `(0 h, −(90 + \|lat\|)°)` (flipped past pole) |
+| `ap_park_1` | OTA on west, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)`. | West | `(0 h, +(90 + \|lat\|)°)` (saddle west, dec past pole) | `(0 h, −(90 + \|lat\|)°)` (saddle west, dec past pole) |
 | `ap_park_2` | OTA level facing east horizon, counterweight straight down. Hemisphere-independent celestial coords `(HA=−6, Dec=0)`. | — (CW down) | `(−6 h, 0°)` | `(−6 h, 0°)` |
 | `ap_park_3` | OTA along polar axis at the visible celestial pole. Sky-Watcher's stock power-up pose. | — (CW along polar) | `(−6 h, +90°)` | `(−6 h, −90°)` |
-| `ap_park_4` | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (flipped past pole) | `(0 h, +(90 − \|lat\|)°)` (natural) |
-| `ap_park_5` | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(0 h, +(90 + \|lat\|)°)` (flipped past pole) | `(−12 h, −(90 − \|lat\|)°)` (natural) |
+| `ap_park_4` | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (saddle east, dec past pole) | `(−12 h, +(90 + \|lat\|)°)` (saddle east, dec past pole) |
+| `ap_park_5` | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(−12 h, +(90 − \|lat\|)°)` (saddle east, dec normal) | `(−12 h, −(90 − \|lat\|)°)` (saddle east, dec normal) |
+
+Note on `SideOfPier` reporting: the codebase's `side_of_pier` uses
+the ASCOM-spec convention (dec-past-pole indicates `pierEast`),
+*not* the AP "OTA east of mount" geometric convention. AP Park 5 N
+has saddle east physically but dec encoder normal (`+57°`), so the
+codebase reports it as `pierWest` (pre-flip). AP Park 1 N has
+saddle west but dec past pole (`+123°`), so the codebase reports
+it as `pierEast` (post-flip). The encoder values match the AP
+physical pose; only the `pierSide` label differs in convention.
 
 The seed step is skipped when the firmware reports an encoder
 reading beyond a small fresh-power-up tolerance

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1389,6 +1389,19 @@ In addition to the codec fixes:
 - **Slew watcher abort on `:f` blocked** — both the slew and
   park completion watchers issue `:L` on both axes and clear
   `slew_in_progress` if either axis reports `blocked=true`.
+- **Transient-error tolerance with best-effort halt** — the
+  slew/park watchers tolerate up to three consecutive
+  `poll_axes_now` failures (with a 100 ms backoff between
+  attempts) before giving up, so a single USB-CDC glitch
+  doesn't take the watcher offline for the rest of a goto.
+  On retry exhaustion the helper fires `:L` on both axes
+  best-effort so the motor isn't left commutating with no
+  observer, then clears `slew_in_progress` and exits.
+  Every successful poll is also emitted at `debug` with the
+  full per-axis snapshot (position, running, blocked, goto)
+  so post-mortems can reconstruct the last-known-good state
+  observed before any failure. See
+  `mount_device::watcher_poll_with_retry`.
 - **EQMOD-style iterative pickup** — Phase A5 added a pickup
   loop in the slew watcher: after both axes report stopped,
   the watcher reads current RA/Dec, compares against the

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -772,15 +772,30 @@ crosses the *visible* celestial pole rather than the below-horizon
 one.
 
 **RA axis:** routed through the negative-`mech_HA` half of the encoder
-range — the half where the counterweight stays at or below the local
-horizon. The RA encoder traverses from its current value through
-`mech_HA = 0` ("home") and the encoder wrap at `−12 h ≡ +12 h` to the
-post-flip target. The driver enforces this by forcing `:G`'s CCW bit
-to `1` on flip slews and adjusting the `:H` increment to the
-complementary magnitude when the canonical-shortest direction would
-have gone the other way (the GTi's mechanical binding zone at
+range (`mech_HA ∈ [−12, 0]`) — the half where the counterweight stays
+at or below the local horizon. The mechanical binding zone at
 `mech_HA ∈ (+6.95, +11.05)` is the same for every observer latitude,
-so the routing rule is hemisphere-independent).
+so the rule is hemisphere-independent.
+
+The safe direction depends on the *current* encoder position:
+
+- `|current_ticks| ≤ cpr_ra/4` (current in the pre-flip envelope,
+  `mech_HA ∈ [−6, +6]`): force CCW (negative delta). Path decreases
+  through the negative half to the target. This is the forward-flip
+  case (pre-flip → post-flip wrap).
+- `|current_ticks| > cpr_ra/4` (current at or past the wrap,
+  `mech_HA` near `±12`): force CW (positive delta). Path increases
+  *away from the wrap* into the safe negative half. This is the
+  flip-back case (post-flip → pre-flip).
+
+A naive "always CCW for flip slews" rule works for forward flips but
+drives the counterweight into the binding zone on flip-back: from
+raw `−cpr/2` going CCW wraps the encoder past `+12` and crosses
+`mech_HA = +6 to +9` (the binding peak). Hardware validation #3 hit
+this exact failure mode on the back-to-Park-3 slew, slamming the CW
+shaft into the pier and dropping the USB-CDC. The current-position-
+aware rule (mirroring the Dec routing) selects the right direction
+in both cases.
 
 **Dec axis:** routed through the visible celestial pole, NOT the
 below-horizon pole. For a polar-aligned mount, only one of the two

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -721,20 +721,29 @@ before any wire motion.
 `DestinationSideOfPier(ra, dec)` and `SlewToCoordinatesAsync(ra,
 dec)` share the same selector:
 
-1. Compute `target_HA = LST − ra` (signed, folded to `[−12, +12)`).
-2. If `flip_policy.enabled = false`, return the current `SideOfPier`.
-3. If `|target_HA| > flip_policy.flip_range_hours`, the target is
-   unflippable — return the current side (only the pre-flip side is
-   reachable).
-4. Otherwise the target lies inside the flip window: return whichever
-   side keeps the mount in its current sky region without an
-   unnecessary flip. Concretely, return the *current* side when the
-   target is reachable from it; return the *opposite* side when the
-   current side's envelope rejects the target.
+1. If `flip_policy.enabled = false`, return the current `SideOfPier`.
+2. Compute `target_HA = LST − ra` (signed, folded to `[−12, +12)`).
+3. If the *current* side's safety envelope covers `target_HA`, stay
+   on the current side (no unnecessary flip). The pre-flip side (the
+   "normal" pointing — `pierWest` in the Northern Hemisphere,
+   `pierEast` in the Southern) covers `target_HA ∈ [ra_min_hours,
+   ra_max_hours]`; the post-flip side covers `target_HA ∈
+   [−flip_range_hours, +flip_range_hours]`.
+4. Otherwise return the *opposite* side.
 
 The driver does not pre-emptively flip; it only flips when the target
 can't be reached from the current side or when `SetSideOfPier` forces
-it.
+it. The post-flip envelope's reach (`flip_range_hours`) is small —
+`0.5 h` by default — so the practical pattern is: pre-flip side
+covers most of the sky; an explicit or implicit flip rotates the
+mount through the meridian to the post-flip side for tracking a
+target past meridian crossing; the next slew that targets HA outside
+the flip window auto-flips back to the pre-flip side.
+
+When neither side's envelope covers the target (e.g. an
+above-the-pole pointing past `ra_max_hours`), the selector returns
+the *opposite* side; the subsequent envelope validation rejects the
+slew with `INVALID_VALUE` regardless of which side was chosen.
 
 #### `SetSideOfPier(side)`
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1045,6 +1045,12 @@ document. Each AP pose describes a fixed mechanical pier side
 both hemispheres — but the driver's natural-vs-flipped pier convention
 flips between hemispheres (N natural = pierWest, S natural = pierEast,
 see `pre_flip_side` in `mount_device.rs`). So a pose like Park 1
+(OTA-on-west-of-mount, mechanically) is on the **natural** side in the
+Northern Hemisphere and on the **flipped** side in the Southern
+Hemisphere — and its dec-encoder representation differs accordingly
+(natural side gives `|dec_enc| ≤ 90°`; flipped side gives `|dec_enc| > 90°`
+via the past-pole encoding).
+
 The codebase's `mech_HA` is hemisphere-independent: the saddle east/west
 position is determined by the encoder alone (`|mech_HA| ≤ 6 h` →
 saddle west; `|mech_HA| > 6 h` → saddle east). The dec encoder *is*

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -284,8 +284,7 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `CanPark` | `true` | implemented (software park) |
 | `CanUnpark` | `true` | implemented |
 | `CanSetPark` | runtime-determined | `true` when the driver was started with `--config <path>` (the path it would write back to); `false` for `Config::default()` runs (smoke-tests, no-arg launches). See [§Park persistence](#park-persistence) |
-| `CanSetPierSide` | `false` | mount manages pier side via slew direction |
-| `CanSetSideOfPier` | `false` | same as above |
+| `CanSetPierSide` | runtime-determined | `true` when `flip_policy.enabled` is set on a hardware-validated mount; `false` otherwise (`SetSideOfPier` returns `NOT_IMPLEMENTED`). See [§Meridian flip](#meridian-flip) |
 | `DoesRefraction` | `false` | mount applies no refraction model; host (rp) provides refracted coords |
 | `TrackingRates` | `[Sidereal]` | sidereal only in MVP |
 
@@ -308,7 +307,7 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `AtPark` | driver-state flag; set by `Park`, cleared by `Unpark` and by any motion command |
 | `AtHome` | `false` (no hardware home concept) |
 | `SideOfPier` | derived from Dec-axis encoder + Dec-axis CPR + site latitude — canonical INDI eqmod convention (`PierSide::East` when `\|dec_encoder\| > cpr_dec/4`, i.e. Dec rotated past either celestial pole). Southern hemisphere inverts. See [§Side-of-pier](#side-of-pier) |
-| `DestinationSideOfPier(ra, dec)` | predicts the pointing state for a slew target — same coordinate-math pipeline as `SlewToCoordinatesAsync` plus the safety-envelope check, then the Dec-encoder past-the-pole classification. See [§Side-of-pier](#side-of-pier) |
+| `DestinationSideOfPier(ra, dec)` | predicts the pointing state the driver would land at for a slew target. Runs the flip-policy decision (current side + target HA + `flip_policy.enabled`), maps to encoder ticks for the chosen side, and validates the per-side safety envelope. With `flip_policy.enabled = false` always returns the current side (driver never plans a flip). See [§Side-of-pier](#side-of-pier) and [§Meridian flip](#meridian-flip) |
 | `SiteLatitude` | from config (read-only; setter returns `NOT_IMPLEMENTED`) |
 | `SiteLongitude` | as above |
 | `SiteElevation` | from config; defaults to `0` |
@@ -332,6 +331,7 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `Park()` | stop tracking, slew both axes to the in-memory park-target encoder pair (loaded from config or captured at handshake — see [§Park lifecycle](#park-lifecycle)), when both report stopped set `AtPark=true`. **Tracking remains off after park** (per ASCOM) |
 | `Unpark()` | clear `AtPark`. Does NOT auto-enable tracking |
 | `SetPark()` | capture current encoder pair, write back into the running config file (only the `mount.park_ra_ticks` / `mount.park_dec_ticks` keys are touched — see [§Park persistence](#park-persistence)), update the in-memory park target. Refuses if the driver was started without `--config`, if not connected, or while slewing |
+| `SetSideOfPier(side)` | request a meridian flip to the named side. No-op success when `side == current_side`; otherwise issues a through-wrap flip slew to the current target. Returns `NOT_IMPLEMENTED` when `flip_policy.enabled = false`; `INVALID_VALUE` when `side` is `Unknown`; the usual `NOT_CONNECTED` / `INVALID_WHILE_PARKED` / `INVALID_OPERATION` (while slewing) refusals otherwise. See [§Meridian flip](#meridian-flip) |
 | `Tracking = true` | refuse with `INVALID_WHILE_PARKED` when parked; otherwise issue `:G<RA>` (Tracking + sidereal) + `:I<RA>` (sidereal step period) + `:J<RA>`. Dec axis untouched |
 | `Tracking = false` | issue `:K<RA>` (decelerate to stop). Allowed while parked — Park already left tracking off and a caller re-asserting that should not error |
 | `FindHome()` | `NOT_IMPLEMENTED` |
@@ -367,11 +367,26 @@ SlewToCoordinatesAsync(ra, dec)
    │
    ├─ validate: !AtPark, ra ∈ [0,24), dec ∈ [-90,90]
    ├─ remember: TargetRightAscension/Declination = (ra, dec)
+   ├─ pick pier side: flip policy (current side + target HA +
+   │           `flip_policy.enabled`) — see [§Meridian flip](#meridian-flip).
+   │           With `enabled = false` always chooses the current side.
    ├─ compute: (ra_target_ticks, dec_target_ticks) from
-   │           ra/dec + LST(now) + sync offset + side-of-pier choice
-   │           (the post-stop pickup loop closes the residual that
-   │           arises from RA drifting at sidereal rate during the
-   │           goto, so the LST snapshot is taken at issue time)
+   │           ra/dec + LST(now) + sync offset + chosen pier side.
+   │           Pre-flip (pierWest) target is `(LST − ra, dec)`;
+   │           flipped (pierEast) target is `(LST − ra + 12 h)` mod 24
+   │           folded signed, with dec past the pole at
+   │           `sign(dec) · (180° − |dec|)`. The post-stop pickup loop
+   │           closes the residual that arises from RA drifting at
+   │           sidereal rate during the goto, so the LST snapshot is
+   │           taken at issue time.
+   ├─ validate per-side safety envelope (pre-flip side reuses
+   │           `ra_*_hours` / `dec_*_degrees`; flipped side uses the
+   │           mirror band through the encoder wrap at ±12 h —
+   │           see [§Meridian flip](#meridian-flip))
+   ├─ flip slew? route the RA axis through the negative-`mech_HA`
+   │           half (counterweight-below-horizon arc). The wire
+   │           sequence below is unchanged; only the encoder target
+   │           and `:G`'s CCW bit differ.
    │
    ├─ for each axis (INDI-style wire sequence — see
    │   indi-eqmod/skywatcher.cpp::SlewTo):
@@ -623,16 +638,151 @@ inherits the RA encoder's sign and misreports it. INDI's convention is
 the canonical one.
 
 `DestinationSideOfPier(targetRA, targetDec)` predicts the pointing
-state without issuing wire traffic. It runs the same coordinate-math
-pipeline `SlewToCoordinatesAsync` uses to pick the target encoder pair
-(`(LST - targetRA, targetDec)` → `(ra_ticks, dec_ticks)`), validates
-the target against the safety envelope with the same
-`INVALID_VALUE` rejection a slew would issue, then applies the
-Dec-encoder past-the-pole check to the target Dec ticks. For any
-target inside the safety envelope, the resulting Dec encoder lands
-within ±90° and `DestinationSideOfPier` therefore predicts `West` in
-the Northern Hemisphere (`East` in the Southern) — the driver never
-plans a meridian flip on its own.
+state without issuing wire traffic. It runs the same flip-policy
+decision tree `SlewToCoordinatesAsync` uses to pick the target side
+(see [§Meridian flip](#meridian-flip)), maps the target to encoder
+ticks for the chosen side, and validates against the corresponding
+per-side safety envelope with the same `INVALID_VALUE` rejection a
+slew would issue. With `flip_policy.enabled = false` the decision
+collapses to "current side", so for any target inside the (pre-flip)
+safety envelope `DestinationSideOfPier` returns `West` in the
+Northern Hemisphere (`East` in the Southern) — the driver does not
+plan flips. With `flip_policy.enabled = true` the prediction can
+return the opposite side when the target requires a flip to reach.
+
+### Meridian flip
+
+A meridian flip transitions the German Equatorial Mount from "normal
+pointing" (`PierSide::West`: counterweight east, OTA west of pier) to
+"flipped pointing" (`PierSide::East`: counterweight west, OTA east of
+pier, Dec axis rotated past the celestial pole) while keeping the OTA
+on the same celestial target. On a flip-capable mount the move is a
+single slew with the RA encoder routed through a half of the encoder
+range that keeps the counterweight clear of the pier.
+
+The GTi's mechanical envelope — hardware-confirmed 2026-05-13 — is
+`mech_HA ∈ [−6.99 h, +6.99 h]` for the pre-flip half. The post-flip
+half is mechanically symmetric across the encoder wrap at `±12 h`: the
+counterweight rises off the local horizon on the mirror side of the
+pier. The routing detail and the geometric symmetry argument live in
+[`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md)
+§2.0; this section specifies the behavioural contract the driver
+implements on top of it.
+
+#### Flip policy
+
+`MountConfig::flip_policy` controls whether and when the driver plans
+a flip. Two fields in MVP (auto-flip-during-tracking knobs are
+deferred to Phase 2.5 — see [§Deferred](#deferred-not-in-mvp)):
+
+- **`enabled: bool`** (default `false`) — master switch. With
+  `enabled = false`: `CanSetPierSide = false`, `SetSideOfPier` returns
+  `NOT_IMPLEMENTED`, `DestinationSideOfPier` always returns the
+  current pier side (driver never plans a flip), and
+  `SlewToCoordinatesAsync` uses the pre-flip (`pierWest` in the
+  Northern Hemisphere) coordinate pipeline only — behaviour identical
+  to Phase 5. With `enabled = true`: the capability flag flips on
+  and the slew planner picks the target pier side per the policy
+  below.
+- **`flip_range_hours: f64`** (default `0.5`) — half-width of the
+  target-HA window around the meridian where the flipped state is
+  mechanically reachable. Targets with `|target_HA| > flip_range_hours`
+  are unflippable (the post-flip `mech_HA` would land outside the
+  symmetric mirror band); the slew planner uses normal pointing only
+  and `DestinationSideOfPier` returns the current side. Valid range
+  `(0, 0.95]`. The upper bound matches the headroom past
+  counterweight-horizontal on the pre-flip side (Phase 1.1 hardware
+  verification); a larger value would push the post-flip `mech_HA`
+  into the unverified mirror of the binding zone.
+
+#### Per-pier-side safety envelopes
+
+The pre-flip safe zone (`MountConfig::ra_min_hours` /
+`ra_max_hours` / `dec_min_degrees` / `dec_max_degrees`, defaults
+`[−6.95, +6.95]` h RA and `[−90, +90]°` Dec) covers `pierWest`
+operation as in Phase 1.1.
+
+The post-flip (`pierEast`) safe zone mirrors the pre-flip RA zone
+through the encoder wrap at `±12 h`. For a target HA satisfying
+`|target_HA| ≤ flip_range_hours`, the post-flip mech-HA is
+`target_HA + 12 h` (folded signed into `[−12, +12)`), which lands in
+the symmetric band `[+12 − flip_range_hours, +12] ∪ [−12, −12 +
+flip_range_hours]`. The Dec encoder lands past either celestial pole
+— `|dec_encoder| > 90°` (Northern Hemisphere; Southern inverts).
+
+A flip-aware slew validates against the envelope for the *chosen*
+side: a flip slew checks the post-flip RA band and the
+past-the-pole Dec mapping; a normal slew checks the pre-flip zone.
+Targets outside the relevant zone are rejected with `INVALID_VALUE`
+before any wire motion.
+
+#### Pier-side decision tree
+
+`DestinationSideOfPier(ra, dec)` and `SlewToCoordinatesAsync(ra,
+dec)` share the same selector:
+
+1. Compute `target_HA = LST − ra` (signed, folded to `[−12, +12)`).
+2. If `flip_policy.enabled = false`, return the current `SideOfPier`.
+3. If `|target_HA| > flip_policy.flip_range_hours`, the target is
+   unflippable — return the current side (only the pre-flip side is
+   reachable).
+4. Otherwise the target lies inside the flip window: return whichever
+   side keeps the mount in its current sky region without an
+   unnecessary flip. Concretely, return the *current* side when the
+   target is reachable from it; return the *opposite* side when the
+   current side's envelope rejects the target.
+
+The driver does not pre-emptively flip; it only flips when the target
+can't be reached from the current side or when `SetSideOfPier` forces
+it.
+
+#### `SetSideOfPier(side)`
+
+`SetSideOfPier(side)` is the explicit flip trigger:
+
+- `side == current_side`: no-op success.
+- `side != current_side`: triggers a through-wrap flip slew that
+  keeps the OTA on the current target while landing on the requested
+  pier side.
+- `PierSide::Unknown`: rejected with `INVALID_VALUE`.
+
+`SetSideOfPier` returns `NOT_IMPLEMENTED` when `flip_policy.enabled
+= false`, and follows the standard `NOT_CONNECTED` /
+`INVALID_WHILE_PARKED` / `INVALID_OPERATION` (already-slewing) gate.
+After a successful flip the next encoder snapshot's `SideOfPier` reads
+the new value (the Dec encoder has moved past the pole);
+`TargetRightAscension` / `TargetDeclination` remain unchanged.
+
+#### Through-wrap slew routing
+
+When the slew planner decides to flip (either via `SetSideOfPier` or
+because the decision tree picked the opposite side), the RA axis is
+routed through the negative-`mech_HA` half of the encoder range — the
+half where the counterweight stays at or below the local horizon. The
+RA encoder traverses from its current value through `mech_HA = 0`
+("home") and the encoder wrap at `−12 h ≡ +12 h` to the post-flip
+target. The Dec encoder simultaneously rotates through the celestial
+pole to land past `±90°`.
+
+The slew lifecycle (see [§Slew lifecycle](#slew-lifecycle)) is
+otherwise unchanged: the same `:K → :G → :I → :H → :M → :J`
+wire sequence per axis, the same EQMOD pickup loop, the same settle
+delay. The flip slew differs from a normal slew only in which
+encoder target the planner computes and which CCW bit `:G` issues for
+the RA axis (forced to the negative-direction sign on a flip slew, so
+the routing goes "under" the polar axis rather than taking the
+shortest encoder path).
+
+#### Hardware validation
+
+`flip_policy.enabled` defaults to `false` until at least one
+successful real-hardware flip on a GTi has been recorded. The
+mechanical symmetry argument (plan §2.8) is strong, but the
+through-wrap traversal is the first time the GTi's negative-`mech_HA`
+half is exercised past the pre-flip safe envelope, and asymmetric
+failure modes like cable wrap will surface there. The first real
+`SetSideOfPier(East)` on hardware is the validation gate; until then
+operators leave `flip_policy.enabled` at its default.
 
 ## Configuration
 
@@ -665,7 +815,11 @@ fields. The transport block is a tagged enum: `usb` or `udp`.
     "settle_after_slew": "2s",
     "tracking_rate": "sidereal",
     "park_ra_ticks": null,
-    "park_dec_ticks": null
+    "park_dec_ticks": null,
+    "flip_policy": {
+      "enabled": false,
+      "flip_range_hours": 0.5
+    }
   }
 }
 ```
@@ -706,6 +860,16 @@ Notes:
   rules around when the driver writes to this file. When absent, the
   park target falls back to the encoder positions captured during the
   init handshake.
+- `flip_policy.enabled` defaults `false`. Set to `true` only after
+  the first real-hardware meridian flip has been verified on the
+  specific mount (see [§Hardware validation](#hardware-validation)).
+  While `false`, `CanSetPierSide` reports `false` and the driver
+  ignores flip routing entirely.
+- `flip_policy.flip_range_hours` defaults `0.5`. Half-width of the
+  target-HA window around the meridian where the flipped state is
+  reachable. Valid range `(0, 0.95]`; the upper bound is the verified
+  safe headroom past counterweight-horizontal on the pre-flip side.
+  See [§Meridian flip](#meridian-flip).
 
 ### CLI arguments
 
@@ -933,6 +1097,7 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase A6 — Dec-encoder `SideOfPier` + `DestinationSideOfPier`** | landed (issue #202) — switches `SideOfPier` from the RA mech-HA split at `HA = 0` to the canonical INDI eqmod Dec-encoder convention (`East` when `\|dec_encoder\| > cpr_dec/4`), and lands `DestinationSideOfPier` reusing the same coordinate-math pipeline as `SlewToCoordinatesAsync`. ConformU expected-issues count moves from 9 to 7: the `DestinationSideOfPier` NotImplemented entry and the four inherited `SOPPierTest` entries clear, the two upstream `TrackingRate Write` entries disappear (unrelated framework fix), and three new "non-flipping mount" entries appear that reflect ConformU's flip-aware-GEM assumption rather than driver bugs. See [§Expected ConformU report](#expected-conformu-report). |
 | **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`, and re-enables `[package.metadata.conformu]` so the full two-phase ConformU integration runs again. |
 | **Phase 5 — user-defined `SetPark` + persistence** | landed (issue #203) — park target now sourced from `mount.park_ra_ticks` / `mount.park_dec_ticks` in the config (fallback: encoder positions captured at handshake), `SetPark` writes the current encoder pair back into the running config file via atomic rename, `CanSetPark` flips on when `--config` is provided. See [§Park lifecycle](#park-lifecycle) and [§Park persistence](#park-persistence). |
+| **Phase 6 — meridian-flip support** | implementation in progress — adds `MountConfig::flip_policy` (`enabled` + `flip_range_hours`), per-pier-side safe envelopes, through-wrap slew routing for flip slews, `SetSideOfPier`, and flip-aware `DestinationSideOfPier`. `flip_policy.enabled` defaults `false` and awaits a successful first real-hardware flip on a GTi before the default is reconsidered. Auto-flip-during-tracking is intentionally deferred to a Phase 2.5 follow-up — the driver only flips on an explicit `SetSideOfPier` or a slew whose target requires the opposite side. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md). See [§Meridian flip](#meridian-flip). |
 
 #### Phase 4 findings (hardware bringup)
 
@@ -1134,7 +1299,7 @@ What's still outstanding from Phase 4:
   tunable goto rate becomes a requirement.
 
 
-### In-scope (Phases 1–3, all landed)
+### In-scope
 
 - USB transport at 115200 baud (`/dev/serial/by-id/...` path in config)
 - UDP transport at 192.168.4.1:11880 (bind to local 192.168.4.x)
@@ -1156,7 +1321,13 @@ What's still outstanding from Phase 4:
   driver has a config path to write to — see [§Park persistence](#park-persistence))
 - `AtPark` / `AtHome` reads
 - `SideOfPier` read (Dec-encoder convention)
-- `DestinationSideOfPier(ra, dec)` prediction
+- `DestinationSideOfPier(ra, dec)` prediction (flip-policy-aware when
+  `flip_policy.enabled` — see [§Meridian flip](#meridian-flip))
+- `SetSideOfPier(side)` — explicit meridian-flip trigger, gated on
+  `flip_policy.enabled` (Phase 6, in progress; default `false` pending
+  first-hardware verification — see [§Meridian flip](#meridian-flip))
+- Per-pier-side safety envelopes and through-wrap slew routing for
+  flip slews (Phase 6, in progress)
 - `Slewing` poll
 - `UTCDate` / `SiderealTime` (host-clock-derived)
 - Mock transport for BDD tests; feature-gated mock for `test_lib.rs` and
@@ -1176,6 +1347,8 @@ What's still outstanding from Phase 4:
 | Polar-alignment helpers, TPOINT, cone error | observational pointing model is the host's concern, not the driver's |
 | WiFi station mode (mount on a routed network) | AP-mode UDP is verified; station mode just changes the bind-address selection — straightforward to add once a station-mode test setup exists |
 | Multi-mount support on a single binary | `rp` assumes one mount per service; multi-mount is a separate concern |
+| Auto-flip during tracking (Phase 2.5: `flip_policy.auto_flip_during_tracking` + `auto_flip_at_meridian_offset_hours`) | hosts like NINA / SGP / `rp` own flip timing themselves; mid-exposure auto-flip is a footgun for astrophotography and a separate state machine. Phase 6 lands explicit `SetSideOfPier`-driven flips only |
+| Altitude-based safety floor (Phase 3 in [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md)) | replaces the rectangular Dec envelope with an altitude floor; independent of Phase 6 and can land in either order |
 
 ## References
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -128,8 +128,9 @@ CPR varies between the GTi's RA and Dec axes and between firmware
 revisions; the driver reads both rather than assuming.
 
 The protocol exposes **no native park position** and **no site lat/lon**.
-We implement software park (target encoder pair sourced from config or
-captured at handshake — see [§Park lifecycle](#park-lifecycle) and
+We implement software park (target encoder pair sourced from config,
+or — failing that — the live snapshot after the optional `home_pose`
+encoder seed, see [§Park lifecycle](#park-lifecycle) and
 [§Park persistence](#park-persistence)) and require site lat/lon in the
 config (see [§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
 
@@ -452,13 +453,22 @@ in this order of preference:
    provided (`Config::default()` run), the `MountConfig` defaults are
    used; in this mode `SetPark` is unreachable so these values do not
    change in-process.
-3. **Handshake-captured fallback** (per axis). The encoder position
-   read during the init handshake's `:j1` / `:j2` step (see
-   [§"Initialisation sequence"](#initialisation-sequence)). On a
-   polar-aligned mount the user typically powered up near the
-   counterweight-down, OTA-on-meridian pose, so this is the closest
-   mechanically-safe "where I started" target available.
-4. **Last resort** — encoder `0`. Only reachable if the handshake
+3. **Live-snapshot fallback** (per axis). The current encoder
+   reading from the [`TransportManager`] snapshot. Two cases:
+   - **Fresh power-up with `home_pose` configured.** The driver
+     runs [`seed_home_pose_after_connect`](#home-pose) before
+     loading the park target, so the snapshot already reflects
+     the home_pose's logical encoder values (e.g. `ap_park_3` →
+     `mech_HA = -6h`, `mech_dec = +90°`). `Park` therefore
+     defaults to "return to the pose the operator powered up at".
+   - **Mid-session reconnect** *or* **fresh power-up without
+     `home_pose`.** The home_pose seed skips on a non-zero
+     firmware encoder (and is a no-op when no `home_pose` is
+     configured), so the snapshot equals the
+     handshake-captured `:j1` / `:j2` reading. This is the
+     "park where the OTA already is" semantic operators expect
+     from a reconnect.
+4. **Last resort** — encoder `0`. Only reachable if the snapshot
    somehow produced no position read, which today is unreachable.
 
 Re-reading the config file on every connect means a successful
@@ -920,8 +930,11 @@ Notes:
   `SetPark` is called. Operators may set them by hand to pin a known
   mechanical pose. See [§Park persistence](#park-persistence) for the
   rules around when the driver writes to this file. When absent, the
-  park target falls back to the encoder positions captured during the
-  init handshake.
+  park target falls back to the live snapshot reading. With
+  `home_pose` set and a fresh power-up, that's the home_pose's
+  logical encoder values (`Park` defaults to "return to the pose
+  you powered up at"); otherwise it's the handshake-captured
+  reading. See [§Park lifecycle](#park-lifecycle).
 - `flip_policy.enabled` defaults `false`. Set to `true` only after
   the first real-hardware meridian flip has been verified on the
   specific mount (see [§Hardware validation](#hardware-validation)).

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -91,36 +91,39 @@ pub struct MountConfig {
     #[serde(default)]
     pub tracking_rate: TrackingRateName,
 
-    /// Safe RA mechanical-hour-angle envelope. Slews / syncs whose
-    /// target falls outside `[ra_min_hours, ra_max_hours]` are
+    /// Counterweight-binding zone in encoder `mech_HA` (signed hours,
+    /// folded to `[−12, +12)`). Slews / syncs whose target's
+    /// `mech_HA` on the chosen pier side falls inside
+    /// `[binding_zone_min_hours, binding_zone_max_hours]` are
     /// rejected with `INVALID_VALUE` and never reach the wire.
     ///
-    /// `mech_HA = 0` is "OTA on the meridian, counterweight down" on
-    /// a polar-aligned Northern-Hemisphere setup. `±6 h` is the
-    /// counterweight-horizontal east / west position; the GTi's
-    /// hardware-verified mechanical limit sits at `±6.99 h` (reached
-    /// cleanly with no audible motor stress or counterweight-pier
-    /// contact during the 2026-05-13 hardware test), aligning with
-    /// INDI eqmod's baked-in `±7 h` envelope for every Sky-Watcher
-    /// mount (`zeroRAEncoder ± (totalRAEncoder/4 +
-    /// totalRAEncoder/24)` in `eqmodbase.cpp::Goto`).
+    /// On the GTi this is **one-sided and asymmetric**: as the OTA
+    /// tracks westward past meridian on natural pierWest, the
+    /// counterweight swings *up* to a max altitude of +57° (south)
+    /// at `mech_HA = +6`, then comes down toward the east horizon at
+    /// `mech_HA = +12`. The arc where the CW is high enough to bind
+    /// the pier from the east side is `(+6.95, +11.05)`. The
+    /// negative-mech_HA side is the mirror: the CW swings *down*
+    /// below horizon (into the ground beneath the pier), so no
+    /// mirror binding zone exists.
     ///
-    /// Defaults are `[-6.95, +6.95]` — `0.05 h` (`3 arcmin`) inside
-    /// the mechanical limit. The buffer covers two needs at once:
-    /// the ASCOM `SlewToCoordinates(ra, dec)` round-trip means the
-    /// driver re-reads LST a few tens of ms after the client
-    /// computed the target, so a target quantised exactly to the
-    /// limit would drift past it; and the deferred Phase 2
-    /// meridian-flip planner will need headroom between the
-    /// configured envelope and the mechanical stops to plan
-    /// multi-stage flip slews. Tune narrower if your specific setup
-    /// (mount-head-extension, OTA length, cable routing) clears
-    /// less; tune wider only after verifying the extra travel on
-    /// hardware.
-    #[serde(default = "default_ra_min_hours")]
-    pub ra_min_hours: f64,
-    #[serde(default = "default_ra_max_hours")]
-    pub ra_max_hours: f64,
+    /// This is **separate from** the `flip_policy.flip_range_hours`
+    /// rule: this check is the hard mechanical-safety floor,
+    /// applied to every slew destination on its chosen pier side
+    /// (natural mech_HA = celestial HA; flipped mech_HA =
+    /// celestial HA + 12 folded). `flip_range_hours` is the
+    /// operational pier-side preference and lives separately.
+    ///
+    /// Defaults are `(6.95, 11.05)` — the hardware-verified GTi
+    /// binding zone. Set `binding_zone_min_hours = binding_zone_max_hours`
+    /// (or any non-overlapping pair) to disable the check entirely;
+    /// only do this for tests or for mounts whose binding zone is
+    /// known to be elsewhere. See the design doc's
+    /// [§Per-pier safety envelopes](../../../docs/services/star-adventurer-gti.md#per-pier-safety-envelopes).
+    #[serde(default = "default_binding_zone_min_hours")]
+    pub binding_zone_min_hours: f64,
+    #[serde(default = "default_binding_zone_max_hours")]
+    pub binding_zone_max_hours: f64,
 
     /// Safe Dec mechanical-degree envelope. Same enforcement and
     /// rationale as the RA limits. Defaults `[-90.0, +90.0]` — the
@@ -482,11 +485,11 @@ fn default_discovery_port() -> Option<u16> {
 fn default_settle_after_slew() -> Duration {
     Duration::from_secs(2)
 }
-fn default_ra_min_hours() -> f64 {
-    -6.95
-}
-fn default_ra_max_hours() -> f64 {
+fn default_binding_zone_min_hours() -> f64 {
     6.95
+}
+fn default_binding_zone_max_hours() -> f64 {
+    11.05
 }
 fn default_dec_min_degrees() -> f64 {
     -90.0
@@ -555,8 +558,8 @@ impl Default for MountConfig {
             site_elevation_m: 0.0,
             settle_after_slew: default_settle_after_slew(),
             tracking_rate: TrackingRateName::Sidereal,
-            ra_min_hours: default_ra_min_hours(),
-            ra_max_hours: default_ra_max_hours(),
+            binding_zone_min_hours: default_binding_zone_min_hours(),
+            binding_zone_max_hours: default_binding_zone_max_hours(),
             dec_min_degrees: default_dec_min_degrees(),
             dec_max_degrees: default_dec_max_degrees(),
             park_ra_ticks: None,

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -335,8 +335,13 @@ impl HomePose {
     pub fn codebase_mech_ha_hours(&self) -> f64 {
         match self {
             Self::ApPark1 => 0.0,
+            // Park 2 and Park 3 share the same RA position ("RA axis
+            // vertical" per the AP doc) — the only difference is the
+            // Dec encoder rotation. Both put the dec axis tilted
+            // south-up out of the east-west horizontal, with target
+            // HA = −6 h in the codebase's convention.
             Self::ApPark2 => -6.0,
-            Self::ApPark3 => 0.0,
+            Self::ApPark3 => -6.0,
             Self::ApPark4 => -12.0,
             Self::ApPark5 => 0.0,
         }
@@ -687,7 +692,14 @@ mod tests {
         // Boundary: lat = 0 falls into the "north" arm by the `>= 0`
         // convention `side_of_pier` uses.
         assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(0.0), 90.0);
-        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(), 0.0);
+        // Park 3 shares the same RA position as Park 2 (both "RA axis
+        // vertical" per the AP doc): codebase mech_HA = −6 h, not 0.
+        // Verified on hardware at LAT 32.7°N (2026-05-15): with
+        // mech_HA = 0 the dec-only slew from Park 3 to celestial dec=0
+        // landed the OTA at the *east* horizon (HA = -6), confirming
+        // the RA position is offset 6 h from the codebase mech_HA = 0
+        // convention.
+        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(), -6.0);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -141,6 +141,80 @@ pub struct MountConfig {
     pub park_ra_ticks: Option<i32>,
     #[serde(default)]
     pub park_dec_ticks: Option<i32>,
+
+    /// Meridian-flip policy. See the design doc's
+    /// [§"Meridian flip"](../../../docs/services/star-adventurer-gti.md#meridian-flip).
+    /// Defaults to `enabled = false` so the driver behaves identically
+    /// to pre-Phase-6 builds until an operator opts in on a
+    /// hardware-validated mount.
+    #[serde(default)]
+    pub flip_policy: FlipPolicy,
+}
+
+/// Master switch + parameters for driver-planned meridian flips.
+///
+/// `enabled = false` (the shipped default) disables every flip code
+/// path: `CanSetPierSide` reports `false`, `SetSideOfPier` returns
+/// `NOT_IMPLEMENTED`, `DestinationSideOfPier` always returns the
+/// current side, and slews use the pre-flip coordinate pipeline only.
+///
+/// With `enabled = true`, the driver may pick the flipped pier side
+/// for a slew (or honour an explicit `SetSideOfPier` call) when the
+/// target's hour angle falls inside the meridian window of width
+/// `2 × flip_range_hours`. See the design doc for the full decision
+/// tree and the per-side safety envelopes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct FlipPolicy {
+    /// Master switch. Defaults `false` until the first real-hardware
+    /// meridian flip on a GTi has been verified.
+    #[serde(default = "default_flip_policy_enabled")]
+    pub enabled: bool,
+
+    /// Half-width of the target-HA window around the meridian where
+    /// the flipped state is mechanically reachable. Targets with
+    /// `|target_HA| > flip_range_hours` are unflippable: the slew
+    /// planner uses normal pointing only and `DestinationSideOfPier`
+    /// returns the current side. Valid range `(0, 0.95]`; the upper
+    /// bound matches the Phase 1.1 hardware-verified headroom past
+    /// counterweight-horizontal on the pre-flip side.
+    #[serde(default = "default_flip_range_hours")]
+    pub flip_range_hours: f64,
+}
+
+impl Default for FlipPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: default_flip_policy_enabled(),
+            flip_range_hours: default_flip_range_hours(),
+        }
+    }
+}
+
+/// Outer bound on `FlipPolicy::flip_range_hours`. Larger values would
+/// push the post-flip mechanical hour angle into the unverified
+/// mirror of the Phase 4 counterweight-up binding zone. See the plan
+/// `docs/plans/star-adventurer-gti-meridian-flip.md` §2.6.
+pub const MAX_FLIP_RANGE_HOURS: f64 = 0.95;
+
+impl FlipPolicy {
+    /// Validate the policy against the constraints documented in the
+    /// design doc and §2.6 of the plan. Returns `Err(message)` on a
+    /// bad value; the caller surfaces it as a startup error.
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        if !self.flip_range_hours.is_finite() {
+            return Err(format!(
+                "flip_policy.flip_range_hours must be finite, got {}",
+                self.flip_range_hours
+            ));
+        }
+        if self.flip_range_hours <= 0.0 || self.flip_range_hours > MAX_FLIP_RANGE_HOURS {
+            return Err(format!(
+                "flip_policy.flip_range_hours must be in (0, {MAX_FLIP_RANGE_HOURS}] hours, got {}",
+                self.flip_range_hours
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -179,6 +253,12 @@ fn default_dec_min_degrees() -> f64 {
 }
 fn default_dec_max_degrees() -> f64 {
     90.0
+}
+fn default_flip_policy_enabled() -> bool {
+    false
+}
+fn default_flip_range_hours() -> f64 {
+    0.5
 }
 fn default_true() -> bool {
     true
@@ -241,6 +321,7 @@ impl Default for MountConfig {
             dec_max_degrees: default_dec_max_degrees(),
             park_ra_ticks: None,
             park_dec_ticks: None,
+            flip_policy: FlipPolicy::default(),
         }
     }
 }
@@ -354,6 +435,130 @@ mod tests {
         let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
         assert_eq!(back.park_ra_ticks, Some(8000));
         assert_eq!(back.park_dec_ticks, Some(-3000));
+    }
+
+    #[test]
+    fn flip_policy_default_is_disabled_with_half_hour_range() {
+        // The shipped default disables every flip code path — a fresh
+        // install must behave identically to pre-Phase-6 builds until
+        // the operator explicitly opts in on a hardware-validated mount.
+        let p = FlipPolicy::default();
+        assert!(!p.enabled);
+        assert!(
+            (p.flip_range_hours - 0.5).abs() < f64::EPSILON,
+            "got {}",
+            p.flip_range_hours
+        );
+    }
+
+    #[test]
+    fn mount_config_default_includes_disabled_flip_policy() {
+        let cfg = MountConfig::default();
+        assert!(!cfg.flip_policy.enabled);
+    }
+
+    #[test]
+    fn mount_config_deserialises_missing_flip_policy_as_default() {
+        // Existing config files written before Phase 6 do not carry
+        // `flip_policy`; the driver must read them as
+        // `FlipPolicy::default()` rather than failing.
+        let json = r#"{
+            "name": "T",
+            "unique_id": "t-001",
+            "description": "T",
+            "site_latitude_deg": 0.0,
+            "site_longitude_deg": 0.0
+        }"#;
+        let m: MountConfig = serde_json::from_str(json).expect("deserialise");
+        assert!(!m.flip_policy.enabled);
+        assert!((m.flip_policy.flip_range_hours - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mount_config_round_trips_enabled_flip_policy_through_json() {
+        let cfg = MountConfig {
+            flip_policy: FlipPolicy {
+                enabled: true,
+                flip_range_hours: 0.7,
+            },
+            ..MountConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialise");
+        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+        assert!(back.flip_policy.enabled);
+        assert!((back.flip_policy.flip_range_hours - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn flip_policy_deserialises_with_partial_fields() {
+        // serde_default on each field means a partial block — only one
+        // key present — fills the other in from the default.
+        let json = r#"{"enabled": true}"#;
+        let p: FlipPolicy = serde_json::from_str(json).expect("deserialise");
+        assert!(p.enabled);
+        assert!((p.flip_range_hours - 0.5).abs() < f64::EPSILON);
+
+        let json = r#"{"flip_range_hours": 0.25}"#;
+        let p: FlipPolicy = serde_json::from_str(json).expect("deserialise");
+        assert!(!p.enabled);
+        assert!((p.flip_range_hours - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn flip_policy_validate_accepts_defaults() {
+        FlipPolicy::default().validate().unwrap();
+    }
+
+    #[test]
+    fn flip_policy_validate_accepts_upper_bound() {
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: MAX_FLIP_RANGE_HOURS,
+        };
+        p.validate().unwrap();
+    }
+
+    #[test]
+    fn flip_policy_validate_rejects_zero() {
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: 0.0,
+        };
+        let err = p.validate().unwrap_err();
+        assert!(err.contains("flip_range_hours"), "got: {err}");
+    }
+
+    #[test]
+    fn flip_policy_validate_rejects_negative() {
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: -0.1,
+        };
+        p.validate().unwrap_err();
+    }
+
+    #[test]
+    fn flip_policy_validate_rejects_above_upper_bound() {
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: MAX_FLIP_RANGE_HOURS + 1e-6,
+        };
+        let err = p.validate().unwrap_err();
+        assert!(err.contains("flip_range_hours"), "got: {err}");
+    }
+
+    #[test]
+    fn flip_policy_validate_rejects_non_finite() {
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: f64::INFINITY,
+        };
+        p.validate().unwrap_err();
+        let p = FlipPolicy {
+            enabled: true,
+            flip_range_hours: f64::NAN,
+        };
+        p.validate().unwrap_err();
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -149,6 +149,16 @@ pub struct MountConfig {
     /// hardware-validated mount.
     #[serde(default)]
     pub flip_policy: FlipPolicy,
+
+    /// Physical pose the mount is in at power-up. The firmware's
+    /// encoder counter resets to `(0, 0)` whenever the mount is
+    /// powered on, and the driver interprets that zero against the
+    /// configured pose so the codebase's celestial-coordinate math
+    /// matches reality. See [`HomePose`] for the supported variants;
+    /// defaults to `OtaOnMeridianAtEquator` for backward compatibility
+    /// with pre-Phase-6 installs.
+    #[serde(default)]
+    pub home_pose: HomePose,
 }
 
 /// Master switch + parameters for driver-planned meridian flips.
@@ -214,6 +224,82 @@ impl FlipPolicy {
             ));
         }
         Ok(())
+    }
+}
+
+/// Physical pose the operator powers the mount up in.
+///
+/// The Sky-Watcher firmware resets its encoder counter to `(0, 0)`
+/// every power-up. The driver's coordinate math interprets `(0, 0)`
+/// against the `home_pose` setting so the user-visible RA/Dec/Alt/Az
+/// reflect where the OTA actually points.
+///
+/// Variants are named after the Astro-Physics
+/// ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
+/// document where applicable. Park 2 is omitted (no clean polar-aligned
+/// interpretation at mid-latitudes); Park 4 / Park 5 are post-flip
+/// equivalents of Park 1 / Park 4 and can be added if/when needed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomePose {
+    /// Codebase's original assumption (pre-Phase-6 default). At
+    /// firmware encoder `(0, 0)`, the Dec axis is horizontal
+    /// east-west, the saddle/OTA is on the west end, the
+    /// counterweight is on the east end, and the OTA points at the
+    /// south meridian at the celestial equator (north observer) /
+    /// north meridian at the equator (south observer). Codebase
+    /// mech_HA = 0, dec_encoder = 0.
+    #[default]
+    OtaOnMeridianAtEquator,
+    /// Astro-Physics Park 1. RA axis at the "horizontal Dec axis"
+    /// position (saddle west, CW east); OTA tube level, pointing at
+    /// the polar-side horizon (az 0° for north, az 180° for south).
+    /// Codebase mech_HA = 0, dec_encoder = `+(90 − |latitude|)` for
+    /// north / `−(90 − |latitude|)` for south.
+    #[serde(rename = "park_1")]
+    Park1,
+    /// Astro-Physics Park 3 — also Sky-Watcher's power-on home. OTA
+    /// tube along the polar axis pointing at the visible celestial
+    /// pole (Polaris for north observers, SCP for south). Counterweight
+    /// shaft along the anti-pole side of the polar axis. Codebase
+    /// mech_HA = 0, dec_encoder = `+90°` for north / `−90°` for south.
+    #[serde(rename = "park_3")]
+    Park3,
+}
+
+impl HomePose {
+    /// Codebase-convention `mech_HA` (signed hours) corresponding to
+    /// firmware encoder `(0, 0)` at this home pose. All three supported
+    /// poses share `mech_HA = 0` (the Dec axis is east-west horizontal
+    /// at power-up); the difference between them is purely in the Dec
+    /// encoder mapping.
+    pub fn codebase_mech_ha_hours(&self) -> f64 {
+        0.0
+    }
+
+    /// Codebase-convention Dec encoder reading (degrees, signed,
+    /// `[−180, +180)`) corresponding to firmware encoder `(0, 0)` at
+    /// this home pose, given the observer's latitude.
+    pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> f64 {
+        let northern = latitude_deg >= 0.0;
+        let lat_abs = latitude_deg.abs();
+        match self {
+            Self::OtaOnMeridianAtEquator => 0.0,
+            Self::Park1 => {
+                if northern {
+                    90.0 - lat_abs
+                } else {
+                    -(90.0 - lat_abs)
+                }
+            }
+            Self::Park3 => {
+                if northern {
+                    90.0
+                } else {
+                    -90.0
+                }
+            }
+        }
     }
 }
 
@@ -322,6 +408,7 @@ impl Default for MountConfig {
             park_ra_ticks: None,
             park_dec_ticks: None,
             flip_policy: FlipPolicy::default(),
+            home_pose: HomePose::default(),
         }
     }
 }
@@ -435,6 +522,80 @@ mod tests {
         let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
         assert_eq!(back.park_ra_ticks, Some(8000));
         assert_eq!(back.park_dec_ticks, Some(-3000));
+    }
+
+    #[test]
+    fn home_pose_default_is_ota_on_meridian_at_equator() {
+        let cfg = MountConfig::default();
+        assert_eq!(cfg.home_pose, HomePose::OtaOnMeridianAtEquator);
+        // And the codebase-convention encoder reading at this default
+        // is (mech_HA=0, dec_enc=0) — the historical assumption.
+        assert_eq!(cfg.home_pose.codebase_mech_ha_hours(), 0.0);
+        assert_eq!(cfg.home_pose.codebase_dec_encoder_degrees(32.7), 0.0);
+    }
+
+    #[test]
+    fn home_pose_deserialises_from_snake_case() {
+        let p: HomePose = serde_json::from_str(r#""park_1""#).expect("park_1");
+        assert_eq!(p, HomePose::Park1);
+        let p: HomePose = serde_json::from_str(r#""park_3""#).expect("park_3");
+        assert_eq!(p, HomePose::Park3);
+        let p: HomePose =
+            serde_json::from_str(r#""ota_on_meridian_at_equator""#).expect("default variant");
+        assert_eq!(p, HomePose::OtaOnMeridianAtEquator);
+    }
+
+    #[test]
+    fn home_pose_park1_dec_encoder_matches_ap_table_north() {
+        // AP doc: Park 1 Northern Hemisphere: Dec = (90 - Latitude).
+        assert!(
+            (HomePose::Park1.codebase_dec_encoder_degrees(32.7157) - (90.0 - 32.7157)).abs() < 1e-9
+        );
+        assert!((HomePose::Park1.codebase_dec_encoder_degrees(45.0) - 45.0).abs() < 1e-9);
+        assert!((HomePose::Park1.codebase_dec_encoder_degrees(0.0) - 90.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn home_pose_park1_dec_encoder_matches_ap_table_south() {
+        // AP doc: Park 1 Southern Hemisphere: Dec = (-90 - Latitude),
+        // which for negative latitude `lat` is `-(90 - |lat|)`.
+        assert!(
+            (HomePose::Park1.codebase_dec_encoder_degrees(-33.9) - (-(90.0 - 33.9))).abs() < 1e-9
+        );
+        assert!((HomePose::Park1.codebase_dec_encoder_degrees(-45.0) - (-45.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn home_pose_park3_is_visible_pole() {
+        // AP Park 3 / Sky-Watcher home: OTA at the visible pole. Codebase
+        // dec_encoder = +90° in N, -90° in S.
+        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(32.7), 90.0);
+        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(-33.9), -90.0);
+        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(0.0), 90.0);
+    }
+
+    #[test]
+    fn home_pose_round_trips_through_mount_config_json() {
+        let cfg = MountConfig {
+            home_pose: HomePose::Park3,
+            ..MountConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialise");
+        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.home_pose, HomePose::Park3);
+    }
+
+    #[test]
+    fn mount_config_deserialises_missing_home_pose_as_default() {
+        let json = r#"{
+            "name": "T",
+            "unique_id": "t-001",
+            "description": "T",
+            "site_latitude_deg": 0.0,
+            "site_longitude_deg": 0.0
+        }"#;
+        let m: MountConfig = serde_json::from_str(json).expect("deserialise");
+        assert_eq!(m.home_pose, HomePose::OtaOnMeridianAtEquator);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -150,15 +150,18 @@ pub struct MountConfig {
     #[serde(default)]
     pub flip_policy: FlipPolicy,
 
-    /// Physical pose the mount is in at power-up. The firmware's
-    /// encoder counter resets to `(0, 0)` whenever the mount is
-    /// powered on, and the driver interprets that zero against the
-    /// configured pose so the codebase's celestial-coordinate math
-    /// matches reality. See [`HomePose`] for the supported variants;
-    /// defaults to `OtaOnMeridianAtEquator` for backward compatibility
-    /// with pre-Phase-6 installs.
+    /// Physical pose the mount is in at power-up.
+    ///
+    /// When `Some(ApPark*)`, the driver seeds the firmware encoder on
+    /// connect (no motion, just `:E1` / `:E2`) so the codebase's
+    /// celestial-coordinate math matches the operator's physical
+    /// pose. When `None` (the default), the driver does no seeding
+    /// and trusts the firmware encoder as-is — the codebase's
+    /// historical pre-Phase-6 behaviour. See [`HomePose`] for the
+    /// supported AP park positions and the wiring in
+    /// `MountDevice::seed_home_pose_after_connect`.
     #[serde(default)]
-    pub home_pose: HomePose,
+    pub home_pose: Option<HomePose>,
 }
 
 /// Master switch + parameters for driver-planned meridian flips.
@@ -227,17 +230,18 @@ impl FlipPolicy {
     }
 }
 
-/// Physical pose the operator powers the mount up in.
+/// Physical pose the operator powers the mount up in, expressed as
+/// one of the Astro-Physics
+/// ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
+/// positions.
 ///
 /// The Sky-Watcher firmware resets its encoder counter to `(0, 0)`
-/// every power-up. The driver's coordinate math interprets `(0, 0)`
-/// against the `home_pose` setting so the user-visible RA/Dec/Alt/Az
-/// reflect where the OTA actually points.
+/// every power-up. When `home_pose: Some(ApPark*)`, the driver
+/// seeds the firmware encoder on connect so the codebase's coordinate
+/// math interprets that zero against the operator's physical pose.
 ///
-/// The five `ApPark*` variants follow the Astro-Physics
-/// ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
-/// document. Each AP pose is mirror-symmetric between the Northern and
-/// Southern Hemispheres around the observer's local meridian — the
+/// Each AP pose is mirror-symmetric between the Northern and Southern
+/// Hemispheres around the observer's local meridian — the
 /// counterweight-shaft direction inverts and the celestial-Dec sign of
 /// the target inverts, so the codebase reading for each pose accounts
 /// for the observer's hemisphere from `site_latitude_deg`. The
@@ -250,18 +254,8 @@ impl FlipPolicy {
 /// for Park 4 (target on the meridian, anti-pole side) and at
 /// `mech_HA = 0` for Park 5 (target on the anti-meridian, pole side
 /// horizon), and the Dec encoder is past the celestial pole.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HomePose {
-    /// Codebase's original assumption (pre-Phase-6 default). At
-    /// firmware encoder `(0, 0)`, the Dec axis is horizontal
-    /// east-west, the saddle/OTA is on the west end, the
-    /// counterweight is on the east end, and the OTA points at the
-    /// south meridian at the celestial equator (north observer) /
-    /// north meridian at the equator (south observer). Codebase
-    /// `mech_HA = 0`, `dec_encoder = 0`.
-    #[default]
-    OtaOnMeridianAtEquator,
     /// AP Park 1. "RA horizontal" (Dec axis east-west horizontal,
     /// saddle on the *west* end, counterweight on the east end). OTA
     /// tube level, pointing at the polar-side horizon — north horizon
@@ -340,7 +334,6 @@ impl HomePose {
     /// the encoder wrap.
     pub fn codebase_mech_ha_hours(&self) -> f64 {
         match self {
-            Self::OtaOnMeridianAtEquator => 0.0,
             Self::ApPark1 => 0.0,
             Self::ApPark2 => -6.0,
             Self::ApPark3 => 0.0,
@@ -362,7 +355,6 @@ impl HomePose {
         let northern = latitude_deg >= 0.0;
         let lat_abs = latitude_deg.abs();
         match self {
-            Self::OtaOnMeridianAtEquator => 0.0,
             Self::ApPark1 => {
                 // Celestial dec at the polar-side horizon = ±(90 − |lat|),
                 // pre-flip side → encoder = celestial dec.
@@ -512,7 +504,7 @@ impl Default for MountConfig {
             park_ra_ticks: None,
             park_dec_ticks: None,
             flip_policy: FlipPolicy::default(),
-            home_pose: HomePose::default(),
+            home_pose: None,
         }
     }
 }
@@ -629,22 +621,18 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_default_is_ota_on_meridian_at_equator() {
+    fn home_pose_default_is_none_for_backward_compat() {
+        // `home_pose: None` means "no encoder seeding on connect" —
+        // the codebase's pre-Phase-6 behaviour. Operators powering up
+        // at an AP park position opt in by setting `home_pose:
+        // "ap_park_<n>"`.
         let cfg = MountConfig::default();
-        assert_eq!(cfg.home_pose, HomePose::OtaOnMeridianAtEquator);
-        // And the codebase-convention encoder reading at this default
-        // is (mech_HA=0, dec_enc=0) — the historical assumption.
-        assert_eq!(cfg.home_pose.codebase_mech_ha_hours(), 0.0);
-        assert_eq!(cfg.home_pose.codebase_dec_encoder_degrees(32.7), 0.0);
+        assert_eq!(cfg.home_pose, None);
     }
 
     #[test]
     fn home_pose_deserialises_from_snake_case() {
         for (json, expected) in [
-            (
-                r#""ota_on_meridian_at_equator""#,
-                HomePose::OtaOnMeridianAtEquator,
-            ),
             (r#""ap_park_1""#, HomePose::ApPark1),
             (r#""ap_park_2""#, HomePose::ApPark2),
             (r#""ap_park_3""#, HomePose::ApPark3),
@@ -760,8 +748,17 @@ mod tests {
 
     #[test]
     fn home_pose_round_trips_through_mount_config_json() {
+        // None round-trips as the missing/null field.
+        let cfg = MountConfig {
+            home_pose: None,
+            ..MountConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialise");
+        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.home_pose, None, "None round trip");
+
+        // Every AP park variant round-trips through Some(...).
         for pose in [
-            HomePose::OtaOnMeridianAtEquator,
             HomePose::ApPark1,
             HomePose::ApPark2,
             HomePose::ApPark3,
@@ -769,17 +766,17 @@ mod tests {
             HomePose::ApPark5,
         ] {
             let cfg = MountConfig {
-                home_pose: pose,
+                home_pose: Some(pose),
                 ..MountConfig::default()
             };
             let json = serde_json::to_string(&cfg).expect("serialise");
             let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
-            assert_eq!(back.home_pose, pose, "round trip for {pose:?}");
+            assert_eq!(back.home_pose, Some(pose), "round trip for {pose:?}");
         }
     }
 
     #[test]
-    fn mount_config_deserialises_missing_home_pose_as_default() {
+    fn mount_config_deserialises_missing_home_pose_as_none() {
         let json = r#"{
             "name": "T",
             "unique_id": "t-001",
@@ -788,7 +785,7 @@ mod tests {
             "site_longitude_deg": 0.0
         }"#;
         let m: MountConfig = serde_json::from_str(json).expect("deserialise");
-        assert_eq!(m.home_pose, HomePose::OtaOnMeridianAtEquator);
+        assert_eq!(m.home_pose, None);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -234,11 +234,22 @@ impl FlipPolicy {
 /// against the `home_pose` setting so the user-visible RA/Dec/Alt/Az
 /// reflect where the OTA actually points.
 ///
-/// Variants are named after the Astro-Physics
+/// The five `ApPark*` variants follow the Astro-Physics
 /// ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
-/// document where applicable. Park 2 is omitted (no clean polar-aligned
-/// interpretation at mid-latitudes); Park 4 / Park 5 are post-flip
-/// equivalents of Park 1 / Park 4 and can be added if/when needed.
+/// document. Each AP pose is mirror-symmetric between the Northern and
+/// Southern Hemispheres around the observer's local meridian — the
+/// counterweight-shaft direction inverts and the celestial-Dec sign of
+/// the target inverts, so the codebase reading for each pose accounts
+/// for the observer's hemisphere from `site_latitude_deg`. The
+/// `codebase_*` accessor helpers do the hemisphere case-split
+/// internally; callers pass `site_latitude_deg` unchanged and get back
+/// a single signed encoder-reading value.
+///
+/// AP Park 4 and Park 5 are "east-side" (post-meridian-flip) poses;
+/// the codebase reads them with `mech_HA` at the encoder wrap (`±12 h`)
+/// for Park 4 (target on the meridian, anti-pole side) and at
+/// `mech_HA = 0` for Park 5 (target on the anti-meridian, pole side
+/// horizon), and the Dec encoder is past the celestial pole.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum HomePose {
@@ -248,55 +259,148 @@ pub enum HomePose {
     /// counterweight is on the east end, and the OTA points at the
     /// south meridian at the celestial equator (north observer) /
     /// north meridian at the equator (south observer). Codebase
-    /// mech_HA = 0, dec_encoder = 0.
+    /// `mech_HA = 0`, `dec_encoder = 0`.
     #[default]
     OtaOnMeridianAtEquator,
-    /// Astro-Physics Park 1. RA axis at the "horizontal Dec axis"
-    /// position (saddle west, CW east); OTA tube level, pointing at
-    /// the polar-side horizon (az 0° for north, az 180° for south).
-    /// Codebase mech_HA = 0, dec_encoder = `+(90 − |latitude|)` for
-    /// north / `−(90 − |latitude|)` for south.
-    #[serde(rename = "park_1")]
-    Park1,
-    /// Astro-Physics Park 3 — also Sky-Watcher's power-on home. OTA
-    /// tube along the polar axis pointing at the visible celestial
-    /// pole (Polaris for north observers, SCP for south). Counterweight
-    /// shaft along the anti-pole side of the polar axis. Codebase
-    /// mech_HA = 0, dec_encoder = `+90°` for north / `−90°` for south.
-    #[serde(rename = "park_3")]
-    Park3,
+    /// AP Park 1. "RA horizontal" (Dec axis east-west horizontal,
+    /// saddle on the *west* end, counterweight on the east end). OTA
+    /// tube level, pointing at the polar-side horizon — north horizon
+    /// for north observers, south horizon for south observers.
+    ///
+    /// AP table: `Dec = (90 − Latitude)` for north,
+    /// `(−90 − Latitude)` for south. Codebase reading:
+    /// `mech_HA = 0`, `dec_encoder = ±(90 − |latitude|)` (sign matches
+    /// the hemisphere).
+    #[serde(rename = "ap_park_1")]
+    ApPark1,
+    /// AP Park 2. "RA axis vertical, Dec = 0". OTA level facing the
+    /// east horizon, counterweight shaft pointing down. The "RA
+    /// axis vertical" description is the visual look near the equator;
+    /// at any latitude the codebase reading is `mech_HA = −6 h`
+    /// (target on the east-rising celestial equator), `dec_encoder
+    /// = 0`. Hemisphere-independent.
+    #[serde(rename = "ap_park_2")]
+    ApPark2,
+    /// AP Park 3 (also Sky-Watcher's power-on home). OTA along the
+    /// polar axis pointing at the visible celestial pole — Polaris
+    /// for north observers, SCP for south observers. Counterweight
+    /// shaft along the anti-pole half of the polar axis.
+    ///
+    /// AP table: `Dec = 90` (visible pole). Codebase reading:
+    /// `mech_HA = 0`, `dec_encoder = +90°` for north / `−90°` for
+    /// south.
+    #[serde(rename = "ap_park_3")]
+    ApPark3,
+    /// AP Park 4. East-side / post-meridian-flip equivalent of Park 1:
+    /// saddle on the *east* end of the Dec axis, counterweight shaft
+    /// horizontal pointing due west. OTA level facing the *anti-polar*
+    /// horizon — south horizon for north observers, north horizon for
+    /// south observers.
+    ///
+    /// AP table: `Dec = (−90 + Latitude)` for north,
+    /// `(90 + Latitude)` for south. The target's celestial dec lands
+    /// at `±(90 − |latitude|)` (sign anti-hemisphere), and the
+    /// post-flip Dec encoder = `sign(dec) · (180 − |dec|) =
+    /// ∓(90 + |latitude|)`. Codebase reading: `mech_HA = −12 h`
+    /// (= `+12 h` via the encoder wrap),
+    /// `dec_encoder = ∓(90 + |latitude|)`.
+    #[serde(rename = "ap_park_4")]
+    ApPark4,
+    /// AP Park 5. East-side / post-meridian-flip equivalent of Park 1
+    /// (mirror of Park 4 across the polar-axis plane): saddle on the
+    /// *east* end, counterweight shaft horizontal pointing due west.
+    /// OTA level facing the *polar-side* horizon — north horizon for
+    /// north observers, south horizon for south observers.
+    ///
+    /// AP table: `Dec = (90 − Latitude)` for north,
+    /// `(−90 − Latitude)` for south. The celestial dec is at the same
+    /// magnitude as Park 1 but reached from the post-flip side, so
+    /// the post-flip Dec encoder = `±(90 + |latitude|)` (sign matches
+    /// the hemisphere). Codebase reading: `mech_HA = 0` (target on
+    /// the anti-meridian, post-flip wrap brings mech_HA back to 0),
+    /// `dec_encoder = ±(90 + |latitude|)`.
+    ///
+    /// (`Note: Park 5 shown below is only available in APCC and the
+    /// AP V2 driver.` per the AP doc — it's an APCC extension, not on
+    /// the keypad.)
+    #[serde(rename = "ap_park_5")]
+    ApPark5,
 }
 
 impl HomePose {
-    /// Codebase-convention `mech_HA` (signed hours) corresponding to
-    /// firmware encoder `(0, 0)` at this home pose. All three supported
-    /// poses share `mech_HA = 0` (the Dec axis is east-west horizontal
-    /// at power-up); the difference between them is purely in the Dec
-    /// encoder mapping.
+    /// Codebase-convention `mech_HA` (signed hours, `[−12, +12)`)
+    /// corresponding to firmware encoder `(0, 0)` at this home pose.
+    ///
+    /// `mech_HA` reflects the RA-axis rotation, independent of pier
+    /// side. Park 1, Park 3, and Park 5 all have the dec axis
+    /// east-west horizontal (`mech_HA = 0`); Park 2 has the OTA at
+    /// the east horizon, which puts target HA = −6 h regardless of
+    /// hemisphere; Park 4 has the target on the meridian but
+    /// approached from the post-flip side, which folds to `−12 h` at
+    /// the encoder wrap.
     pub fn codebase_mech_ha_hours(&self) -> f64 {
-        0.0
+        match self {
+            Self::OtaOnMeridianAtEquator => 0.0,
+            Self::ApPark1 => 0.0,
+            Self::ApPark2 => -6.0,
+            Self::ApPark3 => 0.0,
+            Self::ApPark4 => -12.0,
+            Self::ApPark5 => 0.0,
+        }
     }
 
     /// Codebase-convention Dec encoder reading (degrees, signed,
     /// `[−180, +180)`) corresponding to firmware encoder `(0, 0)` at
     /// this home pose, given the observer's latitude.
+    ///
+    /// Hemisphere handling: each AP pose's celestial-Dec target sign
+    /// inverts between Northern and Southern observers (the OTA
+    /// points at the visible pole / horizon, which has opposite Dec
+    /// signs). This helper folds that into a single signed encoder
+    /// reading.
     pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> f64 {
         let northern = latitude_deg >= 0.0;
         let lat_abs = latitude_deg.abs();
         match self {
             Self::OtaOnMeridianAtEquator => 0.0,
-            Self::Park1 => {
+            Self::ApPark1 => {
+                // Celestial dec at the polar-side horizon = ±(90 − |lat|),
+                // pre-flip side → encoder = celestial dec.
                 if northern {
                     90.0 - lat_abs
                 } else {
                     -(90.0 - lat_abs)
                 }
             }
-            Self::Park3 => {
+            Self::ApPark2 => 0.0,
+            Self::ApPark3 => {
+                // OTA at the visible celestial pole. Encoder = ±90°.
                 if northern {
                     90.0
                 } else {
                     -90.0
+                }
+            }
+            Self::ApPark4 => {
+                // Post-flip, target on the anti-polar horizon at the
+                // meridian. Celestial dec = ∓(90 − |lat|) (sign
+                // opposite the hemisphere). Post-flip Dec encoder =
+                // sign(dec) · (180 − |dec|) = ∓(90 + |lat|).
+                if northern {
+                    -(90.0 + lat_abs)
+                } else {
+                    90.0 + lat_abs
+                }
+            }
+            Self::ApPark5 => {
+                // Post-flip, target on the polar-side horizon at the
+                // anti-meridian. Celestial dec = ±(90 − |lat|) (sign
+                // matches the hemisphere). Post-flip Dec encoder =
+                // sign(dec) · (180 − |dec|) = ±(90 + |lat|).
+                if northern {
+                    90.0 + lat_abs
+                } else {
+                    -(90.0 + lat_abs)
                 }
             }
         }
@@ -536,53 +640,142 @@ mod tests {
 
     #[test]
     fn home_pose_deserialises_from_snake_case() {
-        let p: HomePose = serde_json::from_str(r#""park_1""#).expect("park_1");
-        assert_eq!(p, HomePose::Park1);
-        let p: HomePose = serde_json::from_str(r#""park_3""#).expect("park_3");
-        assert_eq!(p, HomePose::Park3);
-        let p: HomePose =
-            serde_json::from_str(r#""ota_on_meridian_at_equator""#).expect("default variant");
-        assert_eq!(p, HomePose::OtaOnMeridianAtEquator);
+        for (json, expected) in [
+            (
+                r#""ota_on_meridian_at_equator""#,
+                HomePose::OtaOnMeridianAtEquator,
+            ),
+            (r#""ap_park_1""#, HomePose::ApPark1),
+            (r#""ap_park_2""#, HomePose::ApPark2),
+            (r#""ap_park_3""#, HomePose::ApPark3),
+            (r#""ap_park_4""#, HomePose::ApPark4),
+            (r#""ap_park_5""#, HomePose::ApPark5),
+        ] {
+            let got: HomePose = serde_json::from_str(json).expect(json);
+            assert_eq!(got, expected, "json input {json}");
+        }
     }
 
     #[test]
-    fn home_pose_park1_dec_encoder_matches_ap_table_north() {
-        // AP doc: Park 1 Northern Hemisphere: Dec = (90 - Latitude).
+    fn home_pose_ap_park_1_matches_ap_table_both_hemispheres() {
+        // AP table: North Dec = (90 - Lat), South Dec = (-90 - Lat).
+        // North: lat 32.7° → +57.3°. South: lat -33° → -57°.
         assert!(
-            (HomePose::Park1.codebase_dec_encoder_degrees(32.7157) - (90.0 - 32.7157)).abs() < 1e-9
+            (HomePose::ApPark1.codebase_dec_encoder_degrees(32.7) - 57.3).abs() < 1e-9,
+            "Park 1 N at 32.7°: got {}",
+            HomePose::ApPark1.codebase_dec_encoder_degrees(32.7)
         );
-        assert!((HomePose::Park1.codebase_dec_encoder_degrees(45.0) - 45.0).abs() < 1e-9);
-        assert!((HomePose::Park1.codebase_dec_encoder_degrees(0.0) - 90.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn home_pose_park1_dec_encoder_matches_ap_table_south() {
-        // AP doc: Park 1 Southern Hemisphere: Dec = (-90 - Latitude),
-        // which for negative latitude `lat` is `-(90 - |lat|)`.
         assert!(
-            (HomePose::Park1.codebase_dec_encoder_degrees(-33.9) - (-(90.0 - 33.9))).abs() < 1e-9
+            (HomePose::ApPark1.codebase_dec_encoder_degrees(-33.0) - (-57.0)).abs() < 1e-9,
+            "Park 1 S at −33°: got {}",
+            HomePose::ApPark1.codebase_dec_encoder_degrees(-33.0)
         );
-        assert!((HomePose::Park1.codebase_dec_encoder_degrees(-45.0) - (-45.0)).abs() < 1e-9);
+        // mech_HA is 0 for both hemispheres (RA horizontal).
+        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(), 0.0);
     }
 
     #[test]
-    fn home_pose_park3_is_visible_pole() {
-        // AP Park 3 / Sky-Watcher home: OTA at the visible pole. Codebase
-        // dec_encoder = +90° in N, -90° in S.
-        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(32.7), 90.0);
-        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(-33.9), -90.0);
-        assert_eq!(HomePose::Park3.codebase_dec_encoder_degrees(0.0), 90.0);
+    fn home_pose_ap_park_2_is_hemisphere_independent() {
+        // Park 2: "RA axis vertical, Dec = 0", both hemispheres.
+        // The OTA points at the east-rising celestial equator → target
+        // HA = −6 h, dec = 0, regardless of latitude.
+        assert_eq!(HomePose::ApPark2.codebase_mech_ha_hours(), -6.0);
+        for lat in [-89.0, -33.0, 0.0, 32.7, 89.0] {
+            assert_eq!(
+                HomePose::ApPark2.codebase_dec_encoder_degrees(lat),
+                0.0,
+                "Park 2 dec at lat {lat}"
+            );
+        }
+    }
+
+    #[test]
+    fn home_pose_ap_park_3_visible_pole_inverts_with_hemisphere() {
+        // AP Park 3 / Sky-Watcher home: OTA at the visible pole.
+        // North: dec = +90° (NCP). South: dec = -90° (SCP). The
+        // hemisphere case-split sits inside the helper.
+        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(32.7), 90.0);
+        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(-33.0), -90.0);
+        // Boundary: lat = 0 falls into the "north" arm by the `>= 0`
+        // convention `side_of_pier` uses.
+        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(0.0), 90.0);
+        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(), 0.0);
+    }
+
+    #[test]
+    fn home_pose_ap_park_4_post_flip_dec_inverts_with_hemisphere() {
+        // AP table: North Dec_celestial = (−90 + Lat), South =
+        // (90 + Lat). The post-flip Dec encoder is at
+        // sign(dec_celestial) · (180 − |dec_celestial|).
+        // North: lat 32.7° → celestial = −57.3°, encoder = −122.7°.
+        // South: lat −33° → celestial = +57°, encoder = +123°.
+        assert!(
+            (HomePose::ApPark4.codebase_dec_encoder_degrees(32.7) - (-122.7)).abs() < 1e-9,
+            "Park 4 N at 32.7°: got {}",
+            HomePose::ApPark4.codebase_dec_encoder_degrees(32.7)
+        );
+        assert!(
+            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 123.0).abs() < 1e-9,
+            "Park 4 S at −33°: got {}",
+            HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0)
+        );
+        // Park 4 sits at the encoder wrap (anti-meridian post-flip).
+        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(), -12.0);
+    }
+
+    #[test]
+    fn home_pose_ap_park_5_post_flip_dec_matches_hemisphere() {
+        // AP table: North Dec_celestial = (90 − Lat), South =
+        // (−90 − Lat). Post-flip encoder = ±(90 + |lat|),
+        // sign matching the hemisphere.
+        // North: lat 32.7° → encoder = +122.7°.
+        // South: lat −33° → encoder = −123°.
+        assert!(
+            (HomePose::ApPark5.codebase_dec_encoder_degrees(32.7) - 122.7).abs() < 1e-9,
+            "Park 5 N at 32.7°: got {}",
+            HomePose::ApPark5.codebase_dec_encoder_degrees(32.7)
+        );
+        assert!(
+            (HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0) - (-123.0)).abs() < 1e-9,
+            "Park 5 S at −33°: got {}",
+            HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0)
+        );
+        // Park 5 target is on the anti-meridian; post-flip mech_HA
+        // folds back to 0.
+        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(), 0.0);
+    }
+
+    #[test]
+    fn home_pose_park4_and_park5_dec_encoders_are_mirror_images_about_zero() {
+        // Park 4 and Park 5 differ only in which horizon the OTA faces;
+        // the post-flip Dec encoder magnitudes match, with opposite
+        // signs (Park 4's sign is anti-hemisphere, Park 5's is
+        // pro-hemisphere).
+        for lat in [-45.0, -33.0, 32.7, 45.0] {
+            let p4 = HomePose::ApPark4.codebase_dec_encoder_degrees(lat);
+            let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat);
+            assert!((p4 + p5).abs() < 1e-9, "lat {lat}: p4 {p4}, p5 {p5}");
+        }
     }
 
     #[test]
     fn home_pose_round_trips_through_mount_config_json() {
-        let cfg = MountConfig {
-            home_pose: HomePose::Park3,
-            ..MountConfig::default()
-        };
-        let json = serde_json::to_string(&cfg).expect("serialise");
-        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
-        assert_eq!(back.home_pose, HomePose::Park3);
+        for pose in [
+            HomePose::OtaOnMeridianAtEquator,
+            HomePose::ApPark1,
+            HomePose::ApPark2,
+            HomePose::ApPark3,
+            HomePose::ApPark4,
+            HomePose::ApPark5,
+        ] {
+            let cfg = MountConfig {
+                home_pose: pose,
+                ..MountConfig::default()
+            };
+            let json = serde_json::to_string(&cfg).expect("serialise");
+            let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(back.home_pose, pose, "round trip for {pose:?}");
+        }
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -323,27 +323,70 @@ pub enum HomePose {
 
 impl HomePose {
     /// Codebase-convention `mech_HA` (signed hours, `[−12, +12)`)
-    /// corresponding to firmware encoder `(0, 0)` at this home pose.
+    /// corresponding to firmware encoder `(0, 0)` at this home pose
+    /// for the configured latitude.
     ///
-    /// `mech_HA` reflects the RA-axis rotation, independent of pier
-    /// side. Park 1, Park 3, and Park 5 all have the dec axis
-    /// east-west horizontal (`mech_HA = 0`); Park 2 has the OTA at
-    /// the east horizon, which puts target HA = −6 h regardless of
-    /// hemisphere; Park 4 has the target on the meridian but
-    /// approached from the post-flip side, which folds to `−12 h` at
-    /// the encoder wrap.
-    pub fn codebase_mech_ha_hours(&self) -> f64 {
+    /// AP defines each pose by the OTA pointing direction and which
+    /// side of the mount the OTA tube is on (East or West, mechanical).
+    /// The pier-side mechanical designation is the same for both
+    /// hemispheres, but the driver's natural-vs-flipped pier convention
+    /// flips between hemispheres (N natural = pierWest, S natural =
+    /// pierEast — see `pre_flip_side` in `MountDevice`). So a pose like
+    /// Park 1 ("OTA on west side") is the **natural side** in the
+    /// North and the **flipped side** in the South — and its encoder
+    /// representation differs accordingly.
+    ///
+    /// - **Natural side** (mech_HA = celestial HA): used when the
+    ///   pose's mechanical pier matches the hemisphere's natural pier.
+    /// - **Flipped side** (mech_HA = celestial HA + 12, folded): used
+    ///   when the pose is on the opposite mechanical pier.
+    ///
+    /// | Pose | Celestial HA | Mech. pier | N: nat / flip | S: nat / flip |
+    /// |------|--------------|-----------|---------------|----------------|
+    /// | 1    | ±12          | West      | natural       | flipped        |
+    /// | 2    | −6           | —         | natural       | natural        |
+    /// | 3    | (pole)       | —         | natural       | natural        |
+    /// | 4    | 0            | East      | flipped       | natural        |
+    /// | 5    | ±12          | East      | flipped       | natural        |
+    ///
+    /// Concretely:
+    /// - Park 1 N: nat → mech_HA = ±12 folded = `−12`.
+    ///   Park 1 S: flipped → mech_HA = (±12 + 12) folded = `0`.
+    /// - Park 4 N: flipped → mech_HA = `−12`.
+    ///   Park 4 S: nat → mech_HA = `0`.
+    /// - Park 5 N: flipped → mech_HA = `0`.
+    ///   Park 5 S: nat → mech_HA = `−12`.
+    /// - Parks 2 and 3 are hemisphere-neutral for mech_HA (`−6`).
+    pub fn codebase_mech_ha_hours(&self, latitude_deg: f64) -> f64 {
+        let northern = latitude_deg >= 0.0;
         match self {
-            Self::ApPark1 => 0.0,
+            Self::ApPark1 => {
+                if northern {
+                    -12.0
+                } else {
+                    0.0
+                }
+            }
             // Park 2 and Park 3 share the same RA position ("RA axis
-            // vertical" per the AP doc) — the only difference is the
-            // Dec encoder rotation. Both put the dec axis tilted
-            // south-up out of the east-west horizontal, with target
-            // HA = −6 h in the codebase's convention.
+            // vertical" per the AP doc); only the dec rotation differs.
+            // Both put the dec axis south-up out of east-west horizontal
+            // (`mech_HA = −6`), independent of hemisphere.
             Self::ApPark2 => -6.0,
             Self::ApPark3 => -6.0,
-            Self::ApPark4 => -12.0,
-            Self::ApPark5 => 0.0,
+            Self::ApPark4 => {
+                if northern {
+                    -12.0
+                } else {
+                    0.0
+                }
+            }
+            Self::ApPark5 => {
+                if northern {
+                    0.0
+                } else {
+                    -12.0
+                }
+            }
         }
     }
 
@@ -351,27 +394,36 @@ impl HomePose {
     /// `[−180, +180)`) corresponding to firmware encoder `(0, 0)` at
     /// this home pose, given the observer's latitude.
     ///
-    /// Hemisphere handling: each AP pose's celestial-Dec target sign
-    /// inverts between Northern and Southern observers (the OTA
-    /// points at the visible pole / horizon, which has opposite Dec
-    /// signs). This helper folds that into a single signed encoder
-    /// reading.
+    /// Two hemisphere-dependent effects:
+    /// 1. The OTA points at the *visible* pole / horizon, which has
+    ///    opposite celestial-Dec signs between hemispheres.
+    /// 2. The pose's mechanical pier is the natural side for one
+    ///    hemisphere and the flipped side for the other — so the
+    ///    pose-to-encoder mapping uses
+    ///    `dec_enc = celestial_dec` (natural) **or**
+    ///    `dec_enc = sign(dec) · (180 − |dec|)` (flipped) depending on
+    ///    which side the operator's hemisphere makes it.
     pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> f64 {
         let northern = latitude_deg >= 0.0;
         let lat_abs = latitude_deg.abs();
+        // Magnitude common to Parks 1, 4, 5 — the celestial Dec at the
+        // polar-side / anti-polar horizon at this latitude.
+        let horizon_dec_mag = 90.0 - lat_abs;
         match self {
             Self::ApPark1 => {
-                // Celestial dec at the polar-side horizon = ±(90 − |lat|),
-                // pre-flip side → encoder = celestial dec.
+                // OTA on west of mount. N: natural side → encoder =
+                // celestial_dec = +(90−|lat|). S: flipped side →
+                // encoder = −(180 − (90−|lat|)) = −(90+|lat|).
                 if northern {
-                    90.0 - lat_abs
+                    horizon_dec_mag
                 } else {
-                    -(90.0 - lat_abs)
+                    -(90.0 + lat_abs)
                 }
             }
             Self::ApPark2 => 0.0,
             Self::ApPark3 => {
-                // OTA at the visible celestial pole. Encoder = ±90°.
+                // OTA at the visible celestial pole. Natural side for
+                // both hemispheres → encoder = celestial_dec = ±90°.
                 if northern {
                     90.0
                 } else {
@@ -379,25 +431,26 @@ impl HomePose {
                 }
             }
             Self::ApPark4 => {
-                // Post-flip, target on the anti-polar horizon at the
-                // meridian. Celestial dec = ∓(90 − |lat|) (sign
-                // opposite the hemisphere). Post-flip Dec encoder =
-                // sign(dec) · (180 − |dec|) = ∓(90 + |lat|).
+                // OTA on east of mount, OTA level facing anti-polar
+                // horizon. Celestial dec = ∓(90−|lat|) (sign opposite
+                // hemisphere). N: flipped → encoder = sign(dec) ·
+                // (180−|dec|) = −(90+|lat|). S: natural → encoder =
+                // celestial_dec = +(90−|lat|).
                 if northern {
                     -(90.0 + lat_abs)
                 } else {
-                    90.0 + lat_abs
+                    horizon_dec_mag
                 }
             }
             Self::ApPark5 => {
-                // Post-flip, target on the polar-side horizon at the
-                // anti-meridian. Celestial dec = ±(90 − |lat|) (sign
-                // matches the hemisphere). Post-flip Dec encoder =
-                // sign(dec) · (180 − |dec|) = ±(90 + |lat|).
+                // OTA on east of mount, OTA level facing polar-side
+                // horizon. Celestial dec = ±(90−|lat|) (sign matches
+                // hemisphere). N: flipped → encoder = +(90+|lat|).
+                // S: natural → encoder = celestial_dec = −(90−|lat|).
                 if northern {
                     90.0 + lat_abs
                 } else {
-                    -(90.0 + lat_abs)
+                    -horizon_dec_mag
                 }
             }
         }
@@ -651,29 +704,44 @@ mod tests {
 
     #[test]
     fn home_pose_ap_park_1_matches_ap_table_both_hemispheres() {
-        // AP table: North Dec = (90 - Lat), South Dec = (-90 - Lat).
-        // North: lat 32.7° → +57.3°. South: lat -33° → -57°.
+        // AP Park 1: OTA on west side of mount.
+        // - N hemisphere: pierWest is the natural side → encoder =
+        //   celestial dec = +(90 − |lat|). mech_HA = celestial HA =
+        //   ±12 h folded = −12 h (encoder wrap).
+        // - S hemisphere: pierWest is the flipped side → encoder =
+        //   sign(dec) · (180 − |dec|) = −(90 + |lat|). mech_HA =
+        //   (celestial HA + 12) folded = 0 h.
+        // Verified against the AP "Park Positions Defined" doc:
+        // celestial dec = ±(90 − |lat|), OTA at (alt=0, az=0 N) for
+        // north / (alt=0, az=180 S) for south.
+        let n = 32.7_f64;
+        let s = -33.0_f64;
         assert!(
-            (HomePose::ApPark1.codebase_dec_encoder_degrees(32.7) - 57.3).abs() < 1e-9,
-            "Park 1 N at 32.7°: got {}",
-            HomePose::ApPark1.codebase_dec_encoder_degrees(32.7)
+            (HomePose::ApPark1.codebase_dec_encoder_degrees(n) - 57.3).abs() < 1e-9,
+            "Park 1 N dec_enc at 32.7°: got {}",
+            HomePose::ApPark1.codebase_dec_encoder_degrees(n)
         );
         assert!(
-            (HomePose::ApPark1.codebase_dec_encoder_degrees(-33.0) - (-57.0)).abs() < 1e-9,
-            "Park 1 S at −33°: got {}",
-            HomePose::ApPark1.codebase_dec_encoder_degrees(-33.0)
+            (HomePose::ApPark1.codebase_dec_encoder_degrees(s) - (-123.0)).abs() < 1e-9,
+            "Park 1 S dec_enc at −33°: got {}",
+            HomePose::ApPark1.codebase_dec_encoder_degrees(s)
         );
-        // mech_HA is 0 for both hemispheres (RA horizontal).
-        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(), 0.0);
+        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(n), -12.0);
+        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(s), 0.0);
     }
 
     #[test]
     fn home_pose_ap_park_2_is_hemisphere_independent() {
         // Park 2: "RA axis vertical, Dec = 0", both hemispheres.
-        // The OTA points at the east-rising celestial equator → target
-        // HA = −6 h, dec = 0, regardless of latitude.
-        assert_eq!(HomePose::ApPark2.codebase_mech_ha_hours(), -6.0);
+        // OTA at east-rising celestial equator → celestial HA = −6 h,
+        // celestial dec = 0. Both hemispheres land on the natural side
+        // (|dec_enc| = 0 ≤ 90), so encoder = celestial dec for both.
         for lat in [-89.0, -33.0, 0.0, 32.7, 89.0] {
+            assert_eq!(
+                HomePose::ApPark2.codebase_mech_ha_hours(lat),
+                -6.0,
+                "Park 2 mech_HA at lat {lat}"
+            );
             assert_eq!(
                 HomePose::ApPark2.codebase_dec_encoder_degrees(lat),
                 0.0,
@@ -684,73 +752,94 @@ mod tests {
 
     #[test]
     fn home_pose_ap_park_3_visible_pole_inverts_with_hemisphere() {
-        // AP Park 3 / Sky-Watcher home: OTA at the visible pole.
-        // North: dec = +90° (NCP). South: dec = -90° (SCP). The
-        // hemisphere case-split sits inside the helper.
+        // Park 3 / Sky-Watcher home: OTA along polar axis at the
+        // visible pole. Celestial dec = +90 (N) / −90 (S). Natural
+        // side for both hemispheres → encoder = celestial dec.
+        // Verified on hardware at lat 32.7°N (2026-05-15): mech_HA =
+        // −6 h and dec_enc = +90 leaves the OTA pointing at the NCP.
         assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(32.7), 90.0);
         assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(-33.0), -90.0);
-        // Boundary: lat = 0 falls into the "north" arm by the `>= 0`
-        // convention `side_of_pier` uses.
+        // Boundary: lat = 0 falls into the "north" arm via `>= 0`.
         assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(0.0), 90.0);
-        // Park 3 shares the same RA position as Park 2 (both "RA axis
-        // vertical" per the AP doc): codebase mech_HA = −6 h, not 0.
-        // Verified on hardware at LAT 32.7°N (2026-05-15): with
-        // mech_HA = 0 the dec-only slew from Park 3 to celestial dec=0
-        // landed the OTA at the *east* horizon (HA = -6), confirming
-        // the RA position is offset 6 h from the codebase mech_HA = 0
-        // convention.
-        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(), -6.0);
+        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(32.7), -6.0);
+        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(-33.0), -6.0);
     }
 
     #[test]
-    fn home_pose_ap_park_4_post_flip_dec_inverts_with_hemisphere() {
-        // AP table: North Dec_celestial = (−90 + Lat), South =
-        // (90 + Lat). The post-flip Dec encoder is at
-        // sign(dec_celestial) · (180 − |dec_celestial|).
-        // North: lat 32.7° → celestial = −57.3°, encoder = −122.7°.
-        // South: lat −33° → celestial = +57°, encoder = +123°.
+    fn home_pose_ap_park_4_dec_inverts_with_hemisphere() {
+        // AP Park 4: OTA on east side of mount, level, facing the
+        // anti-polar horizon.
+        // AP celestial dec: N = (−90 + Lat) = −(90 − |lat|),
+        //                   S = (+90 + Lat) = +(90 − |lat|).
+        // - N: pierEast is the flipped side → encoder = sign(dec) ·
+        //   (180 − |dec|) = −(90 + |lat|); mech_HA = (0 + 12) folded =
+        //   −12 h.
+        // - S: pierEast is the natural side → encoder = celestial dec
+        //   = +(90 − |lat|); mech_HA = 0 h.
         assert!(
             (HomePose::ApPark4.codebase_dec_encoder_degrees(32.7) - (-122.7)).abs() < 1e-9,
             "Park 4 N at 32.7°: got {}",
             HomePose::ApPark4.codebase_dec_encoder_degrees(32.7)
         );
         assert!(
-            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 123.0).abs() < 1e-9,
+            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 57.0).abs() < 1e-9,
             "Park 4 S at −33°: got {}",
             HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0)
         );
-        // Park 4 sits at the encoder wrap (anti-meridian post-flip).
-        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(), -12.0);
+        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(32.7), -12.0);
+        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(-33.0), 0.0);
     }
 
     #[test]
-    fn home_pose_ap_park_5_post_flip_dec_matches_hemisphere() {
-        // AP table: North Dec_celestial = (90 − Lat), South =
-        // (−90 − Lat). Post-flip encoder = ±(90 + |lat|),
-        // sign matching the hemisphere.
-        // North: lat 32.7° → encoder = +122.7°.
-        // South: lat −33° → encoder = −123°.
+    fn home_pose_ap_park_5_dec_matches_hemisphere() {
+        // AP Park 5 (APCC / AP V2 driver only): OTA on east side of
+        // mount, level, facing the polar-side horizon.
+        // AP celestial dec: N = +(90 − Lat), S = (−90 − Lat) =
+        //                   −(90 − |lat|).
+        // - N: pierEast is the flipped side → encoder = +(90 + |lat|);
+        //   mech_HA = (±12 + 12) folded = 0.
+        // - S: pierEast is the natural side → encoder = celestial dec
+        //   = −(90 − |lat|); mech_HA = ±12 folded = −12.
         assert!(
             (HomePose::ApPark5.codebase_dec_encoder_degrees(32.7) - 122.7).abs() < 1e-9,
             "Park 5 N at 32.7°: got {}",
             HomePose::ApPark5.codebase_dec_encoder_degrees(32.7)
         );
         assert!(
-            (HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0) - (-123.0)).abs() < 1e-9,
+            (HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0) - (-57.0)).abs() < 1e-9,
             "Park 5 S at −33°: got {}",
             HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0)
         );
-        // Park 5 target is on the anti-meridian; post-flip mech_HA
-        // folds back to 0.
-        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(), 0.0);
+        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(32.7), 0.0);
+        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(-33.0), -12.0);
     }
 
     #[test]
-    fn home_pose_park4_and_park5_dec_encoders_are_mirror_images_about_zero() {
-        // Park 4 and Park 5 differ only in which horizon the OTA faces;
-        // the post-flip Dec encoder magnitudes match, with opposite
-        // signs (Park 4's sign is anti-hemisphere, Park 5's is
-        // pro-hemisphere).
+    fn home_pose_park1_park5_share_celestial_target_per_hemisphere() {
+        // Park 1 and Park 5 point at the same celestial coordinates
+        // (polar-side horizon) but on opposite mechanical pier sides.
+        // The Dec encoder magnitudes therefore differ by the "past the
+        // pole" offset: |natural| + |flipped| = |dec| + (180 − |dec|)
+        // = 180°.
+        for lat in [-45.0, -33.0, 32.7, 45.0] {
+            let p1 = HomePose::ApPark1.codebase_dec_encoder_degrees(lat).abs();
+            let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat).abs();
+            assert!(
+                (p1 + p5 - 180.0).abs() < 1e-9,
+                "lat {lat}: |p1| {p1}, |p5| {p5}, sum {} (expected 180)",
+                p1 + p5
+            );
+        }
+    }
+
+    #[test]
+    fn home_pose_park4_and_park5_are_mirrored_anti_polar_vs_polar() {
+        // Park 4 (OTA facing anti-polar horizon) and Park 5 (OTA
+        // facing polar-side horizon) are on the same mechanical pier
+        // (East), so they share the same flipped-vs-natural treatment
+        // per hemisphere — and their celestial Decs are equal in
+        // magnitude but opposite in sign. Therefore the encoder
+        // readings are also equal in magnitude with opposite signs.
         for lat in [-45.0, -33.0, 32.7, 45.0] {
             let p4 = HomePose::ApPark4.codebase_dec_encoder_degrees(lat);
             let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat);

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -352,44 +352,41 @@ impl HomePose {
     /// | 4    | 0            | East      | flipped       | natural        |
     /// | 5    | ±12          | East      | flipped       | natural        |
     ///
-    /// Concretely:
-    /// - Park 1 N: nat → mech_HA = ±12 folded = `−12`.
-    ///   Park 1 S: flipped → mech_HA = (±12 + 12) folded = `0`.
-    /// - Park 4 N: flipped → mech_HA = `−12`.
-    ///   Park 4 S: nat → mech_HA = `0`.
-    /// - Park 5 N: flipped → mech_HA = `0`.
-    ///   Park 5 S: nat → mech_HA = `−12`.
-    /// - Parks 2 and 3 are hemisphere-neutral for mech_HA (`−6`).
-    pub fn codebase_mech_ha_hours(&self, latitude_deg: f64) -> f64 {
-        let northern = latitude_deg >= 0.0;
+    /// Concretely (Northern Hemisphere; Southern mirrors via the
+    /// hemisphere case-split below):
+    /// - Park 1 N: saddle west → `mech_HA = 0` (saddle in west half
+    ///   of polar plane; OTA reaches north horizon via past-pole dec
+    ///   rotation).
+    /// - Park 4 N: saddle east → `mech_HA = −12` (encoder wrap;
+    ///   saddle in east half; OTA reaches south horizon via past-
+    ///   pole dec rotation).
+    /// - Park 5 N: saddle east → `mech_HA = −12` (encoder wrap;
+    ///   OTA reaches north horizon via natural-side dec rotation).
+    /// - Parks 2 and 3 are hemisphere-neutral for mech_HA (`−6`,
+    ///   saddle in the south-up direction, neither east nor west).
+    pub fn codebase_mech_ha_hours(&self, _latitude_deg: f64) -> f64 {
+        // We don't case-split on hemisphere for mech_HA: the saddle
+        // east/west position is a function of the encoder alone,
+        // which is hemisphere-independent. The dec encoder *is*
+        // hemisphere-dependent — see [`codebase_dec_encoder_degrees`].
         match self {
-            Self::ApPark1 => {
-                if northern {
-                    -12.0
-                } else {
-                    0.0
-                }
-            }
+            // Park 1: OTA west of mount → saddle west → mech_HA in
+            // the (−6, +6) range. `mech_HA = 0` is the canonical
+            // saddle-west position (dec axis east-west horizontal).
+            Self::ApPark1 => 0.0,
             // Park 2 and Park 3 share the same RA position ("RA axis
             // vertical" per the AP doc); only the dec rotation differs.
             // Both put the dec axis south-up out of east-west horizontal
-            // (`mech_HA = −6`), independent of hemisphere.
+            // (`mech_HA = −6`).
             Self::ApPark2 => -6.0,
             Self::ApPark3 => -6.0,
-            Self::ApPark4 => {
-                if northern {
-                    -12.0
-                } else {
-                    0.0
-                }
-            }
-            Self::ApPark5 => {
-                if northern {
-                    0.0
-                } else {
-                    -12.0
-                }
-            }
+            // Park 4: OTA east of mount → saddle east → `mech_HA` in
+            // the wrap region. `mech_HA = −12` is the canonical
+            // saddle-east position.
+            Self::ApPark4 => -12.0,
+            // Park 5: OTA east of mount (same saddle side as Park 4,
+            // different dec rotation) → `mech_HA = −12`.
+            Self::ApPark5 => -12.0,
         }
     }
 
@@ -397,15 +394,11 @@ impl HomePose {
     /// `[−180, +180)`) corresponding to firmware encoder `(0, 0)` at
     /// this home pose, given the observer's latitude.
     ///
-    /// Two hemisphere-dependent effects:
-    /// 1. The OTA points at the *visible* pole / horizon, which has
-    ///    opposite celestial-Dec signs between hemispheres.
-    /// 2. The pose's mechanical pier is the natural side for one
-    ///    hemisphere and the flipped side for the other — so the
-    ///    pose-to-encoder mapping uses
-    ///    `dec_enc = celestial_dec` (natural) **or**
-    ///    `dec_enc = sign(dec) · (180 − |dec|)` (flipped) depending on
-    ///    which side the operator's hemisphere makes it.
+    /// Hemisphere-dependent because the OTA points at the visible
+    /// pole / horizon, which has opposite celestial-Dec signs between
+    /// hemispheres. The codebase dec_enc value is the rotation angle
+    /// around the dec axis from the dec=0 reference (which itself is
+    /// hemisphere-dependent at fixed mech_HA).
     pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> f64 {
         let northern = latitude_deg >= 0.0;
         let lat_abs = latitude_deg.abs();
@@ -413,45 +406,50 @@ impl HomePose {
         // polar-side / anti-polar horizon at this latitude.
         let horizon_dec_mag = 90.0 - lat_abs;
         match self {
+            // Park 1: saddle west (mech_HA=0). OTA at polar-side
+            // horizon — north horizon for N (alt=0, az=0), south
+            // horizon for S. From the saddle-west position at
+            // mech_HA=0 the OTA reaches the polar-side horizon via
+            // a past-pole rotation: `dec_enc ≈ ±(90 + |lat|)` (sign
+            // matches hemisphere; magnitude > 90 indicates the
+            // past-pole encoding).
             Self::ApPark1 => {
-                // OTA on west of mount. N: natural side → encoder =
-                // celestial_dec = +(90−|lat|). S: flipped side →
-                // encoder = −(180 − (90−|lat|)) = −(90+|lat|).
                 if northern {
-                    horizon_dec_mag
+                    90.0 + lat_abs
                 } else {
                     -(90.0 + lat_abs)
                 }
             }
             Self::ApPark2 => 0.0,
             Self::ApPark3 => {
-                // OTA at the visible celestial pole. Natural side for
-                // both hemispheres → encoder = celestial_dec = ±90°.
+                // OTA at the visible celestial pole. Both hemispheres
+                // encode this as `dec_enc = ±90°` (sign matches
+                // hemisphere — celestial pole at +Dec in N, −Dec
+                // in S).
                 if northern {
                     90.0
                 } else {
                     -90.0
                 }
             }
+            // Park 4: saddle east (mech_HA=-12). OTA at the anti-
+            // polar horizon — south for N (alt=0, az=180), north
+            // for S. Past-pole rotation gives `dec_enc = ∓(90+|lat|)`
+            // (sign opposite hemisphere).
             Self::ApPark4 => {
-                // OTA on east of mount, OTA level facing anti-polar
-                // horizon. Celestial dec = ∓(90−|lat|) (sign opposite
-                // hemisphere). N: flipped → encoder = sign(dec) ·
-                // (180−|dec|) = −(90+|lat|). S: natural → encoder =
-                // celestial_dec = +(90−|lat|).
                 if northern {
                     -(90.0 + lat_abs)
                 } else {
-                    horizon_dec_mag
+                    90.0 + lat_abs
                 }
             }
+            // Park 5: saddle east (mech_HA=-12, same as Park 4) but
+            // OTA at the polar-side horizon (180° around dec axis
+            // from Park 4). `dec_enc = ±(90 − |lat|)` (natural-side
+            // encoding; |dec_enc| < 90).
             Self::ApPark5 => {
-                // OTA on east of mount, OTA level facing polar-side
-                // horizon. Celestial dec = ±(90−|lat|) (sign matches
-                // hemisphere). N: flipped → encoder = +(90+|lat|).
-                // S: natural → encoder = celestial_dec = −(90−|lat|).
                 if northern {
-                    90.0 + lat_abs
+                    horizon_dec_mag
                 } else {
                     -horizon_dec_mag
                 }
@@ -707,20 +705,21 @@ mod tests {
 
     #[test]
     fn home_pose_ap_park_1_matches_ap_table_both_hemispheres() {
-        // AP Park 1: OTA on west side of mount.
-        // - N hemisphere: pierWest is the natural side → encoder =
-        //   celestial dec = +(90 − |lat|). mech_HA = celestial HA =
-        //   ±12 h folded = −12 h (encoder wrap).
-        // - S hemisphere: pierWest is the flipped side → encoder =
-        //   sign(dec) · (180 − |dec|) = −(90 + |lat|). mech_HA =
-        //   (celestial HA + 12) folded = 0 h.
-        // Verified against the AP "Park Positions Defined" doc:
-        // celestial dec = ±(90 − |lat|), OTA at (alt=0, az=0 N) for
-        // north / (alt=0, az=180 S) for south.
+        // AP Park 1: OTA on west side of mount, level, facing the
+        // polar-side horizon (N: north horizon, S: south horizon).
+        // Saddle is on the west end of the dec axis → mech_HA = 0
+        // (canonical saddle-west position; dec axis east-west
+        // horizontal). To reach the polar-side horizon from this
+        // saddle position, the dec axis must rotate past the pole:
+        // `dec_enc = ±(90 + |lat|)` (sign matches hemisphere).
+        // Verified on hardware at lat 32.7°N (2026-05-17): the
+        // encoder pose previously labelled Park 1 N (mech_HA=−12,
+        // dec_enc=+57.3) physically corresponds to Park 5 N (saddle
+        // east) — see commit fixing the swap.
         let n = 32.7_f64;
         let s = -33.0_f64;
         assert!(
-            (HomePose::ApPark1.codebase_dec_encoder_degrees(n) - 57.3).abs() < 1e-9,
+            (HomePose::ApPark1.codebase_dec_encoder_degrees(n) - 122.7).abs() < 1e-9,
             "Park 1 N dec_enc at 32.7°: got {}",
             HomePose::ApPark1.codebase_dec_encoder_degrees(n)
         );
@@ -729,7 +728,7 @@ mod tests {
             "Park 1 S dec_enc at −33°: got {}",
             HomePose::ApPark1.codebase_dec_encoder_degrees(s)
         );
-        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(n), -12.0);
+        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(n), 0.0);
         assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(s), 0.0);
     }
 
@@ -769,42 +768,43 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_ap_park_4_dec_inverts_with_hemisphere() {
+    fn home_pose_ap_park_4_dec_at_lat_32() {
         // AP Park 4: OTA on east side of mount, level, facing the
-        // anti-polar horizon.
-        // AP celestial dec: N = (−90 + Lat) = −(90 − |lat|),
-        //                   S = (+90 + Lat) = +(90 − |lat|).
-        // - N: pierEast is the flipped side → encoder = sign(dec) ·
-        //   (180 − |dec|) = −(90 + |lat|); mech_HA = (0 + 12) folded =
-        //   −12 h.
-        // - S: pierEast is the natural side → encoder = celestial dec
-        //   = +(90 − |lat|); mech_HA = 0 h.
+        // anti-polar horizon (N: south horizon, S: north horizon).
+        // Saddle east → mech_HA = −12. AP celestial dec:
+        //   N = (−90 + Lat) = −(90 − |lat|),
+        //   S = (+90 + Lat) = +(90 − |lat|).
+        // Past-pole encoding (180° around dec axis from natural-side
+        // reference at this mech_HA): `dec_enc = ∓(90 + |lat|)`
+        // (sign opposite hemisphere).
         assert!(
             (HomePose::ApPark4.codebase_dec_encoder_degrees(32.7) - (-122.7)).abs() < 1e-9,
             "Park 4 N at 32.7°: got {}",
             HomePose::ApPark4.codebase_dec_encoder_degrees(32.7)
         );
         assert!(
-            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 57.0).abs() < 1e-9,
+            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 123.0).abs() < 1e-9,
             "Park 4 S at −33°: got {}",
             HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0)
         );
         assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(32.7), -12.0);
-        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(-33.0), 0.0);
+        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(-33.0), -12.0);
     }
 
     #[test]
-    fn home_pose_ap_park_5_dec_matches_hemisphere() {
+    fn home_pose_ap_park_5_matches_ap_table_both_hemispheres() {
         // AP Park 5 (APCC / AP V2 driver only): OTA on east side of
-        // mount, level, facing the polar-side horizon.
-        // AP celestial dec: N = +(90 − Lat), S = (−90 − Lat) =
-        //                   −(90 − |lat|).
-        // - N: pierEast is the flipped side → encoder = +(90 + |lat|);
-        //   mech_HA = (±12 + 12) folded = 0.
-        // - S: pierEast is the natural side → encoder = celestial dec
-        //   = −(90 − |lat|); mech_HA = ±12 folded = −12.
+        // mount, level, facing the polar-side horizon (N: north,
+        // S: south). Saddle east → mech_HA = −12. Natural-side dec
+        // rotation around the dec axis at this mech_HA reaches the
+        // polar-side horizon: `dec_enc = ±(90 − |lat|)` (sign
+        // matches hemisphere).
+        // Hardware-verified at lat 32.7°N (2026-05-17): slewing to
+        // celestial (LST+12, +57.28) lands at encoder (−cpr/2,
+        // +461,815), saddle east, OTA at north horizon — matches AP
+        // Park 5 N visually.
         assert!(
-            (HomePose::ApPark5.codebase_dec_encoder_degrees(32.7) - 122.7).abs() < 1e-9,
+            (HomePose::ApPark5.codebase_dec_encoder_degrees(32.7) - 57.3).abs() < 1e-9,
             "Park 5 N at 32.7°: got {}",
             HomePose::ApPark5.codebase_dec_encoder_degrees(32.7)
         );
@@ -813,17 +813,17 @@ mod tests {
             "Park 5 S at −33°: got {}",
             HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0)
         );
-        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(32.7), 0.0);
+        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(32.7), -12.0);
         assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(-33.0), -12.0);
     }
 
     #[test]
-    fn home_pose_park1_park5_share_celestial_target_per_hemisphere() {
-        // Park 1 and Park 5 point at the same celestial coordinates
-        // (polar-side horizon) but on opposite mechanical pier sides.
-        // The Dec encoder magnitudes therefore differ by the "past the
-        // pole" offset: |natural| + |flipped| = |dec| + (180 − |dec|)
-        // = 180°.
+    fn home_pose_park1_park5_share_celestial_target_opposite_pier() {
+        // Park 1 (saddle west) and Park 5 (saddle east) point at the
+        // same celestial coordinates (polar-side horizon) but on
+        // opposite mechanical pier sides. The dec-encoder magnitudes
+        // therefore differ by the "past the pole" offset:
+        // `|natural| + |flipped| = |dec| + (180 − |dec|) = 180°`.
         for lat in [-45.0, -33.0, 32.7, 45.0] {
             let p1 = HomePose::ApPark1.codebase_dec_encoder_degrees(lat).abs();
             let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat).abs();
@@ -836,17 +836,25 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_park4_and_park5_are_mirrored_anti_polar_vs_polar() {
+    fn home_pose_park4_and_park5_share_pier_opposite_celestial_dec() {
         // Park 4 (OTA facing anti-polar horizon) and Park 5 (OTA
         // facing polar-side horizon) are on the same mechanical pier
-        // (East), so they share the same flipped-vs-natural treatment
-        // per hemisphere — and their celestial Decs are equal in
-        // magnitude but opposite in sign. Therefore the encoder
-        // readings are also equal in magnitude with opposite signs.
+        // (East, `mech_HA = −12`), and their celestial Decs are equal
+        // in magnitude but opposite in sign. The Park 4 encoder uses
+        // past-pole encoding (|dec_enc| > 90); Park 5 uses
+        // natural-side encoding (|dec_enc| < 90). The magnitudes
+        // therefore add to 180°, and the signs differ — i.e. their
+        // encoder values are equal in magnitude with opposite signs
+        // iff one is past-pole and the other is not.
         for lat in [-45.0, -33.0, 32.7, 45.0] {
-            let p4 = HomePose::ApPark4.codebase_dec_encoder_degrees(lat);
-            let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat);
-            assert!((p4 + p5).abs() < 1e-9, "lat {lat}: p4 {p4}, p5 {p5}");
+            assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(lat), -12.0);
+            assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(lat), -12.0);
+            let p4_abs = HomePose::ApPark4.codebase_dec_encoder_degrees(lat).abs();
+            let p5_abs = HomePose::ApPark5.codebase_dec_encoder_degrees(lat).abs();
+            assert!(
+                (p4_abs + p5_abs - 180.0).abs() < 1e-9,
+                "lat {lat}: |p4| {p4_abs}, |p5| {p5_abs}"
+            );
         }
     }
 

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -246,6 +246,54 @@ pub fn target_encoder_flipped(
     (ra_ticks, dec_ticks)
 }
 
+/// Compute the OTA's celestial pointing `(RA hours, Dec degrees)`
+/// from the encoder snapshot + LST + latitude.
+///
+/// Inverse of [`target_encoder_normal`] / [`target_encoder_flipped`].
+/// Detects post-flip state from the Dec encoder past the celestial
+/// pole (the same convention [`side_of_pier`] uses) and applies the
+/// corresponding celestial mapping:
+///
+/// - Pre-flip: `RA = (LST − mech_HA) mod 24`, `Dec = dec_encoder`.
+/// - Post-flip: `RA = (LST − mech_HA + 12) mod 24`, `Dec = sign(dec_enc) · (180° − |dec_enc|)`.
+///
+/// Without the post-flip correction every read path
+/// (`right_ascension`, `declination`, `altitude`, `azimuth`, and the
+/// slew watcher's pickup-loop residual check) would report the
+/// encoder-direction RA/Dec rather than the OTA's celestial
+/// pointing, and the pickup loop would interpret a successful flip
+/// as a 12-hour RA residual and try to undo it.
+pub fn encoder_to_celestial(
+    ra_ticks: i32,
+    dec_ticks: i32,
+    lst_hours: f64,
+    cpr_ra: u32,
+    cpr_dec: u32,
+    site_latitude_deg: f64,
+) -> (f64, f64) {
+    let mech_ha = ra_ticks_to_mechanical_ha(ra_ticks, cpr_ra);
+    let dec_enc = dec_ticks_to_degrees(dec_ticks, cpr_dec);
+    let pier = side_of_pier(dec_ticks, cpr_dec, site_latitude_deg);
+    let pre_flip_side = if site_latitude_deg >= 0.0 {
+        PierSide::West
+    } else {
+        PierSide::East
+    };
+    let is_flipped = pier != pre_flip_side && pier != PierSide::Unknown;
+    if is_flipped {
+        let ra = (lst_hours - mech_ha + 12.0).rem_euclid(24.0);
+        // `dec_enc.signum()` returns ±1 for any non-zero value; the
+        // degenerate `dec_enc == 0` post-flip case (dec encoder at the
+        // wrap) is unreachable when `is_flipped == true` because
+        // `side_of_pier`'s `|dec_ticks| > cpr/4` check is strict.
+        let dec = dec_enc.signum() * (180.0 - dec_enc.abs());
+        (ra, dec)
+    } else {
+        let ra = (lst_hours - mech_ha).rem_euclid(24.0);
+        (ra, dec_enc)
+    }
+}
+
 /// Return the ASCOM-opposite pier side. `Unknown` maps to `Unknown`
 /// — the driver does not invent a side it has no information about.
 pub fn opposite_pier_side(side: PierSide) -> PierSide {
@@ -1040,6 +1088,94 @@ mod tests {
             LAT_SOUTH,
         );
         assert_eq!(chosen, PierSide::East);
+    }
+
+    // ---------- Phase 6: encoder_to_celestial ----------
+
+    #[test]
+    fn encoder_to_celestial_pre_flip_inverts_pre_flip_pipeline() {
+        // For pre-flip state (Dec encoder within ±90°), the helper
+        // must invert target_encoder_normal exactly.
+        let lst = 5.0;
+        for (ra, dec) in [(12.0, 30.0), (3.5, -45.0), (0.0, 0.0), (23.9, 89.9)] {
+            let (ra_ticks, dec_ticks) = target_encoder_normal(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_back, dec_back) =
+                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, 47.6);
+            assert!(
+                ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
+                "ra round-trip: {ra} → {ra_back}"
+            );
+            assert!(
+                (dec - dec_back).abs() < 1e-4,
+                "dec round-trip: {dec} → {dec_back}"
+            );
+        }
+    }
+
+    #[test]
+    fn encoder_to_celestial_post_flip_inverts_flipped_pipeline_north() {
+        // Plan §2.0 worked example, LAT 45°N: target HA = −0.5, dec
+        // = +45°. After a flip, the encoder lands at the flipped
+        // position; encoder_to_celestial must recover the celestial
+        // RA/Dec of the OTA pointing.
+        let lst = 5.0;
+        for (ra, dec) in [(lst + 0.5, 45.0), (lst - 0.3, 30.0), (lst, 0.0)] {
+            let (ra_ticks, dec_ticks) = target_encoder_flipped(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_back, dec_back) =
+                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, 47.6);
+            assert!(
+                ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
+                "post-flip ra round-trip: {ra} → {ra_back}"
+            );
+            assert!(
+                (dec - dec_back).abs() < 1e-4,
+                "post-flip dec round-trip: {dec} → {dec_back}"
+            );
+        }
+    }
+
+    #[test]
+    fn encoder_to_celestial_post_flip_inverts_flipped_pipeline_south() {
+        // Same flip round-trip but for a southern-hemisphere observer.
+        // The pre-flip side label inverts (pierEast in south), so the
+        // post-flip detection inverts too — `side_of_pier` does this
+        // internally and `encoder_to_celestial` consumes it.
+        let lst = 5.0;
+        for (ra, dec) in [(lst + 0.5, 45.0), (lst, -30.0), (lst, 0.0)] {
+            let (ra_ticks, dec_ticks) = target_encoder_flipped(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_back, dec_back) =
+                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, -33.0);
+            assert!(
+                ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
+                "south post-flip ra round-trip: {ra} → {ra_back}"
+            );
+            assert!(
+                (dec - dec_back).abs() < 1e-4,
+                "south post-flip dec round-trip: {dec} → {dec_back}"
+            );
+        }
+    }
+
+    #[test]
+    fn encoder_to_celestial_at_meridian_dec_zero_is_lst() {
+        // Encoder at (0, 0) means mech_HA = 0 and dec encoder = 0 →
+        // pre-flip pierWest in north → celestial (LST, 0).
+        let lst = 7.25;
+        let (ra, dec) = encoder_to_celestial(0, 0, lst, GTI_CPR, GTI_CPR, 47.6);
+        assert!((ra - lst).abs() < 1e-6, "ra = {ra}, expected {lst}");
+        assert!(dec.abs() < 1e-6, "dec = {dec}");
+    }
+
+    #[test]
+    fn encoder_to_celestial_at_post_flip_wrap_dec_pole_recovers_zero_dec() {
+        // Dec encoder at exactly +cpr/2 ticks (= ±180°, the encoder
+        // wrap). `dec_ticks_to_degrees` folds to -180; side_of_pier
+        // returns East in north (past 90°); celestial dec = -1 *
+        // (180 - 180) = 0. RA mapping uses the post-flip +12h shift.
+        let lst = 12.0;
+        let half_cpr = (GTI_CPR / 2) as i32;
+        let (_ra, dec) = encoder_to_celestial(0, half_cpr, lst, GTI_CPR, GTI_CPR, 47.6);
+        assert!(dec.abs() < 1e-6, "dec at wrap = {dec}");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -311,13 +311,17 @@ pub fn opposite_pier_side(side: PierSide) -> PierSide {
 /// [§"Pier-side decision tree"](../../../docs/services/star-adventurer-gti.md#pier-side-decision-tree)):
 ///
 /// 1. If `policy.enabled == false`, return `current` unchanged.
-/// 2. Compute the target's mechanical hour-angle from `target_ra`
-///    and `lst`.
-/// 3. If the *current* side's safety envelope covers `target_HA`,
-///    stay on the current side. The pre-flip side (`pierWest` in the
-///    Northern Hemisphere, `pierEast` in the Southern) covers
-///    `target_HA ∈ pre_flip_ra_hours_envelope`; the post-flip side
-///    covers `|target_HA| ≤ policy.flip_range_hours`.
+/// 2. Compute the target's celestial-HA and the resulting mech_HA on
+///    each pier side (`mech_HA_normal = HA`; `mech_HA_flipped = HA + 12`
+///    folded).
+/// 3. If the *current* side can reach the target without entering the
+///    counterweight binding zone, stay on the current side. For the
+///    pre-flip side that's `mech_HA_normal ∉ binding_zone`; for the
+///    post-flip side that's `|target_HA| ≤ flip_range_hours` (the
+///    operational rule that keeps the mount on flipped only briefly
+///    past the meridian — there's no mechanical reason to leave the
+///    flipped side at e.g. `mech_HA_flipped = 0` ≈ anti-meridian, but
+///    the operational convention is to flip back).
 /// 4. Otherwise return [`opposite_pier_side`]`(current)`.
 ///
 /// When `current` is [`PierSide::Unknown`] the helper returns
@@ -329,7 +333,7 @@ pub fn select_pier_side_for_target(
     lst_hours: f64,
     current: PierSide,
     policy: &FlipPolicy,
-    pre_flip_ra_hours_envelope: (f64, f64),
+    binding_zone_hours: (f64, f64),
     site_latitude_deg: f64,
 ) -> PierSide {
     if !policy.enabled {
@@ -346,9 +350,14 @@ pub fn select_pier_side_for_target(
         PierSide::East
     };
     let current_covers = if current == pre_flip_side {
-        let (lo, hi) = pre_flip_ra_hours_envelope;
-        (lo..=hi).contains(&target_ha)
+        // Natural side: mech_HA = celestial HA. "Covers" means not in
+        // binding zone — including the safe wrap region near ±12.
+        let (zone_min, zone_max) = binding_zone_hours;
+        !(zone_min <= zone_max && (zone_min..=zone_max).contains(&target_ha))
     } else {
+        // Post-flip side: operational rule, stay on flipped only near
+        // meridian. The binding zone for flipped-side mech_HA is
+        // separately enforced by `check_within_safe_envelope`.
         target_ha.abs() <= policy.flip_range_hours
     };
     if current_covers {
@@ -483,6 +492,13 @@ pub fn pulse_guide_step_period(sidereal_period: u32, rate_factor: f64) -> u32 {
         "rate_factor must be positive (got {rate_factor})"
     );
     ((sidereal_period as f64) / rate_factor).round() as u32
+}
+
+/// Fold an hour-angle value into `[-12, +12)`. Public helper so
+/// callers can compute "flipped" mech_HA = `fold_ha(mech_HA_normal + 12)`
+/// without re-deriving the modular-arithmetic convention.
+pub fn fold_ha(hours: f64) -> f64 {
+    fold_to_signed(hours, 24.0)
 }
 
 /// Fold a value into `[-period/2, +period/2)`. Used by both the RA and
@@ -929,7 +945,7 @@ mod tests {
             flip_range_hours: 0.5,
         }
     }
-    const NORTHERN_ENV: (f64, f64) = (-6.95, 6.95);
+    const BINDING_ZONE: (f64, f64) = (6.95, 11.05);
     const LAT_NORTH: f64 = 45.0;
     const LAT_SOUTH: f64 = -33.0;
 
@@ -941,7 +957,7 @@ mod tests {
         // means "leave the side alone".
         for current in [PierSide::West, PierSide::East, PierSide::Unknown] {
             let chosen =
-                select_pier_side_for_target(0.0, lst, current, &policy, NORTHERN_ENV, LAT_NORTH);
+                select_pier_side_for_target(0.0, lst, current, &policy, BINDING_ZONE, LAT_NORTH);
             assert_eq!(chosen, current, "current={current:?}");
         }
     }
@@ -956,7 +972,7 @@ mod tests {
             12.0,
             PierSide::Unknown,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::Unknown);
@@ -974,7 +990,7 @@ mod tests {
             lst,
             PierSide::West,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::West);
@@ -992,7 +1008,7 @@ mod tests {
             lst,
             PierSide::East,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::East);
@@ -1011,7 +1027,7 @@ mod tests {
             lst,
             PierSide::East,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::West);
@@ -1032,7 +1048,7 @@ mod tests {
             lst,
             PierSide::West,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::East);
@@ -1052,7 +1068,7 @@ mod tests {
             lst,
             PierSide::East,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::East);
@@ -1073,7 +1089,7 @@ mod tests {
             lst,
             PierSide::East,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_SOUTH,
         );
         assert_eq!(chosen, PierSide::East);
@@ -1084,7 +1100,7 @@ mod tests {
             lst,
             PierSide::West,
             &policy,
-            NORTHERN_ENV,
+            BINDING_ZONE,
             LAT_SOUTH,
         );
         assert_eq!(chosen, PierSide::East);

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -133,14 +133,18 @@ pub fn ra_to_mechanical_ha(ra_hours: f64, lst_hours: f64) -> f64 {
 /// Side-of-pier classification derived from the Dec-axis encoder
 /// position, the Dec-axis CPR, and the site latitude.
 ///
-/// ASCOM `PierSide::West` is the "normal" pointing state of a GEM
-/// (counterweight east, OTA on the west side of the pier);
-/// `PierSide::East` is the "beyond-the-pole" / post-meridian-flip
-/// state. For a Northern Hemisphere observer, the Dec encoder stays
-/// within ±90° (= `±cpr_dec/4` ticks) of home for any target reached
-/// without a meridian flip → `PierSide::West`. Once the mount rotates
-/// the Dec axis past the celestial pole (encoder magnitude past 90°)
-/// the OTA has crossed to the east side of the pier →
+/// Per the ASCOM spec, `pierEast` means "Through the Pole — the
+/// cross-axis (Dec) has rotated 180° from its initial pier side";
+/// `pierWest` is the "Normal pointing" state (cross-axis has not
+/// rotated 180°). It's an *operational* (pre-flip vs post-flip)
+/// classification of the Dec axis, not a geometric "OTA east of
+/// pier" classification of the saddle's mechanical position.
+///
+/// For a Northern Hemisphere observer, the Dec encoder stays within
+/// ±90° (= `±cpr_dec/4` ticks) of home for any target reached
+/// without a meridian flip → `PierSide::West`. Once the mount
+/// rotates the Dec axis past the celestial pole (encoder magnitude
+/// past 90°) the cross-axis has rotated through 180° →
 /// `PierSide::East`. Southern hemisphere inverts the convention.
 ///
 /// This is INDI eqmod's canonical GEM convention (see
@@ -148,27 +152,22 @@ pub fn ra_to_mechanical_ha(ra_hours: f64, lst_hours: f64) -> f64 {
 /// → `PIER_EAST`, equivalent to the magnitude-past-90° check applied
 /// to the signed encoder reading our driver carries).
 ///
-/// The earlier RA-meridian split (HA = 0) happens to return the same
-/// value as the Dec-encoder check for every pointing state reachable
-/// inside the safety envelope, which is why the two conventions
-/// agreed on the ConformU `SideofPier` cases the previous
-/// implementation passed. They diverge only when the mount has been
-/// manually positioned with the Dec encoder past the pole (e.g. a
-/// power-cycle with the OTA pointing through the pole); the
-/// Dec-encoder convention reports `PierSide::East` for that state,
-/// the HA convention misreports it as whichever side the RA encoder
-/// happens to sit on.
+/// Caveat: this differs from the AP "Park Positions Defined" naming,
+/// which labels poses by saddle position rather than dec-axis state.
+/// AP Park 1 N (saddle west, dec past pole) reports `pierEast`
+/// here; AP Park 5 N (saddle east, dec normal) reports `pierWest`.
+/// The encoder values for each park pose are still mechanically
+/// correct — only the operational-vs-geometric label disagrees.
 pub fn side_of_pier(dec_ticks: i32, cpr_dec: u32, site_latitude_deg: f64) -> PierSide {
     if cpr_dec == 0 {
         return PierSide::Unknown;
     }
     let quarter = (cpr_dec / 4) as i64;
     // Past-the-pole detection: |Dec encoder| > 90° means the mount
-    // has rotated the Dec axis beyond either celestial pole — which
-    // for a German Equatorial Mount means it is in the
-    // post-meridian-flip / counterweight-up state. The boundary at
-    // exactly ±90° is *not* East: the mount can sit at the pole via
-    // normal-pointing slews without a flip.
+    // has rotated the Dec axis beyond either celestial pole — the
+    // post-meridian-flip / cross-axis-rotated-180° state. The
+    // boundary at exactly ±90° is *not* East: the mount can sit at
+    // the pole via normal-pointing slews without a flip.
     let east_in_north = (dec_ticks as i64).abs() > quarter;
     let northern = site_latitude_deg >= 0.0;
     let east = if northern {

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -23,6 +23,7 @@ use erfars::constants::ERFA_DPI;
 use erfars::rotationtime::Gst06a;
 use erfars::timescales::{Dtf2d, Taitt, Utctai};
 
+use crate::config::FlipPolicy;
 use crate::error::{Result, StarAdvError};
 
 /// Convert RA-axis encoder ticks to a mechanical hour-angle in the range
@@ -189,6 +190,124 @@ pub fn mechanical_ha_to_ra_ticks(mech_ha_hours: f64, cpr: u32) -> i32 {
         return 0;
     }
     (mech_ha_hours * (cpr as f64) / 24.0).round() as i32
+}
+
+/// Compute the target's RA/Dec encoder pair for the "normal"
+/// (pre-flip) pointing state.
+///
+/// The RA encoder is mapped from the mechanical hour-angle
+/// `mech_HA = LST − target_RA` (signed, folded to `[−12, +12)`) and
+/// the Dec encoder is the celestial declination — the existing
+/// behaviour for every slew before Phase 6, extracted into a helper
+/// so [`target_encoder_flipped`] can share the structure.
+pub fn target_encoder_normal(
+    ra_hours: f64,
+    dec_degrees: f64,
+    lst_hours: f64,
+    cpr_ra: u32,
+    cpr_dec: u32,
+) -> (i32, i32) {
+    let mech_ha = ra_to_mechanical_ha(ra_hours, lst_hours);
+    let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, cpr_ra);
+    let dec_ticks = dec_degrees_to_ticks(dec_degrees, cpr_dec);
+    (ra_ticks, dec_ticks)
+}
+
+/// Compute the target's RA/Dec encoder pair for the "flipped"
+/// (post-meridian-flip) pointing state.
+///
+/// `mech_HA_flipped = mech_HA_normal + 12 h` (folded to `[−12, +12)`)
+/// puts the RA encoder at the mirror position across the encoder
+/// wrap at `±12 h`. `dec_encoder_flipped = sign(dec) · (180° − |dec|)`
+/// puts the Dec encoder past the celestial pole on the same
+/// hemispheric side — the OTA rotates through the pole to land on the
+/// other end of the Dec axis, keeping the OTA on the same celestial
+/// target while the counterweight crosses to the opposite side of the
+/// pier. See the design doc's
+/// [§"Meridian flip"](../../../docs/services/star-adventurer-gti.md#meridian-flip).
+///
+/// The `dec = 0` case is degenerate: `sign(0.0).signum()` is `+1.0`,
+/// so the flipped encoder lands at exactly `+180°` (or equivalently
+/// `−180°` after fold). Both encoder values reduce to the same
+/// physical mechanical position at the encoder wrap; downstream
+/// callers don't distinguish between them.
+pub fn target_encoder_flipped(
+    ra_hours: f64,
+    dec_degrees: f64,
+    lst_hours: f64,
+    cpr_ra: u32,
+    cpr_dec: u32,
+) -> (i32, i32) {
+    let mech_ha_normal = ra_to_mechanical_ha(ra_hours, lst_hours);
+    let mech_ha_flipped = fold_to_signed(mech_ha_normal + 12.0, 24.0);
+    let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha_flipped, cpr_ra);
+    let dec_flipped = dec_degrees.signum() * (180.0 - dec_degrees.abs());
+    let dec_ticks = dec_degrees_to_ticks(dec_flipped, cpr_dec);
+    (ra_ticks, dec_ticks)
+}
+
+/// Return the ASCOM-opposite pier side. `Unknown` maps to `Unknown`
+/// — the driver does not invent a side it has no information about.
+pub fn opposite_pier_side(side: PierSide) -> PierSide {
+    match side {
+        PierSide::West => PierSide::East,
+        PierSide::East => PierSide::West,
+        PierSide::Unknown => PierSide::Unknown,
+    }
+}
+
+/// Choose the target pier side for a slew (or for the
+/// `DestinationSideOfPier` prediction).
+///
+/// Decision tree (mirrors the design doc's
+/// [§"Pier-side decision tree"](../../../docs/services/star-adventurer-gti.md#pier-side-decision-tree)):
+///
+/// 1. If `policy.enabled == false`, return `current` unchanged.
+/// 2. Compute the target's mechanical hour-angle from `target_ra`
+///    and `lst`.
+/// 3. If the *current* side's safety envelope covers `target_HA`,
+///    stay on the current side. The pre-flip side (`pierWest` in the
+///    Northern Hemisphere, `pierEast` in the Southern) covers
+///    `target_HA ∈ pre_flip_ra_hours_envelope`; the post-flip side
+///    covers `|target_HA| ≤ policy.flip_range_hours`.
+/// 4. Otherwise return [`opposite_pier_side`]`(current)`.
+///
+/// When `current` is [`PierSide::Unknown`] the helper returns
+/// `Unknown` regardless of policy — the driver has no encoder
+/// classification to anchor a flip decision on. This mirrors how
+/// [`side_of_pier`] degrades when `cpr_dec == 0`.
+pub fn select_pier_side_for_target(
+    target_ra_hours: f64,
+    lst_hours: f64,
+    current: PierSide,
+    policy: &FlipPolicy,
+    pre_flip_ra_hours_envelope: (f64, f64),
+    site_latitude_deg: f64,
+) -> PierSide {
+    if !policy.enabled {
+        return current;
+    }
+    if current == PierSide::Unknown {
+        return PierSide::Unknown;
+    }
+    let target_ha = ra_to_mechanical_ha(target_ra_hours, lst_hours);
+    let northern = site_latitude_deg >= 0.0;
+    let pre_flip_side = if northern {
+        PierSide::West
+    } else {
+        PierSide::East
+    };
+    let current_covers = if current == pre_flip_side {
+        let (lo, hi) = pre_flip_ra_hours_envelope;
+        (lo..=hi).contains(&target_ha)
+    } else {
+        target_ha.abs() <= policy.flip_range_hours
+    };
+    if current_covers {
+        current
+    } else {
+        opposite_pier_side(current)
+    }
 }
 
 /// Convert a declination (degrees, `[-90, +90]`) to Dec-axis encoder ticks.
@@ -656,6 +775,278 @@ mod tests {
         let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
         let shifted = pulse_guide_step_period(p_sid, 0.1);
         assert_eq!(shifted, 10 * p_sid);
+    }
+
+    // ---------- Phase 6: target_encoder_{normal,flipped} ----------
+
+    #[test]
+    fn target_encoder_normal_matches_existing_ra_dec_to_ticks_pipeline() {
+        // The "normal" helper is the existing slew-issue pipeline,
+        // extracted. Targets at LST=12h, RA=12h → mech_HA=0 (meridian);
+        // any dec → encoder reflects that dec.
+        let (ra_ticks, dec_ticks) = target_encoder_normal(12.0, 30.0, 12.0, GTI_CPR, GTI_CPR);
+        assert_eq!(ra_ticks, 0);
+        // Dec encoder at 30° / 360° × CPR.
+        let expected_dec = (30.0 * (GTI_CPR as f64) / 360.0).round() as i32;
+        assert_eq!(dec_ticks, expected_dec);
+    }
+
+    #[test]
+    fn target_encoder_flipped_at_lat45_zenith_east_matches_plan_example() {
+        // Plan §2.0 worked example, LAT 45°N: target HA = −0.5,
+        // dec = +45°. Pre-flip mech_HA = −0.5, dec_enc = +45°. Post-flip
+        // mech_HA = +11.5, dec_enc = +135°.
+        let lst = 5.0; // arbitrary
+        let target_ra = lst + 0.5; // mech_HA = lst − ra = −0.5
+        let target_dec = 45.0;
+        let (ra_ticks, dec_ticks) =
+            target_encoder_flipped(target_ra, target_dec, lst, GTI_CPR, GTI_CPR);
+        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
+        let dec_enc_flipped = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        assert!(
+            (mech_ha_flipped - 11.5).abs() < 1e-6,
+            "expected mech_HA_flipped ≈ +11.5, got {mech_ha_flipped}"
+        );
+        assert!(
+            (dec_enc_flipped - 135.0).abs() < 1e-6,
+            "expected dec_enc_flipped ≈ +135°, got {dec_enc_flipped}"
+        );
+    }
+
+    #[test]
+    fn target_encoder_flipped_wraps_through_negative_for_positive_target_ha() {
+        // target_HA = +0.5 (just west of meridian). Pre-flip mech_HA =
+        // +0.5; post-flip = +0.5 + 12 = +12.5 → folds to −11.5.
+        let lst = 5.0;
+        let target_ra = lst - 0.5; // mech_HA = +0.5
+        let (ra_ticks, _dec) = target_encoder_flipped(target_ra, 30.0, lst, GTI_CPR, GTI_CPR);
+        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
+        assert!(
+            (mech_ha_flipped + 11.5).abs() < 1e-6,
+            "expected mech_HA_flipped ≈ −11.5, got {mech_ha_flipped}"
+        );
+    }
+
+    #[test]
+    fn target_encoder_flipped_at_meridian_lands_at_encoder_wrap() {
+        // target_HA = 0 (exact meridian). Post-flip mech_HA = 0 + 12 = 12
+        // → folds to −12 (per fold_to_signed's `folded >= half → −period`
+        // branch).
+        let lst = 5.0;
+        let target_ra = lst; // mech_HA = 0
+        let (ra_ticks, _) = target_encoder_flipped(target_ra, 30.0, lst, GTI_CPR, GTI_CPR);
+        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
+        assert!(
+            (mech_ha_flipped + 12.0).abs() < 1e-6 || (mech_ha_flipped - 12.0).abs() < 1e-6,
+            "expected mech_HA_flipped at the ±12 wrap, got {mech_ha_flipped}"
+        );
+    }
+
+    #[test]
+    fn target_encoder_flipped_dec_negative_target_flips_through_south_pole() {
+        // dec = −45° → flipped dec_enc = −(180 − 45) = −135°.
+        let (_, dec_ticks) = target_encoder_flipped(6.0, -45.0, 6.0, GTI_CPR, GTI_CPR);
+        let dec_enc = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        assert!(
+            (dec_enc + 135.0).abs() < 1e-6,
+            "expected dec_enc ≈ −135°, got {dec_enc}"
+        );
+    }
+
+    #[test]
+    fn target_encoder_flipped_dec_at_pole_stays_at_pole() {
+        // dec = +90° (celestial pole). Flipped encoder = sign(+90) ·
+        // (180 − 90) = +90. The pole is the same physical position
+        // whether you're flipped or not — only the OTA's rotation about
+        // its optical axis differs.
+        let (_, dec_ticks) = target_encoder_flipped(6.0, 90.0, 6.0, GTI_CPR, GTI_CPR);
+        let dec_enc = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        assert!(
+            (dec_enc - 90.0).abs() < 1e-6,
+            "expected dec_enc ≈ +90°, got {dec_enc}"
+        );
+    }
+
+    // ---------- Phase 6: select_pier_side_for_target ----------
+
+    fn flip_disabled() -> FlipPolicy {
+        FlipPolicy {
+            enabled: false,
+            flip_range_hours: 0.5,
+        }
+    }
+    fn flip_enabled() -> FlipPolicy {
+        FlipPolicy {
+            enabled: true,
+            flip_range_hours: 0.5,
+        }
+    }
+    const NORTHERN_ENV: (f64, f64) = (-6.95, 6.95);
+    const LAT_NORTH: f64 = 45.0;
+    const LAT_SOUTH: f64 = -33.0;
+
+    #[test]
+    fn select_pier_side_when_policy_disabled_returns_current() {
+        let policy = flip_disabled();
+        let lst = 12.0;
+        // Even with target way outside the pre-flip envelope, !enabled
+        // means "leave the side alone".
+        for current in [PierSide::West, PierSide::East, PierSide::Unknown] {
+            let chosen =
+                select_pier_side_for_target(0.0, lst, current, &policy, NORTHERN_ENV, LAT_NORTH);
+            assert_eq!(chosen, current, "current={current:?}");
+        }
+    }
+
+    #[test]
+    fn select_pier_side_returns_unknown_when_current_is_unknown() {
+        // No encoder info means no flip decision — even with the policy
+        // enabled, return Unknown.
+        let policy = flip_enabled();
+        let chosen = select_pier_side_for_target(
+            0.0,
+            12.0,
+            PierSide::Unknown,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::Unknown);
+    }
+
+    #[test]
+    fn select_pier_side_north_pierwest_stays_for_inside_pre_flip_envelope() {
+        // Northern hemisphere, currently on the "normal" (pre-flip) side
+        // = pierWest. Target HA = −3 (well inside [−6.95, +6.95]). Stay.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst + 3.0; // mech_HA = lst − ra = −3
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::West,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::West);
+    }
+
+    #[test]
+    fn select_pier_side_north_piereast_inside_flip_window_stays() {
+        // Currently pierEast (post-flip), target_HA inside the flip
+        // window. Stay flipped (no unnecessary flip back).
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst - 0.3; // mech_HA = +0.3 (within ±0.5)
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::East,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::East);
+    }
+
+    #[test]
+    fn select_pier_side_north_piereast_outside_flip_window_flips_back_to_west() {
+        // Currently pierEast (flipped), target outside the flip window
+        // but inside the pre-flip envelope. Auto-flip back to pierWest
+        // — the post-flip side cannot reach the target.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst + 3.0; // mech_HA = −3, outside ±0.5
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::East,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::West);
+    }
+
+    #[test]
+    fn select_pier_side_north_pierwest_outside_pre_flip_envelope_flips_to_east() {
+        // Currently pierWest, target HA past +6.95 (outside pre-flip
+        // envelope and outside the flip window). Selector returns the
+        // opposite side; subsequent envelope validation will reject the
+        // slew with INVALID_VALUE regardless, but the prediction is
+        // deterministic.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst - 7.5; // mech_HA = +7.5
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::West,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::East);
+    }
+
+    #[test]
+    fn select_pier_side_north_flip_window_boundary_at_exact_flip_range_is_covered() {
+        // |target_HA| = flip_range_hours exactly is on the *inclusive*
+        // edge of the post-flip safe band — staying flipped is
+        // valid. The slew planner's envelope check (issue-time)
+        // matches this boundary handling.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst - 0.5; // mech_HA = +0.5 = flip_range_hours
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::East,
+            &policy,
+            NORTHERN_ENV,
+            LAT_NORTH,
+        );
+        assert_eq!(chosen, PierSide::East);
+    }
+
+    #[test]
+    fn select_pier_side_southern_hemisphere_inverts_normal_side_label() {
+        // In the Southern Hemisphere the "normal" pointing maps to
+        // pierEast (Dec encoder within ±90° reads as East per the
+        // existing side_of_pier convention). So a target inside the
+        // pre-flip envelope on the current normal side means: current =
+        // pierEast → stay pierEast. Mirror of the Northern test above.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let target_ra = lst + 3.0; // mech_HA = −3
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::East,
+            &policy,
+            NORTHERN_ENV,
+            LAT_SOUTH,
+        );
+        assert_eq!(chosen, PierSide::East);
+        // And the post-flip side (pierWest in south): outside flip
+        // window means flip back to East (normal in south).
+        let chosen = select_pier_side_for_target(
+            target_ra,
+            lst,
+            PierSide::West,
+            &policy,
+            NORTHERN_ENV,
+            LAT_SOUTH,
+        );
+        assert_eq!(chosen, PierSide::East);
+    }
+
+    #[test]
+    fn opposite_pier_side_round_trips() {
+        assert_eq!(opposite_pier_side(PierSide::West), PierSide::East);
+        assert_eq!(opposite_pier_side(PierSide::East), PierSide::West);
+        assert_eq!(opposite_pier_side(PierSide::Unknown), PierSide::Unknown);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -12,8 +12,8 @@ pub mod transport;
 pub mod transport_manager;
 
 pub use config::{
-    load_config, Config, MountConfig, ServerConfig, TrackingRateName, TransportConfig, UdpConfig,
-    UsbConfig,
+    load_config, Config, FlipPolicy, MountConfig, ServerConfig, TrackingRateName, TransportConfig,
+    UdpConfig, UsbConfig, MAX_FLIP_RANGE_HOURS,
 };
 pub use error::{Result, StarAdvError};
 pub use mount_device::{

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -12,8 +12,8 @@ pub mod transport;
 pub mod transport_manager;
 
 pub use config::{
-    load_config, Config, FlipPolicy, MountConfig, ServerConfig, TrackingRateName, TransportConfig,
-    UdpConfig, UsbConfig, MAX_FLIP_RANGE_HOURS,
+    load_config, Config, FlipPolicy, HomePose, MountConfig, ServerConfig, TrackingRateName,
+    TransportConfig, UdpConfig, UsbConfig, MAX_FLIP_RANGE_HOURS,
 };
 pub use error::{Result, StarAdvError};
 pub use mount_device::{

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -522,8 +522,22 @@ impl MountDevice {
             } else {
                 ra_delta_canonical
             };
-            let dec_delta =
+            let dec_delta_canonical =
                 fold_delta_to_canonical(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
+            let dec_delta = if is_flip_slew {
+                // Flip slews force the Dec axis to traverse the
+                // visible celestial pole (NCP for north, SCP for
+                // south) rather than the below-horizon pole — see
+                // [`flip_slew_dec_delta`].
+                flip_slew_dec_delta(
+                    dec_delta_canonical,
+                    snap.dec.position_ticks,
+                    params.cpr_dec,
+                    self.config.site_latitude_deg >= 0.0,
+                )
+            } else {
+                dec_delta_canonical
+            };
             // Both axes use the INDI wire sequence: `:K` + poll `:f`
             // (decelerate stop) → `:G goto+fast` → `:I 6` → `:H |delta|`
             // → `:M breaks` → `:J`. The RA-axis `:K` is also the wire
@@ -731,6 +745,59 @@ fn flip_slew_ra_delta(canonical_delta: i32, cpr: u32) -> i32 {
         canonical_delta
     } else {
         canonical_delta - cpr_i
+    }
+}
+
+/// Force a flip slew's Dec delta to traverse the **visible** celestial
+/// pole rather than the below-horizon pole.
+///
+/// During a Dec flip-slew the encoder must cross one of the `±cpr/4`
+/// boundaries (the two celestial poles). For a polar-aligned mount,
+/// only ONE pole is above the local horizon: NCP at altitude `+lat`
+/// for northern observers (encoder `+cpr/4`), SCP at altitude `+|lat|`
+/// for southern (encoder `−cpr/4`). The other pole is below the
+/// horizon and the path through it dips the OTA below the local
+/// horizon — exactly the failure mode we hit during the first
+/// hardware validation when the OTA was driven through SCP at LAT
+/// 32.7°N. (The fold-canonical-delta's boundary case at exactly
+/// `±cpr/2` produces the negative direction, which from `encoder = 0`
+/// pre-flip routes the Dec axis through SCP.)
+///
+/// Rule, expressed in encoder side:
+///
+/// - **Northern** observer:
+///   - `current` in the *pre-flip* half (`|enc| ≤ cpr/4`): force CW
+///     (positive delta) — the path increases toward `+cpr/4` (NCP).
+///   - `current` in the *post-flip* half (`|enc| > cpr/4`): force
+///     CCW (negative delta) — the path decreases back through
+///     `+cpr/4` (NCP).
+/// - **Southern** observer: inverse — the safe pole is `−cpr/4`
+///   (SCP) so the directions flip.
+///
+/// When the canonical shortest path already goes the safe direction,
+/// it's returned unchanged. When it doesn't, the long way around
+/// (`delta − cpr` or `delta + cpr`) lands at the same modular
+/// destination via the safe pole.
+fn flip_slew_dec_delta(
+    canonical_delta: i32,
+    current_ticks: i32,
+    cpr_dec: u32,
+    northern: bool,
+) -> i32 {
+    if cpr_dec == 0 || canonical_delta == 0 {
+        return canonical_delta;
+    }
+    let cpr_i = cpr_dec as i32;
+    let quarter = cpr_i / 4;
+    let in_pre_flip = current_ticks.abs() <= quarter;
+    let safe_direction_positive = if northern { in_pre_flip } else { !in_pre_flip };
+    let canonical_positive = canonical_delta > 0;
+    if canonical_positive == safe_direction_positive {
+        canonical_delta
+    } else if canonical_delta > 0 {
+        canonical_delta - cpr_i
+    } else {
+        canonical_delta + cpr_i
     }
 }
 
@@ -4963,6 +5030,173 @@ mod tests {
     #[test]
     fn flip_slew_ra_delta_handles_zero_cpr_defensively() {
         assert_eq!(flip_slew_ra_delta(12_345, 0), 12_345);
+    }
+
+    // ---------- flip_slew_dec_delta (Dec routing through the visible pole) ----------
+
+    /// Trace the absolute encoder traversal range from `start` by `delta`
+    /// and report `true` iff the trajectory crosses `pole_ticks` (the
+    /// unsafe-pole position) on its way to the end.
+    fn path_crosses_pole(start: i32, delta: i32, pole_ticks: i32, cpr: u32) -> bool {
+        let cpr_i = cpr as i32;
+        let end = start + delta;
+        let (lo, hi) = if end >= start {
+            (start, end)
+        } else {
+            (end, start)
+        };
+        // Test all modular replicas of `pole_ticks` that could fall in
+        // `[lo, hi]`. Since `|delta| ≤ cpr`, at most one replica matters.
+        (-2..=2).any(|k| {
+            let p = pole_ticks + k * cpr_i;
+            p >= lo && p <= hi
+        })
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_park3_start_to_post_flip_positive_uses_natural_cw() {
+        // Park 3: start at encoder +cpr/4 (= +90°, NCP). Target = +135°
+        // encoder = +3*cpr/8 (celestial dec = +45° on the flipped side).
+        // Natural delta = +cpr/8 (positive CW). Path stays in upper
+        // half, doesn't touch SCP. Use canonical.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = quarter; // +90° encoder
+        let target = (cpr as f64 * 3.0 / 8.0).round() as i32; // +135°
+        let canonical = target - current; // +cpr/8
+        assert_eq!(
+            flip_slew_dec_delta(canonical, current, cpr, true),
+            canonical,
+            "Park 3 → +135° should use the natural CW direction"
+        );
+        // Confirm the path avoids SCP (-cpr/4).
+        let issued = flip_slew_dec_delta(canonical, current, cpr, true);
+        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_pre_flip_zero_to_post_flip_dec_zero_takes_long_way() {
+        // The bug case from the first hardware run: starting at encoder
+        // = 0 (codebase historical home), the canonical fold of a slew
+        // to dec_encoder = ±cpr/2 returns negative (CCW), which routes
+        // the Dec axis through −cpr/4 (SCP, below horizon for north).
+        // The fix forces the CW long way through +cpr/4 (NCP).
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let half_cpr = cpr as i32 / 2;
+        let canonical = -half_cpr; // post-flip target for celestial dec = 0
+        let issued = flip_slew_dec_delta(canonical, 0, cpr, true);
+        assert_eq!(issued, half_cpr, "must force CW through NCP");
+        // Verify path crosses NCP and not SCP.
+        assert!(path_crosses_pole(0, issued, quarter, cpr));
+        assert!(!path_crosses_pole(0, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_flip_back_from_upper_post_flip_uses_natural_ccw() {
+        // Flip-back: starting at encoder +3*cpr/8 (= +135°, upper
+        // post-flip), target = 0 (pre-flip celestial equator). Natural
+        // CCW (negative direction) crosses +cpr/4 (NCP). Don't take
+        // the long way — CCW is safe here.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = (cpr as f64 * 3.0 / 8.0).round() as i32;
+        let target = 0;
+        let canonical = target - current; // negative
+        let issued = flip_slew_dec_delta(canonical, current, cpr, true);
+        assert_eq!(
+            issued, canonical,
+            "flip-back from +135° must use natural CCW"
+        );
+        // Verify path crosses NCP (the safe pole) and not SCP.
+        assert!(path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_below_equator_pre_flip_to_post_flip_positive_uses_cw() {
+        // Pre-flip but below celestial equator: encoder = -cpr/8
+        // (= -45°). Target = +3*cpr/8 (= +135° encoder, post-flip
+        // dec=+45). CW path: -45 → 0 → +90 (NCP) → +135. SAFE.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = -(cpr as i32 / 8);
+        let target = (cpr as i32 * 3) / 8;
+        let canonical = target - current; // positive, half cpr
+        let issued = flip_slew_dec_delta(canonical, current, cpr, true);
+        assert_eq!(issued, canonical, "natural CW direction is safe");
+        assert!(path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_below_equator_pre_flip_to_post_flip_negative_forces_long_cw() {
+        // Pre-flip below equator: encoder = -cpr/8. Target =
+        // -3*cpr/8 (post-flip negative). Natural CCW (negative) path:
+        // -cpr/8 → -cpr/4 (SCP) → -3*cpr/8. UNSAFE. Force long-way CW:
+        // -cpr/8 → +cpr/4 (NCP) → +cpr/2 → wraps → -3*cpr/8. SAFE.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = -(cpr as i32 / 8);
+        let target_canonical = -(cpr as i32 * 3) / 8;
+        let canonical = target_canonical - current; // negative
+        let issued = flip_slew_dec_delta(canonical, current, cpr, true);
+        // Forced to positive direction (long way).
+        assert!(issued > 0);
+        // Lands at the same modular destination.
+        assert_eq!((issued - canonical).rem_euclid(cpr as i32), 0);
+        // Path crosses NCP, not SCP.
+        assert!(path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_north_lower_post_flip_to_pre_flip_uses_ccw_through_wrap() {
+        // Lower post-flip: encoder = -3*cpr/8 (= -135°, celestial
+        // dec=-45 on post-flip side). Target = 0 (pre-flip equator).
+        // Natural CW (positive) path: -3*cpr/8 → -cpr/4 (SCP) → 0.
+        // UNSAFE. Force CCW (negative) long-way: -3*cpr/8 →
+        // -cpr/2 → wraps → +cpr/2 → +cpr/4 (NCP) → 0. SAFE.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = -((cpr as i32 * 3) / 8);
+        let canonical = 0 - current; // positive
+        let issued = flip_slew_dec_delta(canonical, current, cpr, true);
+        assert!(issued < 0, "must force CCW long way");
+        assert_eq!((issued - canonical).rem_euclid(cpr as i32), 0);
+        assert!(path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_south_inverts_safe_pole() {
+        // Southern observer: SCP is visible, NCP is below horizon.
+        // Repeat the "park 3 start" case but with southern config:
+        // start at encoder = -cpr/4 (Park 3 south = SCP). Target =
+        // -3*cpr/8. Natural CCW (negative). Should be used as-is.
+        let cpr = GTI_CPR;
+        let quarter = cpr as i32 / 4;
+        let current = -quarter; // SCP for southern Park 3
+        let target = -((cpr as i32 * 3) / 8);
+        let canonical = target - current; // negative
+        let issued = flip_slew_dec_delta(canonical, current, cpr, false);
+        assert_eq!(
+            issued, canonical,
+            "south Park 3 → -3cpr/8 must use natural CCW"
+        );
+        // For south, the unsafe pole is +cpr/4 (NCP). Verify path
+        // doesn't cross it.
+        assert!(!path_crosses_pole(current, issued, quarter, cpr));
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_handles_zero_cpr_defensively() {
+        assert_eq!(flip_slew_dec_delta(12_345, 0, 0, true), 12_345);
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_zero_canonical_returns_zero() {
+        assert_eq!(flip_slew_dec_delta(0, 0, GTI_CPR, true), 0);
     }
 
     // ---------- Phase 6: SetSideOfPier + CanSetPierSide ----------

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -518,7 +518,7 @@ impl MountDevice {
                 // through the negative-mech_HA half — see
                 // [`flip_slew_ra_delta`] and the design doc's
                 // [§"Through-wrap slew routing"](../../../docs/services/star-adventurer-gti.md#through-wrap-slew-routing).
-                flip_slew_ra_delta(ra_delta_canonical, params.cpr_ra)
+                flip_slew_ra_delta(ra_delta_canonical, snap.ra.position_ticks, params.cpr_ra)
             } else {
                 ra_delta_canonical
             };
@@ -720,31 +720,49 @@ fn fold_delta_to_canonical(delta: i32, cpr: u32) -> i32 {
     }
 }
 
-/// Force a flip slew's RA delta to traverse the safe (negative)
-/// `mech_HA` half so the counterweight stays clear of the binding
-/// region at `mech_HA ∈ (+6.95, +11.05)`.
+/// Force a flip slew's RA delta to keep the encoder in the
+/// counterweight-below-horizon half of the RA axis (`mech_HA` in
+/// `[−12, 0]`), avoiding the binding region at `mech_HA ∈ (+6.95,
+/// +11.05)` where the counterweight contacts the pier.
 ///
-/// The mechanical binding zone is at positive `mech_HA`
-/// (counterweight above local horizon for any latitude — the binding
-/// is structural, not horizon-dependent). The safe through-wrap route
-/// keeps the encoder in the negative `mech_HA` half, equivalently:
-/// the RA encoder must decrease (CCW direction). If the canonical
-/// shortest path already decreases, use it; otherwise take the long
-/// way (`delta − cpr`) which has the same end position via the
-/// encoder wrap and the safe CCW direction.
+/// The mechanical binding zone is at positive `mech_HA` and is a
+/// structural property of the mount head independent of observer
+/// latitude. Both forward flips (pre-flip → post-flip) and flip-backs
+/// (post-flip → pre-flip) need their RA paths constrained.
 ///
-/// Northern + Southern hemispheres share this rule: the GTi's binding
-/// is a mechanical property of the mount head independent of
-/// observer latitude.
-fn flip_slew_ra_delta(canonical_delta: i32, cpr: u32) -> i32 {
-    if cpr == 0 {
+/// Rule, expressed by current encoder position:
+///
+/// - `|current_ticks| ≤ cpr/4` (current in the pre-flip envelope,
+///   `mech_HA ∈ [−6, +6]`): force CCW (negative delta). The path
+///   decreases from the safe arc into the negative half, ending in
+///   either `[−6.95, +6.95]` (no-flip target) or near `±cpr/2`
+///   (post-flip wrap).
+/// - `|current_ticks| > cpr/4` (current at or past the wrap,
+///   `mech_HA` near `±12`): force CW (positive delta). The path
+///   increases away from the wrap into the safe negative half. Going
+///   CCW here would step *back across the wrap* into the positive
+///   half and through the binding zone — what hardware validation
+///   #3 exposed.
+///
+/// When the canonical shortest-path direction is already the forced
+/// one, it's returned unchanged. Otherwise the long way around
+/// (`delta − cpr` or `delta + cpr`) lands at the same modular
+/// destination via the safe half.
+fn flip_slew_ra_delta(canonical_delta: i32, current_ticks: i32, cpr: u32) -> i32 {
+    if cpr == 0 || canonical_delta == 0 {
         return canonical_delta;
     }
     let cpr_i = cpr as i32;
-    if canonical_delta <= 0 {
+    let quarter = cpr_i / 4;
+    let in_pre_flip = current_ticks.abs() <= quarter;
+    let safe_direction_positive = !in_pre_flip;
+    let canonical_positive = canonical_delta > 0;
+    if canonical_positive == safe_direction_positive {
         canonical_delta
-    } else {
+    } else if canonical_delta > 0 {
         canonical_delta - cpr_i
+    } else {
+        canonical_delta + cpr_i
     }
 }
 
@@ -4972,50 +4990,72 @@ mod tests {
     }
 
     #[test]
-    fn flip_slew_ra_delta_keeps_negative_delta_intact() {
-        // Canonical CCW (negative) → already on safe direction.
-        let delta = -1_000_000_i32;
-        assert_eq!(flip_slew_ra_delta(delta, GTI_CPR), delta);
+    fn flip_slew_ra_delta_forward_flip_from_pre_flip_zero_uses_natural_ccw() {
+        // Forward flip starting at encoder ≈ 0 (mech_HA ≈ 0, pre-flip
+        // pierWest at meridian). Target = −cpr/2 (post-flip wrap).
+        // Canonical CCW; path stays in negative half. Safe.
+        let cpr = GTI_CPR;
+        let current = 0;
+        let canonical = -(cpr as i32 / 2);
+        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        assert_eq!(issued, canonical, "natural CCW already in the safe half");
     }
 
     #[test]
-    fn flip_slew_ra_delta_inverts_positive_canonical_delta_to_long_way() {
-        // Canonical CW (positive) → must be flipped to long way through
-        // the wrap (CCW, magnitude = cpr − natural).
-        let delta = 1_000_000_i32; // +0.55 cpr
-        let flipped = flip_slew_ra_delta(delta, GTI_CPR);
-        assert_eq!(flipped, delta - GTI_CPR as i32);
-        assert!(flipped < 0, "must be CCW after the flip");
-        // Same destination, modular.
+    fn flip_slew_ra_delta_forward_flip_target_minus_half_h_takes_long_way() {
+        // The plan §2.0 canonical case: pre-flip mech_HA = −0.5, target
+        // post-flip mech_HA = +11.5, canonical = +cpr*11.5/24 -
+        // (-cpr*0.5/24) = +cpr/2 + small. (Approximated by +1.815M
+        // ticks at cpr_ra = 3.6288M.) Force CCW long way through the
+        // wrap.
+        let cpr = GTI_CPR;
+        let current = -75_600; // mech_HA = -0.5
+        let canonical = 1_815_000_i32;
+        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        assert!(issued < 0, "must force CCW long way");
         assert_eq!(
-            (flipped - delta).rem_euclid(GTI_CPR as i32),
+            (issued - canonical).rem_euclid(cpr as i32),
             0,
             "same modular destination"
         );
     }
 
     #[test]
-    fn flip_slew_ra_delta_at_meridian_target_lands_on_negative_half() {
-        // Plan §2.0 canonical case: current encoder near 0 (pre-flip
-        // pierWest at meridian), target encoder = −cpr/2 (post-flip
-        // mech_HA = −12, the boundary). Natural CCW direction, already
-        // safe.
-        let delta = -(GTI_CPR as i32 / 2);
-        assert_eq!(flip_slew_ra_delta(delta, GTI_CPR), delta);
+    fn flip_slew_ra_delta_flip_back_from_minus_half_cpr_uses_natural_cw() {
+        // Flip-back: current at raw -cpr/2 (post-flip wrap, mech_HA = -12).
+        // Target = -cpr/4 (Park 3, mech_HA = -6). Canonical = +cpr/4
+        // (positive CW). The path is mech_HA -12 → -11 → ... → -6,
+        // entirely in the safe negative half. Use canonical.
+        //
+        // Regression for hardware validation #3: my prior `always CCW`
+        // rule forced -3*cpr/4 here, routing through +6 to +9 binding
+        // zone and slamming the CW shaft into the pier.
+        let cpr = GTI_CPR;
+        let current = -(cpr as i32 / 2);
+        let canonical = cpr as i32 / 4;
+        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        assert_eq!(
+            issued, canonical,
+            "flip-back from -cpr/2 must use natural CW"
+        );
+        assert!(issued > 0);
     }
 
     #[test]
-    fn flip_slew_ra_delta_for_target_ha_minus_half_takes_long_way() {
-        // target_HA = −0.5: post-flip mech_HA = +11.5, encoder ≈
-        // +1.74M. Current ≈ −75K. Natural delta = +1.815M (CW,
-        // through binding zone). Flip-aware must invert to CCW.
-        let natural = 1_815_000_i32;
-        let flipped = flip_slew_ra_delta(natural, GTI_CPR);
-        assert!(flipped < 0);
-        assert_eq!(
-            flipped.unsigned_abs(),
-            (GTI_CPR as i32 - natural).unsigned_abs()
-        );
+    fn flip_slew_ra_delta_flip_back_from_plus_half_cpr_forces_cw_through_wrap() {
+        // Flip-back from raw +cpr/2 (mech_HA = +12 = -12 modular,
+        // post-flip wrap from the other direction). Target = -cpr/4.
+        // Canonical = -cpr/4 - +cpr/2 = -3cpr/4 → fold to +cpr/4 (CW,
+        // because |−3cpr/4| > half_cpr). Force CW; path stays in safe
+        // half going from +cpr/2 → +cpr/2 + cpr/4 = +3cpr/4 raw
+        // (modular: -cpr/4 = mech_HA -6).
+        let cpr = GTI_CPR;
+        let current = cpr as i32 / 2;
+        let canonical_raw = -(cpr as i32 / 4) - current; // -3cpr/4
+        let canonical = fold_delta_to_canonical(canonical_raw, cpr); // +cpr/4
+        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        assert!(issued > 0, "post-flip wrap → safe arc must use CW");
+        assert_eq!(issued, canonical, "canonical CW is already safe here");
     }
 
     #[test]
@@ -5029,7 +5069,12 @@ mod tests {
 
     #[test]
     fn flip_slew_ra_delta_handles_zero_cpr_defensively() {
-        assert_eq!(flip_slew_ra_delta(12_345, 0), 12_345);
+        assert_eq!(flip_slew_ra_delta(12_345, 0, 0), 12_345);
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_zero_canonical_returns_zero() {
+        assert_eq!(flip_slew_ra_delta(0, 0, GTI_CPR), 0);
     }
 
     // ---------- flip_slew_dec_delta (Dec routing through the visible pole) ----------

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -39,6 +39,18 @@ use crate::transport_manager::{MountSnapshot, TransportManager};
 /// `GuideRateRightAscension` / `GuideRateDeclination`.
 const DEFAULT_GUIDE_RATE_FRACTION: f64 = 0.5;
 
+/// Maximum absolute encoder reading at connect that
+/// [`MountDevice::seed_home_pose_after_connect`] still treats as
+/// "fresh power-up" and applies the `home_pose` seed to. The
+/// Sky-Watcher firmware does not always read exactly `0` after a
+/// power-cycle — empirically the validation GTi reports `dec = −1`
+/// on connect, a single-tick initialisation artifact (≈ 0.4″ at the
+/// GTi's CPR). Any genuine post-slew encoder reading is tens of
+/// thousands of ticks away from zero, so this tolerance comfortably
+/// distinguishes "just powered up" from "the operator already moved
+/// the mount this session".
+const FRESH_POWER_UP_TICK_TOLERANCE: i32 = 100;
+
 /// In-memory mirror of latched-from-the-client state (Tracking enabled,
 /// AtPark flag, last target). The values that come from the wire (current
 /// RA/Dec, Slewing) are read through [`TransportManager`].
@@ -379,14 +391,21 @@ impl MountDevice {
     /// Skipped when:
     /// - The home pose is the codebase default (no offset needed).
     /// - The firmware reports a non-zero encoder reading at connect
-    ///   time. That indicates the mount has already been slewed or
-    ///   synced this power cycle — re-seeding would clobber it.
+    ///   time **beyond a small fresh-power-up tolerance**. That
+    ///   indicates the mount has already been slewed or synced this
+    ///   power cycle — re-seeding would clobber it. The tolerance
+    ///   exists because the Sky-Watcher firmware does not always
+    ///   read exactly `(0, 0)` after a power-cycle: on the validation
+    ///   GTi we observed `dec = −1` on fresh power-up, a 1-tick
+    ///   initialisation artifact (~0.4″) that obviously still
+    ///   represents the "just powered up" state.
     ///
     /// Documented operator assumption: when `home_pose != default`,
     /// the operator powers up the mount **at** the configured pose and
     /// connects the driver before any slew or sync. Reconnecting
     /// mid-session after a slew is safe (the non-zero-encoder guard
-    /// catches it).
+    /// catches it — a real slew lands tens of thousands of ticks away
+    /// from zero, well outside the tolerance).
     async fn seed_home_pose_after_connect(&self) -> ASCOMResult<()> {
         let Some(home_pose) = self.config.home_pose else {
             // No pose configured — trust the firmware encoder as-is.
@@ -400,11 +419,14 @@ impl MountDevice {
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         let snap = self.transport.snapshot().await;
-        if snap.ra.position_ticks != 0 || snap.dec.position_ticks != 0 {
+        if snap.ra.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
+            || snap.dec.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
+        {
             debug!(
                 ra = snap.ra.position_ticks,
                 dec = snap.dec.position_ticks,
-                "skipping home_pose encoder seed: firmware encoder is non-zero"
+                tolerance = FRESH_POWER_UP_TICK_TOLERANCE,
+                "skipping home_pose encoder seed: firmware encoder is non-zero beyond tolerance"
             );
             return Ok(());
         }
@@ -4444,6 +4466,67 @@ mod tests {
         d.set_connected(true).await.unwrap();
         let s = d.state.read().await;
         assert_eq!(s.park_ra_ticks, Some(0));
+        assert_eq!(s.park_dec_ticks, Some(0));
+    }
+
+    #[tokio::test]
+    async fn home_pose_seed_fires_when_firmware_reports_near_zero_encoder() {
+        // Sky-Watcher firmware does not always read exactly (0, 0)
+        // after a power-cycle: the validation GTi reports dec = -1 on
+        // fresh power-up. Without the FRESH_POWER_UP_TICK_TOLERANCE
+        // guard the strict `!= 0` check would skip the seed and the
+        // mount would silently end up with a wrong celestial mapping
+        // (and a wrong Park target via the snapshot fallback).
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        // Force the dec encoder to a 1-tick fresh-power-up artifact
+        // before the manager opens the transport.
+        {
+            let mut state = factory.mock.state.lock().await;
+            state.dec.position_ticks = -1;
+        }
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+        cfg.mount.site_latitude_deg = 32.7157;
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        // ApPark3 N hemisphere with mock cpr = 0x375F00 = 3,628,800:
+        // expected seed → ra_ticks = -907,200, dec_ticks = +907,200.
+        // If the seed had been skipped, the park target would be
+        // (0, -1) (the pre-seed snapshot).
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(-907200));
+        assert_eq!(s.park_dec_ticks, Some(907200));
+    }
+
+    #[tokio::test]
+    async fn home_pose_seed_skips_when_firmware_encoder_beyond_tolerance() {
+        // A real post-slew encoder is tens of thousands of ticks away
+        // from zero — well beyond FRESH_POWER_UP_TICK_TOLERANCE. The
+        // seed must skip in that case so a mid-session reconnect does
+        // not clobber the operator's slewed-to position.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        {
+            let mut state = factory.mock.state.lock().await;
+            state.ra.position_ticks = 50_000;
+        }
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+        cfg.mount.site_latitude_deg = 32.7157;
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        // Seed skipped → park target falls back to the snapshot (the
+        // pre-seed handshake reading), so park_ra_ticks should equal
+        // the firmware's reported 50,000 (not -907,200).
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(50_000));
         assert_eq!(s.park_dec_ticks, Some(0));
     }
 

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -196,18 +196,28 @@ impl MountDevice {
     /// a hard stop while the encoder counter continues to advance.
     /// On a real-hardware ConformU run that drove the mount into the
     /// counterweight-up region we heard the motor whine and saw the
-    /// axis stop physically for several seconds at a time. The
-    /// configured `ra_min_hours` / `ra_max_hours` (pre-flip side) and
-    /// `flip_policy.flip_range_hours` (post-flip side) express the
-    /// safe envelopes; any target outside the relevant one is
-    /// rejected with `INVALID_VALUE` and never reaches the wire.
+    /// axis stop physically for several seconds at a time.
     ///
-    /// Operates on celestial RA/Dec + LST + `target_is_flipped` rather
-    /// than encoder ticks: the post-flip target encoder lands past the
-    /// celestial pole on the Dec axis (the dec ticks themselves are
-    /// outside `[-cpr_dec/4, +cpr_dec/4]`), so a ticks-based bound
-    /// would falsely reject every flipped target. The celestial-dec
-    /// range check is the actual safety invariant.
+    /// The check is in **encoder `mech_HA` space** (signed hours
+    /// folded to `[−12, +12)`). For a target on the natural pier
+    /// side, `target_mech_HA = celestial_HA`. For a flipped target,
+    /// `target_mech_HA = celestial_HA + 12 h` folded. If the chosen-
+    /// side `mech_HA` falls inside the configured binding zone
+    /// `[binding_zone_min_hours, binding_zone_max_hours]`, the slew
+    /// is rejected with `INVALID_VALUE`.
+    ///
+    /// Note: this is a *destination-only* check (matching INDI EQMOD's
+    /// `EncoderTarget`-style envelope). The slew path is not analysed;
+    /// the slew-direction logic in
+    /// [`flip_slew_ra_delta`](#flip_slew_ra_delta) and the per-axis
+    /// `ccw = current > target` rule in `execute_slew_with_explicit_side`
+    /// pick the safe direction.
+    ///
+    /// `flip_policy.flip_range_hours` is **not** consulted here — that
+    /// rule lives in [`select_pier_side_for_target`] for pier-side
+    /// preference only. Park 1 / Park 5 (anti-meridian poses with
+    /// `mech_HA = ±12` on the chosen pier) are reachable via slew
+    /// because their mech_HA is outside the binding zone.
     ///
     /// Both axes are validated together so a partial-failure slew
     /// can't issue motion on RA before discovering Dec is out of
@@ -219,24 +229,22 @@ impl MountDevice {
         lst_hours: f64,
         target_is_flipped: bool,
     ) -> ASCOMResult<()> {
-        let target_ha = ra_to_mechanical_ha(ra_hours, lst_hours);
-        if target_is_flipped {
-            let flip_range = self.config.flip_policy.flip_range_hours;
-            if target_ha.abs() > flip_range {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_VALUE,
-                    format!(
-                        "flipped target_HA {target_ha:.3} h outside flip window \
-                         [-{flip_range}, +{flip_range}] h"
-                    ),
-                ));
+        let target_mech_ha = {
+            let normal = ra_to_mechanical_ha(ra_hours, lst_hours);
+            if target_is_flipped {
+                crate::coordinates::fold_ha(normal + 12.0)
+            } else {
+                normal
             }
-        } else if !(self.config.ra_min_hours..=self.config.ra_max_hours).contains(&target_ha) {
+        };
+        let zone_min = self.config.binding_zone_min_hours;
+        let zone_max = self.config.binding_zone_max_hours;
+        if zone_min <= zone_max && (zone_min..=zone_max).contains(&target_mech_ha) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_VALUE,
                 format!(
-                    "RA target_HA {target_ha:.3} h outside safe envelope [{}, {}] h",
-                    self.config.ra_min_hours, self.config.ra_max_hours
+                    "target mech_HA {target_mech_ha:.3} h is inside the counterweight \
+                     binding zone [{zone_min}, {zone_max}] h"
                 ),
             ));
         }
@@ -1334,7 +1342,10 @@ impl Telescope for MountDevice {
             lst,
             current_side,
             &self.config.flip_policy,
-            (self.config.ra_min_hours, self.config.ra_max_hours),
+            (
+                self.config.binding_zone_min_hours,
+                self.config.binding_zone_max_hours,
+            ),
             self.config.site_latitude_deg,
         );
         let pre_flip_side = if self.config.site_latitude_deg >= 0.0 {
@@ -1584,7 +1595,10 @@ impl Telescope for MountDevice {
             lst,
             current_side,
             &self.config.flip_policy,
-            (self.config.ra_min_hours, self.config.ra_max_hours),
+            (
+                self.config.binding_zone_min_hours,
+                self.config.binding_zone_max_hours,
+            ),
             self.config.site_latitude_deg,
         );
         self.execute_slew_with_explicit_side(ra, dec, chosen_side)
@@ -2923,8 +2937,9 @@ mod tests {
         let mut cfg = Config::default();
         // Same rationale as `fast_settle_device`: open the
         // mechanical-envelope check for tests that don't exercise it.
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(
             cfg.clone(),
             Arc::new(MockTransportFactory),
@@ -3227,8 +3242,9 @@ mod tests {
         // envelope all the way for these tests; the safety-gate
         // behaviour is covered separately by
         // [`fast_settle_connected_narrow_envelope`].
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(
             cfg.clone(),
             Arc::new(MockTransportFactory),
@@ -3242,19 +3258,24 @@ mod tests {
         d
     }
 
-    /// Like `fast_settle_connected`, but with a narrow mechanical
-    /// envelope so the safety-gate tests can land target coords
-    /// that are clearly outside the envelope without first needing
-    /// to push past the GTi default `±6.95h` / `±90°`.
+    /// Like `fast_settle_connected`, but with a narrow safety
+    /// configuration (a small binding zone + tight Dec range) so the
+    /// safety-gate tests can land target coords that are clearly
+    /// inside the binding zone or outside the Dec band without first
+    /// needing to push past the GTi default `(6.95, 11.05)` /
+    /// `±90°`.
     async fn fast_settle_connected_narrow_envelope() -> MountDevice {
         let mut cfg = Config::default();
         if let crate::config::TransportConfig::Usb(usb) = &mut cfg.transport {
             usb.polling_interval = Duration::from_millis(20);
         }
         cfg.mount.settle_after_slew = Duration::from_millis(0);
-        // Allow exactly the meridian band ±1 h of HA / ±5° of Dec.
-        cfg.mount.ra_min_hours = -1.0;
-        cfg.mount.ra_max_hours = 1.0;
+        // Narrow binding zone covering `mech_HA ∈ [0.5, 1.5] h` so a
+        // target 1 h past meridian on the natural side is inside it,
+        // and tight Dec band `[-5°, +5°]` so off-equator targets are
+        // rejected.
+        cfg.mount.binding_zone_min_hours = 0.5;
+        cfg.mount.binding_zone_max_hours = 1.5;
         cfg.mount.dec_min_degrees = -5.0;
         cfg.mount.dec_max_degrees = 5.0;
         let manager = Arc::new(TransportManager::new(
@@ -3284,14 +3305,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slew_async_refuses_ra_outside_safe_envelope() {
-        // Envelope: HA in [-1 h, +1 h]. Target RA = LST + 3 h puts
-        // mech-HA at -3 h — well outside.
+    async fn slew_async_refuses_ra_target_in_binding_zone() {
+        // Binding zone covers `mech_HA ∈ [0.5, 1.5] h`. Target RA =
+        // LST − 1 puts `mech_HA = LST − (LST − 1) = +1 h` — squarely
+        // in the middle of the zone, so the slew must be rejected
+        // with `INVALID_VALUE` before any wire motion.
         let d = fast_settle_connected_narrow_envelope().await;
         let lst = d.sidereal_time().await.unwrap();
-        let target = (lst + 3.0).rem_euclid(24.0);
+        let target = (lst - 1.0).rem_euclid(24.0);
         let err = d.slew_to_coordinates_async(target, 0.0).await.unwrap_err();
         assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+        assert!(
+            err.message.contains("binding zone"),
+            "error message must call out the binding zone: {}",
+            err.message
+        );
     }
 
     #[tokio::test]
@@ -3437,8 +3465,9 @@ mod tests {
             usb.polling_interval = Duration::from_millis(20);
         }
         cfg.mount.settle_after_slew = Duration::from_millis(0);
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
         let d = MountDevice::new(cfg.mount, manager);
         d.set_connected(true).await.unwrap();
@@ -3518,8 +3547,9 @@ mod tests {
             usb.polling_interval = Duration::from_millis(20);
         }
         cfg.mount.settle_after_slew = Duration::from_millis(0);
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
         let d = MountDevice::new(cfg.mount, manager);
         d.set_connected(true).await.unwrap();
@@ -3587,8 +3617,9 @@ mod tests {
             usb.polling_interval = Duration::from_millis(20);
         }
         cfg.mount.settle_after_slew = Duration::from_millis(0);
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
         let d = MountDevice::new(cfg.mount, manager);
         d.set_connected(true).await.unwrap();
@@ -4023,8 +4054,9 @@ mod tests {
 
     fn device_with_path(path: PathBuf) -> MountDevice {
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(
             cfg.clone(),
             Arc::new(MockTransportFactory),
@@ -4385,8 +4417,9 @@ mod tests {
         if let crate::config::TransportConfig::Usb(usb) = &mut cfg.transport {
             usb.polling_interval = Duration::from_millis(20);
         }
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("config.json");
         seed_default_config(&path);
@@ -4486,8 +4519,9 @@ mod tests {
             state.dec.position_ticks = -1;
         }
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
         cfg.mount.site_latitude_deg = 32.7157;
         let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
@@ -4515,8 +4549,9 @@ mod tests {
             state.ra.position_ticks = 50_000;
         }
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
         cfg.mount.site_latitude_deg = 32.7157;
         let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
@@ -4544,8 +4579,9 @@ mod tests {
         // `Park` from `home_pose: ap_park_3` drove the OTA to
         // meridian / celestial equator instead of NCP.
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
         cfg.mount.site_latitude_deg = 32.7157;
         let manager = Arc::new(TransportManager::new(
@@ -4568,8 +4604,9 @@ mod tests {
         // Config carries park values → driver should use them, not the
         // (zeroed) handshake fallback.
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         cfg.mount.park_ra_ticks = Some(5000);
         cfg.mount.park_dec_ticks = Some(-7000);
         let manager = Arc::new(TransportManager::new(
@@ -5059,8 +5096,9 @@ mod tests {
         // and `IsPulseGuiding` reports `false` consistent with the
         // lack of actual motion.
         let mut cfg = Config::default();
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         let manager = Arc::new(TransportManager::new(
             cfg.clone(),
             Arc::new(StuckAxisFactory),
@@ -5479,8 +5517,9 @@ mod tests {
             usb.polling_interval = Duration::from_millis(20);
         }
         cfg.mount.settle_after_slew = Duration::from_millis(0);
-        cfg.mount.ra_min_hours = -12.0;
-        cfg.mount.ra_max_hours = 12.0;
+        // Disable the binding-zone check for this test.
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
         cfg.mount.flip_policy.enabled = true;
         let manager = Arc::new(TransportManager::new(
             cfg.clone(),

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -24,7 +24,7 @@ use skywatcher_motor_protocol::{Axis, Command};
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::config::{HomePose, MountConfig};
+use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
@@ -379,9 +379,12 @@ impl MountDevice {
     /// mid-session after a slew is safe (the non-zero-encoder guard
     /// catches it).
     async fn seed_home_pose_after_connect(&self) -> ASCOMResult<()> {
-        if self.config.home_pose == HomePose::default() {
+        let Some(home_pose) = self.config.home_pose else {
+            // No pose configured — trust the firmware encoder as-is.
+            // This is the codebase's historical (pre-Phase-6) behaviour
+            // and what existing pre-`home_pose` config files expect.
             return Ok(());
-        }
+        };
         let params = self
             .transport
             .parameters()
@@ -396,11 +399,8 @@ impl MountDevice {
             );
             return Ok(());
         }
-        let mech_ha = self.config.home_pose.codebase_mech_ha_hours();
-        let dec_deg = self
-            .config
-            .home_pose
-            .codebase_dec_encoder_degrees(self.config.site_latitude_deg);
+        let mech_ha = home_pose.codebase_mech_ha_hours();
+        let dec_deg = home_pose.codebase_dec_encoder_degrees(self.config.site_latitude_deg);
         let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
         let dec_ticks = dec_degrees_to_ticks(dec_deg, params.cpr_dec);
         self.transport
@@ -420,7 +420,7 @@ impl MountDevice {
             .map_err(Self::ascom)?;
         self.transport.seed_dec_position(dec_ticks).await;
         debug!(
-            home_pose = ?self.config.home_pose,
+            home_pose = ?home_pose,
             ra_ticks,
             dec_ticks,
             "seeded firmware encoder for home_pose"

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -312,8 +312,14 @@ impl MountDevice {
     /// 2. `self.config.park_*_ticks` for `Config::default()` runs (no
     ///    config file) — these never change in-process because
     ///    `SetPark` is unreachable in that mode.
-    /// 3. The encoder positions captured during the init handshake
-    ///    (`:j1` / `:j2`) when neither of the above provided a value.
+    /// 3. The **current** firmware encoder reading from the snapshot
+    ///    when neither of the above provided a value.
+    ///    `seed_home_pose_after_connect` runs first in [`set_connected`]
+    ///    so the snapshot already reflects the home_pose's logical
+    ///    encoder values on a fresh power-up; a mid-session reconnect
+    ///    (firmware encoder non-zero) leaves the snapshot at the
+    ///    handshake reading, which is the "park where the OTA already
+    ///    is" semantic operators expect from a reconnect.
     ///
     /// Extracted from [`set_connected`] so a failure here (file missing,
     /// malformed JSON, lost transport mid-load) can be rolled back by the
@@ -333,13 +339,16 @@ impl MountDevice {
         } else {
             (self.config.park_ra_ticks, self.config.park_dec_ticks)
         };
-        let params = self
-            .transport
-            .parameters()
-            .await
-            .ok_or(ASCOMError::NOT_CONNECTED)?;
-        let ra_target = config_ra.unwrap_or(params.ra_at_handshake_ticks);
-        let dec_target = config_dec.unwrap_or(params.dec_at_handshake_ticks);
+        // Read the live snapshot rather than `params.ra_at_handshake_ticks`:
+        // `seed_home_pose_after_connect` runs before this function and
+        // mutates the snapshot when the operator has configured a
+        // `home_pose`, so the snapshot is the source-of-truth for the
+        // post-seed encoder state. Using the pre-seed handshake reading
+        // would default the park target to firmware-zero (mech_HA = 0h,
+        // mech_dec = 0°) — not the home_pose the operator powered up at.
+        let snap = self.transport.snapshot().await;
+        let ra_target = config_ra.unwrap_or(snap.ra.position_ticks);
+        let dec_target = config_dec.unwrap_or(snap.dec.position_ticks);
         {
             let mut s = self.state.write().await;
             s.park_ra_ticks = Some(ra_target);
@@ -909,18 +918,26 @@ impl Device for MountDevice {
         if connected {
             self.transport.connect().await.map_err(Self::ascom)?;
             // Post-connect work that can fail (config-file read, parameter
-            // cache lookup) runs inside `load_park_target_after_connect`
-            // so we can roll the connect back on any error — otherwise the
-            // transport ref-count would stay incremented while `*req`
-            // remained false, leaking a connection. Per the Copilot review
-            // on PR #221 (comment 3238682044).
-            if let Err(e) = self.load_park_target_after_connect().await {
+            // cache lookup, encoder seed) runs in functions that the
+            // caller can roll back on any error — otherwise the transport
+            // ref-count would stay incremented while `*req` remained
+            // false, leaking a connection. Per the Copilot review on
+            // PR #221 (comment 3238682044).
+            //
+            // Order matters: `seed_home_pose_after_connect` runs FIRST so
+            // the snapshot reflects the home_pose's logical encoder values
+            // before `load_park_target_after_connect` picks its default
+            // park target from the snapshot. Otherwise the handshake's
+            // pre-seed reading (firmware-zero on a fresh power-up) would
+            // become the park fallback and `Park` would drive the mount
+            // to mech_HA = 0h / mech_dec = 0° instead of the home pose.
+            if let Err(e) = self.seed_home_pose_after_connect().await {
                 if let Err(disc_err) = self.transport.disconnect().await {
                     tracing::warn!("disconnect during set_connected rollback failed: {disc_err}");
                 }
                 return Err(e);
             }
-            if let Err(e) = self.seed_home_pose_after_connect().await {
+            if let Err(e) = self.load_park_target_after_connect().await {
                 if let Err(disc_err) = self.transport.disconnect().await {
                     tracing::warn!("disconnect during set_connected rollback failed: {disc_err}");
                 }
@@ -4417,15 +4434,50 @@ mod tests {
 
     #[tokio::test]
     async fn park_target_defaults_to_handshake_capture_when_config_has_no_values() {
-        // No config park values → driver should fall back to the
-        // encoder positions captured during the handshake. The mock
-        // starts both axes at 0, so park_ra_ticks / park_dec_ticks
-        // should be Some(0) after connect.
+        // No config park values **and no `home_pose`** → driver falls
+        // back to the live snapshot, which on a fresh connect equals
+        // the handshake-captured encoder reading. The mock starts both
+        // axes at 0 and the home_pose seed is a no-op when none is
+        // configured, so park_ra_ticks / park_dec_ticks should be
+        // Some(0) after connect.
         let d = device();
         d.set_connected(true).await.unwrap();
         let s = d.state.read().await;
         assert_eq!(s.park_ra_ticks, Some(0));
         assert_eq!(s.park_dec_ticks, Some(0));
+    }
+
+    #[tokio::test]
+    async fn park_target_defaults_to_home_pose_encoder_when_home_pose_configured() {
+        // Operator configures `home_pose: ap_park_3` (Sky-Watcher's
+        // stock power-up pose) and leaves `park_*_ticks` null. After
+        // connect, `seed_home_pose_after_connect` writes the home_pose's
+        // logical encoder values to the firmware via `:E`, and the
+        // park-target fallback must pick those up from the snapshot —
+        // otherwise `Park` would slew the mount to firmware-encoder-
+        // zero (mech_HA = 0h, mech_dec = 0°) instead of the pose the
+        // operator powered up at. Regression test for the
+        // meridian-flip-phase hardware-validation observation that
+        // `Park` from `home_pose: ap_park_3` drove the OTA to
+        // meridian / celestial equator instead of NCP.
+        let mut cfg = Config::default();
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+        cfg.mount.site_latitude_deg = 32.7157;
+        let manager = Arc::new(TransportManager::new(
+            cfg.clone(),
+            Arc::new(MockTransportFactory),
+        ));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        // ApPark3 codebase convention: mech_HA = -6h, dec encoder = +90°
+        // (northern hemisphere). Mock cpr = 0x375F00 = 3,628,800 for
+        // both axes, so ra = -6/24 * cpr = -907,200 and
+        // dec = 90/360 * cpr = +907,200.
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(-907200));
+        assert_eq!(s.park_dec_ticks, Some(907200));
     }
 
     #[tokio::test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -347,6 +347,141 @@ impl MountDevice {
         );
         Ok(())
     }
+
+    /// Execute a slew to celestial (ra, dec) on the explicitly-chosen
+    /// pier side. Used by both `slew_to_coordinates_async` (where the
+    /// side is picked from the flip policy decision tree) and
+    /// `set_side_of_pier` (where the user pins the side directly).
+    ///
+    /// Caller must have already validated: connected, coords in
+    /// range, not parked. The helper then:
+    ///   1. Computes target encoder ticks for the chosen side
+    ///      (pre-flip or post-flip) and validates against the
+    ///      per-side safety envelope.
+    ///   2. Atomically latches `slew_in_progress` and the
+    ///      target RA/Dec.
+    ///   3. Computes deltas with `fold_delta_to_canonical` (handles a
+    ///      post-through-wrap raw encoder) and applies
+    ///      `flip_slew_ra_delta` on the RA axis for flip slews
+    ///      (forces CCW direction through the safe negative-mech_HA
+    ///      half).
+    ///   4. Issues the INDI wire sequence per axis and hands off to
+    ///      the slew-completion watcher.
+    async fn execute_slew_with_explicit_side(
+        &self,
+        ra: f64,
+        dec: f64,
+        chosen_side: PierSide,
+    ) -> ASCOMResult<()> {
+        let params = self
+            .transport
+            .parameters()
+            .await
+            .ok_or(ASCOMError::NOT_CONNECTED)?;
+        let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
+            .map_err(Self::ascom)?;
+        let pre_flip_side = if self.config.site_latitude_deg >= 0.0 {
+            PierSide::West
+        } else {
+            PierSide::East
+        };
+        let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
+        let (ra_ticks, dec_ticks) = if target_is_flipped {
+            target_encoder_flipped(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+        } else {
+            target_encoder_normal(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+        };
+        // Refuse before any wire motion if the slew target falls
+        // outside the configured mechanical envelope for the chosen
+        // pier side.
+        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
+
+        // Atomically reserve the in-progress slot **before** issuing
+        // any motion. Latch the target + capture the tracking flag in
+        // the same write.
+        let tracking_was_on;
+        {
+            let mut s = self.state.write().await;
+            if s.slew_in_progress {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "slew refused: slew already in progress",
+                ));
+            }
+            s.target_ra_hours = Some(ra);
+            s.target_dec_degrees = Some(dec);
+            tracking_was_on = s.tracking_requested;
+            s.slew_in_progress = true;
+            s.pulse_guiding_ra = false;
+            s.pulse_guiding_dec = false;
+        }
+
+        // From here on, any error path must clear `slew_in_progress`
+        // — otherwise the driver gets stuck reporting Slewing forever.
+        let result: ASCOMResult<()> = async {
+            let snap = self.transport.snapshot().await;
+            let current_side = side_of_pier_calc(
+                snap.dec.position_ticks,
+                params.cpr_dec,
+                self.config.site_latitude_deg,
+            );
+            let is_flip_slew = current_side != chosen_side;
+            // Fold the raw delta to canonical so a snapshot value that
+            // landed outside `[−cpr/2, +cpr/2)` after a prior
+            // through-wrap flip doesn't trigger a full-revolution
+            // correction here.
+            let ra_delta_canonical =
+                fold_delta_to_canonical(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
+            let ra_delta = if is_flip_slew {
+                // Flip slews force the safe (CCW) traversal direction
+                // through the negative-mech_HA half — see
+                // [`flip_slew_ra_delta`] and the design doc's
+                // [§"Through-wrap slew routing"](../../../docs/services/star-adventurer-gti.md#through-wrap-slew-routing).
+                flip_slew_ra_delta(ra_delta_canonical, params.cpr_ra)
+            } else {
+                ra_delta_canonical
+            };
+            let dec_delta =
+                fold_delta_to_canonical(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
+            // Both axes use the INDI wire sequence: `:K` + poll `:f`
+            // (decelerate stop) → `:G goto+fast` → `:I 6` → `:H |delta|`
+            // → `:M breaks` → `:J`. The RA-axis `:K` is also the wire
+            // event that halts any in-progress sidereal tracking;
+            // mirror that into the in-memory `tracking_requested`
+            // flag only after the stop has actually succeeded so the
+            // state never gets ahead of the wire on transport failures.
+            self.stop_and_wait(Axis::Ra).await?;
+            self.state.write().await.tracking_requested = false;
+            issue_slew_axis(&self.transport, Axis::Ra, ra_delta)
+                .await
+                .map_err(Self::ascom)?;
+            self.stop_and_wait(Axis::Dec).await?;
+            issue_slew_axis(&self.transport, Axis::Dec, dec_delta)
+                .await
+                .map_err(Self::ascom)?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            self.state.write().await.slew_in_progress = false;
+            return Err(e);
+        }
+
+        // Hand off to the completion watcher.
+        let settle = {
+            let s = self.state.read().await;
+            s.slew_settle_time.unwrap_or(self.config.settle_after_slew)
+        };
+        spawn_slew_completion_watcher(
+            Arc::clone(&self.state),
+            Arc::clone(&self.transport),
+            self.config.clone(),
+            self.transport.polling_interval_for_watcher(),
+            settle,
+            tracking_was_on,
+        );
+        Ok(())
+    }
 }
 
 /// Upper bound on how long the synchronous `SlewToCoordinates` /
@@ -698,6 +833,16 @@ impl Telescope for MountDevice {
     async fn can_pulse_guide(&self) -> ASCOMResult<bool> {
         Ok(true)
     }
+    async fn can_set_pier_side(&self) -> ASCOMResult<bool> {
+        // Phase 6: CanSetPierSide tracks `flip_policy.enabled`. With
+        // the policy disabled (the shipped default), `SetSideOfPier`
+        // returns NOT_IMPLEMENTED — the driver behaves as a
+        // non-flipping GEM. With it enabled (only after a successful
+        // first real-hardware GTi flip), the slew planner accepts
+        // explicit flip requests. See the design doc's
+        // [§"Meridian flip"](../../../docs/services/star-adventurer-gti.md#meridian-flip).
+        Ok(self.config.flip_policy.enabled)
+    }
     async fn can_set_guide_rates(&self) -> ASCOMResult<bool> {
         Ok(true)
     }
@@ -957,6 +1102,86 @@ impl Telescope for MountDevice {
         Ok(chosen_side)
     }
 
+    async fn set_side_of_pier(&self, side_of_pier: PierSide) -> ASCOMResult<()> {
+        // Phase 6: explicit meridian-flip trigger. With
+        // `flip_policy.enabled = false` (the default), every code path
+        // here short-circuits to NOT_IMPLEMENTED — the driver behaves
+        // as a non-flipping GEM. With the policy enabled, this method
+        // routes through `slew_to_coordinates_async` to the current
+        // celestial target with the chosen side. See the design doc's
+        // [§"`SetSideOfPier(side)`"](../../../docs/services/star-adventurer-gti.md#setsideofpierside).
+        if !self.config.flip_policy.enabled {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::NOT_IMPLEMENTED,
+                "SetSideOfPier requires flip_policy.enabled = true",
+            ));
+        }
+        if side_of_pier == PierSide::Unknown {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_VALUE,
+                "SetSideOfPier rejects PierSide::Unknown",
+            ));
+        }
+        self.ensure_connected().await?;
+        self.ensure_unparked().await?;
+        // Refuse mid-slew. The slew planner also self-refuses via its
+        // own `slew_in_progress` check, but rejecting here yields a
+        // cleaner error before we read the snapshot and compute a
+        // stale celestial target.
+        if self.state.read().await.slew_in_progress {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "SetSideOfPier refused: slew already in progress",
+            ));
+        }
+        // Compute the mount's current celestial position from the
+        // encoder snapshot + LST. A flip slew keeps the OTA on this
+        // same celestial direction while landing on the requested
+        // pier side.
+        let params = self
+            .transport
+            .parameters()
+            .await
+            .ok_or(ASCOMError::NOT_CONNECTED)?;
+        let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
+            .map_err(Self::ascom)?;
+        let snap = self.transport.snapshot().await;
+        let current_side = side_of_pier_calc(
+            snap.dec.position_ticks,
+            params.cpr_dec,
+            self.config.site_latitude_deg,
+        );
+        if side_of_pier == current_side {
+            // No-op success. Per ASCOM, SetSideOfPier(current_side)
+            // is a valid request; we don't issue motion or perturb
+            // the in-memory target.
+            return Ok(());
+        }
+        // The flipped Dec encoder is past the celestial pole, so a
+        // direct ra_ticks → ra → dec_ticks → dec round trip would land
+        // on the wrong sky position. Read the *celestial* current
+        // pointing from the snapshot (LST + mech_HA → RA, and the
+        // hemispheric Dec mapping). `execute_slew_with_explicit_side`
+        // will re-flip the encoder for the chosen side.
+        let cur_mech_ha = ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
+        let cur_ra = mechanical_ha_to_ra(cur_mech_ha, lst);
+        let cur_dec_encoder = dec_ticks_to_degrees(snap.dec.position_ticks, params.cpr_dec);
+        // Folded `[-180, +180)`; convert to celestial declination
+        // `[-90, +90]` by mirroring through ±90°.
+        let cur_dec = if cur_dec_encoder.abs() > 90.0 {
+            cur_dec_encoder.signum() * (180.0 - cur_dec_encoder.abs())
+        } else {
+            cur_dec_encoder
+        };
+        // Drive the slew with the chosen-side encoder math directly,
+        // bypassing the policy decision tree. The selector's
+        // stay-on-current preference is correct for slew_to_coordinates
+        // but wrong for an explicit SetSideOfPier — the user pinned the
+        // side, honour it.
+        self.execute_slew_with_explicit_side(cur_ra, cur_dec, side_of_pier)
+            .await
+    }
+
     // ---- Target setters ----
 
     async fn target_right_ascension(&self) -> ASCOMResult<f64> {
@@ -1120,123 +1345,8 @@ impl Telescope for MountDevice {
             (self.config.ra_min_hours, self.config.ra_max_hours),
             self.config.site_latitude_deg,
         );
-        let pre_flip_side = if self.config.site_latitude_deg >= 0.0 {
-            PierSide::West
-        } else {
-            PierSide::East
-        };
-        let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
-        let is_flip_slew = current_side != chosen_side;
-
-        let (ra_ticks, dec_ticks) = if target_is_flipped {
-            target_encoder_flipped(ra, dec, lst, params.cpr_ra, params.cpr_dec)
-        } else {
-            target_encoder_normal(ra, dec, lst, params.cpr_ra, params.cpr_dec)
-        };
-
-        // Refuse before any wire motion if the slew target falls
-        // outside the configured mechanical envelope for the chosen
-        // pier side. ConformU's pier-flip tests deliberately command
-        // across-the-meridian slews that on a GEM-without-flip
-        // translate to encoders past the counterweight-horizontal
-        // boundary; the safety gate sends those back as
-        // `INVALID_VALUE` instead of stalling the motor against a
-        // hard stop.
-        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
-
-        // Atomically reserve the in-progress slot **before** issuing
-        // any motion. Latch the target + capture the tracking flag in
-        // the same write. We do NOT clear `tracking_requested` here:
-        // if any of the StopMotion / SetMotionMode / ... sends below
-        // fail, the in-memory state would falsely report tracking-off
-        // while the wire is still tracking. The flag is cleared only
-        // after the RA :K actually hits the wire (see the inline
-        // write below).
-        let tracking_was_on;
-        {
-            let mut s = self.state.write().await;
-            if s.slew_in_progress {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "slew refused: slew already in progress",
-                ));
-            }
-            s.target_ra_hours = Some(ra);
-            s.target_dec_degrees = Some(dec);
-            tracking_was_on = s.tracking_requested;
-            s.slew_in_progress = true;
-            s.pulse_guiding_ra = false;
-            s.pulse_guiding_dec = false;
-        }
-
-        // From here on, any error path must clear `slew_in_progress`
-        // — otherwise the driver gets stuck reporting Slewing forever.
-        // Wrap motion-issue in an inner future so a single rollback
-        // covers every `?` failure.
-        let result: ASCOMResult<()> = async {
-            let snap = self.transport.snapshot().await;
-            // Fold the raw delta to canonical so a snapshot value that
-            // landed outside `[−cpr/2, +cpr/2)` after a prior
-            // through-wrap flip doesn't trigger a full-revolution
-            // correction here.
-            let ra_delta_canonical =
-                fold_delta_to_canonical(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
-            let ra_delta = if is_flip_slew {
-                // Flip slews force the safe (CCW) traversal direction
-                // through the negative-mech_HA half — see
-                // [`flip_slew_ra_delta`] and the design doc's
-                // [§"Through-wrap slew routing"](../../../docs/services/star-adventurer-gti.md#through-wrap-slew-routing).
-                flip_slew_ra_delta(ra_delta_canonical, params.cpr_ra)
-            } else {
-                ra_delta_canonical
-            };
-            let dec_delta =
-                fold_delta_to_canonical(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
-            // Both axes use the INDI wire sequence: `:K` + poll `:f`
-            // (decelerate stop — the spec's "motor must be at full stop
-            // before setting the motion mode" requirement) → `:G goto+fast`
-            // → `:I 6` → `:H |delta|` → `:M breaks` → `:J`. The RA-axis
-            // `:K` is also the wire event that halts any in-progress
-            // sidereal tracking; mirror that into the in-memory
-            // `tracking_requested` flag once the stop has actually
-            // succeeded so the state never gets ahead of the wire on
-            // transport failures.
-            self.stop_and_wait(Axis::Ra).await?;
-            self.state.write().await.tracking_requested = false;
-            issue_slew_axis(&self.transport, Axis::Ra, ra_delta)
-                .await
-                .map_err(Self::ascom)?;
-            self.stop_and_wait(Axis::Dec).await?;
-            issue_slew_axis(&self.transport, Axis::Dec, dec_delta)
-                .await
-                .map_err(Self::ascom)?;
-            Ok(())
-        }
-        .await;
-        if let Err(e) = result {
-            self.state.write().await.slew_in_progress = false;
-            return Err(e);
-        }
-
-        // Hand off to the completion watcher. The watcher polls
-        // until both axes report stopped, runs the EQMOD-style
-        // pickup loop (up to 5 iterations) to nudge any residual
-        // under 5", optionally re-issues sidereal tracking on RA
-        // (only if it was on before the slew), applies the settle
-        // delay, then clears `slew_in_progress`.
-        let settle = {
-            let s = self.state.read().await;
-            s.slew_settle_time.unwrap_or(self.config.settle_after_slew)
-        };
-        spawn_slew_completion_watcher(
-            Arc::clone(&self.state),
-            Arc::clone(&self.transport),
-            self.config.clone(),
-            self.transport.polling_interval_for_watcher(),
-            settle,
-            tracking_was_on,
-        );
-        Ok(())
+        self.execute_slew_with_explicit_side(ra, dec, chosen_side)
+            .await
     }
 
     async fn slew_to_target_async(&self) -> ASCOMResult<()> {
@@ -4716,5 +4826,110 @@ mod tests {
     #[test]
     fn flip_slew_ra_delta_handles_zero_cpr_defensively() {
         assert_eq!(flip_slew_ra_delta(12_345, 0), 12_345);
+    }
+
+    // ---------- Phase 6: SetSideOfPier + CanSetPierSide ----------
+
+    async fn flip_enabled_device() -> MountDevice {
+        let mut cfg = Config::default();
+        if let crate::config::TransportConfig::Usb(usb) = &mut cfg.transport {
+            usb.polling_interval = Duration::from_millis(20);
+        }
+        cfg.mount.settle_after_slew = Duration::from_millis(0);
+        cfg.mount.ra_min_hours = -12.0;
+        cfg.mount.ra_max_hours = 12.0;
+        cfg.mount.flip_policy.enabled = true;
+        let manager = Arc::new(TransportManager::new(
+            cfg.clone(),
+            Arc::new(MockTransportFactory),
+        ));
+        MountDevice::new(cfg.mount, manager)
+    }
+
+    async fn flip_enabled_connected_device() -> MountDevice {
+        let d = flip_enabled_device().await;
+        d.set_connected(true).await.unwrap();
+        d
+    }
+
+    #[tokio::test]
+    async fn can_set_pier_side_defaults_to_false() {
+        let d = fast_settle_connected().await;
+        assert!(!d.can_set_pier_side().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_set_pier_side_is_true_when_flip_policy_enabled() {
+        let d = flip_enabled_connected_device().await;
+        assert!(d.can_set_pier_side().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_returns_not_implemented_when_flip_policy_disabled() {
+        let d = fast_settle_connected().await;
+        let err = d.set_side_of_pier(PierSide::East).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_rejects_unknown_with_invalid_value() {
+        let d = flip_enabled_connected_device().await;
+        let err = d.set_side_of_pier(PierSide::Unknown).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_refuses_when_not_connected() {
+        let d = flip_enabled_device().await;
+        let err = d.set_side_of_pier(PierSide::East).await.unwrap_err();
+        assert_eq!(err.code, ASCOMError::NOT_CONNECTED.code);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_refuses_while_parked() {
+        let d = flip_enabled_connected_device().await;
+        // Park puts AtPark = true; SetSideOfPier must refuse with
+        // INVALID_WHILE_PARKED before reaching the slew planner.
+        d.state.write().await.at_park = true;
+        let err = d.set_side_of_pier(PierSide::East).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_WHILE_PARKED);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_refuses_while_slew_in_progress() {
+        let d = flip_enabled_connected_device().await;
+        d.state.write().await.slew_in_progress = true;
+        let err = d.set_side_of_pier(PierSide::East).await.unwrap_err();
+        assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_to_current_side_succeeds_as_noop() {
+        let d = flip_enabled_connected_device().await;
+        // Mock starts with Dec encoder = 0 (within ±90°), site latitude
+        // = 0° (northern convention since `>= 0`), so current side is
+        // pierWest. SetSideOfPier(West) is a no-op.
+        d.set_side_of_pier(PierSide::West).await.unwrap();
+        // State unchanged.
+        assert!(!d.state.read().await.slew_in_progress);
+    }
+
+    #[tokio::test]
+    async fn set_side_of_pier_to_opposite_side_starts_a_flip_slew() {
+        let d = flip_enabled_connected_device().await;
+        d.set_side_of_pier(PierSide::East).await.unwrap();
+        // Slew was issued — the state should now show slew_in_progress
+        // until the watcher clears it. The watcher may have already
+        // completed in the mock (instant-settle config), so accept
+        // either: the slew was either still in progress at this read,
+        // or already finished with the encoder mutated.
+        let s = d.state.read().await;
+        let slewing = s.slew_in_progress;
+        let target_set = s.target_ra_hours.is_some() && s.target_dec_degrees.is_some();
+        drop(s);
+        assert!(
+            slewing || target_set,
+            "expected slew to have been issued (slew_in_progress or target_ra latched)"
+        );
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -28,8 +28,9 @@ use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
-    ra_to_mechanical_ha, select_pier_side_for_target, side_of_pier as side_of_pier_calc,
-    sidereal_step_period, target_encoder_flipped, target_encoder_normal, SIDEREAL_DEG_PER_SEC,
+    ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, select_pier_side_for_target,
+    side_of_pier as side_of_pier_calc, sidereal_step_period, target_encoder_flipped,
+    target_encoder_normal, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::{MountSnapshot, TransportManager};
@@ -553,11 +554,19 @@ impl MountDevice {
             let ra_delta_canonical =
                 fold_delta_to_canonical(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
             let ra_delta = if is_flip_slew {
-                // Flip slews force the safe (CCW) traversal direction
-                // through the negative-mech_HA half — see
+                // Flip slews steer the polar-axis sweep out of the
+                // counterweight binding zone — see
                 // [`flip_slew_ra_delta`] and the design doc's
                 // [§"Through-wrap slew routing"](../../../docs/services/star-adventurer-gti.md#through-wrap-slew-routing).
-                flip_slew_ra_delta(ra_delta_canonical, snap.ra.position_ticks, params.cpr_ra)
+                flip_slew_ra_delta(
+                    ra_delta_canonical,
+                    snap.ra.position_ticks,
+                    params.cpr_ra,
+                    (
+                        self.config.binding_zone_min_hours,
+                        self.config.binding_zone_max_hours,
+                    ),
+                )
             } else {
                 ra_delta_canonical
             };
@@ -779,50 +788,78 @@ fn fold_delta_to_canonical(delta: i32, cpr: u32) -> i32 {
     }
 }
 
-/// Force a flip slew's RA delta to keep the encoder in the
-/// counterweight-below-horizon half of the RA axis (`mech_HA` in
-/// `[−12, 0]`), avoiding the binding region at `mech_HA ∈ (+6.95,
-/// +11.05)` where the counterweight contacts the pier.
+/// Force a flip slew's RA delta to keep the polar-axis sweep out of
+/// the counterweight-binding zone `mech_HA ∈ (zone_min, zone_max)`
+/// (default `(+6.95, +11.05)` on the GTi), where the counterweight
+/// contacts the pier.
 ///
-/// The mechanical binding zone is at positive `mech_HA` and is a
+/// The mechanical binding zone is at positive `mech_HA` only and is a
 /// structural property of the mount head independent of observer
 /// latitude. Both forward flips (pre-flip → post-flip) and flip-backs
 /// (post-flip → pre-flip) need their RA paths constrained.
 ///
-/// Rule, expressed by current encoder position:
+/// Strategy: take the canonical short path unless its linear mech_HA
+/// sweep from `current_ticks` through `current_ticks + canonical_delta`
+/// crosses the binding zone (modulo the 24-hour wrap). If it would,
+/// take the long way around (`canonical ± cpr_i`) which lands at the
+/// same modular destination via the safe arc on the other side.
 ///
-/// - `|current_ticks| ≤ cpr/4` (current in the pre-flip envelope,
-///   `mech_HA ∈ [−6, +6]`): force CCW (negative delta). The path
-///   decreases from the safe arc into the negative half, ending in
-///   either `[−6.95, +6.95]` (no-flip target) or near `±cpr/2`
-///   (post-flip wrap).
-/// - `|current_ticks| > cpr/4` (current at or past the wrap,
-///   `mech_HA` near `±12`): force CW (positive delta). The path
-///   increases away from the wrap into the safe negative half. Going
-///   CCW here would step *back across the wrap* into the positive
-///   half and through the binding zone — what hardware validation
-///   #3 exposed.
-///
-/// When the canonical shortest-path direction is already the forced
-/// one, it's returned unchanged. Otherwise the long way around
-/// (`delta − cpr` or `delta + cpr`) lands at the same modular
-/// destination via the safe half.
-fn flip_slew_ra_delta(canonical_delta: i32, current_ticks: i32, cpr: u32) -> i32 {
+/// Previously a sign-blind heuristic (`|current| > cpr/4 ⇒ "safe is
+/// positive"`) was used. That mis-fired at Park 4 N
+/// (current ≈ -cpr/2, canonical ≈ -4k CCW just past the wrap): the
+/// heuristic flipped the small CCW step into a +cpr/2 + small CW full
+/// revolution that swept across mech_HA (+6.95, +11.05) and slammed
+/// the CW shaft into the pier (hardware validation 2026-05-16). The
+/// path-aware check uses the actual binding zone, so it preserves the
+/// safe canonical step when it doesn't cross.
+fn flip_slew_ra_delta(
+    canonical_delta: i32,
+    current_ticks: i32,
+    cpr: u32,
+    binding_zone_hours: (f64, f64),
+) -> i32 {
     if cpr == 0 || canonical_delta == 0 {
         return canonical_delta;
     }
     let cpr_i = cpr as i32;
-    let quarter = cpr_i / 4;
-    let in_pre_flip = current_ticks.abs() <= quarter;
-    let safe_direction_positive = !in_pre_flip;
-    let canonical_positive = canonical_delta > 0;
-    if canonical_positive == safe_direction_positive {
-        canonical_delta
-    } else if canonical_delta > 0 {
+    let cur_ha = ra_ticks_to_mechanical_ha(current_ticks, cpr);
+    let delta_ha = (canonical_delta as f64) * 24.0 / (cpr as f64);
+    if !canonical_path_crosses_binding_zone(cur_ha, delta_ha, binding_zone_hours) {
+        return canonical_delta;
+    }
+    if canonical_delta > 0 {
         canonical_delta - cpr_i
     } else {
         canonical_delta + cpr_i
     }
+}
+
+/// Does the linear mech_HA sweep from `start_ha` by `delta_ha` enter
+/// `(zone_min, zone_max)` (modulo 24 h)? The sweep is the open
+/// interval `(min(start, start+delta), max(start, start+delta))`; the
+/// binding zone repeats every 24 hours, so we check `k ∈ {-1, 0, +1}`
+/// — enough to cover any `|delta_ha| ≤ 12` path. An empty zone
+/// (`zone_min ≥ zone_max`) is treated as no zone.
+fn canonical_path_crosses_binding_zone(
+    start_ha: f64,
+    delta_ha: f64,
+    binding_zone_hours: (f64, f64),
+) -> bool {
+    let (zone_min, zone_max) = binding_zone_hours;
+    if zone_min >= zone_max {
+        return false;
+    }
+    let path_lo = start_ha.min(start_ha + delta_ha);
+    let path_hi = start_ha.max(start_ha + delta_ha);
+    for k in [-1.0_f64, 0.0, 1.0] {
+        let bz_lo = zone_min + 24.0 * k;
+        let bz_hi = zone_max + 24.0 * k;
+        // Open-interval overlap: paths grazing the boundary stay safe.
+        if path_lo < bz_hi && bz_lo < path_hi {
+            return true;
+        }
+    }
+    false
 }
 
 /// Force a flip slew's Dec delta to traverse the **visible** celestial
@@ -5217,6 +5254,10 @@ mod tests {
 
     const GTI_CPR: u32 = 0x0037_5F00; // 3,628,800
 
+    /// Hardware-verified GTi counterweight binding zone in mech_HA hours
+    /// (matches `default_binding_zone_min/max_hours` in `config.rs`).
+    const GTI_BINDING_ZONE: (f64, f64) = (6.95, 11.05);
+
     #[test]
     fn fold_delta_to_canonical_passes_through_small_deltas() {
         assert_eq!(fold_delta_to_canonical(0, GTI_CPR), 0);
@@ -5262,7 +5303,7 @@ mod tests {
         let cpr = GTI_CPR;
         let current = 0;
         let canonical = -(cpr as i32 / 2);
-        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
         assert_eq!(issued, canonical, "natural CCW already in the safe half");
     }
 
@@ -5276,7 +5317,7 @@ mod tests {
         let cpr = GTI_CPR;
         let current = -75_600; // mech_HA = -0.5
         let canonical = 1_815_000_i32;
-        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
         assert!(issued < 0, "must force CCW long way");
         assert_eq!(
             (issued - canonical).rem_euclid(cpr as i32),
@@ -5298,7 +5339,7 @@ mod tests {
         let cpr = GTI_CPR;
         let current = -(cpr as i32 / 2);
         let canonical = cpr as i32 / 4;
-        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
         assert_eq!(
             issued, canonical,
             "flip-back from -cpr/2 must use natural CW"
@@ -5318,7 +5359,7 @@ mod tests {
         let current = cpr as i32 / 2;
         let canonical_raw = -(cpr as i32 / 4) - current; // -3cpr/4
         let canonical = fold_delta_to_canonical(canonical_raw, cpr); // +cpr/4
-        let issued = flip_slew_ra_delta(canonical, current, cpr);
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
         assert!(issued > 0, "post-flip wrap → safe arc must use CW");
         assert_eq!(issued, canonical, "canonical CW is already safe here");
     }
@@ -5334,12 +5375,82 @@ mod tests {
 
     #[test]
     fn flip_slew_ra_delta_handles_zero_cpr_defensively() {
-        assert_eq!(flip_slew_ra_delta(12_345, 0, 0), 12_345);
+        assert_eq!(flip_slew_ra_delta(12_345, 0, 0, GTI_BINDING_ZONE), 12_345);
     }
 
     #[test]
     fn flip_slew_ra_delta_zero_canonical_returns_zero() {
-        assert_eq!(flip_slew_ra_delta(0, 0, GTI_CPR), 0);
+        assert_eq!(flip_slew_ra_delta(0, 0, GTI_CPR, GTI_BINDING_ZONE), 0);
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_park4_to_park5_north_uses_canonical_through_wrap() {
+        // Hardware regression (2026-05-16): Park 4 N → Park 5 N flip
+        // slew. Snap.ra ≈ raw -1,810,272 (mech_HA -11.974, post-flip
+        // pierEast just east of the saddle-east wrap). The slew planner
+        // chose pierWest (target HA -12 outside the flip window), with
+        // target encoder near +cpr/2 (mech_HA +11.999, the saddle-east
+        // wrap from the other side). fold_delta_to_canonical produces a
+        // small CCW step (~-3.8k ticks) that physically nudges the RA
+        // encoder past the -12 wrap and into +12 folded — the path stays
+        // entirely in the safe arc (no positive mech_HA visited). The
+        // old sign-blind heuristic forced canonical + cpr ≈ +3.625M
+        // ticks CW, a near-full polar-axis revolution that swept
+        // mech_HA through (+6.95, +11.05) and slammed the CW shaft into
+        // the pier — the operator powered the mount off mid-sweep.
+        let cpr = GTI_CPR;
+        let current = -1_810_272_i32;
+        let canonical = -3_798_i32;
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
+        assert_eq!(
+            issued, canonical,
+            "canonical CCW wrap-crossing must be preserved; old long-way CW \
+             would full-revolution through the binding zone"
+        );
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_canonical_path_crossing_binding_zone_takes_long_way() {
+        // Current at mech_HA = +5 (just below the binding zone), target
+        // at mech_HA = +11.5 (just above it). Canonical short path
+        // would sweep mech_HA from +5 to +11.5, entering (+6.95, +11.05)
+        // around mech_HA = +7. Force the long way around through the
+        // safe negative half.
+        let cpr = GTI_CPR;
+        let current = (cpr as i32) * 5 / 24; // mech_HA = +5
+        let canonical = (cpr as i32) * 13 / 48; // +6.5 hours of mech_HA
+        let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
+        assert!(
+            issued < 0,
+            "canonical path enters (6.95, 11.05); must take CCW long way (got {issued})"
+        );
+        assert_eq!(
+            (issued - canonical).rem_euclid(cpr as i32),
+            0,
+            "same modular destination"
+        );
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_empty_binding_zone_always_uses_canonical() {
+        // Empty zone (min ≥ max) disables routing; the function
+        // collapses to the canonical short delta regardless of which
+        // half the current sits in. Matches the BDD-test config that
+        // sets `binding_zone_min = 24.0, binding_zone_max = 0.0` to
+        // bypass the safety gate.
+        let cpr = GTI_CPR;
+        let empty_zone = (24.0_f64, 0.0_f64);
+        for (current, canonical) in [
+            (0_i32, -(cpr as i32 / 2)),
+            (-(cpr as i32 / 2), cpr as i32 / 4),
+            (-1_810_272_i32, -3_798_i32),
+        ] {
+            assert_eq!(
+                flip_slew_ra_delta(canonical, current, cpr, empty_zone),
+                canonical,
+                "empty zone must pass canonical through (current={current}, canonical={canonical})"
+            );
+        }
     }
 
     // ---------- flip_slew_dec_delta (Dec routing through the visible pole) ----------

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -408,7 +408,7 @@ impl MountDevice {
             );
             return Ok(());
         }
-        let mech_ha = home_pose.codebase_mech_ha_hours();
+        let mech_ha = home_pose.codebase_mech_ha_hours(self.config.site_latitude_deg);
         let dec_deg = home_pose.codebase_dec_encoder_degrees(self.config.site_latitude_deg);
         let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
         let dec_ticks = dec_degrees_to_ticks(dec_deg, params.cpr_dec);

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -32,7 +32,7 @@ use crate::coordinates::{
     sidereal_step_period, target_encoder_flipped, target_encoder_normal, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
-use crate::transport_manager::TransportManager;
+use crate::transport_manager::{MountSnapshot, TransportManager};
 
 /// Default guide rate as a fraction of sidereal. ASCOM clients see
 /// this multiplied by `SIDEREAL_DEG_PER_SEC` through
@@ -633,6 +633,26 @@ const PICKUP_TOLERANCE_ARCSEC: f64 = 5.0;
 /// pickup loop at 5 iterations to keep a pathological case (motor
 /// stalled, encoder oscillating, …) from running forever.
 const PICKUP_MAX_ITERATIONS: u32 = 5;
+
+/// Consecutive `poll_axes_now` failures the slew/park watcher
+/// tolerates before giving up. A single transient USB-CDC glitch
+/// (queue flush race, brief renumeration, …) recovers within one
+/// frame and shouldn't take the watcher offline for the rest of
+/// the slew — the original "one strike and exit" policy meant any
+/// pre-binding hiccup left a runaway motor with no observer. Three
+/// attempts × [`WATCHER_POLL_RETRY_BACKOFF`] keeps the cumulative
+/// recovery window well inside the polling cadence so a genuinely
+/// blocked axis is still detected within ~1 s of the firmware
+/// latching the bit.
+const WATCHER_POLL_RETRY_LIMIT: u32 = 3;
+
+/// Sleep between consecutive `poll_axes_now` retry attempts in the
+/// slew/park watcher. Short enough that the cumulative
+/// `WATCHER_POLL_RETRY_LIMIT × WATCHER_POLL_RETRY_BACKOFF` budget
+/// stays inside the next polling tick; long enough that a tokio-
+/// serial read can flush whatever junk the kernel buffered during
+/// a brief CDC glitch before the next attempt.
+const WATCHER_POLL_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 
 /// Issue the per-axis INDI slew sequence:
 /// `:G<axis>` (goto + fast, direction by sign of `delta`) →
@@ -2053,12 +2073,15 @@ fn spawn_slew_completion_watcher(
             }
 
             // Direct poll instead of reading the (now-paused) background
-            // snapshot. On failure (transport closed mid-slew, command
-            // timeout, ...), treat as an abort to avoid spinning.
-            let snap = match transport.poll_axes_now().await {
+            // snapshot. [`watcher_poll_with_retry`] tolerates a handful
+            // of transient transport errors so a single USB-CDC glitch
+            // doesn't take the watcher offline mid-slew; on retry
+            // exhaustion it also issues a best-effort `:L` on both
+            // axes so the motor isn't left commutating with no
+            // observer.
+            let snap = match watcher_poll_with_retry(&transport, "slew_watcher").await {
                 Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!("watcher poll_axes_now failed: {e}");
+                Err(_) => {
                     state.write().await.slew_in_progress = false;
                     return;
                 }
@@ -2378,6 +2401,71 @@ async fn stop_axis_and_wait(
     }
 }
 
+/// Retrying wrapper around [`TransportManager::poll_axes_now`] used by
+/// both the slew and park completion watchers. Tolerates up to
+/// [`WATCHER_POLL_RETRY_LIMIT`] consecutive transport errors so a
+/// single transient USB-CDC glitch (a brief renumeration, a stale
+/// kernel buffer, …) doesn't take the watcher offline for the rest
+/// of a goto.
+///
+/// On every successful poll the snapshot is emitted at `debug` so a
+/// post-mortem can reconstruct the last-known-good state observed
+/// before any failure. On every failed attempt the underlying error
+/// is logged at `warn` with the attempt counter.
+///
+/// On retry exhaustion, the helper makes a best-effort `:L` on both
+/// axes before returning the underlying error: even when we can no
+/// longer observe state, the firmware may still be commutating step
+/// pulses, and a runaway motor with no observer is the worst case
+/// the original exit-on-first-error policy created. The `:L` calls
+/// are fire-and-forget — if they fail too, there's nothing useful
+/// the watcher can do beyond logging and bailing.
+async fn watcher_poll_with_retry(
+    transport: &TransportManager,
+    context: &'static str,
+) -> crate::error::Result<MountSnapshot> {
+    let mut last_err: Option<StarAdvError> = None;
+    for attempt in 0..WATCHER_POLL_RETRY_LIMIT {
+        match transport.poll_axes_now().await {
+            Ok(snap) => {
+                debug!(
+                    context = context,
+                    ra_ticks = snap.ra.position_ticks,
+                    ra_running = snap.ra.running,
+                    ra_blocked = snap.ra.blocked,
+                    ra_goto = snap.ra.goto,
+                    dec_ticks = snap.dec.position_ticks,
+                    dec_running = snap.dec.running,
+                    dec_blocked = snap.dec.blocked,
+                    dec_goto = snap.dec.goto,
+                    "watcher snapshot"
+                );
+                return Ok(snap);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    context = context,
+                    attempt = attempt + 1,
+                    limit = WATCHER_POLL_RETRY_LIMIT,
+                    "watcher poll_axes_now transient error: {e}"
+                );
+                last_err = Some(e);
+                if attempt + 1 < WATCHER_POLL_RETRY_LIMIT {
+                    tokio::time::sleep(WATCHER_POLL_RETRY_BACKOFF).await;
+                }
+            }
+        }
+    }
+    tracing::warn!(
+        context = context,
+        "watcher poll_axes_now retries exhausted — best-effort :L on both axes before bailing"
+    );
+    let _ = transport.send(Command::InstantStop(Axis::Ra)).await;
+    let _ = transport.send(Command::InstantStop(Axis::Dec)).await;
+    Err(last_err
+        .unwrap_or_else(|| StarAdvError::Transport("watcher poll retries exhausted".to_string())))
+}
+
 /// Probe whether the parent directory of `config_path` can host the
 /// staging temp file that `SetPark`'s atomic-rename pattern requires.
 ///
@@ -2644,10 +2732,14 @@ fn spawn_park_completion_watcher(
                 state.write().await.slew_in_progress = false;
                 return;
             }
-            let snap = match transport.poll_axes_now().await {
+            // See [`watcher_poll_with_retry`] in the slew watcher above:
+            // tolerates transient transport errors, debug-logs every
+            // successful snapshot for post-mortems, and issues a
+            // best-effort `:L` on retry exhaustion so the motor halts
+            // even when the wire has gone away.
+            let snap = match watcher_poll_with_retry(&transport, "park_watcher").await {
                 Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!("park watcher poll_axes_now failed: {e}");
+                Err(_) => {
                     state.write().await.slew_in_progress = false;
                     return;
                 }
@@ -5347,5 +5439,145 @@ mod tests {
             slewing || target_set,
             "expected slew to have been issued (slew_in_progress or target_ra latched)"
         );
+    }
+
+    // ---- watcher_poll_with_retry --------------------------------------
+    //
+    // The slew/park watchers' transport-error path used to exit on the
+    // first failed `poll_axes_now`, which made a single transient USB-
+    // CDC glitch take the watcher offline for the rest of the slew. The
+    // helper now retries [`WATCHER_POLL_RETRY_LIMIT`] times and on
+    // exhaustion fires a best-effort `:L` on both axes so a runaway
+    // motor doesn't continue commutating with no observer.
+
+    use crate::transport::{Transport, TransportFactory};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Inject N consecutive transport failures and count `:L<axis>`
+    /// frames that crossed the wire. Shared between the test and the
+    /// inner [`FlakyTransport`] so the test can observe both knobs.
+    struct FlakyController {
+        fail_remaining: AtomicU32,
+        stop_calls_ra: AtomicU32,
+        stop_calls_dec: AtomicU32,
+    }
+
+    /// Wraps [`crate::transport::mock::MockTransport`] and fails the
+    /// first `fail_remaining` round-trips. Every `:L<axis>` frame is
+    /// counted before the fail check so even a `:L` that lands during
+    /// the failure window still registers (the retry-exhaustion path
+    /// fires `:L` regardless of whether the transport is responsive).
+    struct FlakyTransport {
+        inner: crate::transport::mock::MockTransport,
+        ctrl: Arc<FlakyController>,
+    }
+
+    #[async_trait]
+    impl Transport for FlakyTransport {
+        async fn round_trip(
+            &self,
+            request: &[u8],
+            timeout: Duration,
+        ) -> crate::error::Result<Vec<u8>> {
+            if request.len() >= 3 && request[1] == b'L' {
+                match request[2] {
+                    b'1' => {
+                        self.ctrl.stop_calls_ra.fetch_add(1, Ordering::SeqCst);
+                    }
+                    b'2' => {
+                        self.ctrl.stop_calls_dec.fetch_add(1, Ordering::SeqCst);
+                    }
+                    _ => {}
+                }
+            }
+            if self.ctrl.fail_remaining.load(Ordering::SeqCst) > 0 {
+                self.ctrl.fail_remaining.fetch_sub(1, Ordering::SeqCst);
+                return Err(StarAdvError::Transport("flaky test eof".to_string()));
+            }
+            self.inner.round_trip(request, timeout).await
+        }
+
+        async fn close(&self) -> crate::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FlakyTransportFactory {
+        ctrl: Arc<FlakyController>,
+    }
+
+    #[async_trait]
+    impl TransportFactory for FlakyTransportFactory {
+        async fn open(&self, _config: &Config) -> crate::error::Result<Arc<dyn Transport>> {
+            Ok(Arc::new(FlakyTransport {
+                inner: crate::transport::mock::MockTransport::new(),
+                ctrl: self.ctrl.clone(),
+            }))
+        }
+    }
+
+    async fn flaky_manager() -> (Arc<TransportManager>, Arc<FlakyController>) {
+        let ctrl = Arc::new(FlakyController {
+            fail_remaining: AtomicU32::new(0),
+            stop_calls_ra: AtomicU32::new(0),
+            stop_calls_dec: AtomicU32::new(0),
+        });
+        let factory = Arc::new(FlakyTransportFactory { ctrl: ctrl.clone() });
+        let manager = Arc::new(TransportManager::new(Config::default(), factory));
+        // Connect with fail_remaining = 0 so the handshake completes,
+        // then return the controller so the test can flip the failure
+        // budget on without interfering with init.
+        manager.connect().await.unwrap();
+        (manager, ctrl)
+    }
+
+    #[tokio::test]
+    async fn watcher_poll_with_retry_returns_ok_on_first_success() {
+        let (manager, ctrl) = flaky_manager().await;
+        let snap = watcher_poll_with_retry(&manager, "test")
+            .await
+            .expect("happy-path poll should succeed");
+        // No retries needed → no best-effort :L was issued.
+        assert_eq!(ctrl.stop_calls_ra.load(Ordering::SeqCst), 0);
+        assert_eq!(ctrl.stop_calls_dec.load(Ordering::SeqCst), 0);
+        // Mock transport seeds positions at handshake; just confirm the
+        // returned snapshot looks structurally valid (no panic, both
+        // axes populated even if zero).
+        let _ = snap.ra.position_ticks;
+        let _ = snap.dec.position_ticks;
+    }
+
+    #[tokio::test]
+    async fn watcher_poll_with_retry_recovers_after_transient_error() {
+        let (manager, ctrl) = flaky_manager().await;
+        // Fail the next round-trip exactly once: the helper's second
+        // attempt should land on a healthy transport and return Ok.
+        ctrl.fail_remaining.store(1, Ordering::SeqCst);
+        watcher_poll_with_retry(&manager, "test")
+            .await
+            .expect("retry should recover from a single transient error");
+        // No retry-exhaustion path → no best-effort :L.
+        assert_eq!(ctrl.stop_calls_ra.load(Ordering::SeqCst), 0);
+        assert_eq!(ctrl.stop_calls_dec.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn watcher_poll_with_retry_exhausts_then_issues_best_effort_stop() {
+        let (manager, ctrl) = flaky_manager().await;
+        // Saturate the failure budget so every retry attempt errors.
+        ctrl.fail_remaining.store(u32::MAX, Ordering::SeqCst);
+        let err = watcher_poll_with_retry(&manager, "test")
+            .await
+            .expect_err("retry budget should be exhausted");
+        match err {
+            StarAdvError::Transport(_) => {}
+            other => panic!("expected Transport error, got {other:?}"),
+        }
+        // Best-effort `:L` must fire on both axes regardless of whether
+        // it lands — the test counts the frames before the fail check
+        // in the flaky transport.
+        assert_eq!(ctrl.stop_calls_ra.load(Ordering::SeqCst), 1);
+        assert_eq!(ctrl.stop_calls_dec.load(Ordering::SeqCst), 1);
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -24,7 +24,7 @@ use skywatcher_motor_protocol::{Axis, Command};
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::config::MountConfig;
+use crate::config::{HomePose, MountConfig};
 use crate::coordinates::{
     dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
@@ -352,6 +352,78 @@ impl MountDevice {
             from_config_dec = config_dec.is_some(),
             from_file = self.config_file_path.is_some(),
             "park target loaded"
+        );
+        Ok(())
+    }
+
+    /// Post-connect encoder seed for the operator's configured
+    /// [`HomePose`].
+    ///
+    /// The Sky-Watcher firmware's encoder counter resets to `(0, 0)`
+    /// every time the mount powers up. With `home_pose !=
+    /// OtaOnMeridianAtEquator`, the codebase's convention for `(0, 0)`
+    /// doesn't match the operator's physical pose, so we issue
+    /// `:E1` / `:E2` (no-motion encoder seed) right after connect to
+    /// align the firmware's encoder counter with the codebase's
+    /// convention for the configured pose.
+    ///
+    /// Skipped when:
+    /// - The home pose is the codebase default (no offset needed).
+    /// - The firmware reports a non-zero encoder reading at connect
+    ///   time. That indicates the mount has already been slewed or
+    ///   synced this power cycle — re-seeding would clobber it.
+    ///
+    /// Documented operator assumption: when `home_pose != default`,
+    /// the operator powers up the mount **at** the configured pose and
+    /// connects the driver before any slew or sync. Reconnecting
+    /// mid-session after a slew is safe (the non-zero-encoder guard
+    /// catches it).
+    async fn seed_home_pose_after_connect(&self) -> ASCOMResult<()> {
+        if self.config.home_pose == HomePose::default() {
+            return Ok(());
+        }
+        let params = self
+            .transport
+            .parameters()
+            .await
+            .ok_or(ASCOMError::NOT_CONNECTED)?;
+        let snap = self.transport.snapshot().await;
+        if snap.ra.position_ticks != 0 || snap.dec.position_ticks != 0 {
+            debug!(
+                ra = snap.ra.position_ticks,
+                dec = snap.dec.position_ticks,
+                "skipping home_pose encoder seed: firmware encoder is non-zero"
+            );
+            return Ok(());
+        }
+        let mech_ha = self.config.home_pose.codebase_mech_ha_hours();
+        let dec_deg = self
+            .config
+            .home_pose
+            .codebase_dec_encoder_degrees(self.config.site_latitude_deg);
+        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
+        let dec_ticks = dec_degrees_to_ticks(dec_deg, params.cpr_dec);
+        self.transport
+            .send(Command::SetPosition {
+                axis: Axis::Ra,
+                ticks: ra_ticks,
+            })
+            .await
+            .map_err(Self::ascom)?;
+        self.transport.seed_ra_position(ra_ticks).await;
+        self.transport
+            .send(Command::SetPosition {
+                axis: Axis::Dec,
+                ticks: dec_ticks,
+            })
+            .await
+            .map_err(Self::ascom)?;
+        self.transport.seed_dec_position(dec_ticks).await;
+        debug!(
+            home_pose = ?self.config.home_pose,
+            ra_ticks,
+            dec_ticks,
+            "seeded firmware encoder for home_pose"
         );
         Ok(())
     }
@@ -738,6 +810,12 @@ impl Device for MountDevice {
             // remained false, leaking a connection. Per the Copilot review
             // on PR #221 (comment 3238682044).
             if let Err(e) = self.load_park_target_after_connect().await {
+                if let Err(disc_err) = self.transport.disconnect().await {
+                    tracing::warn!("disconnect during set_connected rollback failed: {disc_err}");
+                }
+                return Err(e);
+            }
+            if let Err(e) = self.seed_home_pose_after_connect().await {
                 if let Err(disc_err) = self.transport.disconnect().await {
                     tracing::warn!("disconnect during set_connected rollback failed: {disc_err}");
                 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -28,8 +28,9 @@ use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, dec_ticks_to_degrees, local_sidereal_time_hours, mechanical_ha_to_ra,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
-    ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, side_of_pier as side_of_pier_calc,
-    sidereal_step_period, SIDEREAL_DEG_PER_SEC,
+    ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, select_pier_side_for_target,
+    side_of_pier as side_of_pier_calc, sidereal_step_period, target_encoder_flipped,
+    target_encoder_normal, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::TransportManager;
@@ -165,8 +166,9 @@ impl MountDevice {
         Ok(())
     }
 
-    /// Reject a slew / sync whose target encoder ticks would fall
-    /// outside the configured mechanical envelope.
+    /// Reject a slew / sync / destination-side prediction whose target
+    /// would fall outside the per-pier-side mechanical envelope for
+    /// the chosen pointing state.
     ///
     /// **Why:** the Star Adventurer GTi (like every GEM) has
     /// mechanical limits — slewing past them with cable wraps or the
@@ -175,41 +177,54 @@ impl MountDevice {
     /// On a real-hardware ConformU run that drove the mount into the
     /// counterweight-up region we heard the motor whine and saw the
     /// axis stop physically for several seconds at a time. The
-    /// configured `ra_min_hours` / `ra_max_hours` / `dec_min_degrees` /
-    /// `dec_max_degrees` express the safe envelope; any target
-    /// outside it is rejected with `INVALID_VALUE` and never reaches
-    /// the wire.
+    /// configured `ra_min_hours` / `ra_max_hours` (pre-flip side) and
+    /// `flip_policy.flip_range_hours` (post-flip side) express the
+    /// safe envelopes; any target outside the relevant one is
+    /// rejected with `INVALID_VALUE` and never reaches the wire.
+    ///
+    /// Operates on celestial RA/Dec + LST + `target_is_flipped` rather
+    /// than encoder ticks: the post-flip target encoder lands past the
+    /// celestial pole on the Dec axis (the dec ticks themselves are
+    /// outside `[-cpr_dec/4, +cpr_dec/4]`), so a ticks-based bound
+    /// would falsely reject every flipped target. The celestial-dec
+    /// range check is the actual safety invariant.
     ///
     /// Both axes are validated together so a partial-failure slew
     /// can't issue motion on RA before discovering Dec is out of
     /// range.
     fn check_within_safe_envelope(
         &self,
-        ra_ticks: i32,
-        dec_ticks: i32,
-        cpr_ra: u32,
-        cpr_dec: u32,
+        ra_hours: f64,
+        dec_degrees: f64,
+        lst_hours: f64,
+        target_is_flipped: bool,
     ) -> ASCOMResult<()> {
-        let ra_min_ticks = mechanical_ha_to_ra_ticks(self.config.ra_min_hours, cpr_ra);
-        let ra_max_ticks = mechanical_ha_to_ra_ticks(self.config.ra_max_hours, cpr_ra);
-        if ra_ticks < ra_min_ticks || ra_ticks > ra_max_ticks {
-            let mech_ha = ra_ticks_to_mechanical_ha(ra_ticks, cpr_ra);
+        let target_ha = ra_to_mechanical_ha(ra_hours, lst_hours);
+        if target_is_flipped {
+            let flip_range = self.config.flip_policy.flip_range_hours;
+            if target_ha.abs() > flip_range {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_VALUE,
+                    format!(
+                        "flipped target_HA {target_ha:.3} h outside flip window \
+                         [-{flip_range}, +{flip_range}] h"
+                    ),
+                ));
+            }
+        } else if !(self.config.ra_min_hours..=self.config.ra_max_hours).contains(&target_ha) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_VALUE,
                 format!(
-                    "RA target mech-HA {mech_ha:.3} h outside safe envelope [{}, {}] h",
+                    "RA target_HA {target_ha:.3} h outside safe envelope [{}, {}] h",
                     self.config.ra_min_hours, self.config.ra_max_hours
                 ),
             ));
         }
-        let dec_min_ticks = dec_degrees_to_ticks(self.config.dec_min_degrees, cpr_dec);
-        let dec_max_ticks = dec_degrees_to_ticks(self.config.dec_max_degrees, cpr_dec);
-        if dec_ticks < dec_min_ticks || dec_ticks > dec_max_ticks {
-            let dec_deg = dec_ticks_to_degrees(dec_ticks, cpr_dec);
+        if !(self.config.dec_min_degrees..=self.config.dec_max_degrees).contains(&dec_degrees) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_VALUE,
                 format!(
-                    "Dec target {dec_deg:.3}° outside safe envelope [{}, {}]°",
+                    "Dec target {dec_degrees:.3}° outside safe envelope [{}, {}]°",
                     self.config.dec_min_degrees, self.config.dec_max_degrees
                 ),
             ));
@@ -446,6 +461,61 @@ async fn watcher_should_abort(
     transport: &TransportManager,
 ) -> bool {
     !state.read().await.slew_in_progress || !transport.is_available()
+}
+
+/// Fold an encoder-tick delta into the shortest equivalent path on a
+/// modular axis of period `cpr`.
+///
+/// The Sky-Watcher firmware's encoder counter is wider than the
+/// physical axis's logical period (cpr): a single revolution is `cpr`
+/// ticks, but the counter can run from `−2²³` to `+2²³ − 1` before
+/// the codec's 24-bit field wraps. A through-wrap meridian-flip slew
+/// can therefore leave the encoder counter outside the canonical
+/// `[−cpr/2, +cpr/2)` band (e.g. `−1.89M` for a flip that landed
+/// physically at `+11.5 h`, modular `+1.74M`). Without folding, the
+/// next slew's `target_ticks − current_ticks` would order a full
+/// extra revolution. This helper folds the raw delta to the
+/// shortest-path equivalent in `[−cpr/2, +cpr/2)`.
+fn fold_delta_to_canonical(delta: i32, cpr: u32) -> i32 {
+    if cpr == 0 {
+        return delta;
+    }
+    let cpr_i = cpr as i32;
+    let half_cpr = cpr_i / 2;
+    let modular = delta.rem_euclid(cpr_i);
+    if modular >= half_cpr {
+        modular - cpr_i
+    } else {
+        modular
+    }
+}
+
+/// Force a flip slew's RA delta to traverse the safe (negative)
+/// `mech_HA` half so the counterweight stays clear of the binding
+/// region at `mech_HA ∈ (+6.95, +11.05)`.
+///
+/// The mechanical binding zone is at positive `mech_HA`
+/// (counterweight above local horizon for any latitude — the binding
+/// is structural, not horizon-dependent). The safe through-wrap route
+/// keeps the encoder in the negative `mech_HA` half, equivalently:
+/// the RA encoder must decrease (CCW direction). If the canonical
+/// shortest path already decreases, use it; otherwise take the long
+/// way (`delta − cpr`) which has the same end position via the
+/// encoder wrap and the safe CCW direction.
+///
+/// Northern + Southern hemispheres share this rule: the GTi's binding
+/// is a mechanical property of the mount head independent of
+/// observer latitude.
+fn flip_slew_ra_delta(canonical_delta: i32, cpr: u32) -> i32 {
+    if cpr == 0 {
+        return canonical_delta;
+    }
+    let cpr_i = cpr as i32;
+    if canonical_delta <= 0 {
+        canonical_delta
+    } else {
+        canonical_delta - cpr_i
+    }
 }
 
 /// Per-axis pickup re-slew used by the watcher's EQMOD pickup loop.
@@ -842,19 +912,18 @@ impl Telescope for MountDevice {
     }
 
     async fn destination_side_of_pier(&self, ra: f64, dec: f64) -> ASCOMResult<PierSide> {
-        // Pure prediction — no wire traffic, no slew. Runs the same
-        // coordinate-math pipeline `slew_to_coordinates_async` uses to
-        // pick the target encoder pair, then applies the same Dec >
-        // 90° check `side_of_pier()` uses to classify the resulting
-        // pointing state. The driver never plans a meridian flip, so
-        // any target inside the safety envelope lands with the Dec
-        // encoder within ±90° and therefore predicts pierWest in the
-        // Northern Hemisphere (East in the Southern). Targets outside
-        // the envelope are rejected with `INVALID_VALUE` here for
-        // parity with `slew_to_coordinates_async` — ConformU's
-        // SOPPierTest commands such targets to exercise the
-        // pier-flip code paths, and rejecting them at the
-        // prediction step matches the rejection at the slew step.
+        // Pure prediction — no wire traffic, no slew. Shares the
+        // flip-policy decision tree with `slew_to_coordinates_async`
+        // (see the design doc's
+        // [§"Pier-side decision tree"](../../../docs/services/star-adventurer-gti.md#pier-side-decision-tree)),
+        // then validates the target against the safety envelope for
+        // the chosen side with the same `INVALID_VALUE` rejection a
+        // slew would issue. With `flip_policy.enabled = false` (the
+        // default) the decision tree collapses to "current side", so
+        // any target inside the (pre-flip) safety envelope predicts
+        // `pierWest` in the Northern Hemisphere (`pierEast` in the
+        // Southern). With it enabled, an opposite side is returned
+        // when the current side's envelope rejects the target.
         self.ensure_connected().await?;
         Self::validate_coordinates(ra, dec)?;
         let params = self
@@ -864,15 +933,28 @@ impl Telescope for MountDevice {
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(Self::ascom)?;
-        let mech_ha = ra_to_mechanical_ha(ra, lst);
-        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
-        let dec_ticks = dec_degrees_to_ticks(dec, params.cpr_dec);
-        self.check_within_safe_envelope(ra_ticks, dec_ticks, params.cpr_ra, params.cpr_dec)?;
-        Ok(side_of_pier_calc(
-            dec_ticks,
+        let snap = self.transport.snapshot().await;
+        let current_side = side_of_pier_calc(
+            snap.dec.position_ticks,
             params.cpr_dec,
             self.config.site_latitude_deg,
-        ))
+        );
+        let chosen_side = select_pier_side_for_target(
+            ra,
+            lst,
+            current_side,
+            &self.config.flip_policy,
+            (self.config.ra_min_hours, self.config.ra_max_hours),
+            self.config.site_latitude_deg,
+        );
+        let pre_flip_side = if self.config.site_latitude_deg >= 0.0 {
+            PierSide::West
+        } else {
+            PierSide::East
+        };
+        let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
+        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
+        Ok(chosen_side)
     }
 
     // ---- Target setters ----
@@ -936,13 +1018,17 @@ impl Telescope for MountDevice {
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(Self::ascom)?;
-        let mech_ha = ra_to_mechanical_ha(ra, lst);
-        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
-        let dec_ticks = dec_degrees_to_ticks(dec, params.cpr_dec);
         // Reject syncs that would set the encoder outside the
         // mount's safe mechanical envelope — a bad sync would let
         // the *next* tracking step push the OTA into a hard stop.
-        self.check_within_safe_envelope(ra_ticks, dec_ticks, params.cpr_ra, params.cpr_dec)?;
+        // Sync uses the pre-flip envelope (`target_is_flipped =
+        // false`); operators must `AbortSlew` and re-sync the pre-
+        // flip pointing first if a manual flip left the mount in a
+        // post-flip state.
+        self.check_within_safe_envelope(ra, dec, lst, false)?;
+        let mech_ha = ra_to_mechanical_ha(ra, lst);
+        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
+        let dec_ticks = dec_degrees_to_ticks(dec, params.cpr_dec);
         self.transport
             .send(Command::SetPosition {
                 axis: Axis::Ra,
@@ -1013,18 +1099,50 @@ impl Telescope for MountDevice {
         // pickup loop closes the gap cleanly.
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(Self::ascom)?;
-        let mech_ha = ra_to_mechanical_ha(ra, lst);
-        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
-        let dec_ticks = dec_degrees_to_ticks(dec, params.cpr_dec);
+
+        // Phase 6: determine target pier side via the flip policy. With
+        // `flip_policy.enabled = false` (the default), `chosen_side`
+        // always equals `current_side` and the rest of this function
+        // reduces to the pre-Phase-6 pipeline. With it enabled, a
+        // flip slew may be chosen — see the design doc's
+        // [§"Meridian flip"](../../../docs/services/star-adventurer-gti.md#meridian-flip).
+        let snap = self.transport.snapshot().await;
+        let current_side = side_of_pier_calc(
+            snap.dec.position_ticks,
+            params.cpr_dec,
+            self.config.site_latitude_deg,
+        );
+        let chosen_side = select_pier_side_for_target(
+            ra,
+            lst,
+            current_side,
+            &self.config.flip_policy,
+            (self.config.ra_min_hours, self.config.ra_max_hours),
+            self.config.site_latitude_deg,
+        );
+        let pre_flip_side = if self.config.site_latitude_deg >= 0.0 {
+            PierSide::West
+        } else {
+            PierSide::East
+        };
+        let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
+        let is_flip_slew = current_side != chosen_side;
+
+        let (ra_ticks, dec_ticks) = if target_is_flipped {
+            target_encoder_flipped(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+        } else {
+            target_encoder_normal(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+        };
 
         // Refuse before any wire motion if the slew target falls
-        // outside the configured mechanical envelope. ConformU's
-        // pier-flip tests deliberately command across-the-meridian
-        // slews that on a GEM-without-flip translate to encoders
-        // past the counterweight-horizontal boundary; the safety
-        // gate sends those back as `INVALID_VALUE` instead of
-        // stalling the motor against a hard stop.
-        self.check_within_safe_envelope(ra_ticks, dec_ticks, params.cpr_ra, params.cpr_dec)?;
+        // outside the configured mechanical envelope for the chosen
+        // pier side. ConformU's pier-flip tests deliberately command
+        // across-the-meridian slews that on a GEM-without-flip
+        // translate to encoders past the counterweight-horizontal
+        // boundary; the safety gate sends those back as
+        // `INVALID_VALUE` instead of stalling the motor against a
+        // hard stop.
+        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
 
         // Atomically reserve the in-progress slot **before** issuing
         // any motion. Latch the target + capture the tracking flag in
@@ -1057,8 +1175,23 @@ impl Telescope for MountDevice {
         // covers every `?` failure.
         let result: ASCOMResult<()> = async {
             let snap = self.transport.snapshot().await;
-            let ra_delta = ra_ticks - snap.ra.position_ticks;
-            let dec_delta = dec_ticks - snap.dec.position_ticks;
+            // Fold the raw delta to canonical so a snapshot value that
+            // landed outside `[−cpr/2, +cpr/2)` after a prior
+            // through-wrap flip doesn't trigger a full-revolution
+            // correction here.
+            let ra_delta_canonical =
+                fold_delta_to_canonical(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
+            let ra_delta = if is_flip_slew {
+                // Flip slews force the safe (CCW) traversal direction
+                // through the negative-mech_HA half — see
+                // [`flip_slew_ra_delta`] and the design doc's
+                // [§"Through-wrap slew routing"](../../../docs/services/star-adventurer-gti.md#through-wrap-slew-routing).
+                flip_slew_ra_delta(ra_delta_canonical, params.cpr_ra)
+            } else {
+                ra_delta_canonical
+            };
+            let dec_delta =
+                fold_delta_to_canonical(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
             // Both axes use the INDI wire sequence: `:K` + poll `:f`
             // (decelerate stop — the spec's "motor must be at full stop
             // before setting the motion mode" requirement) → `:G goto+fast`
@@ -1776,8 +1909,19 @@ fn spawn_slew_completion_watcher(
                         let new_ra_ticks =
                             pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
                         let new_dec_ticks = dec_degrees_to_ticks(target_dec, params.cpr_dec);
-                        let ra_delta = new_ra_ticks - snap.ra.position_ticks;
-                        let dec_delta = new_dec_ticks - snap.dec.position_ticks;
+                        // Fold the deltas to canonical so the pickup
+                        // re-slew takes the shortest path even if the
+                        // current encoder snapshot landed outside
+                        // `[−cpr/2, +cpr/2)` after a through-wrap
+                        // flip — see [`fold_delta_to_canonical`].
+                        let ra_delta = fold_delta_to_canonical(
+                            new_ra_ticks - snap.ra.position_ticks,
+                            params.cpr_ra,
+                        );
+                        let dec_delta = fold_delta_to_canonical(
+                            new_dec_ticks - snap.dec.position_ticks,
+                            params.cpr_dec,
+                        );
                         pickup_iterations += 1;
                         debug!(
                             iteration = pickup_iterations,
@@ -4470,5 +4614,107 @@ mod tests {
             g110_count, 1,
             "expected 1 :G110 frame (pulse-start only, no restore), got {g110_count}; log {log:?}"
         );
+    }
+
+    // ---------- Phase 6: through-wrap routing helpers ----------
+
+    const GTI_CPR: u32 = 0x0037_5F00; // 3,628,800
+
+    #[test]
+    fn fold_delta_to_canonical_passes_through_small_deltas() {
+        assert_eq!(fold_delta_to_canonical(0, GTI_CPR), 0);
+        assert_eq!(fold_delta_to_canonical(1, GTI_CPR), 1);
+        assert_eq!(fold_delta_to_canonical(-1, GTI_CPR), -1);
+        assert_eq!(fold_delta_to_canonical(100_000, GTI_CPR), 100_000);
+        assert_eq!(fold_delta_to_canonical(-100_000, GTI_CPR), -100_000);
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_collapses_long_way_to_short_way() {
+        let half = GTI_CPR as i32 / 2;
+        // Delta of +cpr/2 + 100 folds to −cpr/2 + 100 (taking the
+        // shorter path on the modular axis).
+        let folded = fold_delta_to_canonical(half + 100, GTI_CPR);
+        assert_eq!(folded, -half + 100);
+        // Symmetric for the negative direction.
+        let folded = fold_delta_to_canonical(-half - 100, GTI_CPR);
+        assert_eq!(folded, half - 100);
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_recovers_from_through_wrap_encoder() {
+        // After a through-wrap flip slew, the encoder may have landed
+        // at e.g. raw −1,890,000 (= +1,738,800 modular). A subsequent
+        // pickup that computes `target_canonical (+1,738,800) −
+        // current_raw (−1,890,000) = +3,628,800` would order a full
+        // revolution; folding collapses it to the (near-)zero residual
+        // it should be.
+        let target_canonical = 1_738_800_i32;
+        let current_raw = -1_890_000_i32;
+        let raw_delta = target_canonical - current_raw;
+        // raw_delta ≈ cpr. Folded should be small.
+        let folded = fold_delta_to_canonical(raw_delta, GTI_CPR);
+        assert!(folded.abs() < 1000, "expected near-zero, got {folded}");
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_keeps_negative_delta_intact() {
+        // Canonical CCW (negative) → already on safe direction.
+        let delta = -1_000_000_i32;
+        assert_eq!(flip_slew_ra_delta(delta, GTI_CPR), delta);
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_inverts_positive_canonical_delta_to_long_way() {
+        // Canonical CW (positive) → must be flipped to long way through
+        // the wrap (CCW, magnitude = cpr − natural).
+        let delta = 1_000_000_i32; // +0.55 cpr
+        let flipped = flip_slew_ra_delta(delta, GTI_CPR);
+        assert_eq!(flipped, delta - GTI_CPR as i32);
+        assert!(flipped < 0, "must be CCW after the flip");
+        // Same destination, modular.
+        assert_eq!(
+            (flipped - delta).rem_euclid(GTI_CPR as i32),
+            0,
+            "same modular destination"
+        );
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_at_meridian_target_lands_on_negative_half() {
+        // Plan §2.0 canonical case: current encoder near 0 (pre-flip
+        // pierWest at meridian), target encoder = −cpr/2 (post-flip
+        // mech_HA = −12, the boundary). Natural CCW direction, already
+        // safe.
+        let delta = -(GTI_CPR as i32 / 2);
+        assert_eq!(flip_slew_ra_delta(delta, GTI_CPR), delta);
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_for_target_ha_minus_half_takes_long_way() {
+        // target_HA = −0.5: post-flip mech_HA = +11.5, encoder ≈
+        // +1.74M. Current ≈ −75K. Natural delta = +1.815M (CW,
+        // through binding zone). Flip-aware must invert to CCW.
+        let natural = 1_815_000_i32;
+        let flipped = flip_slew_ra_delta(natural, GTI_CPR);
+        assert!(flipped < 0);
+        assert_eq!(
+            flipped.unsigned_abs(),
+            (GTI_CPR as i32 - natural).unsigned_abs()
+        );
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_handles_zero_cpr_defensively() {
+        // cpr = 0 is the degenerate "parameter cache not populated"
+        // case. Callers normally short-circuit on NOT_CONNECTED
+        // before reaching this helper; pass-through is the defensive
+        // fallback so a logic bug there can't divide by zero here.
+        assert_eq!(fold_delta_to_canonical(12_345, 0), 12_345);
+    }
+
+    #[test]
+    fn flip_slew_ra_delta_handles_zero_cpr_defensively() {
+        assert_eq!(flip_slew_ra_delta(12_345, 0), 12_345);
     }
 }

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -26,11 +26,10 @@ use tracing::debug;
 
 use crate::config::MountConfig;
 use crate::coordinates::{
-    dec_degrees_to_ticks, dec_ticks_to_degrees, local_sidereal_time_hours, mechanical_ha_to_ra,
+    dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
-    ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, select_pier_side_for_target,
-    side_of_pier as side_of_pier_calc, sidereal_step_period, target_encoder_flipped,
-    target_encoder_normal, SIDEREAL_DEG_PER_SEC,
+    ra_to_mechanical_ha, select_pier_side_for_target, side_of_pier as side_of_pier_calc,
+    sidereal_step_period, target_encoder_flipped, target_encoder_normal, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::TransportManager;
@@ -64,6 +63,14 @@ struct DriverState {
     /// `ASCOMError(INVALID_OPERATION)` rather than a panic.
     park_ra_ticks: Option<i32>,
     park_dec_ticks: Option<i32>,
+    /// Pier side the most recent slew was *issued for*. Read by the
+    /// slew-completion watcher's pickup loop so it picks
+    /// `target_encoder_normal` vs `target_encoder_flipped` for the
+    /// corrective re-slew. Without this, a successful flip slew would
+    /// be undone by the pickup loop's first iteration (the post-flip
+    /// Dec encoder is past the pole, and a pre-flip encoder target
+    /// would order a slew back through the pole).
+    target_pier_side: Option<PierSide>,
     /// PulseGuide rate on the RA axis as a fraction of sidereal in
     /// `(0, 1)`. `GuideRateRightAscension` is this × `SIDEREAL_DEG_PER_SEC`.
     /// Resets to [`DEFAULT_GUIDE_RATE_FRACTION`] on each disconnect.
@@ -90,6 +97,7 @@ impl Default for DriverState {
             slew_in_progress: false,
             park_ra_ticks: None,
             park_dec_ticks: None,
+            target_pier_side: None,
             guide_rate_ra_fraction: DEFAULT_GUIDE_RATE_FRACTION,
             guide_rate_dec_fraction: DEFAULT_GUIDE_RATE_FRACTION,
             pulse_guiding_ra: false,
@@ -410,6 +418,7 @@ impl MountDevice {
             }
             s.target_ra_hours = Some(ra);
             s.target_dec_degrees = Some(dec);
+            s.target_pier_side = Some(chosen_side);
             tracking_was_on = s.tracking_requested;
             s.slew_in_progress = true;
             s.pulse_guiding_ra = false;
@@ -872,10 +881,17 @@ impl Telescope for MountDevice {
             .parameters()
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
-        let mech_ha = ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(Self::ascom)?;
-        Ok(mechanical_ha_to_ra(mech_ha, lst))
+        let (ra, _dec) = encoder_to_celestial(
+            snap.ra.position_ticks,
+            snap.dec.position_ticks,
+            lst,
+            params.cpr_ra,
+            params.cpr_dec,
+            self.config.site_latitude_deg,
+        );
+        Ok(ra)
     }
 
     async fn right_ascension_rate(&self) -> ASCOMResult<f64> {
@@ -890,10 +906,17 @@ impl Telescope for MountDevice {
             .parameters()
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
-        Ok(dec_ticks_to_degrees(
+        let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
+            .map_err(Self::ascom)?;
+        let (_ra, dec) = encoder_to_celestial(
+            snap.ra.position_ticks,
             snap.dec.position_ticks,
+            lst,
+            params.cpr_ra,
             params.cpr_dec,
-        ))
+            self.config.site_latitude_deg,
+        );
+        Ok(dec)
     }
 
     async fn declination_rate(&self) -> ASCOMResult<f64> {
@@ -1157,22 +1180,19 @@ impl Telescope for MountDevice {
             // the in-memory target.
             return Ok(());
         }
-        // The flipped Dec encoder is past the celestial pole, so a
-        // direct ra_ticks → ra → dec_ticks → dec round trip would land
-        // on the wrong sky position. Read the *celestial* current
-        // pointing from the snapshot (LST + mech_HA → RA, and the
-        // hemispheric Dec mapping). `execute_slew_with_explicit_side`
-        // will re-flip the encoder for the chosen side.
-        let cur_mech_ha = ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
-        let cur_ra = mechanical_ha_to_ra(cur_mech_ha, lst);
-        let cur_dec_encoder = dec_ticks_to_degrees(snap.dec.position_ticks, params.cpr_dec);
-        // Folded `[-180, +180)`; convert to celestial declination
-        // `[-90, +90]` by mirroring through ±90°.
-        let cur_dec = if cur_dec_encoder.abs() > 90.0 {
-            cur_dec_encoder.signum() * (180.0 - cur_dec_encoder.abs())
-        } else {
-            cur_dec_encoder
-        };
+        // Read the *celestial* current pointing from the snapshot —
+        // `encoder_to_celestial` applies the post-flip RA/Dec mapping
+        // when the Dec encoder is past the pole.
+        // `execute_slew_with_explicit_side` will re-compute the target
+        // encoder for the chosen side.
+        let (cur_ra, cur_dec) = encoder_to_celestial(
+            snap.ra.position_ticks,
+            snap.dec.position_ticks,
+            lst,
+            params.cpr_ra,
+            params.cpr_dec,
+            self.config.site_latitude_deg,
+        );
         // Drive the slew with the chosen-side encoder math directly,
         // bypassing the policy decision tree. The selector's
         // stay-on-current preference is correct for slew_to_coordinates
@@ -1939,9 +1959,9 @@ fn spawn_slew_completion_watcher(
             // residual is bounded by the slew duration × sidereal
             // rate (~15"/s of RA drift per second of slew).
             if pickup_iterations < PICKUP_MAX_ITERATIONS {
-                let (target_ra, target_dec) = {
+                let (target_ra, target_dec, target_pier_side) = {
                     let s = state.read().await;
-                    (s.target_ra_hours, s.target_dec_degrees)
+                    (s.target_ra_hours, s.target_dec_degrees, s.target_pier_side)
                 };
                 if let (Some(target_ra), Some(target_dec), Some(params)) =
                     (target_ra, target_dec, transport.parameters().await)
@@ -1967,10 +1987,20 @@ fn spawn_slew_completion_watcher(
                             return;
                         }
                     };
-                    let cur_mech_ha =
-                        ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
-                    let cur_ra = mechanical_ha_to_ra(cur_mech_ha, lst);
-                    let cur_dec = dec_ticks_to_degrees(snap.dec.position_ticks, params.cpr_dec);
+                    // Flip-aware: `encoder_to_celestial` applies the
+                    // post-flip RA/Dec mapping when the Dec encoder is
+                    // past the pole. Without it, the residual check
+                    // would interpret a successful flip as a 12-hour
+                    // RA residual and the pickup loop would try to undo
+                    // the flip on its first iteration.
+                    let (cur_ra, cur_dec) = encoder_to_celestial(
+                        snap.ra.position_ticks,
+                        snap.dec.position_ticks,
+                        lst,
+                        params.cpr_ra,
+                        params.cpr_dec,
+                        config.site_latitude_deg,
+                    );
                     // RA residual is on a 24-hour circle; take the
                     // shorter arc. Convert hours → arc-seconds
                     // (15°/hour × 3600″/°).
@@ -2016,9 +2046,38 @@ fn spawn_slew_completion_watcher(
                             None => polling_interval * 2,
                         };
                         last_pickup_at = Some(now);
-                        let new_ra_ticks =
-                            pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
-                        let new_dec_ticks = dec_degrees_to_ticks(target_dec, params.cpr_dec);
+                        // Flip-aware target-encoder computation. With a
+                        // pre-flip target side, reuse `pickup_target_ra_ticks`
+                        // for the same LST pre-compensation that pre-Phase-6
+                        // builds relied on. With a post-flip target side,
+                        // compute the projected target via
+                        // `target_encoder_flipped` so the pickup re-slew
+                        // lands on the flipped encoder (past-the-pole Dec
+                        // and the mirror-band RA mech_HA) rather than
+                        // undoing the flip back to the pre-flip side.
+                        let pre_flip_side = if config.site_latitude_deg >= 0.0 {
+                            PierSide::West
+                        } else {
+                            PierSide::East
+                        };
+                        let target_is_flipped = target_pier_side
+                            .filter(|s| *s != pre_flip_side && *s != PierSide::Unknown)
+                            .is_some();
+                        let (new_ra_ticks, new_dec_ticks) = if target_is_flipped {
+                            let lst_proj = lst + projection.as_secs_f64() / 3600.0;
+                            target_encoder_flipped(
+                                target_ra,
+                                target_dec,
+                                lst_proj,
+                                params.cpr_ra,
+                                params.cpr_dec,
+                            )
+                        } else {
+                            let new_ra =
+                                pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
+                            let new_dec = dec_degrees_to_ticks(target_dec, params.cpr_dec);
+                            (new_ra, new_dec)
+                        };
                         // Fold the deltas to canonical so the pickup
                         // re-slew takes the shortest path even if the
                         // current encoder snapshot landed outside

--- a/services/star-adventurer-gti/tests/bdd/steps/meridian_flip_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/meridian_flip_steps.rs
@@ -1,0 +1,72 @@
+//! Steps for meridian_flip.feature.
+//!
+//! Most pier-side and connection steps are shared with
+//! `side_of_pier_steps.rs` and `connection_steps.rs`; this file only
+//! adds the steps unique to the Phase 6 meridian-flip behaviour
+//! (flip_policy config seeds, CanSetPierSide read, parametric
+//! SetSideOfPier setter, abort step).
+
+#![allow(unused_variables)]
+
+use crate::world::StarAdventurerWorld;
+use ascom_alpaca::api::telescope::PierSide;
+use cucumber::{given, then, when};
+
+#[given("a star-adventurer service configured with flip_policy enabled")]
+async fn configured_with_flip_policy_enabled(world: &mut StarAdventurerWorld) {
+    world.config_mut().mount.flip_policy.enabled = true;
+    world.start_service().await;
+}
+
+#[given(
+    expr = "a star-adventurer service configured with flip_policy enabled and site latitude {float} degrees"
+)]
+async fn configured_with_flip_policy_enabled_and_site_latitude(
+    world: &mut StarAdventurerWorld,
+    deg: f64,
+) {
+    world.config_mut().mount.flip_policy.enabled = true;
+    world.config_mut().mount.site_latitude_deg = deg;
+    world.start_service().await;
+}
+
+#[when(expr = "I set SideOfPier to {word}")]
+async fn set_side_of_pier_to(world: &mut StarAdventurerWorld, label: String) {
+    world
+        .mount()
+        .set_side_of_pier(pier_side_from_label(&label))
+        .await
+        .expect("SetSideOfPier should succeed in this scenario");
+}
+
+#[when(expr = "I try to set SideOfPier to {word}")]
+async fn try_set_side_of_pier_to(world: &mut StarAdventurerWorld, label: String) {
+    match world
+        .mount()
+        .set_side_of_pier(pier_side_from_label(&label))
+        .await
+    {
+        Ok(()) => world.clear_error(),
+        Err(e) => world.record_error(e),
+    }
+}
+
+#[then(expr = "CanSetPierSide should be {word}")]
+async fn can_set_pier_side_should_be(world: &mut StarAdventurerWorld, expected: String) {
+    let want = match expected.as_str() {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected 'true' or 'false', got {other}"),
+    };
+    let got = world.mount().can_set_pier_side().await.unwrap();
+    assert_eq!(got, want, "CanSetPierSide mismatch");
+}
+
+fn pier_side_from_label(label: &str) -> PierSide {
+    match label {
+        "East" => PierSide::East,
+        "West" => PierSide::West,
+        "Unknown" => PierSide::Unknown,
+        other => panic!("unknown PierSide label: {other}"),
+    }
+}

--- a/services/star-adventurer-gti/tests/bdd/steps/mod.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/mod.rs
@@ -1,6 +1,7 @@
 pub mod abort_steps;
 pub mod connection_steps;
 pub mod coordinate_steps;
+pub mod meridian_flip_steps;
 pub mod metadata_steps;
 pub mod park_steps;
 pub mod pulse_guide_steps;

--- a/services/star-adventurer-gti/tests/bdd/steps/park_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/park_steps.rs
@@ -17,14 +17,40 @@ async fn configured_with_park_ticks(world: &mut StarAdventurerWorld, park_ra: i3
 #[when("I park the mount")]
 async fn park_mount(world: &mut StarAdventurerWorld) {
     world.mount().park().await.unwrap();
+    // ASCOM Park is async-shaped in this driver: park() returns once
+    // the goto motor commands have been issued; the watcher flips
+    // `AtPark` after observing both axes settled at the park target.
+    // Scenarios chaining off "I park the mount" expect AtPark to be
+    // true by the next step — wait for the watcher to land it, with
+    // a deadline matching `the device is parked` in slew_steps.rs.
+    // Windows + macOS CI lost this race against the watcher on PR
+    // #244 while Linux happened to win; the explicit wait makes the
+    // step deterministic across platforms.
+    wait_for_at_park(world).await;
 }
 
 #[when("I try to park the mount")]
 async fn try_park_mount(world: &mut StarAdventurerWorld) {
     match world.mount().park().await {
-        Ok(()) => world.clear_error(),
+        Ok(()) => {
+            world.clear_error();
+            wait_for_at_park(world).await;
+        }
         Err(e) => world.record_error(e),
     }
+}
+
+/// Poll `AtPark` until it flips to `true` or a 5-second deadline
+/// elapses. Matches the pattern in `slew_steps::device_is_parked`.
+async fn wait_for_at_park(world: &mut StarAdventurerWorld) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if world.mount().at_park().await.unwrap_or(false) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("park watcher did not set AtPark within 5s");
 }
 
 #[when("I unpark the mount")]

--- a/services/star-adventurer-gti/tests/bdd/steps/side_of_pier_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/side_of_pier_steps.rs
@@ -17,14 +17,9 @@ async fn dec_encoder_reports_angle(world: &mut StarAdventurerWorld, deg: f64) {
     world.queue_seed("dec_ticks", ticks.into()).await;
 }
 
-#[when("I try to set SideOfPier to East")]
-async fn try_set_side_of_pier_east(world: &mut StarAdventurerWorld) {
-    use ascom_alpaca::api::telescope::PierSide;
-    match world.mount().set_side_of_pier(PierSide::East).await {
-        Ok(()) => world.clear_error(),
-        Err(e) => world.record_error(e),
-    }
-}
+// The parametric `I try to set SideOfPier to {word}` step is
+// registered in `meridian_flip_steps.rs`; existing scenarios that
+// match this phrase exactly resolve there instead.
 
 #[when(expr = "I read DestinationSideOfPier for RA {float} hours and Dec {float} degrees")]
 async fn read_destination_side(world: &mut StarAdventurerWorld, ra: f64, dec: f64) {

--- a/services/star-adventurer-gti/tests/bdd/world.rs
+++ b/services/star-adventurer-gti/tests/bdd/world.rs
@@ -219,13 +219,16 @@ fn default_test_config() -> Config {
             settle_after_slew: Duration::from_millis(0),
             // BDD scenarios pass hardcoded RA / Dec targets (the
             // canonical example is `RA = 6.0 h, Dec = 30°`) whose
-            // computed mech-HA depends on wallclock LST. Open the
-            // safety envelope wide so those scenarios don't
-            // intermittently trip the `INVALID_VALUE` safety gate
-            // — the gate itself is exercised by the unit tests in
-            // `mount_device::tests::*_outside_safe_envelope`.
-            ra_min_hours: -12.0,
-            ra_max_hours: 12.0,
+            // computed mech-HA depends on wallclock LST. Disable the
+            // binding-zone safety gate (empty range: min > max) so
+            // those scenarios don't intermittently trip
+            // `INVALID_VALUE` when the test happens to run at an
+            // LST that puts the target inside the default
+            // `(6.95, 11.05)` zone. The gate itself is exercised by
+            // the unit tests in
+            // `mount_device::tests::slew_async_refuses_ra_target_in_binding_zone`.
+            binding_zone_min_hours: 24.0,
+            binding_zone_max_hours: 0.0,
             ..MountConfig::default()
         },
     }

--- a/services/star-adventurer-gti/tests/features/meridian_flip.feature
+++ b/services/star-adventurer-gti/tests/features/meridian_flip.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Meridian-flip support
   Phase 6 introduces driver-planned meridian flips controlled by
   MountConfig.flip_policy. With enabled = false (the shipped default)

--- a/services/star-adventurer-gti/tests/features/meridian_flip.feature
+++ b/services/star-adventurer-gti/tests/features/meridian_flip.feature
@@ -1,0 +1,93 @@
+@wip
+Feature: Meridian-flip support
+  Phase 6 introduces driver-planned meridian flips controlled by
+  MountConfig.flip_policy. With enabled = false (the shipped default)
+  every flip code path is inert: CanSetPierSide reports false,
+  SetSideOfPier returns NOT_IMPLEMENTED, DestinationSideOfPier always
+  returns the current side, and the slew planner uses the pre-flip
+  coordinate pipeline. With enabled = true, CanSetPierSide reports
+  true and SetSideOfPier(side) triggers a through-wrap flip slew that
+  keeps the OTA on its current celestial target while landing on the
+  requested pier side. The slew planner picks the side via the
+  decision tree shared with DestinationSideOfPier: stay on the
+  current side when its safety envelope covers the target HA, flip
+  to the opposite side otherwise.
+
+  Through-wrap routing is observable on the wire: a flip slew from
+  the Northern-Hemisphere pre-flip side (pierWest at mech_HA ≈ 0)
+  toward the post-flip side issues :G1 with the CCW bit set (mode
+  byte 01 = Goto+Fast+CCW), routing the RA encoder through the
+  negative-mech_HA half (counterweight-below-horizon arc) and the
+  encoder wrap at -12 h to the mirror band on the post-flip side.
+
+  Scenario: CanSetPierSide reports false by default
+    Given a running star-adventurer service
+    When I connect the device
+    Then CanSetPierSide should be false
+
+  Scenario: CanSetPierSide reports true when flip_policy is enabled
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    Then CanSetPierSide should be true
+
+  Scenario: SetSideOfPier returns not-implemented when flip_policy is disabled
+    Given a running star-adventurer service
+    When I connect the device
+    And I try to set SideOfPier to East
+    Then the operation should fail with not-implemented
+
+  Scenario: SetSideOfPier with Unknown returns invalid-value when flip_policy is enabled
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I try to set SideOfPier to Unknown
+    Then the operation should fail with invalid-value
+
+  Scenario: SetSideOfPier refuses when not connected
+    Given a star-adventurer service configured with flip_policy enabled
+    When I try to set SideOfPier to East
+    Then the operation should fail with not-connected
+
+  Scenario: SetSideOfPier refuses while parked
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I park the mount
+    And I try to set SideOfPier to East
+    Then the operation should fail with invalid-while-parked
+
+  Scenario: SetSideOfPier to the current side succeeds without changing pier side
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I set SideOfPier to West
+    Then SideOfPier should be West
+
+  Scenario: SetSideOfPier(East) from pierWest issues a CCW Goto on the RA axis
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I set SideOfPier to East
+    Then the mount should have received command :G101
+
+  Scenario: SetSideOfPier(East) marks Slewing while the flip is in progress
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I set SideOfPier to East
+    Then Slewing should be true
+
+  Scenario: AbortSlew during a SetSideOfPier flip halts both axes
+    Given a star-adventurer service configured with flip_policy enabled
+    When I connect the device
+    And I set SideOfPier to East
+    And I abort the slew
+    Then the mount should have received command :L1
+    And the mount should have received command :L2
+
+  Scenario: DestinationSideOfPier returns the current side when flip_policy is disabled
+    Given a star-adventurer service configured with site latitude 45.0 degrees
+    When I connect the device
+    And I read DestinationSideOfPier for RA 6.0 hours and Dec 30.0 degrees
+    Then DestinationSideOfPier should be West
+
+  Scenario: DestinationSideOfPier returns the current side when target is reachable from it
+    Given a star-adventurer service configured with flip_policy enabled and site latitude 45.0 degrees
+    When I connect the device
+    And I read DestinationSideOfPier for RA 6.0 hours and Dec 30.0 degrees
+    Then DestinationSideOfPier should be West


### PR DESCRIPTION
## Summary

Phase 6 of the Star Adventurer GTi driver — full meridian-flip support. End-to-end validated on real hardware (San Diego, lat 32.7°N) on 2026-05-16. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../blob/worktree-meridian-flip-phase/docs/plans/star-adventurer-gti-meridian-flip.md).

### What's in this PR

- `MountConfig::flip_policy` (`enabled` default `false`, `flip_range_hours` default `0.5`).
- Asymmetric counterweight binding-zone safety envelope (replaces the prior symmetric `ra_min/max_hours` model). Defaults `(+6.95, +11.05)` h of `mech_HA`.
- Configurable `home_pose` (any AP Park 1–5) with hemisphere-aware encoder seeding at connect.
- `SetSideOfPier(side)` + flip-aware `DestinationSideOfPier` + flip-aware `encoder_to_celestial` for the read path.
- Through-wrap slew routing for flip slews — RA axis routed binding-zone-path-aware, Dec axis routed through the visible celestial pole.
- BDD coverage of the flip lifecycle.
- `Park` now defaults to the `home_pose`-seeded values when `park_*_ticks` is null (instead of pre-seed firmware zero).

### Hardware validation, 2026-05-16, lat 32.7°N

End-to-end AP Park sequence ran clean: `Park 3 → Park 2 → staging → SetSideOfPier(East) → Park 4 N → Park 5 N → Park → Park 3 N`. Every pose confirmed visually.

The Park 4 N → Park 5 N flip-back caught a sign-blind heuristic in `flip_slew_ra_delta` (`|current_ticks| > cpr_ra/4 ⇒ "safe direction is positive"`) that mis-fired at the saddle-east wrap on the negative side — issued a +3.625 M-tick CW full polar-axis revolution through the binding zone instead of the safe 3.8 k-tick CCW canonical step. The operator powered the mount off mid-sweep (no mechanical damage). Fixed in commit `072cc72` by replacing the sign proxy with a path-aware check against the configured binding zone. The same Park 5 slew on the fixed driver issued a −3,631-tick CCW step and landed at Park 5 N exactly as predicted.

### Follow-ups

- #242 — `flip_slew_dec_delta` has the structurally analogous sign-blind heuristic. This session didn't exercise the failing edge (dec at Park 4 N was on the `+cpr_dec/2` side of the wrap where the old heuristic happens to be correct). Same patch shape, blocked on a hardware scenario to confirm.
- #243 — log the pre-seed firmware encoder snapshot at connect time. Would have shortcut two diagnostic detours this session (mock-build wire-frame escape, dec-axis-drift puzzle).

### Defaults

- `flip_policy.enabled` stays `false`. Operators opt in once they've replayed the validation locally on their own GTi (cable wrap is the one asymmetric failure mode the symmetry argument doesn't cover, and it's mount-specific).
- `home_pose` stays `None` — pre-Phase-6 behaviour preserved for fresh installs.

## Test plan

- [x] `cargo rail run --profile commit -q` — 295 tests pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] Hardware validation (above) — AP Park 1–5 round-trip end-to-end.
- [x] Fix-validation slew with the binding-zone-aware routing — Park 4 N → Park 5 N, wire matches predicted CCW short step.
- [x] Visual confirmation of every pose by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)