### PR TITLE
ci(nightly): file tracking issues on rolling+safety failures

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -64,3 +64,69 @@ jobs:
         env:
           ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=0"
           RUSTFLAGS: "-Z sanitizer=${{ matrix.sanitizer }}"
+
+  notify-on-failure:
+    # Open or update a tracking issue when the nightly sanitizer run fails so
+    # ASan/LSan findings surface without depending on someone reading
+    # scheduled-workflow logs. Skipped on push, pull_request, and
+    # workflow_dispatch so manual debugging runs don't churn an issue.
+    needs: sanitizers
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = `nightly: safety sanitizers failing`;
+            const body = [
+              `The nightly safety workflow failed on at least one sanitizer.`,
+              ``,
+              `Likely causes: AddressSanitizer detected a memory error (use-after-free,`,
+              `buffer overflow, etc.) or LeakSanitizer detected a memory leak in newly`,
+              `added or recently changed unsafe code. Inspect the failed job in the`,
+              `linked run for the sanitizer report.`,
+              ``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `This issue is opened automatically when the workflow fails on schedule.`,
+              `It will be updated (rather than re-opened) on subsequent failures so the`,
+              `notification cadence stays low. Close it once the underlying issue is`,
+              `resolved; the next failure will reopen.`,
+            ].join("\n");
+            // Search both open AND closed so the body's "the next failure
+            // will reopen" promise is honored. Mirrors the install-astap.yml
+            // pattern.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              labels: "safety-nightly",
+            });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              if (match.state === "closed") {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  state: "open",
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: run ${context.runId}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["safety-nightly", "ci-flake"],
+              });
+            }

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -169,3 +169,70 @@ jobs:
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
         run: cargo test --locked --all-features --doc
+
+  notify-on-failure:
+    # Open or update a tracking issue when the scheduled rolling run fails so
+    # nightly/beta toolchain breaks, Miri regressions, and dependency-update
+    # drift surface without depending on someone reading scheduled-workflow
+    # logs. Skipped on push, pull_request, and workflow_dispatch so manual
+    # debugging runs don't churn an issue.
+    needs: [nightly, discover-miri, miri, update, beta]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = `nightly: rolling workflow failing`;
+            const body = [
+              `The nightly rolling workflow failed on at least one job.`,
+              ``,
+              `Likely causes: a Rust nightly or beta toolchain regression, a Miri`,
+              `finding (undefined behavior or isolation violation), or a transitive`,
+              `dependency update (\`cargo update\`) breaking the build against beta.`,
+              `Inspect the failed jobs in the linked run to see which one is red.`,
+              ``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `This issue is opened automatically when the workflow fails on schedule.`,
+              `It will be updated (rather than re-opened) on subsequent failures so the`,
+              `notification cadence stays low. Close it once the underlying issue is`,
+              `resolved; the next failure will reopen.`,
+            ].join("\n");
+            // Search both open AND closed so the body's "the next failure
+            // will reopen" promise is honored. Mirrors the install-astap.yml
+            // pattern.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              labels: "rolling-nightly",
+            });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              if (match.state === "closed") {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  state: "open",
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again: run ${context.runId}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["rolling-nightly", "ci-flake"],
+              });
+            }


### PR DESCRIPTION
## Summary
- Add `notify-on-failure` jobs to `scheduled.yml` and `safety.yml` that open or update a tracking issue when the scheduled run fails, matching the pattern already used in `install-astap.yml`, `conformu.yml`, `pi-nightly.yml`, and `plate-solver-smoke.yml`.
- Each new job is gated on `failure() && github.event_name == 'schedule'` so manual `workflow_dispatch` and PR runs don't churn an issue.
- New labels (`rolling-nightly`, `safety-nightly`) are distinct from the four existing notifier labels, so threads stay scoped per workflow.
- `bazel.yml` intentionally left out — it's still in shadow mode per `docs/plans/bazel-migration.md` and not yet a required signal.

## Test plan
- [ ] YAML parses (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] PR's `check` workflow stays green (workflow-file-only change, no Rust code touched).
- [ ] After merge, confirm the next scheduled run of `rolling` and `safety` either passes (no issue created) or fails and produces a single issue with label `rolling-nightly` / `safety-nightly`.
- [ ] On a subsequent same-mode failure, confirm a new comment is added rather than a duplicate issue created.
- [ ] On a manual `workflow_dispatch` failure, confirm no issue is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)