### PR TITLE
fix(star-adventurer-gti): correct raw-vs-folded encoder handling in dec helpers (#242)

### DIFF
--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -169,7 +169,7 @@ pub fn side_of_pier(dec_ticks: i32, cpr_dec: u32, site_latitude_deg: f64) -> Pie
     // position. Without folding, a raw in `(3·cpr/4, 5·cpr/4)` whose
     // folded value lies in `(-cpr/4, +cpr/4)` would be misread as
     // post-flip and the East/West label would invert.
-    let folded = fold_delta_to_canonical(dec_ticks, cpr_dec);
+    let folded = fold_to_canonical_band(dec_ticks, cpr_dec);
     // Past-the-pole detection: |Dec encoder| > 90° means the mount
     // has rotated the Dec axis beyond either celestial pole — the
     // post-meridian-flip / cross-axis-rotated-180° state. The
@@ -533,7 +533,7 @@ fn fold_to_signed(value: f64, period: f64) -> f64 {
 /// and the [`side_of_pier`] half-classification would misread the
 /// physical position. This helper collapses the raw value to its
 /// canonical-band equivalent.
-pub fn fold_delta_to_canonical(value: i32, cpr: u32) -> i32 {
+pub fn fold_to_canonical_band(value: i32, cpr: u32) -> i32 {
     if cpr == 0 {
         return value;
     }
@@ -727,7 +727,7 @@ mod tests {
         let cpr_i = GTI_CPR as i32;
         let raw_positive_zone = cpr_i * 7 / 8; // 7·cpr/8, folds to -cpr/8
         assert!(raw_positive_zone.abs() > cpr_i / 4);
-        let folded = fold_delta_to_canonical(raw_positive_zone, GTI_CPR);
+        let folded = fold_to_canonical_band(raw_positive_zone, GTI_CPR);
         assert!(folded.abs() <= cpr_i / 4, "must fold into pre-flip half");
         assert_eq!(
             side_of_pier(raw_positive_zone, GTI_CPR, 47.6),
@@ -750,28 +750,28 @@ mod tests {
     }
 
     #[test]
-    fn fold_delta_to_canonical_passes_through_small_deltas() {
-        assert_eq!(fold_delta_to_canonical(0, GTI_CPR), 0);
-        assert_eq!(fold_delta_to_canonical(1, GTI_CPR), 1);
-        assert_eq!(fold_delta_to_canonical(-1, GTI_CPR), -1);
-        assert_eq!(fold_delta_to_canonical(100_000, GTI_CPR), 100_000);
-        assert_eq!(fold_delta_to_canonical(-100_000, GTI_CPR), -100_000);
+    fn fold_to_canonical_band_passes_through_small_deltas() {
+        assert_eq!(fold_to_canonical_band(0, GTI_CPR), 0);
+        assert_eq!(fold_to_canonical_band(1, GTI_CPR), 1);
+        assert_eq!(fold_to_canonical_band(-1, GTI_CPR), -1);
+        assert_eq!(fold_to_canonical_band(100_000, GTI_CPR), 100_000);
+        assert_eq!(fold_to_canonical_band(-100_000, GTI_CPR), -100_000);
     }
 
     #[test]
-    fn fold_delta_to_canonical_collapses_long_way_to_short_way() {
+    fn fold_to_canonical_band_collapses_long_way_to_short_way() {
         let half = GTI_CPR as i32 / 2;
         // Delta of +cpr/2 + 100 folds to −cpr/2 + 100 (taking the
         // shorter path on the modular axis).
-        let folded = fold_delta_to_canonical(half + 100, GTI_CPR);
+        let folded = fold_to_canonical_band(half + 100, GTI_CPR);
         assert_eq!(folded, -half + 100);
         // Symmetric for the negative direction.
-        let folded = fold_delta_to_canonical(-half - 100, GTI_CPR);
+        let folded = fold_to_canonical_band(-half - 100, GTI_CPR);
         assert_eq!(folded, half - 100);
     }
 
     #[test]
-    fn fold_delta_to_canonical_recovers_from_through_wrap_encoder() {
+    fn fold_to_canonical_band_recovers_from_through_wrap_encoder() {
         // After a through-wrap flip slew, the encoder may have landed
         // at e.g. raw −1,890,000 (= +1,738,800 modular). A subsequent
         // pickup that computes `target_canonical (+1,738,800) −
@@ -782,17 +782,17 @@ mod tests {
         let current_raw = -1_890_000_i32;
         let raw_delta = target_canonical - current_raw;
         // raw_delta ≈ cpr. Folded should be small.
-        let folded = fold_delta_to_canonical(raw_delta, GTI_CPR);
+        let folded = fold_to_canonical_band(raw_delta, GTI_CPR);
         assert!(folded.abs() < 1000, "expected near-zero, got {folded}");
     }
 
     #[test]
-    fn fold_delta_to_canonical_handles_zero_cpr_defensively() {
+    fn fold_to_canonical_band_handles_zero_cpr_defensively() {
         // cpr = 0 is the degenerate "parameter cache not populated"
         // case. Callers normally short-circuit on NOT_CONNECTED
         // before reaching this helper; pass-through is the defensive
         // fallback so a logic bug there can't divide by zero here.
-        assert_eq!(fold_delta_to_canonical(12_345, 0), 12_345);
+        assert_eq!(fold_to_canonical_band(12_345, 0), 12_345);
     }
 
     /// Tiny `f64` helper so the half-revolution fold test can be stated

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -163,12 +163,19 @@ pub fn side_of_pier(dec_ticks: i32, cpr_dec: u32, site_latitude_deg: f64) -> Pie
         return PierSide::Unknown;
     }
     let quarter = (cpr_dec / 4) as i64;
+    // Fold the raw counter into the canonical band before classifying:
+    // raw can sit outside `[-cpr/2, +cpr/2)` after through-wrap flip
+    // slews, and the half-classification only makes sense on the folded
+    // position. Without folding, a raw in `(3·cpr/4, 5·cpr/4)` whose
+    // folded value lies in `(-cpr/4, +cpr/4)` would be misread as
+    // post-flip and the East/West label would invert.
+    let folded = fold_delta_to_canonical(dec_ticks, cpr_dec);
     // Past-the-pole detection: |Dec encoder| > 90° means the mount
     // has rotated the Dec axis beyond either celestial pole — the
     // post-meridian-flip / cross-axis-rotated-180° state. The
     // boundary at exactly ±90° is *not* East: the mount can sit at
     // the pole via normal-pointing slews without a flip.
-    let east_in_north = (dec_ticks as i64).abs() > quarter;
+    let east_in_north = (folded as i64).abs() > quarter;
     let northern = site_latitude_deg >= 0.0;
     let east = if northern {
         east_in_north
@@ -512,6 +519,34 @@ fn fold_to_signed(value: f64, period: f64) -> f64 {
     }
 }
 
+/// Fold an encoder-tick value (position or delta) into the shortest
+/// equivalent representation in `[-cpr/2, +cpr/2)`.
+///
+/// The Sky-Watcher firmware's encoder counter is wider than the physical
+/// axis's logical period (cpr): a single revolution is `cpr` ticks, but
+/// the counter can run from `−2²³` to `+2²³ − 1` before the codec's
+/// 24-bit field wraps. A through-wrap meridian-flip slew can therefore
+/// leave the encoder counter outside the canonical `[−cpr/2, +cpr/2)`
+/// band (e.g. `−1.89M` for a flip that landed physically at `+11.5 h`,
+/// modular `+1.74M`). Without folding, the next slew's
+/// `target_ticks − current_ticks` would order a full extra revolution,
+/// and the [`side_of_pier`] half-classification would misread the
+/// physical position. This helper collapses the raw value to its
+/// canonical-band equivalent.
+pub fn fold_delta_to_canonical(value: i32, cpr: u32) -> i32 {
+    if cpr == 0 {
+        return value;
+    }
+    let cpr_i = cpr as i32;
+    let half_cpr = cpr_i / 2;
+    let modular = value.rem_euclid(cpr_i);
+    if modular >= half_cpr {
+        modular - cpr_i
+    } else {
+        modular
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -678,6 +713,86 @@ mod tests {
         // the helper still has to handle this defensively to stay a
         // total function.
         assert_eq!(side_of_pier(0, 0, 47.6), PierSide::Unknown);
+    }
+
+    #[test]
+    fn side_of_pier_folds_raw_outside_canonical_band() {
+        // `dec_ticks` is the raw encoder counter — it can drift outside
+        // `[-cpr/2, +cpr/2)` after through-wrap flip slews, manual `:E`
+        // writes, or power-up encoder noise. The East/West label must
+        // reflect the *physical* dec-axis position (folded), not the raw
+        // counter value. Raw in `(3·cpr/4, 5·cpr/4)` folds to within
+        // `(-cpr/4, +cpr/4)` — i.e. pre-flip → pierWest for a Northern
+        // observer.
+        let cpr_i = GTI_CPR as i32;
+        let raw_positive_zone = cpr_i * 7 / 8; // 7·cpr/8, folds to -cpr/8
+        assert!(raw_positive_zone.abs() > cpr_i / 4);
+        let folded = fold_delta_to_canonical(raw_positive_zone, GTI_CPR);
+        assert!(folded.abs() <= cpr_i / 4, "must fold into pre-flip half");
+        assert_eq!(
+            side_of_pier(raw_positive_zone, GTI_CPR, 47.6),
+            PierSide::West,
+            "raw in positive disagreement zone must classify by folded position"
+        );
+        // Mirror on the negative side.
+        let raw_negative_zone = -cpr_i * 7 / 8;
+        assert_eq!(
+            side_of_pier(raw_negative_zone, GTI_CPR, 47.6),
+            PierSide::West,
+            "raw in negative disagreement zone must classify by folded position"
+        );
+        // And the southern hemisphere mirror.
+        assert_eq!(
+            side_of_pier(raw_positive_zone, GTI_CPR, -33.9),
+            PierSide::East,
+            "south: raw in disagreement zone must classify by folded position"
+        );
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_passes_through_small_deltas() {
+        assert_eq!(fold_delta_to_canonical(0, GTI_CPR), 0);
+        assert_eq!(fold_delta_to_canonical(1, GTI_CPR), 1);
+        assert_eq!(fold_delta_to_canonical(-1, GTI_CPR), -1);
+        assert_eq!(fold_delta_to_canonical(100_000, GTI_CPR), 100_000);
+        assert_eq!(fold_delta_to_canonical(-100_000, GTI_CPR), -100_000);
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_collapses_long_way_to_short_way() {
+        let half = GTI_CPR as i32 / 2;
+        // Delta of +cpr/2 + 100 folds to −cpr/2 + 100 (taking the
+        // shorter path on the modular axis).
+        let folded = fold_delta_to_canonical(half + 100, GTI_CPR);
+        assert_eq!(folded, -half + 100);
+        // Symmetric for the negative direction.
+        let folded = fold_delta_to_canonical(-half - 100, GTI_CPR);
+        assert_eq!(folded, half - 100);
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_recovers_from_through_wrap_encoder() {
+        // After a through-wrap flip slew, the encoder may have landed
+        // at e.g. raw −1,890,000 (= +1,738,800 modular). A subsequent
+        // pickup that computes `target_canonical (+1,738,800) −
+        // current_raw (−1,890,000) = +3,628,800` would order a full
+        // revolution; folding collapses it to the (near-)zero residual
+        // it should be.
+        let target_canonical = 1_738_800_i32;
+        let current_raw = -1_890_000_i32;
+        let raw_delta = target_canonical - current_raw;
+        // raw_delta ≈ cpr. Folded should be small.
+        let folded = fold_delta_to_canonical(raw_delta, GTI_CPR);
+        assert!(folded.abs() < 1000, "expected near-zero, got {folded}");
+    }
+
+    #[test]
+    fn fold_delta_to_canonical_handles_zero_cpr_defensively() {
+        // cpr = 0 is the degenerate "parameter cache not populated"
+        // case. Callers normally short-circuit on NOT_CONNECTED
+        // before reaching this helper; pass-through is the defensive
+        // fallback so a logic bug there can't divide by zero here.
+        assert_eq!(fold_delta_to_canonical(12_345, 0), 12_345);
     }
 
     /// Tiny `f64` helper so the half-revolution fold test can be stated

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -894,6 +894,14 @@ fn flip_slew_dec_delta(
 /// any modular replica of `pole_ticks`. Used by [`flip_slew_dec_delta`]
 /// to detect when the canonical short path would dip the OTA through
 /// the below-horizon pole.
+///
+/// `start` can sit anywhere in the signed-24-bit wire range
+/// (`±2²³ ≈ ±8.4M ticks`), which for the GTi's `cpr_dec ≈ 3.6M` puts
+/// the relevant modular replica index up to `k = ±3` away from zero.
+/// Rather than enumerating a fixed `k` window, the check shifts the
+/// sweep into pole-relative coordinates `[a, b] = [lo − pole, hi − pole]`
+/// and tests whether that interval contains any integer multiple of
+/// `cpr` — equivalent to the largest multiple `≤ b` being `≥ a`.
 fn canonical_path_crosses_pole(start: i32, delta: i32, pole_ticks: i32, cpr: u32) -> bool {
     let cpr_i = cpr as i32;
     let end = start + delta;
@@ -902,14 +910,12 @@ fn canonical_path_crosses_pole(start: i32, delta: i32, pole_ticks: i32, cpr: u32
     } else {
         (end, start)
     };
-    // `|delta| ≤ cpr` by the canonical-fold invariant, but `start` can
-    // sit far outside `[-cpr/2, +cpr/2)` after through-wrap flips —
-    // scanning `k ∈ [-2, +2]` covers every replica that could fall in
-    // `[lo, hi]`.
-    (-2..=2).any(|k| {
-        let p = pole_ticks + k * cpr_i;
-        p >= lo && p <= hi
-    })
+    let a = lo - pole_ticks;
+    let b = hi - pole_ticks;
+    // Largest multiple of `cpr_i` that is `≤ b`. If that multiple is
+    // also `≥ a` it lies inside `[a, b]`, so the corresponding pole
+    // replica `pole_ticks + k·cpr` lies inside `[lo, hi]`.
+    b.div_euclid(cpr_i) * cpr_i >= a
 }
 
 /// Per-axis pickup re-slew used by the watcher's EQMOD pickup loop.
@@ -5602,6 +5608,61 @@ mod tests {
         assert_eq!(
             issued, canonical,
             "raw outside canonical band must still produce the safe canonical path"
+        );
+    }
+
+    #[test]
+    fn canonical_path_crosses_pole_detects_high_index_modular_replica_near_wire_limit() {
+        // The signed-24-bit wire range carries raw encoder values up to
+        // ~±8.4M ticks. For `cpr_dec = 3.6M` (GTi) the relevant modular
+        // replica of the below-horizon pole can sit at `k = +3`
+        // (≈ +9.98M) and the path-aware check must still find it. A
+        // prior hardcoded `k ∈ -2..=2` scan missed this band and
+        // returned `false` for sweeps that genuinely contain a pole
+        // replica — letting the helper route the OTA through the
+        // below-horizon pole.
+        let cpr = GTI_CPR;
+        let cpr_i = cpr as i32;
+        let pole = -cpr_i / 4; // N: SCP at -cpr/4 = -907,200
+                               // Sweep [+8_300_000, +10_000_000] contains the k=+3 replica
+                               // at -907,200 + 3·3,628,800 = +9,979,200.
+        let start = 8_300_000_i32;
+        let delta = 1_700_000_i32;
+        assert!(
+            canonical_path_crosses_pole(start, delta, pole, cpr),
+            "k=+3 replica at +9_979_200 must be detected inside sweep [+8.3M, +10M]"
+        );
+        // Drive it through `flip_slew_dec_delta` for the end-to-end
+        // assertion: canonical positive must be flipped to the long-way
+        // negative because the canonical path crosses SCP.
+        let issued = flip_slew_dec_delta(delta, start, cpr, true);
+        assert!(
+            issued < 0,
+            "canonical path crosses SCP at wire boundary; must force long way (got {issued})"
+        );
+        assert_eq!(
+            (issued - delta).rem_euclid(cpr_i),
+            0,
+            "long way must land at the same modular destination"
+        );
+        // Mirror replica on the negative side: sweep [-10M, -8.3M]
+        // contains the k=-3 replica at -907_200 - 3·3_628_800 =
+        // -11,793,600... no wait, k=-3 puts it at -11.79M. That's
+        // outside the sweep. The relevant southern-mirror replica
+        // when `pole = -cpr/4` and we're at the negative wire boundary
+        // is k=-2: -907_200 - 2·3_628_800 = -8,164,800, which IS in
+        // [-10M, -8.3M] — well within the old `-2..=2` window. The
+        // negative wire boundary doesn't suffer the same k=±3 miss
+        // because the pole is at -cpr/4, not +cpr/4, so the asymmetry
+        // shifts the danger band onto the positive side only for
+        // northern observers. Southern observers (pole at +cpr/4) get
+        // the mirror — exercise that too.
+        let pole_south = cpr_i / 4;
+        // Sweep [-10M, -8.3M] contains the k=-3 replica at
+        // +907_200 - 3·3_628_800 = -9_979_200.
+        assert!(
+            canonical_path_crosses_pole(-10_000_000, 1_700_000, pole_south, cpr),
+            "k=-3 replica at -9_979_200 must be detected for southern pole"
         );
     }
 

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -844,27 +844,25 @@ fn canonical_path_crosses_binding_zone(
 /// for northern observers (encoder `+cpr/4`), SCP at altitude `+|lat|`
 /// for southern (encoder `−cpr/4`). The other pole is below the
 /// horizon and the path through it dips the OTA below the local
-/// horizon — exactly the failure mode we hit during the first
-/// hardware validation when the OTA was driven through SCP at LAT
-/// 32.7°N. (The fold-canonical-delta's boundary case at exactly
-/// `±cpr/2` produces the negative direction, which from `encoder = 0`
-/// pre-flip routes the Dec axis through SCP.)
+/// horizon — exactly the failure mode hit during the first hardware
+/// validation when the OTA was driven through SCP at lat 32.7°N.
 ///
-/// Rule, expressed in encoder side:
-///
-/// - **Northern** observer:
-///   - `current` in the *pre-flip* half (`|enc| ≤ cpr/4`): force CW
-///     (positive delta) — the path increases toward `+cpr/4` (NCP).
-///   - `current` in the *post-flip* half (`|enc| > cpr/4`): force
-///     CCW (negative delta) — the path decreases back through
-///     `+cpr/4` (NCP).
-/// - **Southern** observer: inverse — the safe pole is `−cpr/4`
-///   (SCP) so the directions flip.
-///
-/// When the canonical shortest path already goes the safe direction,
-/// it's returned unchanged. When it doesn't, the long way around
-/// (`delta − cpr` or `delta + cpr`) lands at the same modular
+/// Strategy (mirroring [`flip_slew_ra_delta`]): take the canonical
+/// short path unless its linear dec-encoder sweep from `current_ticks`
+/// through `current_ticks + canonical_delta` crosses the
+/// below-horizon-pole encoder position at any modular replica
+/// (`−cpr/4` for N, `+cpr/4` for S). If it would, take the long way
+/// around (`canonical ± cpr_dec`), which lands at the same modular
 /// destination via the safe pole.
+///
+/// Previously a sign-blind heuristic (`|current| ≤ cpr/4 ⇒ "safe is
+/// positive (toward NCP for N)"`) was used. It happens to give the
+/// right answer for every realistic flip-slew (current, target) pair
+/// after folding raw to the canonical band, but the path-aware check
+/// makes the safety property explicit, mirrors the RA helper's
+/// structure, and is naturally robust to `current_ticks` outside the
+/// canonical band (the modular-replica scan covers all continuous
+/// sweeps regardless of where raw has accumulated).
 fn flip_slew_dec_delta(
     canonical_delta: i32,
     current_ticks: i32,
@@ -875,22 +873,37 @@ fn flip_slew_dec_delta(
         return canonical_delta;
     }
     let cpr_i = cpr_dec as i32;
-    let quarter = cpr_i / 4;
-    // Fold raw current into [-cpr/2, +cpr/2) before classifying — raw
-    // can drift outside the canonical band after long-way flip slews
-    // or power-up encoder noise, and the half-classification only makes
-    // sense for the folded position.
-    let current_folded = fold_delta_to_canonical(current_ticks, cpr_dec);
-    let in_pre_flip = current_folded.abs() <= quarter;
-    let safe_direction_positive = if northern { in_pre_flip } else { !in_pre_flip };
-    let canonical_positive = canonical_delta > 0;
-    if canonical_positive == safe_direction_positive {
-        canonical_delta
-    } else if canonical_delta > 0 {
+    let unsafe_pole = if northern { -cpr_i / 4 } else { cpr_i / 4 };
+    if !canonical_path_crosses_pole(current_ticks, canonical_delta, unsafe_pole, cpr_dec) {
+        return canonical_delta;
+    }
+    if canonical_delta > 0 {
         canonical_delta - cpr_i
     } else {
         canonical_delta + cpr_i
     }
+}
+
+/// True iff the linear encoder sweep `[start, start + delta]` crosses
+/// any modular replica of `pole_ticks`. Used by [`flip_slew_dec_delta`]
+/// to detect when the canonical short path would dip the OTA through
+/// the below-horizon pole.
+fn canonical_path_crosses_pole(start: i32, delta: i32, pole_ticks: i32, cpr: u32) -> bool {
+    let cpr_i = cpr as i32;
+    let end = start + delta;
+    let (lo, hi) = if end >= start {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    // `|delta| ≤ cpr` by the canonical-fold invariant, but `start` can
+    // sit far outside `[-cpr/2, +cpr/2)` after through-wrap flips —
+    // scanning `k ∈ [-2, +2]` covers every replica that could fall in
+    // `[lo, hi]`.
+    (-2..=2).any(|k| {
+        let p = pole_ticks + k * cpr_i;
+        p >= lo && p <= hi
+    })
 }
 
 /// Per-axis pickup re-slew used by the watcher's EQMOD pickup loop.
@@ -5387,25 +5400,6 @@ mod tests {
 
     // ---------- flip_slew_dec_delta (Dec routing through the visible pole) ----------
 
-    /// Trace the absolute encoder traversal range from `start` by `delta`
-    /// and report `true` iff the trajectory crosses `pole_ticks` (the
-    /// unsafe-pole position) on its way to the end.
-    fn path_crosses_pole(start: i32, delta: i32, pole_ticks: i32, cpr: u32) -> bool {
-        let cpr_i = cpr as i32;
-        let end = start + delta;
-        let (lo, hi) = if end >= start {
-            (start, end)
-        } else {
-            (end, start)
-        };
-        // Test all modular replicas of `pole_ticks` that could fall in
-        // `[lo, hi]`. Since `|delta| ≤ cpr`, at most one replica matters.
-        (-2..=2).any(|k| {
-            let p = pole_ticks + k * cpr_i;
-            p >= lo && p <= hi
-        })
-    }
-
     #[test]
     fn flip_slew_dec_delta_north_park3_start_to_post_flip_positive_uses_natural_cw() {
         // Park 3: start at encoder +cpr/4 (= +90°, NCP). Target = +135°
@@ -5424,7 +5418,7 @@ mod tests {
         );
         // Confirm the path avoids SCP (-cpr/4).
         let issued = flip_slew_dec_delta(canonical, current, cpr, true);
-        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5441,8 +5435,8 @@ mod tests {
         let issued = flip_slew_dec_delta(canonical, 0, cpr, true);
         assert_eq!(issued, half_cpr, "must force CW through NCP");
         // Verify path crosses NCP and not SCP.
-        assert!(path_crosses_pole(0, issued, quarter, cpr));
-        assert!(!path_crosses_pole(0, issued, -quarter, cpr));
+        assert!(canonical_path_crosses_pole(0, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(0, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5462,8 +5456,8 @@ mod tests {
             "flip-back from +135° must use natural CCW"
         );
         // Verify path crosses NCP (the safe pole) and not SCP.
-        assert!(path_crosses_pole(current, issued, quarter, cpr));
-        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+        assert!(canonical_path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5478,8 +5472,8 @@ mod tests {
         let canonical = target - current; // positive, half cpr
         let issued = flip_slew_dec_delta(canonical, current, cpr, true);
         assert_eq!(issued, canonical, "natural CW direction is safe");
-        assert!(path_crosses_pole(current, issued, quarter, cpr));
-        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+        assert!(canonical_path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5499,8 +5493,8 @@ mod tests {
         // Lands at the same modular destination.
         assert_eq!((issued - canonical).rem_euclid(cpr as i32), 0);
         // Path crosses NCP, not SCP.
-        assert!(path_crosses_pole(current, issued, quarter, cpr));
-        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+        assert!(canonical_path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5517,8 +5511,8 @@ mod tests {
         let issued = flip_slew_dec_delta(canonical, current, cpr, true);
         assert!(issued < 0, "must force CCW long way");
         assert_eq!((issued - canonical).rem_euclid(cpr as i32), 0);
-        assert!(path_crosses_pole(current, issued, quarter, cpr));
-        assert!(!path_crosses_pole(current, issued, -quarter, cpr));
+        assert!(canonical_path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, -quarter, cpr));
     }
 
     #[test]
@@ -5539,7 +5533,7 @@ mod tests {
         );
         // For south, the unsafe pole is +cpr/4 (NCP). Verify path
         // doesn't cross it.
-        assert!(!path_crosses_pole(current, issued, quarter, cpr));
+        assert!(!canonical_path_crosses_pole(current, issued, quarter, cpr));
     }
 
     #[test]
@@ -5553,36 +5547,28 @@ mod tests {
     }
 
     #[test]
-    fn flip_slew_dec_delta_folds_raw_current_outside_canonical_band() {
-        // `current_ticks` is the raw encoder counter. After through-wrap
-        // flip slews (or via power-up encoder noise / manual encoder
-        // writes), raw can sit outside `[-cpr/2, +cpr/2)`. The
-        // pre-flip/post-flip half classification only makes sense on the
-        // folded position; without folding, a raw in (3·cpr/4, 5·cpr/4)
-        // whose folded value is in (-cpr/4, +cpr/4) would be misread as
-        // post-flip and the helper would pick the wrong safe direction.
+    fn flip_slew_dec_delta_handles_raw_current_outside_canonical_band() {
+        // `current_ticks` is the raw encoder counter, which can sit
+        // outside `[-cpr/2, +cpr/2)` after through-wrap flip slews,
+        // manual `:E` writes, or power-up encoder noise. The path-aware
+        // check operates on the continuous sweep `[raw, raw + canonical]`
+        // and the modular-replica pole scan, so raw outside the canonical
+        // band is handled naturally — no fold needed. Sanity-check that
+        // a small positive canonical from a raw in the positive
+        // disagreement zone (which a prior heuristic-based version would
+        // have misread as post-flip and routed the long way through the
+        // below-horizon pole) passes through unchanged.
         let cpr = GTI_CPR;
         let cpr_i = cpr as i32;
-        let raw = cpr_i * 7 / 8; // 7·cpr/8 — in the positive disagreement zone
-        assert!(
-            raw.abs() > cpr_i / 4,
-            "raw must look post-flip without folding"
-        );
-        let folded = fold_delta_to_canonical(raw, cpr);
-        assert!(
-            folded.abs() <= cpr_i / 4,
-            "folded must be in the pre-flip half"
-        );
-        // Folded says pre-flip → safe direction (N) is positive; the
-        // canonical positive delta already matches, so the helper must
-        // return it unchanged. Without the fold, the helper would
-        // misclassify as post-flip and force the long way around
-        // (canonical − cpr ≈ −3.5M, a near-full-revolution).
+        let raw = cpr_i * 7 / 8; // 7·cpr/8, folds to -cpr/8
         let canonical = 100_000_i32;
+        // Sweep [+3,175,200, +3,275,200]. The unsafe pole at -cpr/4
+        // (= -907,200) has modular replicas at -cpr/4, +3·cpr/4, etc.;
+        // none fall inside the sweep, so canonical is preserved.
         let issued = flip_slew_dec_delta(canonical, raw, cpr, true);
         assert_eq!(
             issued, canonical,
-            "raw in disagreement zone must fold to pre-flip half before classifying"
+            "raw outside canonical band must still produce the safe canonical path"
         );
     }
 

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use crate::config::MountConfig;
 use crate::coordinates::{
-    dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
+    dec_degrees_to_ticks, encoder_to_celestial, fold_delta_to_canonical, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
     ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, select_pier_side_for_target,
     side_of_pier as side_of_pier_calc, sidereal_step_period, target_encoder_flipped,
@@ -759,33 +759,6 @@ async fn watcher_should_abort(
     transport: &TransportManager,
 ) -> bool {
     !state.read().await.slew_in_progress || !transport.is_available()
-}
-
-/// Fold an encoder-tick delta into the shortest equivalent path on a
-/// modular axis of period `cpr`.
-///
-/// The Sky-Watcher firmware's encoder counter is wider than the
-/// physical axis's logical period (cpr): a single revolution is `cpr`
-/// ticks, but the counter can run from `−2²³` to `+2²³ − 1` before
-/// the codec's 24-bit field wraps. A through-wrap meridian-flip slew
-/// can therefore leave the encoder counter outside the canonical
-/// `[−cpr/2, +cpr/2)` band (e.g. `−1.89M` for a flip that landed
-/// physically at `+11.5 h`, modular `+1.74M`). Without folding, the
-/// next slew's `target_ticks − current_ticks` would order a full
-/// extra revolution. This helper folds the raw delta to the
-/// shortest-path equivalent in `[−cpr/2, +cpr/2)`.
-fn fold_delta_to_canonical(delta: i32, cpr: u32) -> i32 {
-    if cpr == 0 {
-        return delta;
-    }
-    let cpr_i = cpr as i32;
-    let half_cpr = cpr_i / 2;
-    let modular = delta.rem_euclid(cpr_i);
-    if modular >= half_cpr {
-        modular - cpr_i
-    } else {
-        modular
-    }
 }
 
 /// Force a flip slew's RA delta to keep the polar-axis sweep out of
@@ -5264,43 +5237,6 @@ mod tests {
     const GTI_BINDING_ZONE: (f64, f64) = (6.95, 11.05);
 
     #[test]
-    fn fold_delta_to_canonical_passes_through_small_deltas() {
-        assert_eq!(fold_delta_to_canonical(0, GTI_CPR), 0);
-        assert_eq!(fold_delta_to_canonical(1, GTI_CPR), 1);
-        assert_eq!(fold_delta_to_canonical(-1, GTI_CPR), -1);
-        assert_eq!(fold_delta_to_canonical(100_000, GTI_CPR), 100_000);
-        assert_eq!(fold_delta_to_canonical(-100_000, GTI_CPR), -100_000);
-    }
-
-    #[test]
-    fn fold_delta_to_canonical_collapses_long_way_to_short_way() {
-        let half = GTI_CPR as i32 / 2;
-        // Delta of +cpr/2 + 100 folds to −cpr/2 + 100 (taking the
-        // shorter path on the modular axis).
-        let folded = fold_delta_to_canonical(half + 100, GTI_CPR);
-        assert_eq!(folded, -half + 100);
-        // Symmetric for the negative direction.
-        let folded = fold_delta_to_canonical(-half - 100, GTI_CPR);
-        assert_eq!(folded, half - 100);
-    }
-
-    #[test]
-    fn fold_delta_to_canonical_recovers_from_through_wrap_encoder() {
-        // After a through-wrap flip slew, the encoder may have landed
-        // at e.g. raw −1,890,000 (= +1,738,800 modular). A subsequent
-        // pickup that computes `target_canonical (+1,738,800) −
-        // current_raw (−1,890,000) = +3,628,800` would order a full
-        // revolution; folding collapses it to the (near-)zero residual
-        // it should be.
-        let target_canonical = 1_738_800_i32;
-        let current_raw = -1_890_000_i32;
-        let raw_delta = target_canonical - current_raw;
-        // raw_delta ≈ cpr. Folded should be small.
-        let folded = fold_delta_to_canonical(raw_delta, GTI_CPR);
-        assert!(folded.abs() < 1000, "expected near-zero, got {folded}");
-    }
-
-    #[test]
     fn flip_slew_ra_delta_forward_flip_from_pre_flip_zero_uses_natural_ccw() {
         // Forward flip starting at encoder ≈ 0 (mech_HA ≈ 0, pre-flip
         // pierWest at meridian). Target = −cpr/2 (post-flip wrap).
@@ -5367,15 +5303,6 @@ mod tests {
         let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_BINDING_ZONE);
         assert!(issued > 0, "post-flip wrap → safe arc must use CW");
         assert_eq!(issued, canonical, "canonical CW is already safe here");
-    }
-
-    #[test]
-    fn fold_delta_to_canonical_handles_zero_cpr_defensively() {
-        // cpr = 0 is the degenerate "parameter cache not populated"
-        // case. Callers normally short-circuit on NOT_CONNECTED
-        // before reaching this helper; pass-through is the defensive
-        // fallback so a logic bug there can't divide by zero here.
-        assert_eq!(fold_delta_to_canonical(12_345, 0), 12_345);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -903,7 +903,12 @@ fn flip_slew_dec_delta(
     }
     let cpr_i = cpr_dec as i32;
     let quarter = cpr_i / 4;
-    let in_pre_flip = current_ticks.abs() <= quarter;
+    // Fold raw current into [-cpr/2, +cpr/2) before classifying — raw
+    // can drift outside the canonical band after long-way flip slews
+    // or power-up encoder noise, and the half-classification only makes
+    // sense for the folded position.
+    let current_folded = fold_delta_to_canonical(current_ticks, cpr_dec);
+    let in_pre_flip = current_folded.abs() <= quarter;
     let safe_direction_positive = if northern { in_pre_flip } else { !in_pre_flip };
     let canonical_positive = canonical_delta > 0;
     if canonical_positive == safe_direction_positive {
@@ -5618,6 +5623,40 @@ mod tests {
     #[test]
     fn flip_slew_dec_delta_zero_canonical_returns_zero() {
         assert_eq!(flip_slew_dec_delta(0, 0, GTI_CPR, true), 0);
+    }
+
+    #[test]
+    fn flip_slew_dec_delta_folds_raw_current_outside_canonical_band() {
+        // `current_ticks` is the raw encoder counter. After through-wrap
+        // flip slews (or via power-up encoder noise / manual encoder
+        // writes), raw can sit outside `[-cpr/2, +cpr/2)`. The
+        // pre-flip/post-flip half classification only makes sense on the
+        // folded position; without folding, a raw in (3·cpr/4, 5·cpr/4)
+        // whose folded value is in (-cpr/4, +cpr/4) would be misread as
+        // post-flip and the helper would pick the wrong safe direction.
+        let cpr = GTI_CPR;
+        let cpr_i = cpr as i32;
+        let raw = cpr_i * 7 / 8; // 7·cpr/8 — in the positive disagreement zone
+        assert!(
+            raw.abs() > cpr_i / 4,
+            "raw must look post-flip without folding"
+        );
+        let folded = fold_delta_to_canonical(raw, cpr);
+        assert!(
+            folded.abs() <= cpr_i / 4,
+            "folded must be in the pre-flip half"
+        );
+        // Folded says pre-flip → safe direction (N) is positive; the
+        // canonical positive delta already matches, so the helper must
+        // return it unchanged. Without the fold, the helper would
+        // misclassify as post-flip and force the long way around
+        // (canonical − cpr ≈ −3.5M, a near-full-revolution).
+        let canonical = 100_000_i32;
+        let issued = flip_slew_dec_delta(canonical, raw, cpr, true);
+        assert_eq!(
+            issued, canonical,
+            "raw in disagreement zone must fold to pre-flip half before classifying"
+        );
     }
 
     // ---------- Phase 6: SetSideOfPier + CanSetPierSide ----------

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info};
 
 use crate::config::MountConfig;
 use crate::coordinates::{
-    dec_degrees_to_ticks, encoder_to_celestial, fold_delta_to_canonical, local_sidereal_time_hours,
+    dec_degrees_to_ticks, encoder_to_celestial, fold_to_canonical_band, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, pickup_target_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az,
     ra_ticks_to_mechanical_ha, ra_to_mechanical_ha, select_pier_side_for_target,
     side_of_pier as side_of_pier_calc, sidereal_step_period, target_encoder_flipped,
@@ -497,7 +497,7 @@ impl MountDevice {
     ///      per-side safety envelope.
     ///   2. Atomically latches `slew_in_progress` and the
     ///      target RA/Dec.
-    ///   3. Computes deltas with `fold_delta_to_canonical` (handles a
+    ///   3. Computes deltas with `fold_to_canonical_band` (handles a
     ///      post-through-wrap raw encoder) and applies
     ///      `flip_slew_ra_delta` on the RA axis for flip slews
     ///      (forces CCW direction through the safe negative-mech_HA
@@ -569,7 +569,7 @@ impl MountDevice {
             // through-wrap flip doesn't trigger a full-revolution
             // correction here.
             let ra_delta_canonical =
-                fold_delta_to_canonical(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
+                fold_to_canonical_band(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
             let binding_zone = (
                 self.config.binding_zone_min_hours,
                 self.config.binding_zone_max_hours,
@@ -602,7 +602,7 @@ impl MountDevice {
                 ra_delta_canonical
             };
             let dec_delta_canonical =
-                fold_delta_to_canonical(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
+                fold_to_canonical_band(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
             let dec_delta = if is_flip_slew {
                 // Flip slews force the Dec axis to traverse the
                 // visible celestial pole (NCP for north, SCP for
@@ -2440,12 +2440,12 @@ fn spawn_slew_completion_watcher(
                         // re-slew takes the shortest path even if the
                         // current encoder snapshot landed outside
                         // `[−cpr/2, +cpr/2)` after a through-wrap
-                        // flip — see [`fold_delta_to_canonical`].
-                        let ra_delta = fold_delta_to_canonical(
+                        // flip — see [`fold_to_canonical_band`].
+                        let ra_delta = fold_to_canonical_band(
                             new_ra_ticks - snap.ra.position_ticks,
                             params.cpr_ra,
                         );
-                        let dec_delta = fold_delta_to_canonical(
+                        let dec_delta = fold_to_canonical_band(
                             new_dec_ticks - snap.dec.position_ticks,
                             params.cpr_dec,
                         );
@@ -5431,7 +5431,7 @@ mod tests {
         let cpr = GTI_CPR;
         let current = cpr as i32 / 2;
         let canonical_raw = -(cpr as i32 / 4) - current; // -3cpr/4
-        let canonical = fold_delta_to_canonical(canonical_raw, cpr); // +cpr/4
+        let canonical = fold_to_canonical_band(canonical_raw, cpr); // +cpr/4
         let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_CW_EXCLUSION_ZONE).unwrap();
         assert!(issued > 0, "post-flip wrap → safe arc must use CW");
         assert_eq!(issued, canonical, "canonical CW is already safe here");
@@ -5460,7 +5460,7 @@ mod tests {
         // pierEast just east of the saddle-east wrap). The slew planner
         // chose pierWest (target HA -12 outside the flip window), with
         // target encoder near +cpr/2 (mech_HA +11.999, the saddle-east
-        // wrap from the other side). fold_delta_to_canonical produces a
+        // wrap from the other side). fold_to_canonical_band produces a
         // small CCW step (~-3.8k ticks) that physically nudges the RA
         // encoder past the -12 wrap and into +12 folded — the path stays
         // entirely in the safe arc (no positive mech_HA visited). The
@@ -5554,7 +5554,7 @@ mod tests {
         let target_h = 0.9_f64;
         let current = (cur_h * cpr as f64 / 24.0).round() as i32;
         let target = (target_h * cpr as f64 / 24.0).round() as i32;
-        let canonical = fold_delta_to_canonical(target - current, cpr);
+        let canonical = fold_to_canonical_band(target - current, cpr);
         let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_CW_EXCLUSION_ZONE).unwrap();
         assert!(
             issued > 0,
@@ -5781,57 +5781,65 @@ mod tests {
     }
 
     #[test]
-    fn canonical_path_crosses_pole_detects_high_index_modular_replica_near_wire_limit() {
-        // The signed-24-bit wire range carries raw encoder values up to
-        // ~±8.4M ticks. For `cpr_dec = 3.6M` (GTi) the relevant modular
-        // replica of the below-horizon pole can sit at `k = +3`
-        // (≈ +9.98M) and the path-aware check must still find it. A
-        // prior hardcoded `k ∈ -2..=2` scan missed this band and
-        // returned `false` for sweeps that genuinely contain a pole
-        // replica — letting the helper route the OTA through the
-        // below-horizon pole.
+    fn canonical_path_crosses_pole_north_detects_k_plus_3_replica_at_positive_wire_boundary() {
+        // Signed-24-bit wire range carries `start` up to ~+8.4M ticks.
+        // For Northern observer the unsafe pole is `-cpr/4 = -907_200`;
+        // its modular replicas sit at `pole + k·cpr` for any integer k.
+        // With `cpr_dec = 3.6M`, a sweep near `+wire/2` reaches the
+        // `k = +3` replica at `-907_200 + 3·3_628_800 = +9_979_200`.
+        // The prior hardcoded `k ∈ -2..=2` scan missed this band; the
+        // div_euclid check finds it.
         let cpr = GTI_CPR;
         let cpr_i = cpr as i32;
-        let pole = -cpr_i / 4; // N: SCP at -cpr/4 = -907,200
-                               // Sweep [+8_300_000, +10_000_000] contains the k=+3 replica
-                               // at -907,200 + 3·3,628,800 = +9,979,200.
-        let start = 8_300_000_i32;
-        let delta = 1_700_000_i32;
+        let pole = -cpr_i / 4; // SCP for N
+        let start = 8_300_000_i32; // near +wire/2 (= +8.39M)
+        let delta = 1_700_000_i32; // sweep end at +10M, containing +9.98M
         assert!(
             canonical_path_crosses_pole(start, delta, pole, cpr),
             "k=+3 replica at +9_979_200 must be detected inside sweep [+8.3M, +10M]"
         );
-        // Drive it through `flip_slew_dec_delta` for the end-to-end
-        // assertion: canonical positive must be flipped to the long-way
-        // negative because the canonical path crosses SCP.
+        // End-to-end: helper recognises canonical crosses, forces the
+        // long way (negative delta), lands at the same modular dest.
         let issued = flip_slew_dec_delta(delta, start, cpr, true);
         assert!(
             issued < 0,
-            "canonical path crosses SCP at wire boundary; must force long way (got {issued})"
+            "canonical sweep crosses SCP at wire boundary; must force long way (got {issued})"
         );
         assert_eq!(
             (issued - delta).rem_euclid(cpr_i),
             0,
             "long way must land at the same modular destination"
         );
-        // Mirror replica on the negative side: sweep [-10M, -8.3M]
-        // contains the k=-3 replica at -907_200 - 3·3_628_800 =
-        // -11,793,600... no wait, k=-3 puts it at -11.79M. That's
-        // outside the sweep. The relevant southern-mirror replica
-        // when `pole = -cpr/4` and we're at the negative wire boundary
-        // is k=-2: -907_200 - 2·3_628_800 = -8,164,800, which IS in
-        // [-10M, -8.3M] — well within the old `-2..=2` window. The
-        // negative wire boundary doesn't suffer the same k=±3 miss
-        // because the pole is at -cpr/4, not +cpr/4, so the asymmetry
-        // shifts the danger band onto the positive side only for
-        // northern observers. Southern observers (pole at +cpr/4) get
-        // the mirror — exercise that too.
-        let pole_south = cpr_i / 4;
-        // Sweep [-10M, -8.3M] contains the k=-3 replica at
-        // +907_200 - 3·3_628_800 = -9_979_200.
+    }
+
+    #[test]
+    fn canonical_path_crosses_pole_south_detects_k_minus_3_replica_at_negative_wire_boundary() {
+        // Mirror of the Northern case. For Southern observer the unsafe
+        // pole is `+cpr/4 = +907_200`; the modular replicas sit at
+        // `pole + k·cpr`. A sweep near `-wire/2` reaches the `k = -3`
+        // replica at `+907_200 + (-3)·3_628_800 = -9_979_200`. The
+        // same div_euclid check (the helper has no hemisphere-specific
+        // branches) must find it.
+        let cpr = GTI_CPR;
+        let cpr_i = cpr as i32;
+        let pole = cpr_i / 4; // NCP, unsafe for S
+        let start = -10_000_000_i32; // near -wire/2
+        let delta = 1_700_000_i32; // sweep end at -8.3M, containing -9.98M
         assert!(
-            canonical_path_crosses_pole(-10_000_000, 1_700_000, pole_south, cpr),
-            "k=-3 replica at -9_979_200 must be detected for southern pole"
+            canonical_path_crosses_pole(start, delta, pole, cpr),
+            "k=-3 replica at -9_979_200 must be detected inside sweep [-10M, -8.3M]"
+        );
+        // End-to-end through `flip_slew_dec_delta` with `northern=false`
+        // — the test the original combined version was missing.
+        let issued = flip_slew_dec_delta(delta, start, cpr, false);
+        assert!(
+            issued < 0,
+            "canonical sweep crosses NCP at wire boundary; must force long way (got {issued})"
+        );
+        assert_eq!(
+            (issued - delta).rem_euclid(cpr_i),
+            0,
+            "long way must land at the same modular destination"
         );
     }
 


### PR DESCRIPTION
## Summary

Resolves a latent correctness bug discovered while investigating issue #242: `flip_slew_dec_delta` and `side_of_pier` operate on raw encoder counters but apply a half-classification (`|.| > cpr_dec/4`) that is only meaningful on the folded canonical-band value. When raw drifts into the disagreement zone `(3·cpr/4, 5·cpr/4)` — possible after through-wrap flip slews, manual `:E` writes, or power-up encoder noise — the heuristic flips the verdict relative to the OTA's physical position, with downstream effects on routing safety and ASCOM-client-visible pier-side reporting.

The originally-filed bug in #242 (a sign-blindness pattern in `flip_slew_dec_delta` analogous to the RA fix in `072cc72`) turned out *not* to exist: after enumerating every realistic flip-slew (current, target) subcase the heuristic is correct for in-band raw values. But the analysis surfaced a real latent issue (raw vs folded) plus the case for porting the path-aware structure from RA for symmetry and robustness.

## Changes

Three commits, each independently meaningful:

1. **`7aefcf3`** — fold raw `current_ticks` in `flip_slew_dec_delta` before the half-classification. Minimal targeted fix for the latent bug.
2. **`3cd4005`** — same fix applied to `side_of_pier`. Promotes `fold_delta_to_canonical` from `mount_device.rs` to `coordinates.rs` (where the rest of the axis-arithmetic lives) so both call sites import the same helper. This is the more impactful of the two folds — `side_of_pier` is user-visible through the ASCOM `SideOfPier` / `DestinationSideOfPier` getters and feeds the `is_flip_slew` decision plus `set_side_of_pier`'s no-op check.
3. **`3cba41a`** — path-aware rewrite of `flip_slew_dec_delta` to mirror `flip_slew_ra_delta`'s structure. Replaces the heuristic with a direct check of whether the linear encoder sweep `[current, current + canonical]` crosses any modular replica of the below-horizon pole. Promotes the test-module `path_crosses_pole` helper to production `canonical_path_crosses_pole`. Renders commit 1's fold redundant (the path-aware version is naturally robust to raw outside the canonical band).

## Test plan

- [x] `cargo rail run --profile commit -q` — 298 tests pass (was 297 pre-merge; +1 from main's `home_pose` change)
- [x] `cargo fmt --check` clean
- [x] New regression tests:
  - `coordinates::tests::side_of_pier_folds_raw_outside_canonical_band` — covers positive + negative disagreement zone, both hemispheres
  - `mount_device::tests::flip_slew_dec_delta_handles_raw_current_outside_canonical_band` — raw in disagreement zone, sanity-checks path-aware preserves the safe canonical
- [x] All 8 pre-existing `flip_slew_dec_delta_*` semantic tests pass unchanged (verifies behaviour identity for in-band inputs)
- [x] All 4 `fold_delta_to_canonical_*` tests still pass (now in `coordinates` module alongside the function)
- [ ] Hardware re-verification deferred to next session — purely defensive changes, no in-band behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)