### PR TITLE
ci(refresh-astap-shas): fix --force-with-lease "(stale info)" rejection

### DIFF
--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -484,6 +484,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # actions/checkout@v5 with `ref: main` leaves origin's refspec
+          # as `+refs/heads/main:refs/remotes/origin/main` (single-branch
+          # fetch). A plain `git fetch origin $BRANCH` under that refspec
+          # only populates FETCH_HEAD; the remote-tracking ref
+          # `refs/remotes/origin/$BRANCH` is never created. Without that
+          # ref, `git push --force-with-lease` (with no explicit expected
+          # value) rejects with "(stale info)" the moment $BRANCH already
+          # exists on origin — i.e. on every run after the first
+          # successful one, until that branch is merged or deleted.
+          # Extend the refspec and fetch BEFORE the local branch is
+          # created: the lease's baseline is captured at branch-creation
+          # time, not push time, so fetching after `git checkout -B`
+          # is too late. `|| true` covers the very first refresh when
+          # $BRANCH doesn't exist on origin yet.
+          git remote set-branches --add origin "$BRANCH"
+          git fetch origin "$BRANCH" || true
+
           # Always derive the auto-refresh branch from main with the patched
           # action.yml in the worktree. -B creates or resets the local branch
           # to the current HEAD (pinned to main by the checkout step), so a


### PR DESCRIPTION
## Summary

- The `refresh-astap-shas` workflow's `open-pr` job was failing at `git push -u --force-with-lease origin "$BRANCH"` with `(stale info)` on every run after the first successful one (most recently [run 26144185626](https://github.com/ivonnyssen/rusty-photon/actions/runs/26144185626)). The auto-refresh PR was never being opened, so the install-astap nightly's self-healing loop was effectively broken.
- Root cause: `actions/checkout@v5` with `ref: main` leaves origin's refspec as the single-branch `+refs/heads/main:refs/remotes/origin/main`. A plain `git fetch origin "$BRANCH"` under that refspec only populates `FETCH_HEAD` — `refs/remotes/origin/$BRANCH` is never created. Without that local view, `--force-with-lease` (no explicit expected value) has no baseline to validate against and refuses. The very first run pushed fine because the remote branch didn't exist yet; everything after that failed.
- Fix: extend origin's refspec with `git remote set-branches --add`, then `git fetch origin "$BRANCH" || true` **before** `git checkout -B`. Ordering matters — the lease's expected value is captured at branch-creation time, not push time, so fetching after the checkout is too late.

**The force-push target is unchanged**: `chore/auto-refresh-astap-shas` (auto-managed, sole-writer, `concurrency=workflow`). `main` is never the target of any push in this workflow, before or after this change.

## Reproduction

Reproduced the failure locally and verified the fix in a bare-remote + single-branch-clone harness that mirrors what `actions/checkout@v5` produces. Three candidate fixes tested:

| Approach | Result |
| --- | --- |
| Plain `git fetch origin "$BRANCH"` (the obvious-but-wrong fix) | Still rejected — only populates `FETCH_HEAD` |
| `git fetch origin "$BRANCH":refs/remotes/origin/"$BRANCH"` (explicit dest, but **after** `git checkout -B`) | Still rejected — lease baseline captured before the fetch |
| `set-branches --add` + `git fetch origin "$BRANCH"` **before** `git checkout -B` (this PR) | **Works** |

## Test plan

- [ ] CI on this PR exercises the `install-astap` workflow (workflow file diff is touched indirectly via the action under `.github/actions/install-astap/`? — no, only the refresh workflow itself changed, so install-astap CI shouldn't fire on this PR; that's fine).
- [ ] After merge: trigger the `refresh-astap-shas` workflow manually via `workflow_dispatch` and confirm the `open-pr` step pushes successfully and either creates or updates the `chore/auto-refresh-astap-shas` PR. (The existing branch on origin from run 26144185626 will still be there — this should be the first run that successfully overwrites it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)