### PR TITLE
fix(star-adventurer-gti): validate mount identity before sending init commands

### DIFF
--- a/crates/skywatcher-motor-protocol/src/lib.rs
+++ b/crates/skywatcher-motor-protocol/src/lib.rs
@@ -26,8 +26,10 @@
 pub mod codec;
 pub mod command;
 pub mod error;
+pub mod mount_type;
 pub mod response;
 
 pub use command::{Axis, Command, MotionMode};
 pub use error::{ProtocolError, Result};
+pub use mount_type::MountType;
 pub use response::{AxisStatus, Response};

--- a/crates/skywatcher-motor-protocol/src/mount_type.rs
+++ b/crates/skywatcher-motor-protocol/src/mount_type.rs
@@ -58,8 +58,10 @@ impl MountType {
     ///
     /// `version` is the [`crate::Response::U24`] payload of the
     /// [`crate::Command::InquireMotorBoardVersion`] reply, with the codec's
-    /// little-endian-nibble decoding already applied — i.e. for the GTi
-    /// probe wire reply `=03300C\r` the caller passes `0x0003_300C`.
+    /// low-byte-first hex decoding (see [`crate::codec::decode_u24`])
+    /// already applied — i.e. for the GTi probe the wire reply
+    /// `=0C3003\r` decodes to `0x0003_300C`, which is what the caller
+    /// passes in.
     ///
     /// Returns `Ok(MountType)` when the high byte is in the whitelist;
     /// returns `Err(byte)` carrying the unrecognised mount-type byte

--- a/crates/skywatcher-motor-protocol/src/mount_type.rs
+++ b/crates/skywatcher-motor-protocol/src/mount_type.rs
@@ -1,0 +1,162 @@
+//! Sky-Watcher mount-type identification.
+//!
+//! The `:e<axis>` (motor-board-version) reply is the only Sky-Watcher command
+//! that meaningfully identifies the device on the wire. Its 24-bit payload
+//! packs the mount-type ID in the high byte and the firmware-version major /
+//! minor in the mid / low bytes:
+//!
+//! ```text
+//! 0x03_30_0C
+//!   ^^         mount-type ID (0x03 = EQ family, includes the Star Adventurer GTi)
+//!      ^^      firmware version major (0x30)
+//!         ^^   firmware version minor (0x0C)
+//! ```
+//!
+//! [`MountType::from_motor_board_version`] is the whitelist gate used by the
+//! `star-adventurer-gti` driver's connect handshake to refuse to talk to a
+//! device that isn't a Sky-Watcher motor controller before any mount-specific
+//! command (`:F`, `:a`, `:b`, `:g`, …) goes on the wire. See
+//! [issue #254][issue] for the hardware session that motivated this.
+//!
+//! [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
+
+/// Sky-Watcher motor-controller mount-type families, keyed off the high byte
+/// of the `:e` motor-board-version reply.
+///
+/// The byte values are documented in the Sky-Watcher motor-controller command
+/// set and cross-checked against the INDI `indi-eqmod` reference driver.
+/// Variants are named after the mount family rather than a specific model
+/// because the firmware byte does not distinguish between e.g. an EQ3 and an
+/// EQ5 — both report `0x03` / `0x02` from the same firmware build.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum MountType {
+    /// `0x00` — EQ6 / EQ6 Pro German Equatorial.
+    Eq6,
+    /// `0x01` — HEQ5 / HEQ5 Pro German Equatorial.
+    Heq5,
+    /// `0x02` — EQ5 / EQ5 Pro German Equatorial.
+    Eq5,
+    /// `0x03` — EQ3 / EQ3-2 / Star Adventurer GTi German Equatorial.
+    /// The Star Adventurer GTi reports as this family; see the hardware probe
+    /// table in `docs/references/skywatcher-motor-controller-command-set.md`.
+    Eq3,
+    /// `0x04` — EQ8 German Equatorial.
+    Eq8,
+    /// `0x05` — AZ-EQ6 dual-mode (GEM + AltAz).
+    AzEq6,
+    /// `0x06` — AZ-EQ5 dual-mode (GEM + AltAz).
+    AzEq5,
+    /// `0x80` — Star Adventurer (the original single-axis tracker, not the GTi).
+    StarAdventurer,
+    /// `0x82` — AZ-GTi / Star Adventurer GTi (AltAz firmware variant).
+    AzGti,
+}
+
+impl MountType {
+    /// Extract the mount-type byte (high byte of the 24-bit value) from a
+    /// `:e` reply and look it up against the whitelist.
+    ///
+    /// `version` is the [`crate::Response::U24`] payload of the
+    /// [`crate::Command::InquireMotorBoardVersion`] reply, with the codec's
+    /// little-endian-nibble decoding already applied — i.e. for the GTi
+    /// probe wire reply `=03300C\r` the caller passes `0x0003_300C`.
+    ///
+    /// Returns `Ok(MountType)` when the high byte is in the whitelist;
+    /// returns `Err(byte)` carrying the unrecognised mount-type byte
+    /// otherwise so the driver can quote it in operator-facing diagnostics.
+    pub fn from_motor_board_version(version: u32) -> Result<Self, u8> {
+        let mount_id = ((version >> 16) & 0xFF) as u8;
+        match mount_id {
+            0x00 => Ok(Self::Eq6),
+            0x01 => Ok(Self::Heq5),
+            0x02 => Ok(Self::Eq5),
+            0x03 => Ok(Self::Eq3),
+            0x04 => Ok(Self::Eq8),
+            0x05 => Ok(Self::AzEq6),
+            0x06 => Ok(Self::AzEq5),
+            0x80 => Ok(Self::StarAdventurer),
+            0x82 => Ok(Self::AzGti),
+            other => Err(other),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gti_probe_value_decodes_to_eq3_family() {
+        // The Star Adventurer GTi probe value (documented in
+        // docs/references/skywatcher-motor-controller-command-set.md) is
+        // 0x03_30_0C — the value the driver must accept on every connect.
+        assert_eq!(
+            MountType::from_motor_board_version(0x0003_300C).unwrap(),
+            MountType::Eq3
+        );
+    }
+
+    #[test]
+    fn whitelisted_high_bytes_decode_to_named_variants() {
+        for (version, expected) in [
+            (0x0000_0000_u32, MountType::Eq6),
+            (0x0001_FFFF, MountType::Heq5),
+            (0x0002_0000, MountType::Eq5),
+            (0x0003_0000, MountType::Eq3),
+            (0x0004_0000, MountType::Eq8),
+            (0x0005_0000, MountType::AzEq6),
+            (0x0006_0000, MountType::AzEq5),
+            (0x0080_0000, MountType::StarAdventurer),
+            (0x0082_0000, MountType::AzGti),
+        ] {
+            assert_eq!(
+                MountType::from_motor_board_version(version).unwrap(),
+                expected,
+                "version=0x{version:08X}"
+            );
+        }
+    }
+
+    #[test]
+    fn firmware_bytes_do_not_affect_lookup() {
+        // The mid + low bytes are firmware major/minor and must not gate the
+        // whitelist; only the high byte (mount-type ID) is consulted.
+        for low_bytes in [0x0000_u32, 0xABCD, 0xFFFF, 0x300C] {
+            let v = 0x0003_0000 | low_bytes;
+            assert_eq!(
+                MountType::from_motor_board_version(v).unwrap(),
+                MountType::Eq3,
+                "version=0x{v:08X}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_mount_type_byte_surfaces_through_err() {
+        // 0x07 is the gap between the EQ8 family (0x04..=0x06) and the AZ
+        // family (0x80..) per the documented byte assignments. A reply with
+        // this byte must be rejected so the driver doesn't proceed to issue
+        // mount-specific commands against an unknown device.
+        let err = MountType::from_motor_board_version(0x0007_0000).unwrap_err();
+        assert_eq!(err, 0x07);
+
+        // The QHY focuser misroute that motivated issue #254 returned data
+        // that — were the bytes shuffled to look like a `:e` reply — would
+        // decode to something unlike any Sky-Watcher mount-type ID. Pick a
+        // plausible "wrong device" high byte and confirm it's rejected.
+        let err = MountType::from_motor_board_version(0x00FF_0000).unwrap_err();
+        assert_eq!(err, 0xFF);
+    }
+
+    #[test]
+    fn only_the_high_byte_is_consulted_for_rejection() {
+        // A version whose high byte is unknown must reject regardless of how
+        // sensible the firmware bytes look. Symmetric to the
+        // `firmware_bytes_do_not_affect_lookup` test for the accept path.
+        assert_eq!(
+            MountType::from_motor_board_version(0x0099_300C).unwrap_err(),
+            0x99
+        );
+    }
+}

--- a/docs/plans/eager-hardware-validation.md
+++ b/docs/plans/eager-hardware-validation.md
@@ -1,0 +1,305 @@
+# Plan: eager hardware validation across Alpaca services
+
+## Motivation
+
+[Issue #254][issue-254] fixed the immediate Star Adventurer GTi pain
+(wrong-device handshake leaked seven mount-specific commands before the
+identity check) by reordering the handshake so `:e1` runs first and
+strictly validates against a Sky-Watcher mount-type whitelist. The fix
+landed in PR #296 and means the wrong-device case now surfaces a
+clear, port-quoted `INVALID_OPERATION` to the ASCOM client on first
+`Connected = true`.
+
+The follow-up discussion surfaced a deeper question: in an **Alpaca**
+deployment (standalone HTTP daemon, discovery broadcast, multi-client
+refcount, systemd unit lifecycle) why is the wrong-device check
+gated on the first ASCOM client request rather than running at
+service startup? Classic ASCOM (Windows COM in-process driver) has
+to be lazy because the driver *is* the client process. Alpaca looks
+much more like postgres — a daemon that should validate its world
+at boot and exit non-zero on misconfiguration so systemd /
+orchestration treat the failure as a failure instead of advertising
+a broken device on the network.
+
+This plan extends the identity-validation pattern across every
+Alpaca driver service in the workspace, with a small,
+non-invasive addition to `rusty-photon-shared-transport`.
+
+[issue-254]: https://github.com/ivonnyssen/rusty-photon/issues/254
+
+## Scope
+
+Five Alpaca driver services, all (or shortly to be) on
+[`rusty-photon-shared-transport`][shared-transport-plan]:
+
+| Service | Port | Identity-probe equivalent | Shared-transport status |
+|---|---|---|---|
+| `dsd-fp2` | 11119 | DSD identity string | on shared transport (first adopter, PR #283) |
+| `ppba-driver` | 11112 | Pegasus version query | on shared transport (Phase B, PR #276) |
+| `qhy-focuser` | 11113 | JSON identity query | on shared transport (Phase C, PR #280) |
+| `pa-falcon-rotator` | 11118 | Pegasus identity query | on shared transport (Phase D, PR #282) |
+| `star-adventurer-gti` | 11117 | `:e1` + `MountType` whitelist | on shared transport (Phase E, PR #285); identity-probe landed in PR #296 |
+
+Explicitly out of scope:
+
+- `sentinel` (HTTP client polling other Alpaca devices, not a driver).
+- `phd2-guider` (PHD2 client, not Alpaca).
+- `filemonitor` (FITS file watcher, no hardware-bound transport).
+
+[shared-transport-plan]: ./shared-transport-extraction.md
+
+## What "eager validation" means here
+
+At service startup, after config load but **before** binding the
+Alpaca HTTP server and starting the discovery responder:
+
+1. Open the transport.
+2. Run the existing handshake hook (which performs the identity
+   probe by construction — see [§Per-service work](#per-service-work)
+   for the audit checklist).
+3. Tear the transport back down (`Hooks::teardown` runs; transport
+   closes; refcount returns to zero).
+4. On success → proceed to bind the Alpaca server and the discovery
+   responder. The hardware is *not* held between this validation
+   handshake and the first `Connected = true` from a client; we
+   re-acquire on first connect. One extra handshake per service
+   lifetime is the only overhead.
+5. On failure → log the diagnostic at `error!`, return a non-zero
+   `ExitCode` from `main`. systemd / orchestration retries naturally.
+   Operator fixes config and the orchestrator restarts the service.
+
+The deliberate non-goal: **don't hold the hardware for the full
+service lifetime.** That would break:
+
+- The shared-transport ref-count contract (refcount goes 0 → 1 on
+  validation, would stay >0 forever, never reach 0 again).
+- The teardown hook on real client disconnect (`star-adventurer-gti`
+  issues `:L1, :L2, :K1`; `ppba-driver` and friends have their own
+  shutdown commands).
+- The "service holds hardware nobody's using" semantic — leaves the
+  bus / cable busy for tooling that needs to probe it (e.g.
+  `mode==diagnostic` ad-hoc reads from another process).
+
+## Design choices
+
+| Decision | Choice | Rejected alternative + why |
+|---|---|---|
+| Where validation lives | New `SharedTransport::validate_hardware()` method that internally `acquire` + `close`. Per-protocol identity probe stays inside the codec's existing `handshake` hook. | Add a new `Hooks::identify` separate from `handshake` — duplicates the codec's "talk to the device" path and forks the wire sequence between validate and real connect. |
+| Hold vs. release after validate | Release (validate-close-reopen-on-first-client). Two handshakes per service lifetime is cheap; preserves the lazy-acquire / refcount contract. | Hold a synthetic reference for service lifetime — see [§What "eager validation" means here](#what-eager-validation-means-here) above. |
+| Default | Opt-in via `validate_on_start: true` in the service's transport config block. Defaults to `false` so `Config::default()` (smoke tests, `cargo run` with no `--config`) still comes up cleanly. Production config files set it to `true`. | Default-on workspace-wide — wrecks every `cargo run` smoke test and every BDD scenario that starts the server without hardware. |
+| Failure-mode behavior | Hard fail: log the diagnostic to stderr at `error!`, return `ExitCode::from(2)` from `main`. | Warn-and-continue — the discovery responder broadcasts a device that isn't really there, defeats the purpose. Retry-loop at startup — postpones the problem; orchestrators already do retry. |
+| Transient mount-off-at-boot tolerance | Allow opt-in `validate_on_start_retries: u32` (default 0) with a fixed backoff. Operators powering the mount on the same circuit as the host can set `validate_on_start_retries: 5`. | Always-retry — masks legitimate config errors. Never-retry — friction for the dome-power case. |
+
+## Shared-transport API addition
+
+```rust
+// crates/rusty-photon-shared-transport/src/lib.rs
+impl<C: Codec> SharedTransport<C> {
+    /// Eagerly open the transport, run the handshake (which
+    /// encompasses the codec's identity check), then close. Used at
+    /// service startup to validate the configured transport target
+    /// before binding the Alpaca HTTP server.
+    ///
+    /// On success the transport returns to its pre-validate state
+    /// (closed, refcount = 0); the first real client's
+    /// `Connected = true` triggers a fresh `acquire()`.
+    /// Identity-probe failures surface the same
+    /// `SessionError<C::Error>` shape `acquire()` would, so
+    /// per-service error mapping (`SessionError → service error →
+    /// ASCOMError` for runtime, plus `std::process::ExitCode` for
+    /// startup) reuses the existing routing.
+    pub async fn validate_hardware(&self) -> Result<(), SessionError<C::Error>> {
+        let session = self.acquire().await?;
+        session.close().await.map_err(SessionError::Transport)
+    }
+}
+```
+
+That's the entire shared-crate change. Three lines of new public
+surface; leverages the existing acquire / handshake / teardown /
+refcount plumbing verbatim. The validation path is structurally
+identical to a real client connect + immediate disconnect, so there's
+no second code path to maintain.
+
+### Implications for shared-transport's existing hooks
+
+- **`Hooks::handshake`** is the identity-probe contract. Today only
+  `star-adventurer-gti`'s handshake actually rejects on identity
+  mismatch (`SkywatcherCodecError::WrongDevice`, landed in PR #296).
+  The other four services' handshakes need audit — the eager-validation
+  rollout is the forcing function to harden them.
+- **`Hooks::teardown`** runs on validate-close just as on real
+  disconnect. Audit each service's teardown for "safe to send to a
+  freshly initialized device that's never moved" — most halt-equivalent
+  commands are idempotent, but worth verifying. For `star-adventurer-gti`
+  the existing `:L1, :L2, :K1` sequence is fine.
+- **`Hooks::while_open`** (background poll) starts on `acquire`, cancels
+  on `close`. Validate-close cancels it cleanly via the existing
+  `WhileOpen::cancelled()` signal — no change needed.
+- **No new hook needed.** Resist the temptation to add a separate
+  `Hooks::identify`; the existing `handshake` is already the
+  identity-probe checkpoint by construction (it's the first wire code
+  path that runs).
+
+## Per-service work
+
+| Service | Audit | Likely change |
+|---|---|---|
+| `star-adventurer-gti` | Already done in PR #296. | Add `validate_on_start` config field + `main.rs` call to `validate_hardware()`. |
+| `dsd-fp2` | Confirm handshake checks an identity string and rejects on mismatch. | If not: port the `WrongDevice` pattern (codec error variant + diagnostic + service error variant + ASCOM mapping); add config field; `main.rs` hook. |
+| `ppba-driver` | Same — Pegasus PPBA has a version/identity query; confirm handshake rejects non-PPBA replies. | Same. |
+| `pa-falcon-rotator` | Same — Pegasus Falcon shares Pegasus identity shape; potentially share an identity-probe helper with `ppba-driver`. | Same; possible shared `pegasus-protocol` crate consolidation (track as a separate cleanup, not blocking). |
+| `qhy-focuser` | QHY's JSON identity probe — confirm rejection on non-QHY JSON. | Same. |
+
+For each service, the per-service change is roughly:
+
+- New `WrongDevice { port, reason }` error variant in the service's
+  error enum (where missing — `star-adventurer-gti` already has it).
+- Wrong-device routing through
+  `SessionError → service error → ASCOMError` for runtime ASCOM
+  consistency (`star-adventurer-gti`'s `codec.rs` is the template).
+- `validate_on_start: bool` (and the two companion fields below) on
+  the transport config block.
+- `main.rs` call site:
+
+```rust
+if cfg.transport.validate_on_start {
+    info!("validating hardware before binding Alpaca server");
+    manager
+        .transport()
+        .validate_hardware()
+        .await
+        .map_err(|e| {
+            error!(error = %ServiceError::from(e), "hardware validation failed");
+            ExitCode::from(2)
+        })?;
+}
+```
+
+## Config surface (per service)
+
+```rust
+// In each service's TransportConfig (USB / UDP variants both):
+#[serde(default)]
+pub validate_on_start: bool,
+#[serde(default)]
+pub validate_on_start_retries: u32,
+#[serde(default = "default_validate_retry_backoff", with = "humantime_serde")]
+pub validate_on_start_retry_backoff: Duration,
+```
+
+Defaults: `validate_on_start: false`, `validate_on_start_retries: 0`,
+`validate_on_start_retry_backoff: 2s`. Production operators flip on;
+tests / smoke runs unaffected.
+
+The retry semantics: on `ConnectionFailed` / `Timeout` /
+`Transport(connection closed)` (i.e. the "device not yet ready" cluster
+of errors), retry up to `validate_on_start_retries` times with
+`validate_on_start_retry_backoff` between attempts. On `WrongDevice`
+or `Protocol` errors, fail immediately — these are config errors, not
+transient hardware-not-ready conditions, and retrying just adds
+seconds of confusion before the operator gets the diagnostic.
+
+## CLI surface (per service)
+
+Add `--check-device` to force a one-shot validation pass and exit
+(orchestration / dome-startup-script helper):
+
+```bash
+star-adventurer-gti --config /etc/dome.json --check-device
+# exit 0 → hardware verified
+# exit 2 → wrong device or transient failure
+```
+
+This is independent of `validate_on_start`; useful for "verify before
+service install" workflows and CI hardware-attached smoke tests. Maps
+to the same `validate_hardware()` call as the implicit start-time
+validation.
+
+## Test strategy
+
+- **Shared-transport**: one unit test in
+  `crates/rusty-photon-shared-transport/` exercising
+  `validate_hardware` on a mock that fails the handshake (asserts
+  refcount returns to zero, transport never re-opens implicitly).
+- **Per-service**: one integration test asserting
+  `validate_on_start = true` + wrong-device mock → service `main`
+  returns non-zero. Easiest path: extract main into a
+  `pub async fn run(...) -> Result<(), ServiceError>` that returns,
+  and call it directly with a wrong-device mock factory from a
+  unit test.
+- **BDD**: existing scenarios assume `validate_on_start = false`
+  (the default). Add one scenario per service: "service refuses to
+  start when configured port targets the wrong device." This BDD
+  step needs the harness to start the service with a wrong-device
+  mock factory — practically that means the existing BDD world
+  builder grows a `with_wrong_device_factory()` option.
+- **CI nightly hardware-attached run** ([pi5 nightly
+  runner][pi5]): set `validate_on_start: true` in the nightly
+  config; failed validation paged via the existing nightly-failures
+  Slack hook.
+
+[pi5]: ../../docs/operations/pi-nightly-runner.md
+
+## Failure-mode matrix
+
+| Scenario | `validate_on_start = false` (current) | `validate_on_start = true` |
+|---|---|---|
+| Mount powered off at boot | Service starts. First client connect fails with `ConnectionFailed`. | Service exits 2. Orchestrator retries. Operator turns on mount. With `validate_on_start_retries > 0`, intermediate retry attempts before exiting. |
+| Mount powered on, wrong device | Service starts. First client connect surfaces `WrongDevice`. | Service exits 2 immediately with the same diagnostic at the operator's terminal. |
+| Mount powered on, transient handshake failure (CRC error, dropped byte) | Service starts. First client connect retries on next attempt. | With `validate_on_start_retries > 0`, retry; else exit 2. |
+| Mount powered on, correct device | Service starts. First client connect succeeds. | Service starts (after a brief validate-handshake), first client connect succeeds — one extra handshake at boot is the cost. |
+
+## Phasing
+
+Mirror the [shared-transport-extraction precedent][shared-transport-plan]
+(PR-per-phase):
+
+1. **Phase 0** — `rusty-photon-shared-transport`: add
+   `validate_hardware()` + tests. One PR. Touches one file in one
+   crate; review effort minimal.
+2. **Phase 1** — `star-adventurer-gti`: add config field + `main.rs`
+   hook + per-service test + BDD scenario + design-doc update.
+   Already has the `WrongDevice` plumbing from PR #296, so this is
+   pure wiring.
+3. **Phase 2** — `dsd-fp2`: audit handshake's identity check; bring
+   it up to spec if needed; wire eager validation.
+4. **Phase 3** — `pa-falcon-rotator`: same.
+5. **Phase 4** — `qhy-focuser`: same.
+6. **Phase 5** — `ppba-driver`: same. Possibly bundle with Phase 3
+   if a shared `pegasus-protocol` crate makes sense.
+7. **Phase 6** (optional) — workspace docs: a
+   `docs/skills/eager-hardware-validation.md` that codifies the
+   pattern for future driver services. Cross-link from the design
+   doc of each service.
+
+Each phase is independently mergeable (services without
+`validate_on_start: true` in their production config are
+unaffected by their own phase landing).
+
+## Open questions worth surfacing before starting
+
+1. **systemd unit semantics.** Should we ship a sample `.service`
+   file in `deploy/` with `Restart=on-failure` + a `RestartSec=`
+   matched to `validate_on_start_retry_backoff`? Otherwise operators
+   reinvent the retry budget at the orchestrator layer.
+2. **Discovery responder during validation.** The Alpaca discovery
+   responder bind happens before or after validation? Recommended: **after**.
+   Don't advertise a device we haven't confirmed.
+3. **Multi-mount hosts.** A host running `ppba-driver` +
+   `qhy-focuser` + `pa-falcon-rotator` on the same USB bus will
+   validate three serial ports in parallel at boot. Order-of-operations
+   dependency on `/dev/serial/by-id/...` paths under udev settling —
+   worth one round of validation against a real Pi at the dome before
+   defaulting `validate_on_start` to `true` for the workspace.
+4. **`Config::default()` ergonomics.** `Config::default()` is what
+   `cargo run -p <service>` without `--config` uses. Should
+   `Config::default()`'s `validate_on_start` definitely be `false`?
+   (Yes — otherwise every dev-loop `cargo run` fails.) Documenting
+   this explicitly here so a future contributor doesn't flip the
+   default and break local dev workflows.
+5. **Bundling Pegasus identity in a crate.** `ppba-driver` and
+   `pa-falcon-rotator` both speak the Pegasus protocol family.
+   Their identity probes could share a `pegasus-protocol` crate
+   (analogous to `skywatcher-motor-protocol`). Track separately
+   if Phase 3 / Phase 5 audits surface enough duplication.

--- a/docs/references/skywatcher-motor-controller-command-set.md
+++ b/docs/references/skywatcher-motor-controller-command-set.md
@@ -124,14 +124,21 @@ beyond test fixtures.
 
 After opening the transport, before the first motion command:
 
-1. `:F1`, `:F2` — initialize both axes
-2. `:a1`, `:a2` — record CPR per axis
-3. `:b1` — record TMR_Freq
-4. `:g1`, `:g2` — record high-speed ratio per axis
-5. `:e1` — log mount type / firmware version
+1. `:e1` — identity gate (mount-type whitelist; see the
+   `skywatcher_motor_protocol::MountType` enum). On a wrong-device
+   handshake (frame malformed, payload wrong shape, mount-type byte
+   outside the whitelist) the driver stops here and surfaces
+   `StarAdvError::WrongDevice` — bounding the wrong-device blast radius
+   to a single inquiry. Motivated by the 2026-05-17 hardware session
+   where the operator pointed the driver at a QHY focuser by mistake
+   (issue #254).
+2. `:F1`, `:F2` — initialize both axes
+3. `:a1`, `:a2` — record CPR per axis
+4. `:b1` — record TMR_Freq
+5. `:g1`, `:g2` — record high-speed ratio per axis
 6. `:j1`, `:j2` — record initial encoder positions
 
-These values seed the in-memory parameter cache used by the coordinate
+Steps 2–6 seed the in-memory parameter cache used by the coordinate
 module and the slew planner.
 
 ## See also

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -172,7 +172,7 @@ Mount-side parameters are queried at connect time rather than hard-coded:
 | Counts per revolution (per axis) | `:a1` / `:a2` | `0x375F00` = 3,628,800 | encoder-tick ↔ angle conversion |
 | Timer-interrupt frequency | `:b1` | `0xF42400` ≈ 16 MHz | step-period (T1 preset) calculation |
 | High-speed ratio | `:g1` / `:g2` | mount-specific (e.g. 16, 32, 64) | high-speed-slew step-period scaling |
-| Motor board version | `:e1` | `0x03300C` (mount type 0x03, fw v0x30.0x0C) | mount-family detection (EQ vs AZ) |
+| Motor board version | `:e1` | `0x03300C` (mount type 0x03, fw v0x30.0x0C) | mount-family detection (EQ vs AZ), **and identity gate** (see [§Initialisation sequence](#initialisation-sequence)) |
 
 CPR varies between the GTi's RA and Dec axes and between firmware
 revisions; the driver reads both rather than assuming.
@@ -276,18 +276,42 @@ signed-`i32` encoder counts only.
 
 After opening the transport and before the first motion command:
 
-1. `:F1` → expect `=\r` (Initialize axis 1)
-2. `:F2` → expect `=\r` (Initialize axis 2)
-3. `:a1` → record RA-axis CPR
-4. `:a2` → record Dec-axis CPR
-5. `:b1` → record TMR_Freq
-6. `:g1` → record RA-axis high-speed ratio
-7. `:g2` → record Dec-axis high-speed ratio
-8. `:e1` → log mount type / firmware version
+1. `:e1` → **identity gate**. Decode as
+   [`skywatcher_motor_protocol::Response::U24`]; the high byte must be a
+   known Sky-Watcher mount-type ID (see
+   [`MountType::from_motor_board_version`][mount-type]). On any other
+   reply (framing malformed, payload wrong shape, mount-type byte
+   outside the whitelist) the driver aborts the handshake with
+   [`StarAdvError::WrongDevice`][wrong-device] *before* sending
+   anything else — the wrong device sees exactly one frame (`:e1\r`).
+2. `:F1` → expect `=\r` (Initialize axis 1)
+3. `:F2` → expect `=\r` (Initialize axis 2)
+4. `:a1` → record RA-axis CPR
+5. `:a2` → record Dec-axis CPR
+6. `:b1` → record TMR_Freq
+7. `:g1` → record RA-axis high-speed ratio
+8. `:g2` → record Dec-axis high-speed ratio
 9. `:j1` / `:j2` → record initial encoder positions
 
-These values seed the in-memory mount-parameters cache used by the
-coordinate module and the slew planner.
+Steps 4-9 seed the in-memory mount-parameters cache used by the
+coordinate module and the slew planner. The motor-board-version reply
+from step 1 is also cached (`MountParameters::motor_board_version`)
+for diagnostic logging.
+
+**Why `:e1` is first** (issue #254): the 2026-05-17 San Diego hardware
+session pointed the driver at `/dev/serial/...` for a QHY focuser by
+mistake. The pre-fix handshake had already sent seven mount-specific
+commands (`:F1`, `:F2`, `:a1`, `:a2`, `:b1`, `:g1`, `:g2`) to the wrong
+device before reaching the identity check at step 8. Reordering so
+`:e1` is first and strictly-validated bounds the wrong-device blast
+radius to a single innocuous inquiry, and the ASCOM error surfaced to
+the operator names the configured port plus the wrong-device
+hypothesis (see [`StarAdvError::WrongDevice`][wrong-device]'s `Display`
+shape).
+
+[mount-type]: ../../crates/skywatcher-motor-protocol/src/mount_type.rs
+[wrong-device]: ../../services/star-adventurer-gti/src/error.rs
+[`skywatcher_motor_protocol::Response::U24`]: ../../crates/skywatcher-motor-protocol/src/response.rs
 
 ### Commands used by the MVP
 
@@ -1555,11 +1579,15 @@ open transport (serial: tokio-serial open + raw mode;
                 UDP: bind to config.bind_address, set timeout)
    ↓
 init handshake:
+  :e1               (motor board version)  → identity gate +
+                                              mount-type whitelist
+                                              (issue #254);
+                                              wrong-device handshake
+                                              stops here.
   :F1, :F2          (initialize axes)
   :a1, :a2          (CPR per axis)         → cache
   :b1               (TMR_Freq)             → cache
   :g1, :g2          (high-speed ratio)     → cache
-  :e1               (motor board version)  → debug! log
   :j1, :j2          (initial positions)    → cache
    ↓
 load park target from config / handshake → in-memory park ticks

--- a/services/star-adventurer-gti/src/codec.rs
+++ b/services/star-adventurer-gti/src/codec.rs
@@ -71,16 +71,37 @@ pub enum SkywatcherCodecError {
     #[error("device returned non-matching response ({0} frame(s) read)")]
     SkipExhausted(usize),
     /// The connect handshake's `:e1` identity probe came back with a
-    /// reply that is not a Sky-Watcher motor-board-version frame — either
-    /// the frame is malformed or the mount-type byte is outside the
-    /// [`skywatcher_motor_protocol::MountType`] whitelist. Carried
-    /// through this error type so the handshake hook can stop the
-    /// connect sequence before issuing any device-specific command (`:F`,
-    /// `:a`, `:b`, `:g`, …) and the device-layer mapping can route the
-    /// structured context (port label + reason) into
+    /// reply that isn't a Sky-Watcher motor-board-version. Surfaces in
+    /// any of the following situations (all routed through
+    /// `wrong_device_for_e1` in `manager.rs`):
+    ///
+    /// - [`ProtocolError::FrameError`] — missing `=` prefix, missing
+    ///   `\r` terminator, embedded `\r`, structurally invalid.
+    /// - [`ProtocolError::PayloadError`] — `=...\r` arrived but with
+    ///   the wrong body length / shape for the U24 motor-board-version
+    ///   payload (e.g. a 3-hex-byte status-shaped body).
+    /// - [`ProtocolError::HexError`] — payload bytes that aren't ASCII
+    ///   hex digits.
+    /// - [`ProtocolError::MountError`] — device replied with a
+    ///   structurally-valid `!X\r` error frame. A real Sky-Watcher
+    ///   controller supports `:e` per the protocol spec, so a mount-side
+    ///   error to `:e1` indicates an incompatible device.
+    /// - Mount-type byte outside the
+    ///   [`skywatcher_motor_protocol::MountType`] whitelist (post-decode
+    ///   check; reply was structurally valid but the high byte of the
+    ///   U24 isn't a known Sky-Watcher mount family).
+    ///
+    /// Carried through this error type so the handshake hook can stop
+    /// the connect sequence before issuing any device-specific command
+    /// (`:F`, `:a`, `:b`, `:g`, …) and the device-layer mapping can
+    /// route the structured context (port label + reason) into
     /// [`StarAdvError::WrongDevice`] for an operator-friendly diagnostic.
     /// See [issue #254][issue].
     ///
+    /// [`ProtocolError::FrameError`]: skywatcher_motor_protocol::ProtocolError::FrameError
+    /// [`ProtocolError::PayloadError`]: skywatcher_motor_protocol::ProtocolError::PayloadError
+    /// [`ProtocolError::HexError`]: skywatcher_motor_protocol::ProtocolError::HexError
+    /// [`ProtocolError::MountError`]: skywatcher_motor_protocol::ProtocolError::MountError
     /// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
     #[error("wrong device on {port}: {reason}")]
     WrongDevice { port: String, reason: String },

--- a/services/star-adventurer-gti/src/codec.rs
+++ b/services/star-adventurer-gti/src/codec.rs
@@ -91,8 +91,8 @@ pub enum SkywatcherCodecError {
 /// codec error type so `?` works without losing the structured
 /// transport-error variant. The device-layer
 /// `From<SessionError<SkywatcherCodecError>> for StarAdvError` then
-/// re-expands the [`Transport`] arm via the same
-/// [`transport_to_staradv`] helper used for top-level
+/// re-expands the [`Transport`] arm via the canonical
+/// `From<TransportError> for StarAdvError` impl used for top-level
 /// [`SessionError::Transport`].
 impl From<SessionError<SkywatcherCodecError>> for SkywatcherCodecError {
     fn from(err: SessionError<SkywatcherCodecError>) -> Self {
@@ -241,37 +241,32 @@ pub fn decode_frame_for(cmd: &Command, frame: &[u8]) -> Result<Response, Protoco
 }
 
 /// Single classification point for a [`TransportError`] into
-/// [`StarAdvError`]. Both the top-level [`SessionError::Transport`] arm
-/// and the nested [`SessionError::Codec`] of
-/// [`SkywatcherCodecError::Transport`] arm route through this helper so
-/// a connect-time transport failure (surfaced through the handshake
-/// hook as `Codec(Transport(_))`) gets the *same* `Timeout` /
+/// [`StarAdvError`]. Every other transport-arm in this module
+/// (`From<SkywatcherCodecError>::Transport(_)`, `From<SessionError<…>>
+/// ::Transport(_)`) delegates here via `.into()`, so a connect-time
+/// transport failure (surfaced through the handshake hook as
+/// `Codec(Transport(_))`) gets the *same* `Timeout` /
 /// `ConnectionFailed` / `Transport` classification a steady-state
-/// failure (surfaced as top-level `Transport(_)`) would. Without this,
-/// a connect-time timeout would land as `INVALID_OPERATION` instead of
-/// the structured ASCOM timeout the client expects.
-fn transport_to_staradv(t: TransportError) -> StarAdvError {
-    match t {
-        TransportError::Open(e) => StarAdvError::ConnectionFailed(e.to_string()),
-        TransportError::Io(e) => StarAdvError::Io(e),
-        TransportError::Timeout(d) => {
-            StarAdvError::Timeout(format!("transport timeout after {d:?}"))
-        }
-        TransportError::Eof => StarAdvError::Transport("connection closed".to_string()),
-        TransportError::Framing(s) => StarAdvError::Transport(format!("framing: {s}")),
-    }
-}
-
-/// Direct conversion from a shared-transport [`TransportError`].
+/// failure (surfaced as top-level `Transport(_)`) would. Without this
+/// single point, a connect-time timeout would land as
+/// `INVALID_OPERATION` instead of the structured ASCOM timeout the
+/// client expects.
 ///
-/// Lets the device layer write `.map_err(StarAdvError::from)?` on a
-/// `Session::close()` (which returns `Result<_, TransportError>`)
-/// instead of wrapping the [`TransportError`] in a
-/// [`SessionError::Transport`] just to reuse the existing
-/// `From<SessionError<…>>` mapping.
+/// Also used directly via `.map_err(StarAdvError::from)?` on a
+/// `Session::close()` (which returns `Result<_, TransportError>`) —
+/// no need to wrap the [`TransportError`] in a
+/// [`SessionError::Transport`] just to reuse the mapping.
 impl From<TransportError> for StarAdvError {
     fn from(t: TransportError) -> Self {
-        transport_to_staradv(t)
+        match t {
+            TransportError::Open(e) => StarAdvError::ConnectionFailed(e.to_string()),
+            TransportError::Io(e) => StarAdvError::Io(e),
+            TransportError::Timeout(d) => {
+                StarAdvError::Timeout(format!("transport timeout after {d:?}"))
+            }
+            TransportError::Eof => StarAdvError::Transport("connection closed".to_string()),
+            TransportError::Framing(s) => StarAdvError::Transport(format!("framing: {s}")),
+        }
     }
 }
 
@@ -283,13 +278,14 @@ impl From<TransportError> for StarAdvError {
 impl From<SkywatcherCodecError> for StarAdvError {
     fn from(err: SkywatcherCodecError) -> Self {
         match err {
-            // Transport-arm routing goes through `transport_to_staradv` so
-            // a timeout surfaced *through* the handshake hook (Codec arm
-            // in the outer `From<SessionError<…>>`) gets the same
+            // Transport-arm routing delegates to the canonical
+            // `From<TransportError> for StarAdvError` so a timeout
+            // surfaced *through* the handshake hook (Codec arm in the
+            // outer `From<SessionError<…>>`) gets the same
             // classification as one that surfaces on a steady-state
             // request (top-level Transport arm). See PR #280 for the
             // bug class.
-            SkywatcherCodecError::Transport(t) => transport_to_staradv(t),
+            SkywatcherCodecError::Transport(t) => t.into(),
             SkywatcherCodecError::Protocol(pe) => StarAdvError::Protocol(pe),
             SkywatcherCodecError::SkipExhausted(n) => StarAdvError::Transport(format!(
                 "device returned non-matching response ({n} frame{s} read)",
@@ -310,7 +306,7 @@ impl From<SkywatcherCodecError> for StarAdvError {
 impl From<SessionError<SkywatcherCodecError>> for StarAdvError {
     fn from(err: SessionError<SkywatcherCodecError>) -> Self {
         match err {
-            SessionError::Transport(t) => transport_to_staradv(t),
+            SessionError::Transport(t) => t.into(),
             SessionError::Codec(c) => c.into(),
             SessionError::SkipExhausted(n) => StarAdvError::Transport(format!(
                 "device returned non-matching response ({n} frame{s} read)",

--- a/services/star-adventurer-gti/src/codec.rs
+++ b/services/star-adventurer-gti/src/codec.rs
@@ -275,31 +275,43 @@ impl From<TransportError> for StarAdvError {
     }
 }
 
-impl From<SessionError<SkywatcherCodecError>> for StarAdvError {
-    fn from(err: SessionError<SkywatcherCodecError>) -> Self {
+/// Per-variant classification for the codec's own error type. The
+/// `From<SessionError<…>> for StarAdvError` impl below delegates the
+/// `SessionError::Codec(_)` arm here so each error layer owns its own
+/// variants: adding a new `SkywatcherCodecError` variant updates one
+/// match arm instead of two.
+impl From<SkywatcherCodecError> for StarAdvError {
+    fn from(err: SkywatcherCodecError) -> Self {
         match err {
-            // Both transport arms route through `transport_to_staradv`
-            // in error.rs so a timeout that surfaces *through* the
-            // handshake hook (Codec arm) gets the same classification
-            // as one that surfaces on a steady-state request
-            // (Transport arm). See PR #280 for the bug class.
-            SessionError::Transport(t) => transport_to_staradv(t),
-            SessionError::Codec(SkywatcherCodecError::Transport(t)) => transport_to_staradv(t),
-            SessionError::Codec(SkywatcherCodecError::Protocol(pe)) => StarAdvError::Protocol(pe),
-            SessionError::Codec(SkywatcherCodecError::SkipExhausted(n)) => {
-                StarAdvError::Transport(format!(
-                    "device returned non-matching response ({n} frame{s} read)",
-                    s = if n == 1 { "" } else { "s" }
-                ))
-            }
+            // Transport-arm routing goes through `transport_to_staradv` so
+            // a timeout surfaced *through* the handshake hook (Codec arm
+            // in the outer `From<SessionError<…>>`) gets the same
+            // classification as one that surfaces on a steady-state
+            // request (top-level Transport arm). See PR #280 for the
+            // bug class.
+            SkywatcherCodecError::Transport(t) => transport_to_staradv(t),
+            SkywatcherCodecError::Protocol(pe) => StarAdvError::Protocol(pe),
+            SkywatcherCodecError::SkipExhausted(n) => StarAdvError::Transport(format!(
+                "device returned non-matching response ({n} frame{s} read)",
+                s = if n == 1 { "" } else { "s" }
+            )),
             // WrongDevice carries port-label context the handshake hook
             // captured (see `MountManager::new` in manager.rs); preserve
             // it as the structured `StarAdvError::WrongDevice` so the
             // operator-facing message lands intact in ASCOM's
             // `INVALID_OPERATION` reply.
-            SessionError::Codec(SkywatcherCodecError::WrongDevice { port, reason }) => {
+            SkywatcherCodecError::WrongDevice { port, reason } => {
                 StarAdvError::WrongDevice { port, reason }
             }
+        }
+    }
+}
+
+impl From<SessionError<SkywatcherCodecError>> for StarAdvError {
+    fn from(err: SessionError<SkywatcherCodecError>) -> Self {
+        match err {
+            SessionError::Transport(t) => transport_to_staradv(t),
+            SessionError::Codec(c) => c.into(),
             SessionError::SkipExhausted(n) => StarAdvError::Transport(format!(
                 "device returned non-matching response ({n} frame{s} read)",
                 s = if n == 1 { "" } else { "s" }
@@ -600,6 +612,64 @@ mod tests {
                 assert!(s.contains("non-matching") && s.contains('7'));
             }
             other => panic!("expected Transport, got {other:?}"),
+        }
+    }
+
+    // ============================================================================
+    // From<SkywatcherCodecError> for StarAdvError — the standalone per-variant
+    // classification the outer `From<SessionError<…>>` delegates to. Tests here
+    // cover the impl directly so a regression in the codec→staradv arm wouldn't
+    // be masked by the outer impl's `SessionError::Codec(c) => c.into()`
+    // delegation.
+    // ============================================================================
+
+    #[test]
+    fn codec_error_transport_timeout_routes_to_timeout() {
+        let err: StarAdvError = SkywatcherCodecError::Transport(TransportError::Timeout(
+            std::time::Duration::from_secs(3),
+        ))
+        .into();
+        match err {
+            StarAdvError::Timeout(s) => assert!(s.contains('3')),
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codec_error_protocol_passes_through() {
+        let err: StarAdvError =
+            SkywatcherCodecError::Protocol(ProtocolError::FrameError("bad".into())).into();
+        assert!(matches!(err, StarAdvError::Protocol(_)));
+    }
+
+    #[test]
+    fn codec_error_skip_exhausted_maps_to_transport_with_count() {
+        let err: StarAdvError = SkywatcherCodecError::SkipExhausted(2).into();
+        match err {
+            StarAdvError::Transport(s) => {
+                assert!(s.contains("non-matching") && s.contains('2'));
+            }
+            other => panic!("expected Transport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codec_error_wrong_device_preserves_port_and_reason() {
+        // The whole point of routing WrongDevice through structured
+        // fields instead of stringifying is that the operator-facing
+        // diagnostic survives intact — verify the per-variant impl
+        // doesn't lose either field.
+        let err: StarAdvError = SkywatcherCodecError::WrongDevice {
+            port: "/dev/ttyACM7".into(),
+            reason: "mount-type byte 0xFF unknown".into(),
+        }
+        .into();
+        match err {
+            StarAdvError::WrongDevice { port, reason } => {
+                assert_eq!(port, "/dev/ttyACM7");
+                assert!(reason.contains("0xFF"));
+            }
+            other => panic!("expected WrongDevice, got {other:?}"),
         }
     }
 

--- a/services/star-adventurer-gti/src/codec.rs
+++ b/services/star-adventurer-gti/src/codec.rs
@@ -70,6 +70,20 @@ pub enum SkywatcherCodecError {
     /// quote the count for log triage.
     #[error("device returned non-matching response ({0} frame(s) read)")]
     SkipExhausted(usize),
+    /// The connect handshake's `:e1` identity probe came back with a
+    /// reply that is not a Sky-Watcher motor-board-version frame — either
+    /// the frame is malformed or the mount-type byte is outside the
+    /// [`skywatcher_motor_protocol::MountType`] whitelist. Carried
+    /// through this error type so the handshake hook can stop the
+    /// connect sequence before issuing any device-specific command (`:F`,
+    /// `:a`, `:b`, `:g`, …) and the device-layer mapping can route the
+    /// structured context (port label + reason) into
+    /// [`StarAdvError::WrongDevice`] for an operator-friendly diagnostic.
+    /// See [issue #254][issue].
+    ///
+    /// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
+    #[error("wrong device on {port}: {reason}")]
+    WrongDevice { port: String, reason: String },
 }
 
 /// Flatten a [`SessionError`] arising inside a handshake / teardown
@@ -86,6 +100,20 @@ impl From<SessionError<SkywatcherCodecError>> for SkywatcherCodecError {
             SessionError::Transport(t) => Self::Transport(t),
             SessionError::Codec(c) => c,
             SessionError::SkipExhausted(n) => Self::SkipExhausted(n),
+        }
+    }
+}
+
+impl SkywatcherCodecError {
+    /// Build a [`SkywatcherCodecError::WrongDevice`] from a port label and
+    /// a free-form reason. Lives on the codec error so the handshake hook
+    /// can construct it without reaching into either the `StarAdvError`
+    /// type (one layer above the hook's return-type constraint) or the
+    /// protocol crate (one layer below it).
+    pub fn wrong_device(port: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::WrongDevice {
+            port: port.into(),
+            reason: reason.into(),
         }
     }
 }
@@ -263,6 +291,14 @@ impl From<SessionError<SkywatcherCodecError>> for StarAdvError {
                     "device returned non-matching response ({n} frame{s} read)",
                     s = if n == 1 { "" } else { "s" }
                 ))
+            }
+            // WrongDevice carries port-label context the handshake hook
+            // captured (see `MountManager::new` in manager.rs); preserve
+            // it as the structured `StarAdvError::WrongDevice` so the
+            // operator-facing message lands intact in ASCOM's
+            // `INVALID_OPERATION` reply.
+            SessionError::Codec(SkywatcherCodecError::WrongDevice { port, reason }) => {
+                StarAdvError::WrongDevice { port, reason }
             }
             SessionError::SkipExhausted(n) => StarAdvError::Transport(format!(
                 "device returned non-matching response ({n} frame{s} read)",

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -31,6 +31,24 @@ impl Default for TransportConfig {
     }
 }
 
+impl TransportConfig {
+    /// Human-readable label for the configured transport target. Used by
+    /// the connect handshake's wrong-device diagnostic (see
+    /// [`crate::error::StarAdvError::WrongDevice`] and issue #254) to
+    /// quote the configured port in operator-facing error messages.
+    ///
+    /// * USB → the configured serial-port path verbatim (e.g.
+    ///   `/dev/serial/by-id/...` or `/dev/ttyACM0`).
+    /// * UDP → `address:port` (the form an operator would type into a
+    ///   tool like `nc -u`).
+    pub fn port_label(&self) -> String {
+        match self {
+            Self::Usb(u) => u.port.clone(),
+            Self::Udp(u) => format!("{}:{}", u.address, u.port),
+        }
+    }
+}
+
 /// USB-CDC serial transport config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsbConfig {
@@ -613,6 +631,23 @@ mod tests {
         // bind_address is mandatory for UDP and must be on the 192.168.4.0/24
         // subnet when the mount is in AP mode.
         assert!(udp.bind_address.to_string().starts_with("192.168.4."));
+    }
+
+    #[test]
+    fn port_label_usb_returns_serial_path_verbatim() {
+        let cfg = TransportConfig::Usb(UsbConfig {
+            port: "/dev/serial/by-id/usb-Some_Device-port0".into(),
+            ..UsbConfig::default()
+        });
+        assert_eq!(cfg.port_label(), "/dev/serial/by-id/usb-Some_Device-port0");
+    }
+
+    #[test]
+    fn port_label_udp_formats_address_and_port() {
+        let cfg = TransportConfig::Udp(UdpConfig::default());
+        // UdpConfig::default() targets the GTi's AP-mode address on the
+        // documented port.
+        assert_eq!(cfg.port_label(), "192.168.4.1:11880");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -39,12 +39,16 @@ impl TransportConfig {
     ///
     /// * USB → the configured serial-port path verbatim (e.g.
     ///   `/dev/serial/by-id/...` or `/dev/ttyACM0`).
-    /// * UDP → `address:port` (the form an operator would type into a
-    ///   tool like `nc -u`).
+    /// * UDP → [`SocketAddr`]'s `Display` form, which brackets IPv6
+    ///   correctly (`[fe80::1]:11880`) and leaves IPv4 unbracketed
+    ///   (`192.168.4.1:11880`). Matches the canonical operator-typing
+    ///   form a tool like `nc -u` accepts.
+    ///
+    /// [`SocketAddr`]: std::net::SocketAddr
     pub fn port_label(&self) -> String {
         match self {
             Self::Usb(u) => u.port.clone(),
-            Self::Udp(u) => format!("{}:{}", u.address, u.port),
+            Self::Udp(u) => std::net::SocketAddr::new(u.address, u.port).to_string(),
         }
     }
 }
@@ -648,6 +652,20 @@ mod tests {
         // UdpConfig::default() targets the GTi's AP-mode address on the
         // documented port.
         assert_eq!(cfg.port_label(), "192.168.4.1:11880");
+    }
+
+    #[test]
+    fn port_label_udp_brackets_ipv6_addresses() {
+        // `SocketAddr`'s Display brackets v6 so the resulting label is
+        // unambiguous (without brackets `fe80::1:11880` could read as
+        // address `fe80::1` port `11880` *or* address `fe80::1:11880`
+        // with no port). Matches the canonical operator-typing form.
+        let cfg = TransportConfig::Udp(UdpConfig {
+            address: "fe80::1".parse().expect("parse v6"),
+            port: 11880,
+            ..UdpConfig::default()
+        });
+        assert_eq!(cfg.port_label(), "[fe80::1]:11880");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/error.rs
+++ b/services/star-adventurer-gti/src/error.rs
@@ -59,7 +59,7 @@ pub enum StarAdvError {
     ///
     /// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
     #[error(
-        "handshake to {port} returned malformed data ({reason}); this device may not be a \
+        "handshake to {port} returned unexpected data ({reason}); this device may not be a \
          Sky-Watcher motor controller. Common cause: wrong serial port (e.g. pointing at a \
          power box, focuser, or other device sharing the host's USB bus). Verify that {port} \
          is the GTi serial endpoint."

--- a/services/star-adventurer-gti/src/error.rs
+++ b/services/star-adventurer-gti/src/error.rs
@@ -55,14 +55,16 @@ pub enum StarAdvError {
     /// The most likely cause is that the configured transport target
     /// (serial port or UDP host) points at a different device — a power
     /// box, focuser, or unrelated USB-CDC peripheral sharing the host's
-    /// USB bus. See [issue #254][issue].
+    /// USB bus on the serial path, or the wrong host / wrong network on
+    /// the UDP path. See [issue #254][issue].
     ///
     /// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
     #[error(
         "handshake to {port} returned unexpected data ({reason}); this device may not be a \
-         Sky-Watcher motor controller. Common cause: wrong serial port (e.g. pointing at a \
-         power box, focuser, or other device sharing the host's USB bus). Verify that {port} \
-         is the GTi serial endpoint."
+         Sky-Watcher motor controller. Common cause: the configured transport target points \
+         at the wrong device (e.g. wrong serial port to a focuser / power box / other \
+         USB-CDC peripheral, or wrong UDP host). Verify that {port} is the GTi's transport \
+         endpoint."
     )]
     WrongDevice { port: String, reason: String },
 }
@@ -148,7 +150,27 @@ mod tests {
         assert!(msg.contains("/dev/ttyUSB1"), "msg: {msg}");
         assert!(msg.contains("unknown mount-type byte 0xFF"), "msg: {msg}");
         assert!(msg.contains("Sky-Watcher"), "msg: {msg}");
-        assert!(msg.contains("wrong serial port"), "msg: {msg}");
+        assert!(msg.contains("wrong device"), "msg: {msg}");
+        assert!(msg.contains("transport endpoint"), "msg: {msg}");
+    }
+
+    #[test]
+    fn wrong_device_display_works_for_udp_target() {
+        // The transport-agnostic wording must also fit a UDP
+        // misconfiguration (the GTi has built-in WiFi AP at
+        // `192.168.4.1:11880`). The label that lands in {port} is
+        // produced by `TransportConfig::port_label()` and looks like
+        // `192.168.4.1:11880` for v4 / `[fe80::1]:11880` for v6 —
+        // neither contains the substring "serial", so the message
+        // must not be locked to serial-specific phrasing.
+        let err = StarAdvError::WrongDevice {
+            port: "192.168.4.1:11880".into(),
+            reason: "unknown mount-type byte 0xFF".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("192.168.4.1:11880"), "msg: {msg}");
+        assert!(msg.contains("wrong UDP host"), "msg: {msg}");
+        assert!(msg.contains("transport endpoint"), "msg: {msg}");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/error.rs
+++ b/services/star-adventurer-gti/src/error.rs
@@ -49,31 +49,39 @@ pub enum StarAdvError {
     /// site stays a total function.
     #[error("timekeeping error: {0}")]
     Timekeeping(String),
+
+    /// The connect handshake's first wire query (`:e1`) returned a reply
+    /// that doesn't look like a Sky-Watcher motor-board-version response.
+    /// The most likely cause is that the configured transport target
+    /// (serial port or UDP host) points at a different device — a power
+    /// box, focuser, or unrelated USB-CDC peripheral sharing the host's
+    /// USB bus. See [issue #254][issue].
+    ///
+    /// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
+    #[error(
+        "handshake to {port} returned malformed data ({reason}); this device may not be a \
+         Sky-Watcher motor controller. Common cause: wrong serial port (e.g. pointing at a \
+         power box, focuser, or other device sharing the host's USB bus). Verify that {port} \
+         is the GTi serial endpoint."
+    )]
+    WrongDevice { port: String, reason: String },
 }
 
-impl StarAdvError {
-    /// Map a driver error to the closest ASCOM error code.
-    pub fn to_ascom_error(self) -> ASCOMError {
-        let msg = self.to_string();
-        match self {
-            Self::NotConnected => ASCOMError::new(ASCOMErrorCode::NOT_CONNECTED, msg),
-            Self::InvalidValue(_) => ASCOMError::new(ASCOMErrorCode::INVALID_VALUE, msg),
-            Self::Parked => ASCOMError::new(ASCOMErrorCode::INVALID_WHILE_PARKED, msg),
-            _ => ASCOMError::invalid_operation(msg),
-        }
-    }
-}
-
-/// `?` and `Into::into` sugar for the same conversion as
-/// [`StarAdvError::to_ascom_error`]. The method stays as the explicit
-/// form; this impl lets idiomatic Rust call sites convert implicitly,
-/// matching the [`PpbaError`]/[`QhyFocuserError`] shape.
+/// Map a driver error to the closest ASCOM error code.
 ///
-/// [`PpbaError`]: ../../../services/ppba-driver/src/error.rs
-/// [`QhyFocuserError`]: ../../../services/qhy-focuser/src/error.rs
+/// This is the single point of truth for the [`StarAdvError`] →
+/// [`ASCOMError`] conversion; call sites use `.into()` /
+/// `ASCOMError::from(err)` to invoke it. Inline-matched here so there's no
+/// detour through an intermediate named helper.
 impl From<StarAdvError> for ASCOMError {
     fn from(err: StarAdvError) -> Self {
-        err.to_ascom_error()
+        let msg = err.to_string();
+        match err {
+            StarAdvError::NotConnected => ASCOMError::new(ASCOMErrorCode::NOT_CONNECTED, msg),
+            StarAdvError::InvalidValue(_) => ASCOMError::new(ASCOMErrorCode::INVALID_VALUE, msg),
+            StarAdvError::Parked => ASCOMError::new(ASCOMErrorCode::INVALID_WHILE_PARKED, msg),
+            _ => ASCOMError::invalid_operation(msg),
+        }
     }
 }
 
@@ -88,19 +96,19 @@ mod tests {
 
     #[test]
     fn not_connected_maps_to_ascom_not_connected() {
-        let err = StarAdvError::NotConnected.to_ascom_error();
+        let err: ASCOMError = StarAdvError::NotConnected.into();
         assert_eq!(err.code, ASCOMErrorCode::NOT_CONNECTED);
     }
 
     #[test]
     fn invalid_value_maps_to_ascom_invalid_value() {
-        let err = StarAdvError::InvalidValue("ra out of range".to_string()).to_ascom_error();
+        let err: ASCOMError = StarAdvError::InvalidValue("ra out of range".to_string()).into();
         assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
     }
 
     #[test]
     fn parked_maps_to_ascom_invalid_while_parked() {
-        let err = StarAdvError::Parked.to_ascom_error();
+        let err: ASCOMError = StarAdvError::Parked.into();
         assert_eq!(err.code, ASCOMErrorCode::INVALID_WHILE_PARKED);
     }
 
@@ -113,10 +121,34 @@ mod tests {
             StarAdvError::InvalidOperation("double connect".into()),
             StarAdvError::Config("missing".into()),
             StarAdvError::Timekeeping("ERFA Utctai returned -1".into()),
+            StarAdvError::WrongDevice {
+                port: "/dev/ttyUSB1".into(),
+                reason: "test reason".into(),
+            },
         ] {
-            let mapped = err.to_ascom_error();
+            let mapped: ASCOMError = err.into();
             assert_eq!(mapped.code, ASCOMErrorCode::INVALID_OPERATION);
         }
+    }
+
+    #[test]
+    fn wrong_device_display_quotes_port_and_suggests_cause() {
+        // The operator-facing message must name the port (twice — once
+        // in the diagnostic head, once in the verify-the-port trailer)
+        // and call out the wrong-device hypothesis. The handshake hook
+        // in `manager.rs` constructs this variant only after the `:e1`
+        // reply fails framing or whitelist, so the message correctly
+        // implies "we tried to identify the device and it wasn't a
+        // Sky-Watcher".
+        let err = StarAdvError::WrongDevice {
+            port: "/dev/ttyUSB1".into(),
+            reason: "unknown mount-type byte 0xFF".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("/dev/ttyUSB1"), "msg: {msg}");
+        assert!(msg.contains("unknown mount-type byte 0xFF"), "msg: {msg}");
+        assert!(msg.contains("Sky-Watcher"), "msg: {msg}");
+        assert!(msg.contains("wrong serial port"), "msg: {msg}");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -487,8 +487,8 @@ async fn poll_loop(
 /// [`SkywatcherCodecError::Transport`] variant rather than being
 /// stringified into [`ProtocolError::FrameError`]; the device layer's
 /// `From<SessionError<SkywatcherCodecError>> for StarAdvError` then
-/// routes the inner [`TransportError`] through the same
-/// `transport_to_staradv` helper a top-level
+/// routes the inner [`TransportError`] through the canonical
+/// `From<TransportError> for StarAdvError` impl a top-level
 /// `SessionError::Transport(_)` uses, so a connect-time timeout gets
 /// classified as `StarAdvError::Timeout` instead of collapsing to
 /// `Protocol(FrameError("transport timeout after 5s"))` and surfacing

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use rusty_photon_shared_transport::{
     Connection, Hooks, Session, SharedTransport, TransportFactory, WhileOpen,
 };
-use skywatcher_motor_protocol::{Axis, AxisStatus, Command, Response};
+use skywatcher_motor_protocol::{Axis, AxisStatus, Command, MountType, Response};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tracing::{debug, warn};
@@ -118,12 +118,17 @@ impl MountManager {
             TransportConfig::Usb(usb) => (usb.polling_interval, usb.command_timeout),
             TransportConfig::Udp(udp) => (udp.polling_interval, udp.command_timeout),
         };
+        // Capture once; the handshake hook quotes this in the
+        // [`StarAdvError::WrongDevice`] diagnostic when the `:e1` identity
+        // probe rejects the device on the other end of the wire (issue #254).
+        let port_label: Arc<str> = Arc::from(config.transport.port_label());
 
         let hooks = build_hooks(
             Arc::clone(&parameters),
             Arc::clone(&snapshot),
             Arc::clone(&poll_pause_depth),
             polling_interval,
+            Arc::clone(&port_label),
         );
         let transport = SharedTransport::new(factory, SkywatcherCodec, hooks);
 
@@ -262,17 +267,20 @@ fn build_hooks(
     snapshot: Arc<RwLock<MountSnapshot>>,
     poll_pause_depth: Arc<AtomicU32>,
     polling_interval: Duration,
+    port_label: Arc<str>,
 ) -> Hooks<SkywatcherCodec> {
     let p_hs = Arc::clone(&parameters);
     let s_hs = Arc::clone(&snapshot);
     let s_poll = Arc::clone(&snapshot);
     let depth_poll = Arc::clone(&poll_pause_depth);
     let p_td = Arc::clone(&parameters);
+    let port_hs = Arc::clone(&port_label);
     Hooks {
         handshake: Box::new(move |conn| {
             let parameters = Arc::clone(&p_hs);
             let snapshot = Arc::clone(&s_hs);
-            Box::pin(handshake(conn, parameters, snapshot))
+            let port_label = Arc::clone(&port_hs);
+            Box::pin(handshake(conn, parameters, snapshot, port_label))
         }),
         teardown: Box::new(move |conn| {
             let parameters = Arc::clone(&p_td);
@@ -286,31 +294,86 @@ fn build_hooks(
     }
 }
 
-/// `0→1` handshake: initialise both axes, query parameters, seed the
-/// snapshot with the initial encoder positions.
+/// `0→1` handshake.
+///
+/// **`:e1` first.** The motor-board-version inquiry runs as the very first
+/// wire command, with the reply validated against the
+/// [`MountType`] whitelist *before* any mount-specific
+/// initialisation (`:F1` / `:F2`) goes on the wire. If the device on the
+/// other end isn't a Sky-Watcher motor controller (wrong serial port,
+/// foreign USB-CDC peripheral, etc.), the handshake aborts after sending
+/// exactly one frame (`:e1\r`) and surfaces
+/// [`SkywatcherCodecError::WrongDevice`] carrying the port label and a
+/// human-readable reason. See [issue #254][issue] for the hardware session
+/// that motivated this and the operator-facing diagnostic shape.
+///
+/// On success, the rest of the handshake follows the documented order:
+/// initialise both axes, query parameters, seed the snapshot with the
+/// initial encoder positions.
+///
+/// [issue]: https://github.com/ivonnyssen/rusty-photon/issues/254
 async fn handshake(
     conn: &Connection<SkywatcherCodec>,
     parameters: Arc<RwLock<Option<MountParameters>>>,
     snapshot: Arc<RwLock<MountSnapshot>>,
+    port_label: Arc<str>,
 ) -> std::result::Result<(), SkywatcherCodecError> {
-    // Step 1–2: initialise both axes.
+    // Step 1: identify the device. `:e1` is the first (and, on a wrong-
+    // device handshake, the *only*) frame on the wire. Transport-level
+    // failures (timeout, EOF, framing) propagate as-is so the existing
+    // `Timeout` / `Transport` classifications survive; protocol-level
+    // failures (frame malformed, payload wrong shape, unexpected
+    // response kind) are converted to `WrongDevice` so the operator
+    // sees a hint about the cause instead of a cryptic codec error.
+    let board = match request_typed(conn, Command::InquireMotorBoardVersion(Axis::Ra)).await {
+        Ok(Response::U24(v)) => v,
+        Ok(other) => {
+            return Err(SkywatcherCodecError::wrong_device(
+                port_label.as_ref(),
+                format!("expected motor-board-version U24, got {other:?}"),
+            ));
+        }
+        Err(SkywatcherCodecError::Protocol(pe)) => {
+            return Err(SkywatcherCodecError::wrong_device(
+                port_label.as_ref(),
+                format!("malformed `:e1` reply: {pe}"),
+            ));
+        }
+        // Transport / SkipExhausted / pre-existing WrongDevice variants
+        // bubble through unchanged — those classifications are already
+        // correct for their respective failure modes.
+        Err(other) => return Err(other),
+    };
+    let mount_type = MountType::from_motor_board_version(board).map_err(|byte| {
+        SkywatcherCodecError::wrong_device(
+            port_label.as_ref(),
+            format!(
+                "`:e1` reply mount-type byte {byte:#04X} is not a known Sky-Watcher \
+                 mount-controller ID (reply: {board:#08X})"
+            ),
+        )
+    })?;
+    debug!(
+        motor_board = format!("{board:#08X}"),
+        mount_type = ?mount_type,
+        "motor-board version validated"
+    );
+
+    // Step 2–3: now safe to issue mount-specific init. Initialise both
+    // axes.
     for axis in [Axis::Ra, Axis::Dec] {
         expect_ack(request_typed(conn, Command::Initialize(axis)).await?)?;
     }
 
-    // Step 3–4: per-axis CPR.
+    // Step 4–5: per-axis CPR.
     let cpr_ra = expect_u24(request_typed(conn, Command::InquireCpr(Axis::Ra)).await?)?;
     let cpr_dec = expect_u24(request_typed(conn, Command::InquireCpr(Axis::Dec)).await?)?;
-    // Step 5: TMR_Freq.
+    // Step 6: TMR_Freq.
     let tmr_freq = expect_u24(request_typed(conn, Command::InquireTmrFreq).await?)?;
-    // Step 6–7: high-speed ratio per axis.
+    // Step 7–8: high-speed ratio per axis.
     let hsr_ra = expect_u24(request_typed(conn, Command::InquireHighSpeedRatio(Axis::Ra)).await?)?;
     let hsr_dec =
         expect_u24(request_typed(conn, Command::InquireHighSpeedRatio(Axis::Dec)).await?)?;
-    // Step 8: motor-board version (logged only).
-    let board =
-        expect_u24(request_typed(conn, Command::InquireMotorBoardVersion(Axis::Ra)).await?)?;
-    debug!(motor_board = format!("{board:#08X}"), "motor-board version");
 
     // Step 9–10: initial encoder positions seed the snapshot.
     let pos_ra = expect_position(request_typed(conn, Command::InquirePosition(Axis::Ra)).await?)?;
@@ -1095,5 +1158,196 @@ mod tests {
         ] {
             assert!(validate_command_args(&cmd).is_ok(), "rejected {cmd:?}");
         }
+    }
+
+    // ========================================================================
+    // Issue #254: `:e1` runs first and gates the rest of the handshake.
+    //
+    // On a wrong-device handshake the driver must send exactly one frame
+    // (`:e1\r`), then bail out with a structured `StarAdvError::WrongDevice`
+    // carrying the configured port label and a reason naming the failure mode
+    // — no `:F1` / `:F2` / `:a*` / `:b*` / `:g*` / `:j*` should reach a device
+    // that isn't a Sky-Watcher motor controller.
+    // ========================================================================
+
+    #[tokio::test]
+    async fn acquire_issues_e1_as_the_very_first_wire_frame() {
+        // The first frame in the command log must be `:e1\r`. Everything
+        // else (`:F*`, `:a*`, `:b*`, `:g*`, `:j*`) follows only after the
+        // device has been identified.
+        let factory = CapturingMockFactory::new();
+        let state = Arc::clone(&factory.state);
+        let m = MountManager::new(Config::default(), Arc::new(factory));
+        let session = m.transport().acquire().await.unwrap();
+        let log = state.lock().await.command_log.clone();
+        assert!(!log.is_empty(), "handshake produced no wire frames");
+        assert_eq!(
+            log[0],
+            b":e1\r",
+            "first wire frame must be `:e1`; got {:?}",
+            std::str::from_utf8(&log[0]).unwrap_or("<non-utf8>")
+        );
+        // Sanity: the rest of the handshake still ran (`:F1` shows up
+        // somewhere after `:e1`), so reordering didn't drop commands.
+        assert!(
+            log.iter().any(|f| f == b":F1\r"),
+            "`:F1` missing from handshake log: {log:?}"
+        );
+        session.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handshake_rejects_unknown_mount_type_byte_without_issuing_mount_commands() {
+        // Seed a motor-board-version with a high byte outside the
+        // `MountType` whitelist before the handshake reaches the wire.
+        // `0xFF` is a plausible "wrong device" byte: no Sky-Watcher motor
+        // controller reports it (the documented IDs top out at `0x06` for
+        // the EQ family and `0x82` for AZ-GTi).
+        let factory = CapturingMockFactory::new();
+        let state = Arc::clone(&factory.state);
+        state.lock().await.motor_board_version = 0x00FF_0000;
+        let m = MountManager::new(Config::default(), Arc::new(factory));
+        let err = m
+            .transport()
+            .acquire()
+            .await
+            .expect_err("acquire must reject a wrong-device handshake");
+        let mapped = StarAdvError::from(err);
+        match mapped {
+            StarAdvError::WrongDevice { port, reason } => {
+                // Default `UsbConfig` port path is documented in
+                // `config.rs::UsbConfig::default`.
+                assert_eq!(port, "/dev/ttyACM0", "wrong port in diagnostic");
+                assert!(
+                    reason.contains("0xFF"),
+                    "reason must quote the rejected byte; got {reason:?}"
+                );
+                assert!(
+                    reason.contains("Sky-Watcher"),
+                    "reason must call out the whitelist mismatch; got {reason:?}"
+                );
+            }
+            other => panic!("expected WrongDevice, got {other:?}"),
+        }
+        // The driver must NOT have issued any of the mount-specific init
+        // commands. `:e1\r` is allowed (and required); everything else
+        // would have leaked a write to the wrong device.
+        let log = state.lock().await.command_log.clone();
+        assert_eq!(
+            log.len(),
+            1,
+            "expected exactly one wire frame after wrong-device rejection, got {log:?}"
+        );
+        assert_eq!(log[0], b":e1\r");
+        assert!(
+            !m.is_available(),
+            "RollbackGuard should roll the refcount back on handshake failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn handshake_rejects_unexpected_e1_response_kind_as_wrong_device() {
+        // Build a transport whose first `recv_frame` returns a malformed
+        // `:e1` reply: a 3-hex-byte status payload (`=100\r`), which the
+        // codec accepts structurally (it's a well-formed `=...\r`) but
+        // which `Response::decode` cannot turn into a U24 motor-board
+        // version. The driver must surface this as `WrongDevice`, not as
+        // a `Protocol(FrameError(...))` that would map to a generic
+        // `INVALID_OPERATION` with no port hint.
+        struct FakeTransport {
+            served: AtomicBool,
+        }
+
+        #[async_trait]
+        impl FrameTransport for FakeTransport {
+            async fn send_frame(
+                &mut self,
+                _bytes: &[u8],
+            ) -> std::result::Result<(), TransportError> {
+                Ok(())
+            }
+            async fn recv_frame(
+                &mut self,
+                buf: &mut Vec<u8>,
+            ) -> std::result::Result<(), TransportError> {
+                if !self.served.swap(true, Ordering::SeqCst) {
+                    buf.clear();
+                    buf.extend_from_slice(b"=100\r");
+                    Ok(())
+                } else {
+                    Err(TransportError::Eof)
+                }
+            }
+        }
+
+        struct FakeFactory;
+
+        #[async_trait]
+        impl TransportFactory for FakeFactory {
+            async fn open(&self) -> std::result::Result<Box<dyn FrameTransport>, TransportError> {
+                Ok(Box::new(FakeTransport {
+                    served: AtomicBool::new(false),
+                }))
+            }
+        }
+
+        let m = MountManager::new(Config::default(), Arc::new(FakeFactory));
+        let err = m
+            .transport()
+            .acquire()
+            .await
+            .expect_err("malformed `:e1` reply must reject");
+        let mapped = StarAdvError::from(err);
+        match mapped {
+            StarAdvError::WrongDevice { port, reason } => {
+                assert_eq!(port, "/dev/ttyACM0");
+                // Either route is acceptable: the response decoded as a
+                // non-U24 variant (`Response::Status` here), or the
+                // payload check rejected the shape. Both end up in
+                // `WrongDevice` per the handshake hook's branching.
+                assert!(
+                    reason.contains("malformed") || reason.contains("expected motor-board"),
+                    "reason should describe the malformed-:e1 cause; got {reason:?}"
+                );
+            }
+            other => panic!("expected WrongDevice, got {other:?}"),
+        }
+        assert!(
+            !m.is_available(),
+            "RollbackGuard should roll the refcount back on wrong-device failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_device_diagnostic_quotes_the_configured_port() {
+        // The diagnostic is a smell-test for an operator who just pointed
+        // the driver at the wrong serial port — the message must name
+        // *their* configured port, not a hardcoded default, so the
+        // verify-the-port hint is actionable.
+        let factory = CapturingMockFactory::new();
+        let state = Arc::clone(&factory.state);
+        state.lock().await.motor_board_version = 0x0099_0000;
+        let mut cfg = Config::default();
+        if let TransportConfig::Usb(usb) = &mut cfg.transport {
+            usb.port = "/dev/serial/by-id/usb-Foo_Bar-port0".into();
+        }
+        let m = MountManager::new(cfg, Arc::new(factory));
+        let err = m.transport().acquire().await.expect_err("reject");
+        let ascom: ascom_alpaca::ASCOMError = StarAdvError::from(err).into();
+        // The to-string is what an ASCOM client surfaces to the operator
+        // — assert the actionable bits are in it.
+        let msg = ascom.message.to_string();
+        assert!(
+            msg.contains("/dev/serial/by-id/usb-Foo_Bar-port0"),
+            "port path missing from ASCOM error message: {msg}"
+        );
+        assert!(
+            msg.contains("Sky-Watcher motor controller"),
+            "wrong-device hint missing: {msg}"
+        );
+        assert!(
+            msg.contains("wrong serial port"),
+            "verify-the-port hint missing: {msg}"
+        );
     }
 }

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -350,9 +350,18 @@ async fn handshake(
             ));
         }
         Err(SkywatcherCodecError::Protocol(pe)) => {
+            // Covers every `ProtocolError` shape: `FrameError` (missing
+            // `=` prefix / `\r`), `PayloadError` (wrong-shape body),
+            // `HexError` (non-hex payload), and `MountError` (the device
+            // replied with a structurally-valid `!X\r` error frame —
+            // valid but not what a Sky-Watcher motor controller should
+            // send for `:e1`, which is part of the protocol's standard
+            // command set). "Unexpected" reads correctly across all
+            // four; the per-error stringification (`{pe}`) carries the
+            // specific cause for log triage.
             return Err(SkywatcherCodecError::wrong_device(
                 port_label.as_ref(),
-                format!("malformed `:e1` reply: {pe}"),
+                format!("unexpected `:e1` reply: {pe}"),
             ));
         }
         // Transport / SkipExhausted / pre-existing WrongDevice variants
@@ -1322,8 +1331,8 @@ mod tests {
                 // payload check rejected the shape. Both end up in
                 // `WrongDevice` per the handshake hook's branching.
                 assert!(
-                    reason.contains("malformed") || reason.contains("expected motor-board"),
-                    "reason should describe the malformed-:e1 cause; got {reason:?}"
+                    reason.contains("unexpected") || reason.contains("expected motor-board"),
+                    "reason should describe the unexpected-:e1 cause; got {reason:?}"
                 );
             }
             other => panic!("expected WrongDevice, got {other:?}"),
@@ -1331,6 +1340,95 @@ mod tests {
         assert!(
             !m.is_available(),
             "RollbackGuard should roll the refcount back on wrong-device failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn handshake_rejects_mount_error_reply_to_e1_as_wrong_device() {
+        // A device that speaks `:`/`!` framing but doesn't recognise
+        // `:e` replies `!0\r` (UnknownCommand). The frame is
+        // structurally valid (it is decodable as
+        // `ProtocolError::MountError(UnknownCommand)`), so this is a
+        // distinct path from the malformed-framing case in
+        // `handshake_rejects_unexpected_e1_response_kind_as_wrong_device`.
+        // Still wrong-device — a real Sky-Watcher controller supports
+        // `:e` from the protocol spec — but the diagnostic shouldn't
+        // call this "malformed"; it's an unexpected (but well-formed)
+        // reply.
+        struct MountErrorTransport {
+            served: AtomicBool,
+        }
+
+        #[async_trait]
+        impl FrameTransport for MountErrorTransport {
+            async fn send_frame(
+                &mut self,
+                _bytes: &[u8],
+            ) -> std::result::Result<(), TransportError> {
+                Ok(())
+            }
+            async fn recv_frame(
+                &mut self,
+                buf: &mut Vec<u8>,
+            ) -> std::result::Result<(), TransportError> {
+                if !self.served.swap(true, Ordering::SeqCst) {
+                    buf.clear();
+                    buf.extend_from_slice(b"!0\r");
+                    Ok(())
+                } else {
+                    Err(TransportError::Eof)
+                }
+            }
+        }
+
+        struct MountErrorFactory;
+
+        #[async_trait]
+        impl TransportFactory for MountErrorFactory {
+            async fn open(&self) -> std::result::Result<Box<dyn FrameTransport>, TransportError> {
+                Ok(Box::new(MountErrorTransport {
+                    served: AtomicBool::new(false),
+                }))
+            }
+        }
+
+        let m = MountManager::new(Config::default(), Arc::new(MountErrorFactory));
+        let err = m
+            .transport()
+            .acquire()
+            .await
+            .expect_err("a `!0\\r` reply to `:e1` must reject as wrong-device");
+        let mapped = StarAdvError::from(err);
+        match mapped {
+            StarAdvError::WrongDevice { port, reason } => {
+                assert_eq!(port, "/dev/ttyACM0");
+                // The reason carries the underlying ProtocolError
+                // stringification — `MountError(UnknownCommand)` formats
+                // as "mount error: UnknownCommand" per its `thiserror`
+                // attribute. The wrapper prefix is "unexpected", NOT
+                // "malformed" — a `!X\r` frame is well-formed; it's the
+                // *content* that's wrong for our query.
+                assert!(
+                    reason.contains("unexpected"),
+                    "reason should use the broader 'unexpected' wording, not 'malformed'; got {reason:?}"
+                );
+                assert!(
+                    reason.contains("mount error") || reason.contains("UnknownCommand"),
+                    "reason should quote the underlying ProtocolError; got {reason:?}"
+                );
+            }
+            other => panic!("expected WrongDevice, got {other:?}"),
+        }
+        // And the top-level Display string must not contradict — it
+        // says "unexpected data", not "malformed data".
+        let staradv = StarAdvError::WrongDevice {
+            port: "/dev/ttyACM0".into(),
+            reason: "unexpected `:e1` reply: mount error: UnknownCommand".into(),
+        };
+        assert!(
+            staradv.to_string().contains("returned unexpected data"),
+            "WrongDevice Display must say 'unexpected', not 'malformed'; got: {}",
+            staradv
         );
     }
 

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -318,13 +318,29 @@ async fn handshake(
     snapshot: Arc<RwLock<MountSnapshot>>,
     port_label: Arc<str>,
 ) -> std::result::Result<(), SkywatcherCodecError> {
-    // Step 1: identify the device. `:e1` is the first (and, on a wrong-
-    // device handshake, the *only*) frame on the wire. Transport-level
-    // failures (timeout, EOF, framing) propagate as-is so the existing
-    // `Timeout` / `Transport` classifications survive; protocol-level
-    // failures (frame malformed, payload wrong shape, unexpected
-    // response kind) are converted to `WrongDevice` so the operator
-    // sees a hint about the cause instead of a cryptic codec error.
+    // Step 1: identify the device. `:e1` is the first (and, on a
+    // wrong-device handshake, the *only*) frame on the wire.
+    //
+    // The two "frame-shaped" error sources are deliberately routed
+    // differently — easy to confuse from the variant names alone:
+    //
+    // - `SkywatcherCodecError::Transport(TransportError::*)` —
+    //   *transport-layer* failures (`Timeout`, `Eof`, `Io`, `Open`,
+    //   `Framing` — the last being e.g. UDP datagram-bounds /
+    //   max-frame violations). Propagated unchanged so the existing
+    //   `Timeout` / `ConnectionFailed` / `Transport` classifications
+    //   survive into the operator-facing ASCOM error.
+    //
+    // - `SkywatcherCodecError::Protocol(ProtocolError::*)` —
+    //   *codec-layer* response-frame failures (`FrameError` for
+    //   missing `=` prefix / missing `\r`, `PayloadError` for
+    //   wrong-shape body, `HexError` for non-hex payload bytes),
+    //   plus the `Ok(other)` case where the device sent a
+    //   structurally valid but type-wrong reply (e.g. a
+    //   `Response::Status` `:f`-shaped frame instead of the U24
+    //   motor-board-version we asked for). All converted to
+    //   `WrongDevice` so the operator sees an actionable diagnostic
+    //   instead of a cryptic codec error.
     let board = match request_typed(conn, Command::InquireMotorBoardVersion(Axis::Ra)).await {
         Ok(Response::U24(v)) => v,
         Ok(other) => {

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -1327,13 +1327,18 @@ mod tests {
         match mapped {
             StarAdvError::WrongDevice { port, reason } => {
                 assert_eq!(port, "/dev/ttyACM0");
-                // Either route is acceptable: the response decoded as a
-                // non-U24 variant (`Response::Status` here), or the
-                // payload check rejected the shape. Both end up in
-                // `WrongDevice` per the handshake hook's branching.
+                // The path is unambiguous: `Response::decode` for
+                // `InquireMotorBoardVersion` returns
+                // `Err(ProtocolError::PayloadError("expected 6-hex-byte
+                // u24 payload, got 3 bytes"))` for the `=100\r` reply,
+                // which `wrong_device_for_e1` reclassifies as
+                // `WrongDevice` with reason `"unexpected `:e1` reply:
+                // payload error: ..."`. There is no "non-U24 success
+                // reply" branch — that path was structurally
+                // unreachable and was removed in the 5ccfcd1 refactor.
                 assert!(
-                    reason.contains("unexpected") || reason.contains("expected motor-board"),
-                    "reason should describe the unexpected-:e1 cause; got {reason:?}"
+                    reason.contains("unexpected") && reason.contains("payload error"),
+                    "reason should describe the PayloadError → WrongDevice path; got {reason:?}"
                 );
             }
             other => panic!("expected WrongDevice, got {other:?}"),
@@ -1350,8 +1355,8 @@ mod tests {
         // `:e` replies `!0\r` (UnknownCommand). The frame is
         // structurally valid (it is decodable as
         // `ProtocolError::MountError(UnknownCommand)`), so this is a
-        // distinct path from the malformed-framing case in
-        // `handshake_rejects_unexpected_e1_response_kind_as_wrong_device`.
+        // distinct path from the wrong-payload-length case in
+        // `handshake_rejects_e1_with_wrong_payload_length_as_wrong_device`.
         // Still wrong-device — a real Sky-Watcher controller supports
         // `:e` from the protocol spec — but the diagnostic shouldn't
         // call this "malformed"; it's an unexpected (but well-formed)

--- a/services/star-adventurer-gti/src/manager.rs
+++ b/services/star-adventurer-gti/src/manager.rs
@@ -301,8 +301,8 @@ fn build_hooks(
 /// [`MountType`] whitelist *before* any mount-specific
 /// initialisation (`:F1` / `:F2`) goes on the wire. If the device on the
 /// other end isn't a Sky-Watcher motor controller (wrong serial port,
-/// foreign USB-CDC peripheral, etc.), the handshake aborts after sending
-/// exactly one frame (`:e1\r`) and surfaces
+/// foreign USB-CDC peripheral, wrong UDP host, etc.), the handshake
+/// aborts after sending exactly one frame (`:e1\r`) and surfaces
 /// [`SkywatcherCodecError::WrongDevice`] carrying the port label and a
 /// human-readable reason. See [issue #254][issue] for the hardware session
 /// that motivated this and the operator-facing diagnostic shape.
@@ -321,8 +321,7 @@ async fn handshake(
     // Step 1: identify the device. `:e1` is the first (and, on a
     // wrong-device handshake, the *only*) frame on the wire.
     //
-    // The two "frame-shaped" error sources are deliberately routed
-    // differently — easy to confuse from the variant names alone:
+    // Error routing:
     //
     // - `SkywatcherCodecError::Transport(TransportError::*)` —
     //   *transport-layer* failures (`Timeout`, `Eof`, `Io`, `Open`,
@@ -332,43 +331,22 @@ async fn handshake(
     //   survive into the operator-facing ASCOM error.
     //
     // - `SkywatcherCodecError::Protocol(ProtocolError::*)` —
-    //   *codec-layer* response-frame failures (`FrameError` for
-    //   missing `=` prefix / missing `\r`, `PayloadError` for
-    //   wrong-shape body, `HexError` for non-hex payload bytes),
-    //   plus the `Ok(other)` case where the device sent a
-    //   structurally valid but type-wrong reply (e.g. a
-    //   `Response::Status` `:f`-shaped frame instead of the U24
-    //   motor-board-version we asked for). All converted to
-    //   `WrongDevice` so the operator sees an actionable diagnostic
-    //   instead of a cryptic codec error.
-    let board = match request_typed(conn, Command::InquireMotorBoardVersion(Axis::Ra)).await {
-        Ok(Response::U24(v)) => v,
-        Ok(other) => {
-            return Err(SkywatcherCodecError::wrong_device(
-                port_label.as_ref(),
-                format!("expected motor-board-version U24, got {other:?}"),
-            ));
-        }
-        Err(SkywatcherCodecError::Protocol(pe)) => {
-            // Covers every `ProtocolError` shape: `FrameError` (missing
-            // `=` prefix / `\r`), `PayloadError` (wrong-shape body),
-            // `HexError` (non-hex payload), and `MountError` (the device
-            // replied with a structurally-valid `!X\r` error frame —
-            // valid but not what a Sky-Watcher motor controller should
-            // send for `:e1`, which is part of the protocol's standard
-            // command set). "Unexpected" reads correctly across all
-            // four; the per-error stringification (`{pe}`) carries the
-            // specific cause for log triage.
-            return Err(SkywatcherCodecError::wrong_device(
-                port_label.as_ref(),
-                format!("unexpected `:e1` reply: {pe}"),
-            ));
-        }
-        // Transport / SkipExhausted / pre-existing WrongDevice variants
-        // bubble through unchanged — those classifications are already
-        // correct for their respective failure modes.
-        Err(other) => return Err(other),
-    };
+    //   *codec-layer* response failures (`FrameError`, `PayloadError`,
+    //   `HexError`, plus `MountError` for a structurally-valid `!X\r`
+    //   reply). All converted to `WrongDevice`.
+    //
+    // The handshake uses the same `expect_u24` shape as the U24
+    // inquiries below (`:a`, `:b`, `:g`) — `Response::decode` for
+    // `Command::InquireMotorBoardVersion` only constructs
+    // `Response::U24` on success, so the non-U24 case `expect_u24`
+    // would catch is structurally unreachable; mapping a Protocol error
+    // once on the outer call covers every failure mode.
+    let board = expect_u24(
+        request_typed(conn, Command::InquireMotorBoardVersion(Axis::Ra))
+            .await
+            .map_err(|e| wrong_device_for_e1(e, &port_label))?,
+    )
+    .map_err(|e| wrong_device_for_e1(e, &port_label))?;
     let mount_type = MountType::from_motor_board_version(board).map_err(|byte| {
         SkywatcherCodecError::wrong_device(
             port_label.as_ref(),
@@ -554,6 +532,28 @@ async fn poll_axis_via_session(
     out.goto = s.goto;
     out.blocked = s.blocked;
     Ok(())
+}
+
+/// Convert any [`SkywatcherCodecError::Protocol`] arising from the
+/// `:e1` round-trip into a [`SkywatcherCodecError::WrongDevice`]
+/// carrying the configured port label and a human-readable reason.
+/// Transport / `SkipExhausted` / pre-existing `WrongDevice` variants
+/// pass through unchanged — those classifications are already correct
+/// for their respective failure modes.
+///
+/// Used twice in the handshake — once on the `request_typed` result
+/// (catches `FrameError` / `PayloadError` / `HexError` from the
+/// codec's response decode, plus `MountError` from a `!X\r` reply)
+/// and once on the `expect_u24` result (catches the
+/// structurally-unreachable-in-practice non-U24 response case, where
+/// `expect_u24` synthesises a `FrameError("expected U24, got X")`).
+fn wrong_device_for_e1(err: SkywatcherCodecError, port_label: &str) -> SkywatcherCodecError {
+    match err {
+        SkywatcherCodecError::Protocol(pe) => {
+            SkywatcherCodecError::wrong_device(port_label, format!("unexpected `:e1` reply: {pe}"))
+        }
+        other => other,
+    }
 }
 
 fn expect_ack(r: Response) -> std::result::Result<(), SkywatcherCodecError> {
@@ -1271,14 +1271,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handshake_rejects_unexpected_e1_response_kind_as_wrong_device() {
-        // Build a transport whose first `recv_frame` returns a malformed
-        // `:e1` reply: a 3-hex-byte status payload (`=100\r`), which the
-        // codec accepts structurally (it's a well-formed `=...\r`) but
-        // which `Response::decode` cannot turn into a U24 motor-board
-        // version. The driver must surface this as `WrongDevice`, not as
-        // a `Protocol(FrameError(...))` that would map to a generic
-        // `INVALID_OPERATION` with no port hint.
+    async fn handshake_rejects_e1_with_wrong_payload_length_as_wrong_device() {
+        // Build a transport whose first `recv_frame` returns an `=...\r`
+        // frame that is structurally valid (the codec accepts it) but
+        // whose payload is the wrong length for the `:e1` U24 decoder:
+        // 3 hex bytes instead of the required 6. `Response::decode`
+        // surfaces this as `Err(ProtocolError::PayloadError(...))`. The
+        // driver must reclassify it as `WrongDevice` so the operator
+        // sees an actionable diagnostic instead of a generic
+        // `INVALID_OPERATION` codec error.
         struct FakeTransport {
             served: AtomicBool,
         }
@@ -1435,9 +1436,9 @@ mod tests {
     #[tokio::test]
     async fn wrong_device_diagnostic_quotes_the_configured_port() {
         // The diagnostic is a smell-test for an operator who just pointed
-        // the driver at the wrong serial port — the message must name
-        // *their* configured port, not a hardcoded default, so the
-        // verify-the-port hint is actionable.
+        // the driver at the wrong transport target (serial port or UDP
+        // host) — the message must name *their* configured port, not a
+        // hardcoded default, so the verify-the-port hint is actionable.
         let factory = CapturingMockFactory::new();
         let state = Arc::clone(&factory.state);
         state.lock().await.motor_board_version = 0x0099_0000;
@@ -1460,7 +1461,11 @@ mod tests {
             "wrong-device hint missing: {msg}"
         );
         assert!(
-            msg.contains("wrong serial port"),
+            msg.contains("wrong device"),
+            "wrong-device hypothesis missing: {msg}"
+        );
+        assert!(
+            msg.contains("transport endpoint"),
             "verify-the-port hint missing: {msg}"
         );
     }

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -3037,7 +3037,13 @@ impl FrameTransport for FlakyFrameTransport {
         let axis = bytes[2];
         let reply: Vec<u8> = match cmd {
             b'F' | b'K' | b'L' => b"=\r".to_vec(),
-            b'a' | b'b' | b'e' => b"=005F37\r".to_vec(),
+            b'a' | b'b' => b"=005F37\r".to_vec(),
+            // `:e` returns the documented GTi motor-board-version
+            // (`0x0003_300C`, high byte `0x03` = EQ family) so the
+            // `:e1`-first handshake's mount-type whitelist (issue #254)
+            // accepts it. The wire encoding is little-byte-first hex
+            // (`0x0003_300C` → bytes `0x0C, 0x30, 0x03` → "0C3003").
+            b'e' => b"=0C3003\r".to_vec(),
             b'g' => b"=01\r".to_vec(),
             b'j' => {
                 // Biased position 0 → 0x800000 → "000080".

--- a/services/star-adventurer-gti/tests/features/connection_lifecycle.feature
+++ b/services/star-adventurer-gti/tests/features/connection_lifecycle.feature
@@ -15,10 +15,14 @@ Feature: Connection lifecycle
     Then the device should be connected
 
   Scenario: Connect runs the initialisation handshake in order
+    The :e1 motor-board-version inquiry runs first so the driver can refuse
+    to send mount-specific init commands to a device that isn't a Sky-Watcher
+    motor controller. See issue #254.
     Given a running star-adventurer service
     When I connect the device
     Then the mount should have received commands in order:
       | command |
+      | :e1     |
       | :F1     |
       | :F2     |
       | :a1     |
@@ -26,7 +30,6 @@ Feature: Connection lifecycle
       | :b1     |
       | :g1     |
       | :g2     |
-      | :e1     |
       | :j1     |
       | :j2     |
 


### PR DESCRIPTION
## Summary

- Reorder the connect handshake so `:e1` (motor-board-version) is the first wire command, gating every mount-specific command (`:F`, `:a`, `:b`, `:g`, …) behind a strict Sky-Watcher mount-type whitelist. On a wrong-device handshake the driver now sends **exactly one frame** (`:e1\r`) and bails out.
- New `StarAdvError::WrongDevice { port, reason }` carries an operator-friendly diagnostic naming the configured port and the wrong-device hypothesis — replaces the cryptic `protocol error: payload error: expected empty '=\r' ack, got 9 payload bytes` from the motivating hardware session.
- New `skywatcher_motor_protocol::MountType` enum + whitelist gate; documented + INDI-cross-checked Sky-Watcher mount-type byte values.
- Inline the redundant `StarAdvError::to_ascom_error` into the existing `From<StarAdvError> for ASCOMError` impl.

Closes #254.

## Test plan

- [x] `cargo rail run --profile commit` (cargo check + nextest, `--locked --all-features --all-targets`) — 413 tests pass.
- [x] `cargo test -p star-adventurer-gti --test bdd` — 126 BDD scenarios pass, including the updated `connection_lifecycle.feature` wire-order table with `:e1` first.
- [x] `cargo fmt` clean; clippy `-D warnings` clean (enforced by the pre-commit hook).
- [x] Four new unit tests in `manager.rs`:
   - `acquire_issues_e1_as_the_very_first_wire_frame`
   - `handshake_rejects_unknown_mount_type_byte_without_issuing_mount_commands` — confirms only `:e1\r` is on the wire when the mount-type byte is rejected
   - `handshake_rejects_unexpected_e1_response_kind_as_wrong_device` — covers the structurally-valid-but-wrong-payload case
   - `wrong_device_diagnostic_quotes_the_configured_port`
- [x] New protocol-crate tests cover `MountType::from_motor_board_version` accept / reject paths.
- [x] Manual: the existing flaky-transport mock in `mount_device/tests.rs` needed its `:e` reply switched from the CPR value to the documented GTi motor-board-version (`0x0003_300C`) — was passing under the pre-fix unvalidated handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)