### PR TITLE
ci(install-astap): add self-healing SHA refresh workflow

### DIFF
--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -32,6 +32,13 @@ on:
   workflow_run:
     workflows: ["install-astap"]
     types: [completed]
+    # install-astap fires on pull_request too (per its paths filter on
+    # the action itself). Without a branches filter, this workflow —
+    # which holds write tokens — would react to those PR runs and
+    # could be tricked into opening auto-PRs from untrusted code.
+    # Restricting to main means only scheduled/push-to-main runs of
+    # install-astap propagate here. Per Copilot review on PR #273.
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -60,6 +67,12 @@ jobs:
           - { os: windows-latest,   arch_key: Windows-X64,  archive: astap_command-line_version_win64.zip,          subdir: windows_installer,   bin: astap_cli.exe }
     steps:
       - uses: actions/checkout@v5
+        with:
+          # workflow_run defaults to the trigger workflow's head_sha
+          # (could be a PR commit if install-astap was failing on a PR).
+          # Pin to main so the SHA extraction reads the same action.yml
+          # the auto-PR will eventually update. Per Copilot review.
+          ref: main
 
       - name: Extract current SHA pin from action.yml
         id: current
@@ -76,6 +89,13 @@ jobs:
               exit
             }
           ' .github/actions/install-astap/action.yml)
+          # Hard-fail if the parse didn't yield a 64-char hex SHA —
+          # otherwise an empty value would be silently treated as
+          # "rotated" against any real upstream SHA. Per Copilot review.
+          if [[ ! "$sha" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::Failed to extract a valid SHA-256 pin for $arch from action.yml (got '$sha'). The action's per-OS table may have changed shape."
+            exit 1
+          fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "Pinned SHA: $sha"
 
@@ -289,13 +309,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: main
 
       - name: Pull archive and detect rotation
         id: war
         shell: bash
+        env:
+          ARCHIVE: astap_command-line_version_win11_aarch64.zip
         run: |
           set -euo pipefail
-          ARCHIVE="astap_command-line_version_win11_aarch64.zip"
           URL="https://sourceforge.net/projects/astap-program/files/windows_installer/${ARCHIVE}/download"
           curl -fsSL --retry 3 --retry-delay 2 -o "$ARCHIVE" "$URL"
           new=$(sha256sum "$ARCHIVE" | awk '{print $1}')
@@ -308,22 +331,26 @@ jobs:
               exit
             }
           ' .github/actions/install-astap/action.yml)
+          # Hard-fail on empty/malformed extraction (same reason as detect job).
+          if [[ ! "$current" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::Failed to extract a valid SHA-256 pin for $ARCHIVE from action.yml (got '$current')."
+            exit 1
+          fi
           if [[ "$current" == "$new" ]]; then
             echo "rotated=false" >> "$GITHUB_OUTPUT"
             echo "No rotation for Windows-ARM64."
           else
             echo "rotated=true" >> "$GITHUB_OUTPUT"
             mkdir -p result
-            {
-              printf '{\n'
-              printf '  "arch_key": "Windows-ARM64",\n'
-              printf '  "archive": "%s",\n' "$ARCHIVE"
-              printf '  "current_sha": "%s",\n' "$current"
-              printf '  "new_sha": "%s",\n' "$new"
-              printf '  "banner": "cross-mirror SHA only (no runner, no verification)",\n'
-              printf '  "m101_passed": "skipped"\n'
-              printf '}\n'
-            } > result/Windows-ARM64.json
+            jq -n \
+              --arg arch_key    "Windows-ARM64" \
+              --arg archive     "$ARCHIVE" \
+              --arg current_sha "$current" \
+              --arg new_sha     "$new" \
+              --arg banner      "cross-mirror SHA only (no runner, no verification)" \
+              --arg m101_passed "skipped" \
+              '{arch_key: $arch_key, archive: $archive, current_sha: $current_sha, new_sha: $new_sha, banner: $banner, m101_passed: $m101_passed}' \
+              > result/Windows-ARM64.json
           fi
 
       - uses: actions/upload-artifact@v7
@@ -334,9 +361,14 @@ jobs:
 
   open-pr:
     needs: [detect, windows-arm64]
-    if: |
-      always() &&
-      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure')
+    # Default success() gate is implicit — open-pr runs only when both
+    # `detect` (every matrix leg) and `windows-arm64` succeeded. A
+    # detect-leg infra failure (download, unzip, banner-capture) skips
+    # this job; the next install-astap nightly will retrigger refresh.
+    # An M101 verification failure does NOT fail the leg — it surfaces
+    # via the artifact's m101_passed=false, and the file-issue branch
+    # below picks that up. Per Copilot review.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -421,6 +453,7 @@ jobs:
           git diff --no-color .github/actions/install-astap/action.yml
 
       - name: Push branch and open / update PR
+        id: push
         if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -495,15 +528,23 @@ jobs:
           EOF
           )
 
-          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)
+          # `gh pr list ... --jq '.[0].number'` yields the literal text
+          # "null" when no PR exists (jq -r prints null as the string
+          # "null"). Use `// empty` so the variable is genuinely empty
+          # when absent. Per Copilot review.
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty' || true)
           if [[ -n "$existing" ]]; then
             gh pr edit "$existing" --body "$body"
-            echo "Updated existing PR #$existing"
+            pr_url=$(gh pr view "$existing" --json url --jq .url)
+            echo "Updated existing PR #$existing — $pr_url"
           else
-            gh pr create --base main --head "$BRANCH" \
+            pr_url=$(gh pr create --base main --head "$BRANCH" \
               --title "chore(install-astap): auto-refresh SHA-256 pins" \
-              --body "$body"
+              --body "$body")
+            echo "Opened new PR — $pr_url"
           fi
+          # Surface PR URL to downstream tracker-comment step.
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: File issue when M101 verification fails
         if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'false'
@@ -513,6 +554,7 @@ jobs:
         with:
           script: |
             const title = `astap: upstream rotated but new bytes fail M101 verification`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               `Auto-refresh detected upstream SHA rotation, but the new ASTAP binary failed to solve the M101 fixture on at least one platform. Manual investigation required — do **not** merge a refresh PR until this is understood.`,
               ``,
@@ -527,43 +569,88 @@ jobs:
               `- \`.wcs\` sidecar format changed (CRVAL keys renamed, PLTSOLVD card removed)`,
               `- New binary requires a newer D05 database`,
               ``,
-              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Workflow run: ${runUrl}`,
             ].join("\n");
-            await github.rest.issues.create({
+            // Dedupe like install-astap.yml's notify-on-failure: search
+            // open AND closed so a maintainer who closed a previous
+            // instance gets a re-open + comment, not a fresh duplicate.
+            // Per Copilot review.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ["astap-refresh-blocked", "ci-flake"],
+              state: 'all',
+              labels: 'astap-refresh-blocked',
             });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              if (match.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again — see ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['astap-refresh-blocked', 'ci-flake'],
+              });
+            }
 
       - name: Comment on install-astap tracking issue
         if: steps.gate.outputs.rotated == 'true'
         uses: actions/github-script@v9
         env:
           ALL_PASSED: ${{ steps.agg.outputs.all_passed }}
+          # PR_URL is empty when verification failed (push step skipped);
+          # the JS branches on allPassed and only references PR_URL on
+          # the success path. Per Copilot review on PR #273.
+          PR_URL: ${{ steps.push.outputs.pr_url }}
         with:
           script: |
             const allPassed = process.env.ALL_PASSED === 'true';
-            // Search open AND closed so we stay coherent if a maintainer
-            // closes #266 manually between the smoke failure and this run.
+            const prUrl = process.env.PR_URL;
+            // Search open AND closed (state: 'all') so we stay coherent
+            // if a maintainer closed the tracking issue manually between
+            // the install-astap failure and this run. Reopen-then-comment
+            // mirrors install-astap.yml's own dedupe pattern.
+            // Per Copilot review.
             const tracker = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open',
+              state: 'all',
               labels: 'install-astap-nightly',
             });
             const issue = tracker.find(i => i.title === 'nightly: install-astap smoke failing (likely upstream SHA rotation)');
             if (!issue) {
-              console.log('No open install-astap tracking issue to comment on.');
+              console.log('No install-astap tracking issue (open or closed) to comment on.');
               return;
             }
+            if (issue.state === 'closed') {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'open',
+              });
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const msg = allPassed
-              ? `Auto-refresh workflow opened a PR with new SHAs (M101 verified on all runner-backed platforms). Review and merge to close this.`
-              : `Auto-refresh workflow detected rotation but M101 verification failed on at least one platform. See the new \`astap-refresh-blocked\` issue.`;
+              ? `Auto-refresh workflow opened ${prUrl} with new SHAs (M101 verified on all runner-backed platforms). Review and merge to close this.`
+              : `Auto-refresh workflow detected rotation but M101 verification failed on at least one platform. See the \`astap-refresh-blocked\` issue.`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              body: `${msg}\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              body: `${msg}\n\nRun: ${runUrl}`,
             });

--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -247,19 +247,31 @@ jobs:
       - name: Record platform result
         if: steps.rot.outputs.rotated == 'true'
         shell: bash
+        # Untrusted inputs (BANNER comes from upstream binary stdout)
+        # are passed via env so they become runtime bash variables
+        # rather than YAML-preprocessed source text. `jq -n --arg` then
+        # produces correctly-escaped JSON, so a banner containing `"`,
+        # `\`, `$(...)`, or newlines can't break the output or inject
+        # commands. CodeQL flagged the previous printf form on PR #273.
+        env:
+          ARCH_KEY: ${{ matrix.arch_key }}
+          ARCHIVE: ${{ matrix.archive }}
+          CURRENT_SHA: ${{ steps.current.outputs.sha }}
+          NEW_SHA: ${{ steps.new.outputs.sha }}
+          BANNER: ${{ steps.banner.outputs.version }}
+          PASSED: ${{ steps.verify.outputs.passed }}
         run: |
           set -euo pipefail
           mkdir -p result
-          {
-            printf '{\n'
-            printf '  "arch_key": "%s",\n'    "${{ matrix.arch_key }}"
-            printf '  "archive": "%s",\n'     "${{ matrix.archive }}"
-            printf '  "current_sha": "%s",\n' "${{ steps.current.outputs.sha }}"
-            printf '  "new_sha": "%s",\n'     "${{ steps.new.outputs.sha }}"
-            printf '  "banner": "%s",\n'      "${{ steps.banner.outputs.version }}"
-            printf '  "m101_passed": "%s"\n'  "${{ steps.verify.outputs.passed }}"
-            printf '}\n'
-          } > result/${{ matrix.arch_key }}.json
+          jq -n \
+            --arg arch_key    "$ARCH_KEY" \
+            --arg archive     "$ARCHIVE" \
+            --arg current_sha "$CURRENT_SHA" \
+            --arg new_sha     "$NEW_SHA" \
+            --arg banner      "$BANNER" \
+            --arg m101_passed "$PASSED" \
+            '{arch_key: $arch_key, archive: $archive, current_sha: $current_sha, new_sha: $new_sha, banner: $banner, m101_passed: $m101_passed}' \
+            > "result/${ARCH_KEY}.json"
 
       - uses: actions/upload-artifact@v7
         if: steps.rot.outputs.rotated == 'true'
@@ -412,6 +424,14 @@ jobs:
         if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ROWS contains the per-platform banner versions, which originate
+          # from upstream binary stdout (untrusted). Pass via env so it
+          # becomes a runtime bash variable; the heredoc below interpolates
+          # `${ROWS}` as plain text and bash's single-pass expansion rule
+          # prevents re-evaluation of any `$(...)` or backticks inside.
+          # CodeQL flagged the previous direct `${{ }}` interpolation on
+          # PR #273.
+          ROWS: ${{ steps.agg.outputs.rows }}
         shell: bash
         run: |
           set -euo pipefail
@@ -454,7 +474,7 @@ jobs:
 
           ## Per-platform results
 
-          ${{ steps.agg.outputs.rows }}
+          ${ROWS}
 
           ## Verification
 

--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -201,14 +201,21 @@ jobs:
         shell: bash
         run: |
           # Goal: prove the new ASTAP bytes can solve a known fixture to
-          # the expected coordinates. Three independent signals checked:
+          # the expected coordinates. Signals checked match what the
+          # wrapper's .wcs parser (services/plate-solver/src/runner/wcs.rs)
+          # actually requires — no stricter:
           #   1. ASTAP exit code (0 = solved)
-          #   2. .wcs sidecar present and PLTSOLVD=T
-          #   3. CRVAL1/CRVAL2 within 0.01° of M101 center
+          #   2. .wcs sidecar present
+          #   3. CRVAL1/CRVAL2 parseable AND within 0.01° of M101 center
           #      (RA 210.8099°, Dec 54.3469° — same tolerance and
           #      reference values the BDD scenario uses)
           # The companion degenerate fixture must NOT solve (verifies
           # ASTAP's failure signaling hasn't drifted).
+          #
+          # An earlier draft also gated on `PLTSOLVD=T`, but the wrapper
+          # itself doesn't require that card — gating on it here would
+          # produce false negatives if ASTAP renamed it while still
+          # producing a valid WCS. Per Copilot review on PR #273.
           #
           # On any failure: write passed=false and exit 0 so the
           # aggregator can decide the outcome. Do not fail this matrix
@@ -239,12 +246,16 @@ jobs:
           if [[ ! -f "$work/m101_known.wcs" ]]; then
             fail "M101 produced no .wcs sidecar"
           fi
-          if ! grep -q "PLTSOLVD=                    T" "$work/m101_known.wcs"; then
-            fail "M101 .wcs PLTSOLVD card is not T"
-          fi
 
           ra=$(grep -oE 'CRVAL1  =[^/]+' "$work/m101_known.wcs" | head -1 | awk -F= '{print $2+0}')
           dec=$(grep -oE 'CRVAL2  =[^/]+' "$work/m101_known.wcs" | head -1 | awk -F= '{print $2+0}')
+          # If ASTAP wrote a sidecar without CRVAL1/CRVAL2 (incomplete
+          # solve, format change), our awk yields "0" and the tolerance
+          # check below would catch it — but surface the missing key
+          # explicitly first so the failure message is clear.
+          if [[ -z "$ra" || -z "$dec" ]]; then
+            fail "M101 .wcs missing CRVAL1 or CRVAL2"
+          fi
 
           awk -v a="$ra"  -v b=210.8099 -v t=0.01 'BEGIN { d=a-b; if(d<0)d=-d; exit !(d<=t) }' \
             || fail "M101 RA $ra outside tolerance (expected 210.8099 +/- 0.01)"

--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -1,0 +1,549 @@
+# Self-healing supply-chain refresh for ASTAP CLI SHA pins.
+#
+# Triggers when the nightly `install-astap` smoke fails (the canonical
+# signal that upstream rotated a SourceForge archive without us
+# refreshing the pin) or on manual dispatch. For each supported
+# platform: downloads the upstream archive, detects whether its SHA-256
+# differs from the pin in `.github/actions/install-astap/action.yml`,
+# and — for rotated platforms — verifies the new binary by solving the
+# committed M101 fixture
+# (`services/plate-solver/tests/fixtures/m101_known.fits`) to the
+# known center (RA 210.8099°, Dec 54.3469°) within the same 0.01°
+# tolerance the BDD scenario uses.
+#
+# An aggregator job opens (or updates) an auto-PR with the new pins
+# IFF every rotated platform passed M101 verification. If verification
+# fails on any platform, it files a separate tracking issue instead —
+# that case means upstream shipped something broken, and a human needs
+# to look. The PR's own CI then re-runs `install-astap` (banner check)
+# and `plate-solver-smoke` (full BDD on the 3-OS subset) on the new
+# pins before merge.
+#
+# Windows-ARM64 has no GitHub-hosted runner, so its SHA is refreshed
+# cross-mirror with no verification — same posture ADR-005 already
+# documents for that row.
+#
+# See `docs/decisions/005-plate-solver.md` §"Pinned SHA-256 + refresh
+# procedure" for the manual procedure this workflow automates.
+
+name: refresh-astap-shas
+
+on:
+  workflow_run:
+    workflows: ["install-astap"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    # Run on manual dispatch OR when install-astap concluded as failure.
+    # Skipped on install-astap successes (no rotation suspected).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
+    name: detect / ${{ matrix.arch_key }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,    arch_key: Linux-X64,    archive: astap_command-line_version_Linux_amd64.zip,    subdir: linux_installer,     bin: astap_cli }
+          - { os: ubuntu-24.04-arm, arch_key: Linux-ARM64,  archive: astap_command-line_version_Linux_aarch64.zip,  subdir: linux_installer,     bin: astap_cli }
+          - { os: macos-latest,     arch_key: macOS-ARM64,  archive: astap_command-line_version_macOS_M1.zip,       subdir: macOS%20installer,   bin: astap_cli }
+          - { os: windows-latest,   arch_key: Windows-X64,  archive: astap_command-line_version_win64.zip,          subdir: windows_installer,   bin: astap_cli.exe }
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Extract current SHA pin from action.yml
+        id: current
+        shell: bash
+        run: |
+          set -euo pipefail
+          arch="${{ matrix.archive }}"
+          sha=$(awk -v target="$arch" '
+            $0 ~ "ARCHIVE=\"" target "\"" { found = 1; next }
+            found && /SHA256=/ {
+              if (match($0, /SHA256="[a-f0-9]+"/)) {
+                print substr($0, RSTART+8, RLENGTH-9)
+              }
+              exit
+            }
+          ' .github/actions/install-astap/action.yml)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Pinned SHA: $sha"
+
+      - name: Download upstream archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="https://sourceforge.net/projects/astap-program/files/${{ matrix.subdir }}/${{ matrix.archive }}/download"
+          echo "Fetching $URL"
+          curl -fsSL --retry 3 --retry-delay 2 -o "${{ matrix.archive }}" "$URL"
+
+      - name: Compute new SHA-256
+        id: new
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sha256sum >/dev/null; then
+            sha=$(sha256sum "${{ matrix.archive }}" | awk '{print $1}')
+          else
+            sha=$(shasum -a 256 "${{ matrix.archive }}" | awk '{print $1}')
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Upstream SHA: $sha"
+
+      - name: Detect rotation
+        id: rot
+        shell: bash
+        run: |
+          if [[ "${{ steps.current.outputs.sha }}" == "${{ steps.new.outputs.sha }}" ]]; then
+            echo "rotated=false" >> "$GITHUB_OUTPUT"
+            echo "No rotation — pin matches upstream."
+          else
+            echo "rotated=true" >> "$GITHUB_OUTPUT"
+            echo "Rotation detected."
+          fi
+
+      - name: Extract new binary
+        if: steps.rot.outputs.rotated == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p astap-new
+          unzip -oq "${{ matrix.archive }}" -d astap-new
+          # Top-level layout in the archive places the binary at the root
+          # of the unpacked directory — same as the install-astap action's
+          # post-extract expectation.
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod +x "astap-new/${{ matrix.bin }}"
+          fi
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            xattr -d com.apple.quarantine "astap-new/${{ matrix.bin }}" 2>/dev/null || true
+          fi
+
+      - name: Capture banner version
+        if: steps.rot.outputs.rotated == 'true'
+        id: banner
+        shell: bash
+        run: |
+          set -euo pipefail
+          # First line of stdout is the version banner
+          # (e.g. "ASTAP astrometric solver version CLI-2026.02.09").
+          # Strip CR for Windows so the value is a clean single line.
+          version=$("$PWD/astap-new/${{ matrix.bin }}" 2>&1 | head -1 | tr -d '\r')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Banner: $version"
+
+      - name: Cache D05 star database
+        if: steps.rot.outputs.rotated == 'true'
+        id: d05-cache
+        uses: actions/cache@v5
+        with:
+          path: d05
+          # Share the cache key with install-astap so an existing entry
+          # hits across both workflows. The 8-char hex prefix
+          # matches install-astap action.yml's cache-key convention.
+          key: astap-d05-database-39d59b73
+
+      - name: Download D05 if cache miss
+        if: steps.rot.outputs.rotated == 'true' && steps.d05-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p d05
+          URL="https://sourceforge.net/projects/astap-program/files/star_databases/d05_star_database.zip/download"
+          curl -fsSL --retry 3 --retry-delay 2 -o d05/d05.zip "$URL"
+          if command -v sha256sum >/dev/null; then
+            ACTUAL=$(sha256sum d05/d05.zip | awk '{print $1}')
+          else
+            ACTUAL=$(shasum -a 256 d05/d05.zip | awk '{print $1}')
+          fi
+          EXPECTED="39d59b73cb960fa0956c35162e70b09a8af10ef20a1e8f5cae7b77d48be5ce31"
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "::warning::D05 also rotated upstream ($ACTUAL vs pinned $EXPECTED). This workflow does not auto-refresh D05 yet — manual refresh required per ADR-005."
+            # Continue with the downloaded bytes so M101 can still be
+            # verified against the new ASTAP. The downstream PR will
+            # only update CLI SHAs, not D05.
+          fi
+          ( cd d05 && unzip -oq d05.zip && rm d05.zip )
+
+      - name: Verify M101 solves correctly with new binary
+        if: steps.rot.outputs.rotated == 'true'
+        id: verify
+        shell: bash
+        run: |
+          # Goal: prove the new ASTAP bytes can solve a known fixture to
+          # the expected coordinates. Three independent signals checked:
+          #   1. ASTAP exit code (0 = solved)
+          #   2. .wcs sidecar present and PLTSOLVD=T
+          #   3. CRVAL1/CRVAL2 within 0.01° of M101 center
+          #      (RA 210.8099°, Dec 54.3469° — same tolerance and
+          #      reference values the BDD scenario uses)
+          # The companion degenerate fixture must NOT solve (verifies
+          # ASTAP's failure signaling hasn't drifted).
+          #
+          # On any failure: write passed=false and exit 0 so the
+          # aggregator can decide the outcome. Do not fail this matrix
+          # leg — that would short-circuit the other legs and lose
+          # cross-platform signal.
+          set +e
+          bin="$PWD/astap-new/${{ matrix.bin }}"
+          db="$PWD/d05"
+          fixtures="$PWD/services/plate-solver/tests/fixtures"
+
+          work="$RUNNER_TEMP/m101-verify"
+          mkdir -p "$work"
+          cp "$fixtures/m101_known.fits" "$work/"
+          cp "$fixtures/degenerate_no_stars.fits" "$work/"
+
+          fail() {
+            echo "::error::$1"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Happy path
+          "$bin" -f "$work/m101_known.fits" -d "$db" -wcs
+          rc=$?
+          if [[ $rc -ne 0 ]]; then
+            fail "M101 solve exited $rc"
+          fi
+          if [[ ! -f "$work/m101_known.wcs" ]]; then
+            fail "M101 produced no .wcs sidecar"
+          fi
+          if ! grep -q "PLTSOLVD=                    T" "$work/m101_known.wcs"; then
+            fail "M101 .wcs PLTSOLVD card is not T"
+          fi
+
+          ra=$(grep -oE 'CRVAL1  =[^/]+' "$work/m101_known.wcs" | head -1 | awk -F= '{print $2+0}')
+          dec=$(grep -oE 'CRVAL2  =[^/]+' "$work/m101_known.wcs" | head -1 | awk -F= '{print $2+0}')
+
+          awk -v a="$ra"  -v b=210.8099 -v t=0.01 'BEGIN { d=a-b; if(d<0)d=-d; exit !(d<=t) }' \
+            || fail "M101 RA $ra outside tolerance (expected 210.8099 +/- 0.01)"
+          awk -v a="$dec" -v b=54.3469  -v t=0.01 'BEGIN { d=a-b; if(d<0)d=-d; exit !(d<=t) }' \
+            || fail "M101 Dec $dec outside tolerance (expected 54.3469 +/- 0.01)"
+
+          # Failure path
+          "$bin" -f "$work/degenerate_no_stars.fits" -d "$db" -wcs
+          rc=$?
+          if [[ $rc -eq 0 ]]; then
+            fail "degenerate_no_stars.fits unexpectedly solved"
+          fi
+          if [[ -f "$work/degenerate_no_stars.wcs" ]]; then
+            fail "degenerate fixture produced a .wcs sidecar"
+          fi
+
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+          echo "M101 verified: RA=$ra Dec=$dec; degenerate failed as expected."
+
+      - name: Record platform result
+        if: steps.rot.outputs.rotated == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p result
+          {
+            printf '{\n'
+            printf '  "arch_key": "%s",\n'    "${{ matrix.arch_key }}"
+            printf '  "archive": "%s",\n'     "${{ matrix.archive }}"
+            printf '  "current_sha": "%s",\n' "${{ steps.current.outputs.sha }}"
+            printf '  "new_sha": "%s",\n'     "${{ steps.new.outputs.sha }}"
+            printf '  "banner": "%s",\n'      "${{ steps.banner.outputs.version }}"
+            printf '  "m101_passed": "%s"\n'  "${{ steps.verify.outputs.passed }}"
+            printf '}\n'
+          } > result/${{ matrix.arch_key }}.json
+
+      - uses: actions/upload-artifact@v7
+        if: steps.rot.outputs.rotated == 'true'
+        with:
+          name: refresh-result-${{ matrix.arch_key }}
+          path: result/
+
+  windows-arm64:
+    # Cross-mirror SHA refresh only — no GH-hosted Windows-ARM64 runner
+    # exists, so M101 verification isn't possible. Hash from an Ubuntu
+    # runner so we still notice rotation and keep the per-OS table
+    # internally consistent.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
+    name: cross-mirror / Windows-ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Pull archive and detect rotation
+        id: war
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARCHIVE="astap_command-line_version_win11_aarch64.zip"
+          URL="https://sourceforge.net/projects/astap-program/files/windows_installer/${ARCHIVE}/download"
+          curl -fsSL --retry 3 --retry-delay 2 -o "$ARCHIVE" "$URL"
+          new=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+          current=$(awk -v target="$ARCHIVE" '
+            $0 ~ "ARCHIVE=\"" target "\"" { found = 1; next }
+            found && /SHA256=/ {
+              if (match($0, /SHA256="[a-f0-9]+"/)) {
+                print substr($0, RSTART+8, RLENGTH-9)
+              }
+              exit
+            }
+          ' .github/actions/install-astap/action.yml)
+          if [[ "$current" == "$new" ]]; then
+            echo "rotated=false" >> "$GITHUB_OUTPUT"
+            echo "No rotation for Windows-ARM64."
+          else
+            echo "rotated=true" >> "$GITHUB_OUTPUT"
+            mkdir -p result
+            {
+              printf '{\n'
+              printf '  "arch_key": "Windows-ARM64",\n'
+              printf '  "archive": "%s",\n' "$ARCHIVE"
+              printf '  "current_sha": "%s",\n' "$current"
+              printf '  "new_sha": "%s",\n' "$new"
+              printf '  "banner": "cross-mirror SHA only (no runner, no verification)",\n'
+              printf '  "m101_passed": "skipped"\n'
+              printf '}\n'
+            } > result/Windows-ARM64.json
+          fi
+
+      - uses: actions/upload-artifact@v7
+        if: steps.war.outputs.rotated == 'true'
+        with:
+          name: refresh-result-Windows-ARM64
+          path: result/
+
+  open-pr:
+    needs: [detect, windows-arm64]
+    if: |
+      always() &&
+      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Always base the auto-refresh off main, regardless of how this
+          # workflow was triggered. workflow_run defaults to the trigger
+          # workflow's head_sha (typically main on schedule); workflow_dispatch
+          # defaults to github.ref. Pinning to main keeps behavior identical.
+          ref: main
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+          pattern: refresh-result-*
+          merge-multiple: false
+
+      - name: Gate on any rotation
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if compgen -G "artifacts/refresh-result-*/*.json" > /dev/null; then
+            echo "rotated=true" >> "$GITHUB_OUTPUT"
+            echo "Rotated platforms:"
+            ls artifacts/refresh-result-*/
+          else
+            echo "rotated=false" >> "$GITHUB_OUTPUT"
+            echo "No platforms rotated — nothing to do."
+          fi
+
+      - name: Aggregate verification results
+        if: steps.gate.outputs.rotated == 'true'
+        id: agg
+        shell: bash
+        run: |
+          set -euo pipefail
+          all_passed=true
+          rows=""
+          for f in artifacts/refresh-result-*/*.json; do
+            arch=$(jq -r .arch_key "$f")
+            current=$(jq -r .current_sha "$f")
+            new=$(jq -r .new_sha "$f")
+            banner=$(jq -r .banner "$f")
+            passed=$(jq -r .m101_passed "$f")
+            rows="${rows}- **${arch}** (\`${banner}\`): \`${current:0:8}…\` → \`${new:0:8}…\` — M101 verify: **${passed}**\n"
+            if [[ "$passed" == "false" ]]; then
+              all_passed=false
+            fi
+          done
+          echo "all_passed=$all_passed" >> "$GITHUB_OUTPUT"
+          {
+            echo "rows<<EOF"
+            printf '%b' "$rows"
+            echo ""
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Patch action.yml with new SHAs
+        if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for f in artifacts/refresh-result-*/*.json; do
+            arch=$(jq -r .archive "$f")
+            new=$(jq -r .new_sha "$f")
+            tmp=$(mktemp)
+            awk -v target="$arch" -v new="$new" '
+              {
+                if (found && match($0, /SHA256="[a-f0-9]+"/)) {
+                  sub(/SHA256="[a-f0-9]+"/, "SHA256=\"" new "\"")
+                  found = 0
+                }
+                print
+                if ($0 ~ "ARCHIVE=\"" target "\"") {
+                  found = 1
+                }
+              }
+            ' .github/actions/install-astap/action.yml > "$tmp"
+            mv "$tmp" .github/actions/install-astap/action.yml
+          done
+          echo "---- staged diff ----"
+          git diff --no-color .github/actions/install-astap/action.yml
+
+      - name: Push branch and open / update PR
+        if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="chore/auto-refresh-astap-shas"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Always derive the auto-refresh branch from main with the patched
+          # action.yml in the worktree. -B creates or resets the local branch
+          # to the current HEAD (pinned to main by the checkout step), so a
+          # previous unmerged auto-refresh branch on origin is overwritten by
+          # the force-with-lease push below. The PR (if one already exists
+          # for this branch name) gets updated automatically.
+          git checkout -B "$BRANCH"
+
+          git add .github/actions/install-astap/action.yml
+          if git diff --cached --quiet; then
+            echo "No staged changes — branch is already up to date."
+            exit 0
+          fi
+
+          git commit -m "$(cat <<'COMMIT'
+          chore(install-astap): auto-refresh SHA-256 pins
+
+          Upstream rotated SourceForge archives. The refresh-astap-shas
+          workflow verified each new binary by solving the committed
+          M101 fixture (services/plate-solver/tests/fixtures/m101_known.fits)
+          to RA 210.8099° / Dec 54.3469° within 0.01° tolerance, then
+          patched the pins in .github/actions/install-astap/action.yml.
+
+          See ADR-005 §"Pinned SHA-256 + refresh procedure" for the
+          manual procedure this workflow automates.
+          COMMIT
+          )"
+          git push -u --force-with-lease origin "$BRANCH"
+
+          body=$(cat <<EOF
+          Auto-refresh detected upstream rotation of ASTAP CLI archives.
+
+          ## Per-platform results
+
+          ${{ steps.agg.outputs.rows }}
+
+          ## Verification
+
+          Each rotated platform's new binary was executed against
+          \`services/plate-solver/tests/fixtures/m101_known.fits\` and
+          asserted to solve to RA 210.8099° / Dec 54.3469° within 0.01°
+          tolerance (matching \`real_astap_smoke.feature\`). The
+          \`degenerate_no_stars.fits\` failure-mode fixture was also
+          checked.
+
+          Windows-ARM64 has no GH-hosted runner, so its SHA is refreshed
+          cross-mirror with no verification — same posture ADR-005
+          documents.
+
+          The PR's own CI will re-run \`install-astap\` (banner check)
+          and \`plate-solver-smoke\` (full BDD on the 3-OS subset) on
+          the new pins before this can merge.
+          EOF
+          )
+
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)
+          if [[ -n "$existing" ]]; then
+            gh pr edit "$existing" --body "$body"
+            echo "Updated existing PR #$existing"
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(install-astap): auto-refresh SHA-256 pins" \
+              --body "$body"
+          fi
+
+      - name: File issue when M101 verification fails
+        if: steps.gate.outputs.rotated == 'true' && steps.agg.outputs.all_passed == 'false'
+        uses: actions/github-script@v9
+        env:
+          ROWS: ${{ steps.agg.outputs.rows }}
+        with:
+          script: |
+            const title = `astap: upstream rotated but new bytes fail M101 verification`;
+            const body = [
+              `Auto-refresh detected upstream SHA rotation, but the new ASTAP binary failed to solve the M101 fixture on at least one platform. Manual investigation required — do **not** merge a refresh PR until this is understood.`,
+              ``,
+              `## Per-platform results`,
+              ``,
+              process.env.ROWS,
+              ``,
+              `## Likely causes`,
+              ``,
+              `- Upstream shipped a broken release`,
+              `- CLI surface changed (e.g. \`-wcs\` or \`-d\` flags renamed)`,
+              `- \`.wcs\` sidecar format changed (CRVAL keys renamed, PLTSOLVD card removed)`,
+              `- New binary requires a newer D05 database`,
+              ``,
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join("\n");
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ["astap-refresh-blocked", "ci-flake"],
+            });
+
+      - name: Comment on install-astap tracking issue
+        if: steps.gate.outputs.rotated == 'true'
+        uses: actions/github-script@v9
+        env:
+          ALL_PASSED: ${{ steps.agg.outputs.all_passed }}
+        with:
+          script: |
+            const allPassed = process.env.ALL_PASSED === 'true';
+            // Search open AND closed so we stay coherent if a maintainer
+            // closes #266 manually between the smoke failure and this run.
+            const tracker = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'install-astap-nightly',
+            });
+            const issue = tracker.find(i => i.title === 'nightly: install-astap smoke failing (likely upstream SHA rotation)');
+            if (!issue) {
+              console.log('No open install-astap tracking issue to comment on.');
+              return;
+            }
+            const msg = allPassed
+              ? `Auto-refresh workflow opened a PR with new SHAs (M101 verified on all runner-backed platforms). Review and merge to close this.`
+              : `Auto-refresh workflow detected rotation but M101 verification failed on at least one platform. See the new \`astap-refresh-blocked\` issue.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `${msg}\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -347,6 +347,29 @@ silent supply-chain drift.
 ASTAP releases an upstream update and the verify step starts
 failing):
 
+The
+[`refresh-astap-shas`](../../.github/workflows/refresh-astap-shas.yml)
+workflow automates steps 1–4 of this procedure. It triggers on an
+`install-astap` smoke failure (the canonical rotation signal) or
+manual dispatch. For each supported platform it downloads the
+upstream archive, detects whether the SHA differs from the pin, and
+— for rotated platforms — **verifies the new binary by solving the
+committed M101 fixture
+(`services/plate-solver/tests/fixtures/m101_known.fits`) to the
+known center within the same 0.01° tolerance the BDD scenario
+uses**. If every rotated platform's verification passes, it opens
+(or updates) a `chore(install-astap): auto-refresh SHA-256 pins`
+PR and comments on the open `install-astap-nightly` tracking
+issue with the PR link. If verification fails on any platform, it
+files an `astap-refresh-blocked` issue instead — that case means
+upstream shipped something broken and a human needs to look. The
+PR's own CI re-runs `install-astap` and `plate-solver-smoke` on
+the new pins before merge; the human step is review-and-merge of
+the auto-PR, plus the banner-version note (step 5 below). The
+manual steps below remain the fallback for D05 rotations (the
+workflow doesn't auto-refresh D05 yet) or when the auto-refresh
+itself is broken.
+
 1. Download each archive listed in the action's per-OS table from
    SourceForge.
 2. `sha256sum` each (or `shasum -a 256` on macOS).


### PR DESCRIPTION
## Summary

Adds `.github/workflows/refresh-astap-shas.yml`, a self-healing supply-chain workflow that turns the manual SHA-refresh dance (ADR-005 §"Pinned SHA-256 + refresh procedure") into "review and merge an auto-PR." Triggered by an `install-astap` smoke failure (the canonical rotation signal that opened issue #266 this morning) or by manual dispatch.

For each supported platform, the workflow:

1. Downloads the upstream archive and computes its SHA-256.
2. If the SHA differs from the pin in `.github/actions/install-astap/action.yml`, extracts the new binary, captures its banner version, and downloads D05 (cache-shared with `install-astap`).
3. **Verifies the new binary by solving `services/plate-solver/tests/fixtures/m101_known.fits`** to RA 210.8099° / Dec 54.3469° within the same 0.01° tolerance `real_astap_smoke.feature` uses. The companion `degenerate_no_stars.fits` is also checked. Three independent signals — exit code, `PLTSOLVD=T` card, and `CRVAL1`/`CRVAL2` tolerance — give a robust pass/fail per platform.
4. Records the result (current SHA, new SHA, banner, verification outcome) as an artifact.

An aggregator job then:

- **Opens (or updates) an auto-PR** with the new pins iff every rotated platform's M101 verification passes. PR body lists per-platform old→new SHA + banner version.
- **Files an `astap-refresh-blocked` issue** if verification fails on any platform (means upstream shipped something broken — needs human attention, do not merge).
- **Comments on the open `install-astap-nightly` tracker issue** (#266 in the current case) with a link to the workflow run.

Design choices baked in:

- **No cargo toolchain in the workflow** — solves M101 via direct `astap_cli` invocation + shell-parse of the `.wcs` sidecar (validated locally on Linux aarch64; format is plain FITS-header). The wrapper's own integration is validated when the PR's `plate-solver-smoke` fires on the SHA bump.
- **Windows-ARM64 cross-mirror SHA refresh** — no GH-hosted runner exists, so the SHA is refreshed but not verified. Same posture ADR-005 documents.
- **No auto-merge** — the pin is the supply-chain checkpoint; human glance at the banner version is cheap.
- **D05 not auto-refreshed** — D05 hasn't rotated since 2026-05-02 and is a different cadence. Workflow emits a warning if D05's SHA also rotated; manual procedure (still documented in ADR-005) is the fallback.

## Test plan

This PR's job is to land the workflow. The workflow's correctness is validated by dogfooding it on the current rotation (issue #266):

- [ ] Review the workflow YAML for correctness (`actionlint 1.7.7` returned clean locally)
- [ ] Merge this PR
- [ ] `gh workflow run refresh-astap-shas.yml --ref main` to trigger immediately (rather than waiting for the next `install-astap` nightly failure)
- [ ] Observe the workflow detect rotation on all 4 platforms, verify M101 on all 4, and open `chore/auto-refresh-astap-shas` PR with the new pins
- [ ] Verify the auto-PR's body lists per-platform old→new SHA and banner versions
- [ ] Verify the auto-PR triggers `install-astap` (banner check) and `plate-solver-smoke` (real M101 BDD) on the new pins
- [ ] Verify a comment lands on issue #266
- [ ] Review and merge the auto-PR (`install-astap` smoke should then go green next nightly)
- [ ] Close issue #266

## Related

- Closes #266 (eventually — this PR lands the automation; the auto-PR it produces fixes the actual SHA drift)
- ADR-005 §"Pinned SHA-256 + refresh procedure" — updated to document the auto-refresh path