### PR TITLE
docs(refresh-astap-shas): correct PR-body claim that PR CI re-runs install-astap

### DIFF
--- a/.github/workflows/refresh-astap-shas.yml
+++ b/.github/workflows/refresh-astap-shas.yml
@@ -15,9 +15,13 @@
 # IFF every rotated platform passed M101 verification. If verification
 # fails on any platform, it files a separate tracking issue instead —
 # that case means upstream shipped something broken, and a human needs
-# to look. The PR's own CI then re-runs `install-astap` (banner check)
-# and `plate-solver-smoke` (full BDD on the 3-OS subset) on the new
-# pins before merge.
+# to look. The aggregator job's own M101 verification is the only
+# ASTAP validation that runs before merge — `pull_request`-triggered
+# workflows (`install-astap`, `plate-solver-smoke`) do NOT fire on the
+# auto-PR because GitHub Actions suppresses workflows triggered by
+# GITHUB_TOKEN-authored events. A maintainer can close/reopen the
+# auto-PR to wake a redundant PR-CI signal if desired
+# (https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
 #
 # Windows-ARM64 has no GitHub-hosted runner, so its SHA is refreshed
 # cross-mirror with no verification — same posture ADR-005 already
@@ -550,9 +554,21 @@ jobs:
           cross-mirror with no verification — same posture ADR-005
           documents.
 
-          The PR's own CI will re-run \`install-astap\` (banner check)
-          and \`plate-solver-smoke\` (full BDD on the 3-OS subset) on
-          the new pins before this can merge.
+          Full verification logs:
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          ## PR CI
+
+          \`pull_request\`-triggered workflows (\`install-astap\`,
+          \`plate-solver-smoke\`, etc.) do not run on this PR. GitHub
+          Actions suppresses workflows triggered by GITHUB_TOKEN-authored
+          events, and this PR was opened by GITHUB_TOKEN — so the M101
+          verification above (run on this workflow's own runners) is the
+          only ASTAP validation that runs before merge.
+
+          To wake PR CI for a redundant signal, close and reopen this
+          PR — a human-authored \`pull_request: reopened\` event is not
+          suppressed.
           EOF
           )
 

--- a/docs/decisions/005-plate-solver.md
+++ b/docs/decisions/005-plate-solver.md
@@ -363,12 +363,17 @@ PR and comments on the open `install-astap-nightly` tracking
 issue with the PR link. If verification fails on any platform, it
 files an `astap-refresh-blocked` issue instead — that case means
 upstream shipped something broken and a human needs to look. The
-PR's own CI re-runs `install-astap` and `plate-solver-smoke` on
-the new pins before merge; the human step is review-and-merge of
-the auto-PR, plus the banner-version note (step 5 below). The
-manual steps below remain the fallback for D05 rotations (the
-workflow doesn't auto-refresh D05 yet) or when the auto-refresh
-itself is broken.
+aggregator job's M101 verification (described above) is the only
+ASTAP validation that runs before merge — `pull_request`-triggered
+workflows do NOT run on the auto-PR because [GitHub Actions
+suppresses workflows triggered by `GITHUB_TOKEN`-authored
+events](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+A maintainer can close/reopen the auto-PR to wake the PR's CI for
+a redundant signal. The human step is review-and-merge of the
+auto-PR plus the banner-version note (step 5 below). The manual
+steps below remain the fallback for D05 rotations (the workflow
+doesn't auto-refresh D05 yet) or when the auto-refresh itself is
+broken.
 
 1. Download each archive listed in the action's per-OS table from
    SourceForge.


### PR DESCRIPTION
## Summary

The auto-PR body, the workflow's top-of-file comment, and ADR-005 all claimed that `install-astap` and `plate-solver-smoke` would re-run on the auto-PR's own CI before merge. That's false — [GitHub Actions suppresses `pull_request` workflows triggered by `GITHUB_TOKEN`-authored events](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), and the auto-PR is opened by `GITHUB_TOKEN`. So no `pull_request` workflows fire.

Confirmed empirically with **PR #278** (the first PR opened by `refresh-astap-shas` after #277 fixed the push step): only CodeQL ran, despite `install-astap`'s `pull_request` paths filter matching exactly the file PR #278 touches.

## What changed

1. **PR body template** now links to the workflow run that did the M101 verification (so reviewers can audit the actual validation logs) and adds a `## PR CI` section explaining what does *not* run and how a maintainer can wake PR CI on demand (close + reopen the PR — a human-authored `pull_request: reopened` event is not suppressed).
2. **Workflow top-of-file comment** corrected with the same accurate description.
3. **ADR-005 §"Pinned SHA-256 + refresh procedure"** corrected to match.

No code changes. No behavioral change to the workflow. Pure docs + PR-body template.

## Why the substance is fine even though the description was wrong

The aggregator job's per-platform M101 verification on each GitHub-hosted runner (`detect / Linux-X64`, `detect / Linux-ARM64`, `detect / Windows-X64`, `detect / macOS-ARM64`) is and has always been the canonical pre-merge validation — exactly what `real_astap_smoke.feature` would check, on the same runner pool. PR #278's pins were verified that way before merge ([run 26197630921](https://github.com/ivonnyssen/rusty-photon/actions/runs/26197630921)). The validation has been correct from the start; only the description of *where* it runs was wrong.

## Test plan

- [ ] Visual diff review on the PR-body template — the next auto-refresh run will use the new wording.
- [ ] (Optional, post-merge) Manually `gh workflow run refresh-astap-shas` against a synthetic rotation to render the new body — but since there is no upstream rotation right now, the workflow's gate will short-circuit at "no platforms rotated" and not actually open a PR. The next real rotation will be the first to render the new template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)