### PR TITLE
ci(codeowners): gate all paths to @ivonnyssen as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Every path in this repo is owned by @ivonnyssen.
+#
+# Paired with the main_protection ruleset's require_code_owner_review +
+# required_approving_review_count: 1: PRs touching any file need an
+# approval from a code owner before they can merge. github-actions[bot]
+# is intentionally NOT a code owner, so an auto-generated PR (e.g. from
+# refresh-astap-shas) can't satisfy the merge gate by self-approving
+# even if its workflow has pull-request write permission.
+#
+# Admin role keeps bypass via bypass_actors on the ruleset, so own-PRs
+# aren't deadlocked by GitHub's no-self-approval rule.
+
+*  @ivonnyssen


### PR DESCRIPTION
## Summary

Adds a repo-wide `CODEOWNERS` file (`*  @ivonnyssen`) to back a hardened `main_protection` ruleset, applied alongside this PR via API:

- `required_approving_review_count: 0 → 1`
- `require_code_owner_review: false → true`
- `bypass_actors: [{ admin role, bypass_mode: pull_request }]`
- Plus repo-level **Actions → Allow GitHub Actions to create and approve pull requests** flipped on.

## Why

`refresh-astap-shas` (PR #273) failed on `gh pr create` last night with `GitHub Actions is not permitted to create or approve pull requests` — the bot pushed the patched branch but couldn't open the PR. Flipping the Actions flag unblocks creation, but that flag is coupled in GitHub's permission model: enabling create also enables approve. CODEOWNERS + code-owner-review on the ruleset closes the gap — even though `github-actions[bot]` now has approve capability, its approval doesn't satisfy the merge gate because it isn't a code owner. Admin bypass (mode: `pull_request`) keeps own-PRs un-deadlocked by GitHub's no-self-approval rule.

## Test plan

- [ ] Merge this PR (admin bypass available since you're the only code owner).
- [ ] Manually open a PR from the already-pushed `chore/auto-refresh-astap-shas` branch (or re-run `refresh-astap-shas` via `workflow_dispatch`) to confirm the bot can now create PRs and that the PR requires owner approval before merge.
- [ ] After that PR merges, the `install-astap` nightly should go green on next run, closing the `install-astap-nightly` tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)