### PR TITLE
star-adventurer-gti: log seed encoder snapshot at connect, tighten tolerance

### DIFF
--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1086,16 +1086,27 @@ physical pose; only the `pierSide` label differs in convention.
 
 The seed step is skipped when the firmware reports an encoder
 reading beyond a small fresh-power-up tolerance
-(`FRESH_POWER_UP_TICK_TOLERANCE`, currently 100 ticks ≈ 10″ at the
+(`FRESH_POWER_UP_TICK_TOLERANCE`, currently 10 ticks ≈ 4″ at the
 GTi's CPR). The tolerance exists because the Sky-Watcher firmware
 does not always read exactly `(0, 0)` after a power-cycle —
 empirically the validation GTi reports `dec = −1` on connect, a
 single-tick initialisation artifact (~0.4″) that obviously still
 represents the just-powered-up state. Any genuine post-slew
-encoder is tens of thousands of ticks away from zero, so the
-tolerance comfortably distinguishes "fresh power-up" from
-"already slewed this session". Reconnecting mid-session after a
-slew is therefore still safe.
+encoder is tens of thousands of ticks away from zero, so a tight
+tolerance is enough to absorb the firmware artifact without ever
+masking a real mid-session position. Reconnecting mid-session
+after a slew is therefore still safe.
+
+`seed_home_pose_after_connect` emits two `info!()`-level log lines
+per connect (when `home_pose` is configured) so hardware-validation
+sessions can sanity-check the firmware encoder state at a glance: a
+`pre-seed encoder snapshot at connect` line with the firmware's
+pre-seed `(ra, dec)` ticks, and a `seeded firmware encoder for
+home_pose` line with the post-seed values. Operators expect the
+pre-seed pair to read approximately `(0, 0)` on a fresh power-up;
+any larger reading is a signal that either the previous slew's
+state survived the connection state machine or the build is
+running against a mock transport rather than the real wire.
 
 Documented operator assumption: when `home_pose` is set, the operator
 powers up the mount **at** the configured pose and connects the

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use skywatcher_motor_protocol::command::{ModeKind, MotionMode, Speed};
 use skywatcher_motor_protocol::{Axis, Command};
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::config::MountConfig;
 use crate::coordinates::{
@@ -50,7 +50,7 @@ const DEFAULT_GUIDE_RATE_FRACTION: f64 = 0.5;
 /// thousands of ticks away from zero, so this tolerance comfortably
 /// distinguishes "just powered up" from "the operator already moved
 /// the mount this session".
-const FRESH_POWER_UP_TICK_TOLERANCE: i32 = 100;
+const FRESH_POWER_UP_TICK_TOLERANCE: i32 = 10;
 
 /// In-memory mirror of latched-from-the-client state (Tracking enabled,
 /// AtPark flag, last target). The values that come from the wire (current
@@ -428,6 +428,12 @@ impl MountDevice {
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         let snap = self.transport.snapshot().await;
+        info!(
+            pre_seed_ra_ticks = snap.ra.position_ticks,
+            pre_seed_dec_ticks = snap.dec.position_ticks,
+            home_pose = ?home_pose,
+            "pre-seed encoder snapshot at connect"
+        );
         if snap.ra.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
             || snap.dec.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
         {
@@ -459,10 +465,10 @@ impl MountDevice {
             .await
             .map_err(Self::ascom)?;
         self.transport.seed_dec_position(dec_ticks).await;
-        debug!(
+        info!(
+            seeded_ra_ticks = ra_ticks,
+            seeded_dec_ticks = dec_ticks,
             home_pose = ?home_pose,
-            ra_ticks,
-            dec_ticks,
             "seeded firmware encoder for home_pose"
         );
         Ok(())
@@ -4599,6 +4605,33 @@ mod tests {
         // the firmware's reported 50,000 (not -907,200).
         let s = d.state.read().await;
         assert_eq!(s.park_ra_ticks, Some(50_000));
+        assert_eq!(s.park_dec_ticks, Some(0));
+    }
+
+    #[tokio::test]
+    async fn home_pose_seed_skips_just_above_fresh_power_up_tolerance() {
+        // Pins the tight 10-tick fresh-power-up floor. A reading of 50
+        // ticks (~18″ at the GTi's CPR) is well above the single-tick
+        // firmware artifact and indicates the operator has already moved
+        // the mount; the seed must skip so the slewed-to position is not
+        // clobbered. If the tolerance is ever loosened back toward the
+        // historical 100-tick floor, this test catches it.
+        use crate::transport::mock::CapturingMockFactory;
+        let factory = CapturingMockFactory::new();
+        {
+            let mut state = factory.mock.state.lock().await;
+            state.ra.position_ticks = 50;
+        }
+        let mut cfg = Config::default();
+        cfg.mount.binding_zone_min_hours = 24.0;
+        cfg.mount.binding_zone_max_hours = 0.0;
+        cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+        cfg.mount.site_latitude_deg = 32.7157;
+        let manager = Arc::new(TransportManager::new(cfg.clone(), Arc::new(factory)));
+        let d = MountDevice::new(cfg.mount, manager);
+        d.set_connected(true).await.unwrap();
+        let s = d.state.read().await;
+        assert_eq!(s.park_ra_ticks, Some(50));
         assert_eq!(s.park_dec_ticks, Some(0));
     }
 


### PR DESCRIPTION
## Summary

- `seed_home_pose_after_connect` now emits two `info!()` log lines per connect when `home_pose` is configured: `pre-seed encoder snapshot at connect` (firmware encoder before `:E1`/`:E2`) and `seeded firmware encoder for home_pose` (post-seed values, promoted from `debug!()`). Field names are grep-distinguishable (`pre_seed_*` vs `seeded_*`); both fire exactly once per connect so log volume stays bounded. Operator-derived advantage during hardware sessions is high — see #243 for the two 2026-05-16 state-mismatch puzzles a pre-seed snapshot would have collapsed into one-line diagnoses.
- `FRESH_POWER_UP_TICK_TOLERANCE` lowered from 100 → 10 ticks (~4″ at the GTi's CPR; still comfortably above the empirical 1-tick firmware initialisation artifact). 100 ticks (~36″) was overly generous; the tighter floor is more conservative against any future firmware state that lands non-zero but small after power-up.
- Design doc updated to reflect both changes; pre-existing arcsec math bug fixed (`100 ticks ≈ 10″` was off by ~3.5×).

## Test plan

- [x] `cargo rail run --profile commit -q` — 296 tests pass (1 skipped, unrelated ConformU).
- [x] `cargo fmt --check` — clean.
- [x] `cargo build --locked --all-features --all-targets -p star-adventurer-gti` — clean.
- [x] New unit test `home_pose_seed_skips_just_above_fresh_power_up_tolerance` pins the new 10-tick boundary at 50 ticks so the value cannot silently drift back toward 100.
- [x] Existing tests `home_pose_seed_fires_when_firmware_reports_near_zero_encoder` (dec=-1 → fires) and `home_pose_seed_skips_when_firmware_encoder_beyond_tolerance` (ra=50_000 → skips) still pass unchanged under the new tolerance.
- [ ] Hardware-validation session on the GTi: confirm the two `info!()` lines fire at connect and the pre-seed pair reads `(0, 0)` (±10) on a fresh power-up.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)