### PR TITLE
fix(qhy-focuser): roll back SerialManager refcount on open/handshake failure (#258)

### DIFF
--- a/docs/services/qhy-focuser.md
+++ b/docs/services/qhy-focuser.md
@@ -151,6 +151,13 @@ cargo run -p qhy-focuser --features mock
 5. Move detection: polling compares position to target, clears `is_moving` when reached
 6. On disconnect: ref-count decremented, port closed when last device disconnects
 
+**Failure recovery.** If open (step 2) or handshake (step 3) fails, the
+ref-count is rolled back and any partial reader/writer is released. A
+subsequent `set_connected(true)` re-enters the first-connection path and
+re-attempts open + handshake from scratch — the device does not wedge on
+a transient failure (unplugged USB during handshake, slow-to-boot
+firmware, bad serial path, etc.).
+
 ## References
 
 - **INDI QHY Focuser Driver** (reference implementation used for protocol reverse-engineering): [qhy_focuser.cpp](https://github.com/indilib/indi-3rdparty/blob/master/indi-qhy/qhy_focuser.cpp), [qhy_focuser.h](https://github.com/indilib/indi-3rdparty/blob/master/indi-qhy/qhy_focuser.h)

--- a/services/qhy-focuser/src/serial_manager.rs
+++ b/services/qhy-focuser/src/serial_manager.rs
@@ -80,26 +80,42 @@ impl SerialManager {
     ///
     /// Increments the connection reference count. If this is the first connection,
     /// opens the serial port, performs handshake, and starts polling.
+    ///
+    /// If open or handshake fails on the 0→1 transition, the refcount is rolled
+    /// back and any partial reader/writer is released, so a subsequent connect()
+    /// re-enters this first-connection path instead of short-circuiting through
+    /// the fast path (issue #258).
     pub async fn connect(&self) -> Result<()> {
         let count = self.connection_count.fetch_add(1, Ordering::SeqCst);
 
         if count == 0 {
             debug!("First device connecting, opening serial port");
 
-            let pair: SerialPair = self
+            let pair: SerialPair = match self
                 .serial_factory
                 .open(
                     &self.config.port,
                     self.config.baud_rate,
                     self.config.timeout,
                 )
-                .await?;
+                .await
+            {
+                Ok(p) => p,
+                Err(e) => {
+                    self.connection_count.fetch_sub(1, Ordering::SeqCst);
+                    return Err(e);
+                }
+            };
 
             *self.reader.lock().await = Some(pair.reader);
             *self.writer.lock().await = Some(pair.writer);
 
-            // Handshake: get version
-            self.perform_handshake().await?;
+            if let Err(e) = self.perform_handshake().await {
+                *self.reader.lock().await = None;
+                *self.writer.lock().await = None;
+                self.connection_count.fetch_sub(1, Ordering::SeqCst);
+                return Err(e);
+            }
 
             self.serial_available.store(true, Ordering::SeqCst);
 
@@ -869,6 +885,179 @@ mod mock_tests {
         assert_eq!(state.position, Some(1000));
         assert!(!state.is_moving, "should detect move completion");
         assert_eq!(state.target_position, None);
+
+        manager.disconnect().await;
+    }
+
+    // ========================================================================
+    // Open/handshake failure rollback (issue #258)
+    // ========================================================================
+
+    use std::sync::atomic::AtomicI32;
+
+    /// Test-only factory that wraps [`MockSerialPortFactory`] and injects
+    /// failures into `open()` and/or the first `read_line()` of the next
+    /// reader, so the rollback path in [`SerialManager::connect`] can be
+    /// exercised end-to-end.
+    ///
+    /// Cloning the factory is shallow — all clones share the same counters,
+    /// so a test handle held alongside the manager's `Arc<dyn ...>` observes
+    /// the same state.
+    #[derive(Clone, Default)]
+    struct InjectableFactory {
+        inner: MockSerialPortFactory,
+        fail_opens_remaining: Arc<AtomicI32>,
+        fail_handshakes_remaining: Arc<AtomicI32>,
+        successful_opens: Arc<AtomicU32>,
+    }
+
+    impl InjectableFactory {
+        fn fail_next_open(self) -> Self {
+            self.fail_opens_remaining.fetch_add(1, Ordering::SeqCst);
+            self
+        }
+
+        fn fail_next_handshake(self) -> Self {
+            self.fail_handshakes_remaining
+                .fetch_add(1, Ordering::SeqCst);
+            self
+        }
+
+        fn successful_opens(&self) -> u32 {
+            self.successful_opens.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SerialPortFactory for InjectableFactory {
+        async fn open(&self, port: &str, baud_rate: u32, timeout: Duration) -> Result<SerialPair> {
+            if self.fail_opens_remaining.fetch_sub(1, Ordering::SeqCst) > 0 {
+                return Err(QhyFocuserError::Communication(
+                    "simulated open failure".to_string(),
+                ));
+            }
+            let pair = self.inner.open(port, baud_rate, timeout).await?;
+            self.successful_opens.fetch_add(1, Ordering::SeqCst);
+
+            let reader: Box<dyn SerialReader> = if self
+                .fail_handshakes_remaining
+                .fetch_sub(1, Ordering::SeqCst)
+                > 0
+            {
+                Box::new(HandshakeFailingReader {
+                    inner: pair.reader,
+                    fail_once: AtomicBool::new(true),
+                })
+            } else {
+                pair.reader
+            };
+
+            Ok(SerialPair {
+                reader,
+                writer: pair.writer,
+            })
+        }
+
+        async fn port_exists(&self, port: &str) -> bool {
+            self.inner.port_exists(port).await
+        }
+    }
+
+    struct HandshakeFailingReader {
+        inner: Box<dyn SerialReader>,
+        fail_once: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl SerialReader for HandshakeFailingReader {
+        async fn read_line(&mut self) -> Result<Option<String>> {
+            if self.fail_once.swap(false, Ordering::SeqCst) {
+                return Err(QhyFocuserError::Communication(
+                    "simulated handshake read failure".to_string(),
+                ));
+            }
+            self.inner.read_line().await
+        }
+    }
+
+    fn manager_with(factory: InjectableFactory) -> Arc<SerialManager> {
+        Arc::new(SerialManager::new(test_config(), Arc::new(factory)))
+    }
+
+    #[tokio::test]
+    async fn test_connect_open_failure_rolls_back_count() {
+        let factory = InjectableFactory::default().fail_next_open();
+        let manager = manager_with(factory.clone());
+
+        let err = manager.connect().await.unwrap_err();
+        assert!(
+            format!("{err:?}").contains("simulated open failure"),
+            "got: {err:?}"
+        );
+        assert!(!manager.is_available());
+
+        // Retry: factory's fail counter is exhausted, open succeeds.
+        // Without the rollback fix the refcount would still be 1 from the
+        // failed attempt, the fast path would short-circuit, and
+        // is_available would stay false forever.
+        manager.connect().await.unwrap();
+        assert!(manager.is_available());
+        assert_eq!(factory.successful_opens(), 1);
+
+        manager.disconnect().await;
+        assert!(!manager.is_available());
+    }
+
+    #[tokio::test]
+    async fn test_connect_handshake_failure_rolls_back_count_and_releases_port() {
+        let factory = InjectableFactory::default().fail_next_handshake();
+        let manager = manager_with(factory.clone());
+
+        let err = manager.connect().await.unwrap_err();
+        assert!(
+            format!("{err:?}").contains("simulated handshake read failure"),
+            "got: {err:?}"
+        );
+        assert!(!manager.is_available());
+        assert_eq!(
+            factory.successful_opens(),
+            1,
+            "open() was called once for the failed attempt"
+        );
+
+        // Retry: factory now succeeds end-to-end. The rollback fix means
+        // the next connect() re-enters the first-connection path and
+        // re-opens the port (reader/writer were released), proven by
+        // successful_opens advancing from 1 to 2.
+        manager.connect().await.unwrap();
+        assert!(manager.is_available());
+        assert_eq!(
+            factory.successful_opens(),
+            2,
+            "second connect() should re-open the port"
+        );
+
+        manager.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn test_connect_recovery_disconnect_returns_count_to_zero() {
+        let factory = InjectableFactory::default().fail_next_open();
+        let manager = manager_with(factory.clone());
+
+        let _ = manager.connect().await.unwrap_err();
+        manager.connect().await.unwrap();
+        assert!(manager.is_available());
+
+        manager.disconnect().await;
+        assert!(!manager.is_available());
+
+        // A subsequent connect should fully re-open the port — proves
+        // the refcount returned cleanly to 0 with no residual count from
+        // the initial failed attempt.
+        manager.connect().await.unwrap();
+        assert!(manager.is_available());
+        assert_eq!(factory.successful_opens(), 2);
 
         manager.disconnect().await;
     }


### PR DESCRIPTION
## Summary

Fixes #258 for `qhy-focuser`. Surfaced by Copilot review on PR #256.

`SerialManager::connect()` bumped `connection_count` from 0 to 1
*before* opening the port and running the handshake. On any failure
(`serial_factory.open`, GetVersion, SetSpeed, GetPosition, or
ReadTemperature) the function returned the error but left
`connection_count == 1` and — on handshake failure — held the physical
port open via `reader`/`writer`. The next `set_connected(true)` then
short-circuited on the elevated refcount, skipped the first-connection
path entirely, and the device stayed permanently dead until process
restart.

This is more dangerous than the race fixed in #250: the race needs two
concurrent clients, but this wedge fires on any single handshake
timeout, unplugged USB, wrong `/dev/tty*`, or device still booting.

## Fix

Shape A from issue #258 (matches `star-adventurer-gti`'s
`transport_manager.rs:180`): on each error path during the 0→1
transition, decrement the refcount and drop any partial reader/writer
before propagating. A subsequent `connect()` re-enters the
first-connection path and re-attempts open + handshake from scratch.

## Tests

Three new tests in `serial_manager::mock_tests`, using a thin
test-only `InjectableFactory` that wraps `MockSerialPortFactory` and
can fail the next `open()` or the first reader read. The factory
tracks `successful_opens` so the rollback can be asserted
behaviourally (a second `connect()` calling `open()` again proves the
fast path did NOT short-circuit):

- `test_connect_open_failure_rolls_back_count`
- `test_connect_handshake_failure_rolls_back_count_and_releases_port`
- `test_connect_recovery_disconnect_returns_count_to_zero`

All three fail on `main` and pass with the fix.

## Out of scope

- `ppba-driver` has the same defect with four failure points
  (`open` + `Ping` + `refresh_status` + `refresh_power_stats`);
  tracked in #258 for a separate PR.
- `pa-falcon-rotator` and `star-adventurer-gti` already roll back
  correctly (verified by inspection — see #258).

## Docs

Added a "Failure recovery" note to the Connection Lifecycle section of
`docs/services/qhy-focuser.md` per AGENTS.md rule 2.

## Test plan

- [x] `cargo rail run --profile commit -q` → 105/105 tests pass (+3 vs main)
- [x] `cargo test -p qhy-focuser --features mock --test bdd` → 7 features, 37 scenarios, 129 steps — all pass
- [x] `cargo clippy -p qhy-focuser --all-features --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)