### PR TITLE
fix(qhy-focuser): serialize set_connected via requested_connection write lock (#250)

### DIFF
--- a/services/qhy-focuser/src/focuser_device.rs
+++ b/services/qhy-focuser/src/focuser_device.rs
@@ -78,7 +78,16 @@ impl Device for QhyFocuserDevice {
     }
 
     async fn set_connected(&self, connected: bool) -> ASCOMResult<()> {
-        if self.connected().await? == connected {
+        // Hold the write lock across the whole check-and-modify so two
+        // concurrent `Connected=true` requests for this device don't both
+        // observe `requested_connection == false`, both call
+        // `SerialManager::connect` (incrementing the shared refcount twice),
+        // and then both set the single per-device flag — see issue #250 and
+        // the matching fix in PR #241 (pa-falcon-rotator commit 8cd6e16).
+        let mut requested = self.requested_connection.write().await;
+        let serial_ok = self.serial_manager.is_available();
+        let already = *requested && serial_ok;
+        if already == connected {
             return Ok(());
         }
         match connected {
@@ -87,11 +96,11 @@ impl Device for QhyFocuserDevice {
                     .connect()
                     .await
                     .map_err(Self::to_ascom_error)?;
-                *self.requested_connection.write().await = true;
+                *requested = true;
                 debug!("Focuser device connected");
             }
             false => {
-                *self.requested_connection.write().await = false;
+                *requested = false;
                 self.serial_manager.disconnect().await;
                 debug!("Focuser device disconnected");
             }


### PR DESCRIPTION
## Summary

Fixes #250.

`QhyFocuserDevice::set_connected` was not serialised with the per-device
`requested_connection` flag. Two concurrent `Connected=true` requests
against the same focuser could both observe `connected() == false`, both
call `SerialManager::connect` (incrementing the shared refcount twice),
and then both set the single per-device bool. A single later
`Connected=false` decremented the refcount only once, leaving the serial
port physically open even though the device was logically disconnected —
the port stayed stranded until the process exited.

## Fix

Hold the `requested_connection` write lock for the whole check-and-modify
body so a second concurrent caller waits, observes the already-true flag
on re-check, and short-circuits without re-incrementing the refcount. The
fix shape is identical to the one applied to `FalconRotatorDevice` and
`FalconStatusSwitchDevice` in PR #241 (commit `8cd6e16`).

Concurrent `connected()` readers take the read lock and so will block
briefly during a connect, which is acceptable — handshake is ~30 ms of
serial roundtrips.

## Out of scope

`ppba-driver`'s `switch_device.rs` and `observingconditions_device.rs`
carry the same pattern and will be addressed in their own PR.

## Test plan

- [x] `cargo rail run --profile commit -q` → 102/102 tests pass
- [x] `cargo test -p qhy-focuser --features mock --test bdd` → 7 features, 37 scenarios, 129 steps — all pass
- [x] `cargo clippy -p qhy-focuser --all-features --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)