### PR TITLE
refactor(star-adventurer-gti): extract enable_sidereal_tracking_ra helper

### DIFF
--- a/services/star-adventurer-gti/src/mount_device/slew.rs
+++ b/services/star-adventurer-gti/src/mount_device/slew.rs
@@ -20,9 +20,9 @@ use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
 use skywatcher_motor_protocol::command::{ModeKind, MotionMode, Speed};
 use skywatcher_motor_protocol::{Axis, Command, Response};
 
-use crate::coordinates::ra_ticks_to_mechanical_ha;
+use crate::coordinates::{ra_ticks_to_mechanical_ha, sidereal_step_period};
 use crate::error::StarAdvError;
-use crate::transport_manager::TransportManager;
+use crate::transport_manager::{MountParameters, TransportManager};
 
 /// Upper bound on how long [`stop_axis_and_wait`] will poll `:f<axis>`
 /// after a `:K` (decelerate stop) before giving up. The firmware
@@ -121,6 +121,35 @@ pub(super) async fn stop_axis_and_wait(
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+/// Re-engage sidereal tracking on the RA axis. Issues the canonical
+/// three-step sequence: `:G1 TRACKING` → `:I1 sidereal_period` → `:J1`.
+///
+/// Caller is responsible for the prior `:K1` + stop-wait — `:G` returns
+/// `!2 MotorNotStopped` if the motor is still decelerating. Returns on
+/// first wire failure so the caller picks the policy:
+/// `set_tracking(true)` maps to `ASCOMError` and propagates; the slew /
+/// pulse-guide watchers log at `warn` and continue.
+pub(super) async fn enable_sidereal_tracking_ra(
+    transport: &TransportManager,
+    params: &MountParameters,
+) -> crate::error::Result<()> {
+    let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
+    transport
+        .send(Command::SetMotionMode {
+            axis: Axis::Ra,
+            mode: MotionMode::TRACKING,
+        })
+        .await?;
+    transport
+        .send(Command::SetStepPeriod {
+            axis: Axis::Ra,
+            period,
+        })
+        .await?;
+    transport.send(Command::StartMotion(Axis::Ra)).await?;
+    Ok(())
 }
 
 /// Per-axis pickup re-slew used by the watcher's EQMOD pickup loop.

--- a/services/star-adventurer-gti/src/mount_device/telescope.rs
+++ b/services/star-adventurer-gti/src/mount_device/telescope.rs
@@ -29,6 +29,7 @@ use crate::coordinates::{
 
 use super::inherent::validate_guide_rate;
 use super::park_persistence::write_park_to_config;
+use super::slew::enable_sidereal_tracking_ra;
 use super::watchers::{clear_pulse_flag, spawn_park_completion_watcher, spawn_pulse_guide_watcher};
 use super::{pre_flip_side_for_latitude, MountDevice};
 
@@ -214,13 +215,11 @@ impl Telescope for MountDevice {
             // allowed — Park itself leaves tracking off, but a caller
             // re-asserting that should not error.
             self.ensure_unparked().await?;
-            // Compute the sidereal step period from the cached parameters.
             let params = self
                 .transport
                 .parameters()
                 .await
                 .ok_or(ASCOMError::NOT_CONNECTED)?;
-            let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
             // Per Sky-Watcher spec §2: "Motor must be at full stop
             // status before setting the motion mode." The RA axis
             // may already be running — from a prior tracking enable,
@@ -229,22 +228,7 @@ impl Telescope for MountDevice {
             // for the running flag to clear before re-issuing the
             // tracking-mode `:G`/`:I`/`:J` sequence.
             self.stop_and_wait(Axis::Ra).await?;
-            self.transport
-                .send(Command::SetMotionMode {
-                    axis: Axis::Ra,
-                    mode: MotionMode::TRACKING,
-                })
-                .await
-                .map_err(Self::ascom)?;
-            self.transport
-                .send(Command::SetStepPeriod {
-                    axis: Axis::Ra,
-                    period,
-                })
-                .await
-                .map_err(Self::ascom)?;
-            self.transport
-                .send(Command::StartMotion(Axis::Ra))
+            enable_sidereal_tracking_ra(&self.transport, &params)
                 .await
                 .map_err(Self::ascom)?;
         } else {

--- a/services/star-adventurer-gti/src/mount_device/watchers.rs
+++ b/services/star-adventurer-gti/src/mount_device/watchers.rs
@@ -474,11 +474,12 @@ pub(super) fn spawn_slew_completion_watcher(
             }
 
             // Slew completed cleanly. Re-enable tracking if the user had
-            // it on before the slew, then apply the settle delay. Only
-            // mark tracking_requested=true if the StartMotion actually
-            // succeeds — otherwise Tracking() would lie about the wire
-            // state. The earlier mode/period sends are best-effort but
-            // failures are logged for diagnosis.
+            // it on before the slew, then apply the settle delay. The
+            // helper short-circuits on the first failing send, so
+            // `tracking_requested = true` flips only when all three wire
+            // commands succeed — otherwise Tracking() would lie about
+            // the wire state. A single warn covers the failure path
+            // (the failing-send error includes which command failed).
             //
             // Re-check abort / disconnect before issuing the tracking
             // wire sequence — same race-window argument as the pickup

--- a/services/star-adventurer-gti/src/mount_device/watchers.rs
+++ b/services/star-adventurer-gti/src/mount_device/watchers.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use ascom_alpaca::api::telescope::PierSide;
-use skywatcher_motor_protocol::command::MotionMode;
 use skywatcher_motor_protocol::{Axis, Command};
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -32,12 +31,14 @@ use tracing::debug;
 use crate::config::MountConfig;
 use crate::coordinates::{
     dec_degrees_to_ticks, encoder_to_celestial, fold_to_canonical_band, local_sidereal_time_hours,
-    pickup_target_ra_ticks, sidereal_step_period, target_encoder_flipped,
+    pickup_target_ra_ticks, target_encoder_flipped,
 };
 use crate::error::StarAdvError;
 use crate::transport_manager::{MountSnapshot, TransportManager};
 
-use super::slew::{pickup_reslew_axis, stop_axis_and_wait, AXIS_STOP_TIMEOUT};
+use super::slew::{
+    enable_sidereal_tracking_ra, pickup_reslew_axis, stop_axis_and_wait, AXIS_STOP_TIMEOUT,
+};
 use super::{pre_flip_side_for_latitude, DriverState};
 
 /// Minimum wallclock duration the slew watcher will keep
@@ -491,32 +492,13 @@ pub(super) fn spawn_slew_completion_watcher(
             }
             if tracking_was_on {
                 if let Some(params) = transport.parameters().await {
-                    let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
-                    if let Err(e) = transport
-                        .send(Command::SetMotionMode {
-                            axis: Axis::Ra,
-                            mode: MotionMode::TRACKING,
-                        })
-                        .await
-                    {
-                        tracing::warn!("post-slew SetMotionMode TRACKING failed: {e}");
-                    }
-                    if let Err(e) = transport
-                        .send(Command::SetStepPeriod {
-                            axis: Axis::Ra,
-                            period,
-                        })
-                        .await
-                    {
-                        tracing::warn!("post-slew SetStepPeriod failed: {e}");
-                    }
-                    match transport.send(Command::StartMotion(Axis::Ra)).await {
-                        Ok(_) => {
+                    match enable_sidereal_tracking_ra(&transport, &params).await {
+                        Ok(()) => {
                             state.write().await.tracking_requested = true;
                         }
                         Err(e) => {
                             tracing::warn!(
-                                "post-slew StartMotion failed; tracking not re-enabled: {e}"
+                                "post-slew tracking restart failed; tracking not re-enabled: {e}"
                             );
                         }
                     }
@@ -674,25 +656,8 @@ pub(super) fn spawn_pulse_guide_watcher(
             let still_want_restore = state.read().await.pulse_guiding_ra;
             if still_want_restore {
                 if let Some(params) = transport.parameters().await {
-                    let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
-                    if let Err(e) = transport
-                        .send(Command::SetMotionMode {
-                            axis: Axis::Ra,
-                            mode: MotionMode::TRACKING,
-                        })
-                        .await
-                    {
-                        tracing::warn!("pulse-guide restore :G1 failed: {e}");
-                    } else if let Err(e) = transport
-                        .send(Command::SetStepPeriod {
-                            axis: Axis::Ra,
-                            period,
-                        })
-                        .await
-                    {
-                        tracing::warn!("pulse-guide restore :I1 failed: {e}");
-                    } else if let Err(e) = transport.send(Command::StartMotion(Axis::Ra)).await {
-                        tracing::warn!("pulse-guide restore :J1 failed: {e}");
+                    if let Err(e) = enable_sidereal_tracking_ra(&transport, &params).await {
+                        tracing::warn!("pulse-guide tracking restore failed: {e}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Collapse three duplicated `:G1 TRACKING` + `:I1 sidereal_period` + `:J1` sequences into a single `enable_sidereal_tracking_ra(transport, params)` helper in `mount_device/slew.rs`, alongside the existing wire helpers (`stop_axis_and_wait`, `issue_slew_axis`, `pickup_reslew_axis`).
- The helper returns `Result<(), StarAdvError>` and lets each call site pick its own policy:
  - `Telescope::set_tracking(true)` maps to `ASCOMError` and propagates.
  - `spawn_slew_completion_watcher` post-slew restore logs at `warn`; flips `tracking_requested = true` only on full success (preserves the prior "only if StartMotion succeeds" rule).
  - `spawn_pulse_guide_watcher` RA-only restore logs at `warn`.
- Happy-path wire frames are unchanged. On failure, both watchers now short-circuit on the first failing send — the pulse-guide watcher already did this; the slew watcher previously emitted up to three warnings, which was almost certainly accidental (a SetMotionMode failure guarantees the next two sends also fail with the same underlying error).

Closes #262. Spotted during the issue-253 refactor (PR #261); deliberately deferred so the structural move stayed clean.

## Test plan

- [x] `cargo rail run --profile commit -q` — 308/308 tests pass
- [x] `cargo fmt --all -- --check` (pre-commit hook)
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings` (pre-commit hook)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)