### PR TITLE
docs(star-adventurer-gti): design unpark_from_ap_position + recovery actions

### DIFF
--- a/docs/plans/star-adventurer-gti-unpark-from-ap-position.md
+++ b/docs/plans/star-adventurer-gti-unpark-from-ap-position.md
@@ -1,0 +1,310 @@
+# Star Adventurer GTi: required `unpark_from_ap_position` + recovery actions
+
+## Status: design landed; implementation not started
+
+Design captured in
+[`docs/services/star-adventurer-gti.md` §Unpark from AP position](../services/star-adventurer-gti.md#unpark-from-ap-position).
+Conversation log lives on issue #248 (the tracker for picking this up).
+
+## Motivation
+
+The driver currently makes the operator's start-up position assumption
+*implicit* — `home_pose: null` is a valid config and means "trust
+whatever raw encoder the firmware reports," which on fresh power-up is
+`(0, 0)` regardless of where the OTA physically is. The driver then
+runs coordinate math against that zero as if it corresponded to a real
+celestial pointing. This is the largest correctness gap in the driver:
+every position the driver reports rests on an operator assumption that
+no API surface ever asks them to commit to.
+
+The fix is to require the assumption explicitly. Every install
+declares `mount.unpark_from_ap_position`; the ship default is
+`ap_park_0` = "current position, I will plate-solve" (safe, requires
+operator effort to recover position); operators with a permanent setup
+opt into a named park (`ap_park_1..ap_park_5`) to get the auto-seed
+flow.
+
+Three runtime Actions round out the surface so operators don't have
+to edit config files mid-session: `SetUnparkFromApPosition` (persist a
+new value, applies on next fresh-power-up), `SetPreferredApPark`
+(park target for `Park()`), and `UnparkFromApPosition` (recovery
+operation that runs the safe-reset-then-seed sequence).
+
+This plan is not a bug fix — the driver works today for installs that
+configure `home_pose` correctly. It's the structural change that turns
+an implicit, easy-to-get-wrong assumption into an explicit, hard-to-
+get-wrong contract.
+
+## Scope summary
+
+- **Config schema change**: rename `home_pose` → `unpark_from_ap_position`,
+  add `ApPark0` enum variant, make the field required with ship default
+  `ap_park_0`. Add `preferred_ap_park` field (optional, default
+  `ap_park_3`).
+- **Three custom ASCOM Actions**: `SetUnparkFromApPosition`,
+  `SetPreferredApPark`, `UnparkFromApPosition`. Wired through
+  `Action(name, parameters)` dispatch, advertised via `SupportedActions`.
+- **`ResetMountEncoders` internal helper**: stop both axes → wait
+  for idle → write `:E1` / `:E2` → clear driver state. Invoked by
+  `UnparkFromApPosition(ap_park_N≥1)` and (degenerate case, stops are
+  no-ops) by the fresh-power-up auto-seed.
+- **Rename `seed_home_pose_after_connect` → `seed_after_connect`**.
+  Skip when configured pose is `ap_park_0`. Otherwise unchanged.
+- **`Park()` uses `preferred_ap_park` as the target** when no explicit
+  `park_ra_ticks` / `park_dec_ticks` override is set in config.
+- **No migration** — driver isn't released; we just rename.
+
+## Pre-implementation: open questions to resolve
+
+None blocking. The design conversation resolved every open thread:
+
+- Eager vs lazy `SetUnparkFromApPosition`: **lazy** (persist + apply on
+  next fresh-power-up). Operators wanting an "immediate apply" path use
+  `UnparkFromApPosition(park)`.
+- `Unpark()` semantics: **unchanged** (just clears `AtPark` flag). The
+  recovery flow is the explicit `UnparkFromApPosition(park)` Action.
+- Confirmation gate after fresh-power-up seed: **deferred** to a future
+  config flag, to be added if hardware sessions show operator
+  discipline ("if you power-cycle after a crash, physically re-park
+  first") isn't enough.
+
+## Phase A — Config schema + `ApPark0` variant
+
+**Files**
+
+- `services/star-adventurer-gti/src/config.rs`
+- `services/star-adventurer-gti/src/lib.rs` (re-exports if needed)
+- BDD test configs in `services/star-adventurer-gti/tests/features/*.feature`
+  (whichever scenarios set `home_pose`)
+
+**Changes**
+
+1. Rename the existing `HomePose` enum → `ApPark`. Add an `ApPark0`
+   variant with `#[serde(rename = "ap_park_0")]`. Update all
+   `#[serde(rename = "ap_park_N")]` annotations.
+2. Update `ApPark::codebase_mech_ha` / `codebase_dec_encoder` to
+   return some sentinel (or be inapplicable) for `ApPark0`. Probably
+   cleanest: change return types to `Option<f64>` and have `ApPark0`
+   return `None` — callers must handle the "no seed values" case
+   anyway. Document the contract.
+3. Rename `MountConfig::home_pose: Option<HomePose>` →
+   `MountConfig::unpark_from_ap_position: ApPark` (required, no
+   `Option`). Use `#[serde(default = "default_unpark_from_ap_position")]`
+   with the default returning `ApPark::ApPark0` so existing configs
+   without the field load cleanly.
+4. Add `MountConfig::preferred_ap_park: ApPark` (default
+   `ApPark::ApPark3`). Same defaulted-required pattern. Reject
+   `ApPark0` via a custom serde validation (it's not a slew target).
+
+**Tests**
+
+- Config deserialization unit tests in `config.rs`: round-trip each
+  `ApPark` variant, default applied when field missing, error when
+  `preferred_ap_park: "ap_park_0"`.
+- `home_pose` → `unpark_from_ap_position` is a hard rename — any test
+  config that referenced `home_pose` fails loudly until updated. That's
+  intentional; no migration shim.
+
+## Phase B — `ResetMountEncoders` helper
+
+**Files**
+
+- `services/star-adventurer-gti/src/mount_device.rs`
+
+**Changes**
+
+Add a private async helper:
+
+```rust
+async fn reset_mount_encoders(
+    &self,
+    ra_target_ticks: i32,
+    dec_target_ticks: i32,
+) -> ASCOMResult<()> {
+    // 1. Stop both axes via existing stop_axis_and_wait helper.
+    self.stop_axis_and_wait(Axis::Ra, AXIS_STOP_TIMEOUT).await?;
+    self.stop_axis_and_wait(Axis::Dec, AXIS_STOP_TIMEOUT).await?;
+    // 2. Write the encoder seed values.
+    self.transport.send(Command::SetPosition { axis: Axis::Ra, ticks: ra_target_ticks }).await?;
+    self.transport.send(Command::SetPosition { axis: Axis::Dec, ticks: dec_target_ticks }).await?;
+    // 3. Clear driver-internal slew / target / tracking-flag state.
+    let mut state = self.state.write().await;
+    state.slew_in_progress = false;
+    state.target_ra_hours = None;
+    state.target_dec_degrees = None;
+    state.tracking_requested = false;
+    Ok(())
+}
+```
+
+**Tests**
+
+- Mock-transport test asserting the wire ordering: two `:K`s, polling
+  for idle, then two `:E`s with the configured tick values.
+- Test that in-memory state is cleared (slew_in_progress, target_*,
+  tracking_requested).
+- Test failure path: if `stop_axis_and_wait` returns an error, the
+  encoder write is *not* attempted (motion still in flight).
+
+## Phase C — Rename + adapt `seed_home_pose_after_connect`
+
+**Files**
+
+- `services/star-adventurer-gti/src/mount_device.rs`
+- Existing tests for `seed_home_pose_after_connect`
+
+**Changes**
+
+1. Rename `seed_home_pose_after_connect` → `seed_after_connect`.
+2. Short-circuit: if `unpark_from_ap_position == ApPark::ApPark0`,
+   return immediately. No log lines, no encoder writes.
+3. Otherwise: compute seed ticks from `ApPark::codebase_*` helpers
+   (which now return `Option<f64>` — `Some(_)` is guaranteed for any
+   non-`ApPark0` variant), call `reset_mount_encoders` internally.
+   The stop steps are no-ops on a fresh-power-up mount (motors idle)
+   but make the function correct regardless of when it runs.
+4. Update the `info!()` log line text: `seeded firmware encoder for
+   home_pose` → `seeded firmware encoder for unpark_from_ap_position`.
+   Pre-seed snapshot log line is unchanged.
+
+**Tests**
+
+- Existing `seed_home_pose_after_connect` tests get renamed and updated
+  for the new field name.
+- New test: `ap_park_0` configured + fresh-power-up encoder → no `:E`
+  writes, no `info!()` log lines beyond the standard connect path.
+- New test: `ap_park_3` configured + non-fresh encoder → seed skipped
+  (existing tolerance-based behaviour preserved).
+
+## Phase D — Custom Action dispatch
+
+**Files**
+
+- `services/star-adventurer-gti/src/mount_device.rs`
+
+**Changes**
+
+1. Implement `async fn supported_actions(&self) -> ASCOMResult<Vec<String>>`
+   in the `ITelescope` impl. Returns `vec!["SetUnparkFromApPosition",
+   "SetPreferredApPark", "UnparkFromApPosition"]`.
+2. Implement `async fn action(&self, action_name: &str, parameters: &str)
+   -> ASCOMResult<String>` with a `match` on action name dispatching
+   to the three handlers. Unknown names return
+   `ASCOMErrorCode::ACTION_NOT_IMPLEMENTED`.
+3. Each handler:
+   - **`SetUnparkFromApPosition(park)`**: parse `park` parameter as
+     `ApPark`. Update in-memory `MountConfig::unpark_from_ap_position`.
+     Persist to config file using the same atomic-rename pattern as
+     `SetPark` (commit `c8260c1` — `services/star-adventurer-gti/src/config.rs`'s
+     `write_back_park_ticks` is the template).
+   - **`SetPreferredApPark(park)`**: parse `park`. Reject `ap_park_0`
+     with `ASCOMErrorCode::INVALID_VALUE`. Update in-memory + persist.
+   - **`UnparkFromApPosition(park)`**: parse `park`. Refuses if not
+     parked (parameter validation), if disconnected (`NOT_CONNECTED`),
+     or if slewing (`INVALID_OPERATION`). For `ap_park_0`, semantically
+     equivalent to standard `Unpark()` — just clears `AtPark`. For
+     `ap_park_1..ap_park_5`, computes the park's seed ticks, calls
+     `reset_mount_encoders(ra_ticks, dec_ticks)`, then clears `AtPark`.
+
+**Tests**
+
+- Per action: parameter parsing (valid + invalid park names), refusal
+  conditions, success path.
+- `UnparkFromApPosition(ap_park_0)` ≡ `Unpark()` end state.
+- `UnparkFromApPosition(ap_park_3)` writes the expected encoder
+  values via the mock transport and clears `AtPark`.
+- `SetUnparkFromApPosition(ap_park_3)` updates in-memory config and
+  the on-disk file (use `tempfile` for the config path).
+- `SupportedActions` returns the three names.
+
+## Phase E — `Park()` uses `preferred_ap_park`
+
+**Files**
+
+- `services/star-adventurer-gti/src/mount_device.rs`
+
+**Changes**
+
+`Park()` currently slews to the in-memory `park_ra_ticks` /
+`park_dec_ticks`. Change the resolution order:
+
+1. If `park_ra_ticks` AND `park_dec_ticks` are both set in config
+   (raw-encoder override), use them. Today's behaviour for backwards
+   compatibility within the codebase.
+2. Otherwise, compute target ticks from `preferred_ap_park` using
+   the `ApPark::codebase_*` helpers + current site latitude.
+3. (Falls back to live snapshot only if neither path produces a
+   target — degenerate case for `preferred_ap_park = ap_park_0`
+   which should already be rejected at config-deserialize time, but
+   keep the fallback for defense.)
+
+**Tests**
+
+- Existing park tests pass against the new resolution order (those
+  that explicitly set `park_ra_ticks` keep working — they hit path 1).
+- New test: config with only `preferred_ap_park = ap_park_3` → `Park()`
+  slews to the Park 3 encoder pair.
+
+## Phase F — Documentation polish + BDD scenarios
+
+**Files**
+
+- `docs/services/star-adventurer-gti.md` (already done in the design
+  pass; verify cross-references are accurate after the rename lands)
+- `services/star-adventurer-gti/tests/features/` (new feature file)
+- `services/star-adventurer-gti/tests/bdd/steps/` (new step modules)
+
+**Changes**
+
+1. Sweep `mount_device.rs` doc comments for stale `home_pose`
+   references; rename to `unpark_from_ap_position`.
+2. Update BDD feature files that reference `home_pose` config.
+3. Add a new BDD feature `unpark_from_ap_position.feature` with
+   scenarios for:
+   - Fresh power-up + `ap_park_0` → no seed, encoder unchanged.
+   - Fresh power-up + `ap_park_3` → encoder seeded to Park 3 values.
+   - `UnparkFromApPosition(ap_park_3)` from any encoder state →
+     reset-then-seed sequence runs.
+   - `UnparkFromApPosition(ap_park_0)` ≡ `Unpark()`.
+   - `SetUnparkFromApPosition(ap_park_2)` persists and applies on
+     subsequent fresh-power-up.
+
+## Pass criterion
+
+- `cargo rail run --profile commit -q` passes (full unit + integration
+  suite).
+- `cargo fmt --check` clean.
+- New BDD scenarios green.
+- ConformU report unchanged from the pre-change baseline (the new
+  Actions are vendor extensions; ConformU's standard test set doesn't
+  cover them and shouldn't regress on anything else).
+- Hardware re-validation deferred to next physical session; the change
+  is purely structural for in-band behaviour and shouldn't alter any
+  slew or sync semantics for an operator who configures
+  `unpark_from_ap_position` to match what they had as `home_pose`.
+
+## Risks and open questions for implementation time
+
+- **Atomic file rewrites with multiple Actions writing config.** The
+  `SetPark` precedent handles a single field; two new Actions also
+  write back. Need to confirm the rewrite touches only the targeted
+  keys and doesn't accidentally rewrite the whole file (which would
+  clobber operator-edited fields the driver doesn't know about). The
+  `write_back_park_ticks` pattern reads-modifies-writes the parsed
+  JSON; that should work for any field if generalised carefully.
+- **`Action` parameter encoding.** ASCOM `Action` parameters are
+  passed as a single `&str`. Standard practice for vendor actions is
+  either a single token (e.g. `"ap_park_3"`) or a structured payload
+  (JSON, comma-separated, etc.). Single-token is simpler and covers
+  all three actions here.
+- **Backwards compatibility within the *codebase*.** Existing tests,
+  BDD scenarios, log messages, and doc references all need a sweep.
+  The compiler catches the type-level renames; tests catch the
+  serde-rename; doc / log / scenario sweeps need explicit grep
+  passes.
+- **Confirmation gate** for the `Unpark()`-after-fresh-seed danger:
+  deferred per the design. If a hardware session demonstrates the
+  failure mode (operator power-cycled after a crash without
+  re-parking, then unparked and slewed into something), we'll need to
+  revisit and likely add a `require_unpark_confirmation: bool` config
+  flag plus a `ConfirmHomePoseObserved` Action.

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -129,10 +129,12 @@ revisions; the driver reads both rather than assuming.
 
 The protocol exposes **no native park position** and **no site lat/lon**.
 We implement software park (target encoder pair sourced from config,
-or — failing that — the live snapshot after the optional `home_pose`
-encoder seed, see [§Park lifecycle](#park-lifecycle) and
-[§Park persistence](#park-persistence)) and require site lat/lon in the
-config (see [§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
+or — failing that — the live snapshot after the
+`unpark_from_ap_position` encoder seed, see
+[§Park lifecycle](#park-lifecycle), [§Park persistence](#park-persistence),
+and [§Unpark from AP position](#unpark-from-ap-position)) and require
+site lat/lon in the config (see
+[§ASCOM Telescope Mapping](#ascom-telescope-mapping)).
 
 ## Protocol Reference
 
@@ -340,7 +342,7 @@ Every property/method on `ITelescopeV3`, what the driver returns, and why.
 | `PulseGuide(direction, duration)` | rate-shifted tracking pulse on the targeted axis; returns immediately after spawning the watcher task. Refuses when parked / disconnected / slewing / same-axis pulse already in flight. `duration = 0` is a no-op success. See [§PulseGuide lifecycle](#pulseguide-lifecycle) for the wire path. |
 | `SetGuideRateRightAscension(deg_per_sec)` | validate `(0, SIDEREAL_DEG_PER_SEC)` exclusive; store as fraction = `deg_per_sec / SIDEREAL_DEG_PER_SEC`. Out-of-range → `INVALID_VALUE`. |
 | `SetGuideRateDeclination(deg_per_sec)` | same shape as RA. |
-| `Action(name, parameters)` | `ACTION_NOT_IMPLEMENTED` for all action names in MVP |
+| `Action(name, parameters)` | Driver-specific Actions: `SetUnparkFromApPosition`, `SetPreferredApPark`, `UnparkFromApPosition`. See [§Custom Actions for runtime control](#custom-actions-for-runtime-control). All other action names return `ACTION_NOT_IMPLEMENTED`. |
 
 #### Host-clock dependency for LST-using reads
 
@@ -455,19 +457,20 @@ in this order of preference:
    change in-process.
 3. **Live-snapshot fallback** (per axis). The current encoder
    reading from the [`TransportManager`] snapshot. Two cases:
-   - **Fresh power-up with `home_pose` configured.** The driver
-     runs [`seed_home_pose_after_connect`](#home-pose) before
-     loading the park target, so the snapshot already reflects
-     the home_pose's logical encoder values (e.g. `ap_park_3` →
-     `mech_HA = -6h`, `mech_dec = +90°`). `Park` therefore
-     defaults to "return to the pose the operator powered up at".
-   - **Mid-session reconnect** *or* **fresh power-up without
-     `home_pose`.** The home_pose seed skips on a non-zero
-     firmware encoder (and is a no-op when no `home_pose` is
-     configured), so the snapshot equals the
-     handshake-captured `:j1` / `:j2` reading. This is the
-     "park where the OTA already is" semantic operators expect
-     from a reconnect.
+   - **Fresh power-up with `unpark_from_ap_position` set to a named
+     park (`ap_park_1..ap_park_5`).** The driver runs
+     [`seed_after_connect`](#unpark-from-ap-position) before loading
+     the park target, so the snapshot already reflects the named
+     pose's logical encoder values (e.g. `ap_park_3` → `mech_HA =
+     -6h`, `mech_dec = +90°`). `Park` therefore defaults to "return
+     to the pose the operator powered up at".
+   - **Mid-session reconnect** *or* **fresh power-up with
+     `unpark_from_ap_position = "ap_park_0"`.** The seed skips on a
+     non-fresh firmware encoder (and is unconditionally a no-op when
+     `ap_park_0` is configured), so the snapshot equals the
+     handshake-captured `:j1` / `:j2` reading. This is the "park
+     where the OTA already is" semantic operators expect from a
+     reconnect.
 4. **Last resort** — encoder `0`. Only reachable if the snapshot
    somehow produced no position read, which today is unreachable.
 
@@ -954,7 +957,8 @@ fields. The transport block is a tagged enum: `usb` or `udp`.
       "enabled": false,
       "flip_range_hours": 0.5
     },
-    "home_pose": null
+    "unpark_from_ap_position": "ap_park_0",
+    "preferred_ap_park": "ap_park_3"
   }
 }
 ```
@@ -1008,10 +1012,11 @@ Notes:
   mechanical pose. See [§Park persistence](#park-persistence) for the
   rules around when the driver writes to this file. When absent, the
   park target falls back to the live snapshot reading. With
-  `home_pose` set and a fresh power-up, that's the home_pose's
-  logical encoder values (`Park` defaults to "return to the pose
-  you powered up at"); otherwise it's the handshake-captured
-  reading. See [§Park lifecycle](#park-lifecycle).
+  `unpark_from_ap_position` set to a named park (`ap_park_1..ap_park_5`)
+  and a fresh power-up, that's the named pose's logical encoder values
+  (`Park` defaults to "return to the pose you powered up at"); otherwise
+  it's the handshake-captured reading. See
+  [§Park lifecycle](#park-lifecycle).
 - `flip_policy.enabled` defaults `false`. Set to `true` only after
   the first real-hardware meridian flip has been verified on the
   specific mount (see [§Hardware validation](#hardware-validation)).
@@ -1022,23 +1027,61 @@ Notes:
   reachable. Valid range `(0, 0.95]`; the upper bound is the verified
   safe headroom past counterweight-horizontal on the pre-flip side.
   See [§Meridian flip](#meridian-flip).
-- `home_pose` defaults `null` — no encoder seeding on connect, the
-  driver trusts whatever encoder value the firmware reports.
-  Operators powering up the mount at a recognised Astro-Physics park
-  position set it to the matching `ap_park_<n>` string (`"ap_park_1"`
-  through `"ap_park_5"`) and the driver issues `:E1` / `:E2` on
-  connect to seed the firmware encoder to the codebase's convention
-  for that pose. See [§Home pose](#home-pose).
+- `unpark_from_ap_position` is **required** (no default in the schema
+  sense, but the ship default is `"ap_park_0"`). Carries the
+  operator's declared physical position assumption — one of
+  `"ap_park_0"` through `"ap_park_5"`. `ap_park_0` ("current
+  position") is the safe-by-default value: no encoder seeding on
+  connect; the driver trusts whatever the firmware reports and the
+  operator plate-solves and `SyncToCoordinates` to ground-truth.
+  Setting it to a named park (`ap_park_1..ap_park_5`) tells the driver
+  to seed the firmware encoder via `:E1` / `:E2` on every
+  fresh-power-up connect to the codebase's convention for that
+  pose — the operator's contract is to physically place the OTA at
+  that park before powering on. Runtime-modifiable via the
+  `SetUnparkFromApPosition` custom Action (persisted to the same
+  config file). See [§Unpark from AP position](#unpark-from-ap-position).
+- `preferred_ap_park` (optional) — the AP park `Park()` slews to.
+  Defaults to `"ap_park_3"` (the visible-celestial-pole pose, the
+  Sky-Watcher stock power-up pose). Runtime-modifiable via the
+  `SetPreferredApPark` custom Action. The legacy
+  `park_ra_ticks` / `park_dec_ticks` keys remain as raw-encoder
+  overrides for ops pinning a specific tick pair; when both are
+  set, the explicit tick pair wins.
 
-### Home pose
+### Unpark from AP position
+
+#### The position-assumption problem
 
 The Sky-Watcher firmware resets its encoder counter to `(0, 0)` on
-every power-up. The codebase's coordinate math interprets that zero
-against the configured `home_pose`, so the operator's physical
-power-up pose lines up with the driver's celestial-coordinate
-readings without an explicit `SyncToCoordinates` step.
+every power-up. Raw `0` is a coordinate-frame value, not a
+physical-position value — which celestial point it corresponds to is
+purely a function of where the operator physically placed the OTA
+before powering on. The driver therefore *always* relies on an
+operator-supplied position assumption to anchor the encoder math.
 
-The five named poses follow the Astro-Physics
+Every install declares that assumption explicitly via the required
+`mount.unpark_from_ap_position` config field. The field carries one
+of the named AP-park strings (`ap_park_0` through `ap_park_5`) and
+has no default in the schema sense — but the **ship default** is
+`ap_park_0`, which encodes the safest possible assumption ("I don't
+know where the OTA is; I will plate-solve and sync"). Operators who
+run a permanent observatory at a specific physical park override the
+default to the matching `ap_park_N` and the driver seeds the firmware
+encoder accordingly on fresh-power-up connect.
+
+#### The named poses
+
+| `unpark_from_ap_position` | Semantics | AP description | Mech. pier | N hem (mech_HA, dec_enc) | S hem (mech_HA, dec_enc) |
+|---|---|---|---|---|---|
+| `ap_park_0` (default) | **Current position.** No seeding — trust the firmware encoder as-is. Operator's responsibility is to plate-solve and `SyncToCoordinates` before any blind-pointing slew. Safe default for unknown / variable physical setups. | — | — | — | — |
+| `ap_park_1` | Fresh-power-up seed to this pose. | OTA on west, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)`. | West | `(0 h, +(90 + \|lat\|)°)` (saddle west, dec past pole) | `(0 h, −(90 + \|lat\|)°)` (saddle west, dec past pole) |
+| `ap_park_2` | Fresh-power-up seed to this pose. | OTA level facing east horizon, counterweight straight down. Hemisphere-independent celestial coords `(HA=−6, Dec=0)`. | — (CW down) | `(−6 h, 0°)` | `(−6 h, 0°)` |
+| `ap_park_3` | Fresh-power-up seed to this pose. | OTA along polar axis at the visible celestial pole. Sky-Watcher's stock power-up pose. | — (CW along polar) | `(−6 h, +90°)` | `(−6 h, −90°)` |
+| `ap_park_4` | Fresh-power-up seed to this pose. | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (saddle east, dec past pole) | `(−12 h, +(90 + \|lat\|)°)` (saddle east, dec past pole) |
+| `ap_park_5` | Fresh-power-up seed to this pose. | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(−12 h, +(90 − \|lat\|)°)` (saddle east, dec normal) | `(−12 h, −(90 − \|lat\|)°)` (saddle east, dec normal) |
+
+The named poses (1–5) follow the Astro-Physics
 ["Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
 document. Each AP pose describes a fixed mechanical pier side
 (OTA-on-west-of-mount or OTA-on-east-of-mount) that's the same for
@@ -1058,22 +1101,13 @@ hemisphere-dependent — at fixed `mech_HA`, the dec=0 reference points
 at different celestial coords for N vs S, so the rotation needed to
 reach the AP-described OTA pointing differs in magnitude.
 
-The encoder values below were corrected via hardware verification at
+The encoder values above were corrected via hardware verification at
 lat 32.7°N on 2026-05-17. The earlier mapping (commit `2725a2f`) had
 Park 1 and Park 5 swapped: it claimed Park 1 N was at
 `(mech_HA=−12, dec_enc=+(90−|lat|)°)`, but that encoder pose
 physically corresponds to AP Park 5 N (saddle east). The corrected
 mapping places each AP pose at the encoder values that physically
 match it.
-
-| `home_pose` | AP description | Mech. pier | N hem (mech_HA, dec_enc) | S hem (mech_HA, dec_enc) |
-|---|---|---|---|---|
-| `null` (default) | No seeding — trust the firmware encoder as-is. Pre-Phase-6 behaviour. | — | — | — |
-| `ap_park_1` | OTA on west, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)`. | West | `(0 h, +(90 + \|lat\|)°)` (saddle west, dec past pole) | `(0 h, −(90 + \|lat\|)°)` (saddle west, dec past pole) |
-| `ap_park_2` | OTA level facing east horizon, counterweight straight down. Hemisphere-independent celestial coords `(HA=−6, Dec=0)`. | — (CW down) | `(−6 h, 0°)` | `(−6 h, 0°)` |
-| `ap_park_3` | OTA along polar axis at the visible celestial pole. Sky-Watcher's stock power-up pose. | — (CW along polar) | `(−6 h, +90°)` | `(−6 h, −90°)` |
-| `ap_park_4` | OTA on east, level, facing anti-polar horizon. Celestial Dec = `∓(90 − \|lat\|)` (sign anti-hemisphere). | East | `(−12 h, −(90 + \|lat\|)°)` (saddle east, dec past pole) | `(−12 h, +(90 + \|lat\|)°)` (saddle east, dec past pole) |
-| `ap_park_5` | OTA on east, level, facing polar-side horizon. Celestial Dec = `±(90 − \|lat\|)` (sign matches hemisphere). APCC-only in AP's own software. | East | `(−12 h, +(90 − \|lat\|)°)` (saddle east, dec normal) | `(−12 h, −(90 − \|lat\|)°)` (saddle east, dec normal) |
 
 Note on `SideOfPier` reporting: the codebase's `side_of_pier` uses
 the ASCOM-spec convention (dec-past-pole indicates `pierEast`),
@@ -1084,33 +1118,107 @@ saddle west but dec past pole (`+123°`), so the codebase reports
 it as `pierEast` (post-flip). The encoder values match the AP
 physical pose; only the `pierSide` label differs in convention.
 
-The seed step is skipped when the firmware reports an encoder
-reading beyond a small fresh-power-up tolerance
-(`FRESH_POWER_UP_TICK_TOLERANCE`, currently 10 ticks ≈ 4″ at the
-GTi's CPR). The tolerance exists because the Sky-Watcher firmware
-does not always read exactly `(0, 0)` after a power-cycle —
-empirically the validation GTi reports `dec = −1` on connect, a
-single-tick initialisation artifact (~0.4″) that obviously still
-represents the just-powered-up state. Any genuine post-slew
-encoder is tens of thousands of ticks away from zero, so a tight
-tolerance is enough to absorb the firmware artifact without ever
-masking a real mid-session position. Reconnecting mid-session
-after a slew is therefore still safe.
+#### Fresh-power-up auto-seed
 
-`seed_home_pose_after_connect` emits two `info!()`-level log lines
-per connect (when `home_pose` is configured) so hardware-validation
-sessions can sanity-check the firmware encoder state at a glance: a
-`pre-seed encoder snapshot at connect` line with the firmware's
-pre-seed `(ra, dec)` ticks, and a `seeded firmware encoder for
-home_pose` line with the post-seed values. Operators expect the
-pre-seed pair to read approximately `(0, 0)` on a fresh power-up;
-any larger reading is a signal that either the previous slew's
-state survived the connection state machine or the build is
-running against a mock transport rather than the real wire.
+`seed_after_connect` (renamed from `seed_home_pose_after_connect`)
+fires on every connect when the configured
+`unpark_from_ap_position` is one of `ap_park_1..ap_park_5` AND the
+firmware encoder reading is within `FRESH_POWER_UP_TICK_TOLERANCE`
+(currently 10 ticks, ~4″) of `(0, 0)`. When the configured value is
+`ap_park_0` the seed is unconditionally skipped — the operator has
+asserted that they will ground-truth the position themselves and the
+driver does not touch the encoder.
 
-Documented operator assumption: when `home_pose` is set, the operator
-powers up the mount **at** the configured pose and connects the
-driver before any slew or sync.
+The tolerance exists because the Sky-Watcher firmware does not always
+read exactly `(0, 0)` after a power-cycle — empirically the
+validation GTi reports `dec = −1` on connect, a single-tick
+initialisation artifact (~0.4″) that obviously still represents the
+just-powered-up state. Any genuine post-slew encoder is tens of
+thousands of ticks away from zero, so a tight tolerance is enough
+to absorb the firmware artifact without ever masking a real
+mid-session position. Reconnecting mid-session after a slew is
+therefore still safe — the seed skips on non-fresh encoders and
+the live session state is preserved.
+
+`seed_after_connect` emits two `info!()`-level log lines per connect
+(when the configured pose is one of the named parks): a `pre-seed
+encoder snapshot at connect` line with the firmware's pre-seed `(ra,
+dec)` ticks, and a `seeded firmware encoder for unpark_from_ap_position`
+line with the post-seed values. Operators expect the pre-seed pair
+to read approximately `(0, 0)` on a fresh power-up; any larger
+reading is a signal that either the previous slew's state survived
+the connection state machine or the build is running against a mock
+transport rather than the real wire.
+
+Documented operator assumption: when `unpark_from_ap_position` is
+set to one of `ap_park_1..ap_park_5`, the operator powers up the
+mount **at** that configured pose and connects the driver before
+any slew or sync.
+
+#### Custom Actions for runtime control
+
+Three driver-specific Actions (ASCOM `Action(name, parameters)`)
+expose runtime control over the position assumption and the
+preferred-park target. All three are advertised via `SupportedActions`.
+
+| Action name | Parameters | Behaviour |
+|---|---|---|
+| `SetUnparkFromApPosition` | `park` (`ap_park_0..ap_park_5`) | Validates the park name, writes the value into the running config file (atomic-rename pattern, mirrors `SetPark` persistence — see [§Park persistence](#park-persistence)), updates the in-memory config. The new value takes effect on the *next* fresh-power-up auto-seed; the current session's encoder is not touched. Refuses if the driver was started without `--config`. |
+| `SetPreferredApPark` | `park` (`ap_park_1..ap_park_5`) | Sets the AP-park target that `Park()` will slew to. Persisted to config alongside the same file-write pattern. `ap_park_0` is not a valid value here — "current position" is not a slew target. The legacy `park_ra_ticks` / `park_dec_ticks` config keys remain as raw-encoder overrides for ops who pinned a specific tick pair; when both forms are set, the explicit tick pair wins. |
+| `UnparkFromApPosition` | `park` (`ap_park_0..ap_park_5`) | Recovery operation. For `ap_park_0`, semantically equivalent to standard `Unpark()` — clears `AtPark`, no encoder change. For any named park (`ap_park_1..ap_park_5`), runs the [`ResetMountEncoders` sequence](#resetmountencoders-sequence) to safely write the park's encoder values *regardless of the current encoder state*, then clears `AtPark`. Operator is asserting "the OTA is physically at this park"; the driver makes firmware state match. |
+
+Standard ASCOM `Unpark()` is unchanged — it always just clears the
+`AtPark` flag with no encoder write. The two operations
+(`Unpark()` and `UnparkFromApPosition(ap_park_0)`) are structurally
+equivalent; the custom Action exists to express the recovery flow
+for the named-park cases.
+
+#### `ResetMountEncoders` sequence
+
+Wraps the bare `:E1` / `:E2` writes in a safe-stop-then-seed envelope
+so the operation works correctly regardless of in-flight firmware
+state (pending `:G` goto, active `:I` tracking, latched `:M`
+brakes):
+
+```
+:K1                          stop RA  (existing stop_axis_and_wait)
+:K2                          stop Dec
+poll :f1, :f2 until idle
+:E1 <ra_ticks_for_park>      write seed encoder
+:E2 <dec_ticks_for_park>     write seed encoder
+clear driver-internal slew / target / tracking-flag state
+```
+
+Invoked by:
+
+- `UnparkFromApPosition(ap_park_N)` for `N ≥ 1` (operator-confirmed
+  physical position).
+- Auto-seed path on fresh-power-up connect (the stop steps are no-ops
+  in that state; the encoder writes are the only meaningful work).
+
+Not invoked by the standard `Unpark()` flow — that path is for
+"resume from where I parked," and writing the encoder there would
+silently destroy session state.
+
+#### Recovery procedures
+
+What to do after various crash / disconnect scenarios:
+
+| Scenario | Procedure |
+|---|---|
+| Driver crashed, mount still powered, OTA points at solvable sky | Reconnect (no power cycle) → `UnparkFromApPosition(ap_park_0)` (or standard `Unpark()`) → plate-solve current view → `SyncToCoordinates(plate_solved_coords)`. Encoder counter is intact from the session; sync writes the offset to match celestial truth. |
+| Driver crashed, mount still powered, OTA points at unsolvable sky (below horizon, clouded out) | Reconnect → `UnparkFromApPosition(ap_park_N)` where `N` is the AP park you've physically positioned the OTA at. The `ResetMountEncoders` sequence stops in-flight motion and writes the park's encoder values; subsequent slews start from a known frame. Alternatively, power-cycle the mount and let the fresh-power-up auto-seed run from the persisted `unpark_from_ap_position` config value. |
+| Mount lost power (planned shutdown or otherwise) | Before the next power-on, physically position the OTA at whatever `unpark_from_ap_position` is configured for (or update the config / call `SetUnparkFromApPosition` first). On power-on connect, the fresh-power-up auto-seed writes the encoder to that park's values. |
+
+The only genuinely dangerous pattern is "crash + power-cycle without
+re-parking AND with a non-`ap_park_0` `unpark_from_ap_position`
+configured" — the auto-seed will fire against fresh-power-up encoder
+and the driver will believe the OTA is at the configured park when
+it's actually wherever the crash left it. The operator-discipline
+mitigation is "if you power-cycle after a crash, physically re-park
+first." A heavier mitigation (refusing `Unpark()` after fresh-seed
+without an explicit operator confirmation gate) is deferred — opt-in
+behind a future config flag if hardware sessions show it's needed.
 
 ### CLI arguments
 
@@ -1344,7 +1452,8 @@ init handshake:
    ↓
 load park target from config / handshake → in-memory park ticks
    ↓
-if home_pose is set AND firmware encoder is (0, 0):
+if unpark_from_ap_position ∈ ap_park_1..ap_park_5
+   AND firmware encoder is within FRESH_POWER_UP_TICK_TOLERANCE of (0, 0):
   :E1, :E2  (seed encoder to the AP pose's codebase convention)
    ↓
 start background polling task (interval = config.polling_interval)
@@ -1610,7 +1719,8 @@ What's still outstanding from Phase 4:
 - Connect / disconnect lifecycle, ref-counted transport
 - Init handshake: `:F`, `:a`, `:b`, `:g`, `:e`, `:j`
 - ASCOM device metadata (`Description`, `DriverInfo`, `DriverVersion`,
-  `InterfaceVersion`, `Name`, `SupportedActions = []`)
+  `InterfaceVersion`, `Name`, `SupportedActions` lists the three
+  driver-specific Actions — see [§Unpark from AP position](#unpark-from-ap-position))
 - Site lat/lon/elevation from config (read-only via ASCOM)
 - `RightAscension` / `Declination` reads (encoder + LST + sync offset)
 - `Azimuth` / `Altitude` reads (derived from RA/Dec)
@@ -1647,7 +1757,7 @@ What's still outstanding from Phase 4:
 | `RightAscensionRate`, `DeclinationRate` setters | custom-rate tracking; not needed for sidereal-only MVP |
 | `TrackingRate` setter (lunar / solar / king) | sidereal covers astrophotography; lunar/solar are uncommon and add a small mode-switch matrix |
 | `FindHome`, `CanFindHome` | no hardware home sensor on the GTi |
-| `Action` / custom commands | no driver-specific actions in MVP |
+| Operator-confirmation gate on `Unpark()` after fresh-power-up seed | Hardware-discipline mitigation for the "crash + power-cycle without re-park" failure mode. Today's design relies on operator discipline ("if you power-cycle after a crash, physically re-park first"); a confirmation gate is the heavier alternative. Deferred behind a future config flag, to be added if hardware sessions show the discipline assumption breaks. |
 | Polar-alignment helpers, TPOINT, cone error | observational pointing model is the host's concern, not the driver's |
 | WiFi station mode (mount on a routed network) | AP-mode UDP is verified; station mode just changes the bind-address selection — straightforward to add once a station-mode test setup exists |
 | Multi-mount support on a single binary | `rp` assumes one mount per service; multi-mount is a separate concern |
@@ -1670,7 +1780,7 @@ What's still outstanding from Phase 4:
   reference driver and protocol-decoding documentation.
 - [Astro-Physics "Park Positions Defined"](https://astro-physics.info/tech_support/mounts/park-positions-defined.pdf)
   — canonical reference for the five named park positions (Park 1
-  through Park 5) the [§Home pose](#home-pose) config exposes,
+  through Park 5) the [§Unpark from AP position](#unpark-from-ap-position) config exposes,
   including the per-hemisphere celestial-Dec formulae and the
   east-side / west-side scope orientations.
 


### PR DESCRIPTION
## Summary

Design doc + implementation plan for a structural change to start-up position handling: replaces the implicit \`home_pose: Option<HomePose>\` model with an explicit, required \`unpark_from_ap_position: ApPark\` field. Adds three driver-specific ASCOM Actions (\`SetUnparkFromApPosition\`, \`SetPreferredApPark\`, \`UnparkFromApPosition\`) and documents the \`ResetMountEncoders\` safe-reset-then-seed sequence + crash-recovery procedures.

**No code changes.** This PR lands the design + plan; implementation is tracked by a follow-up issue.

## Why

Today's driver lets the operator's start-up position assumption stay implicit — \`home_pose: null\` is valid and means "trust whatever the firmware reports," which on fresh power-up is \`(0, 0)\` regardless of where the OTA physically is. The driver then runs coordinate math against that zero as if it represented a real celestial pointing. Every position the driver reports rests on an operator assumption no API surface ever asks them to commit to.

The new design makes the assumption explicit:

- \`ap_park_0\` = "current position" — safe default. Operator plate-solves to ground-truth. No encoder seed.
- \`ap_park_1..ap_park_5\` = named AP park positions. Driver auto-seeds the firmware encoder on every fresh-power-up connect.
- \`UnparkFromApPosition(park)\` Action covers the recovery flow where the operator physically repositioned the OTA mid-session.

Standard ASCOM \`Unpark()\` is unchanged and is structurally equivalent to \`UnparkFromApPosition(ap_park_0)\`.

## Test plan

- [ ] Review the design doc section: \`docs/services/star-adventurer-gti.md\` §Unpark from AP position
- [ ] Review the implementation plan: \`docs/plans/star-adventurer-gti-unpark-from-ap-position.md\`
- [ ] Confirm the phase breakdown is workable; surface any missing concerns before merge

No CI gates beyond docs lint should fire (no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)