### PR TITLE
feat(star-adventurer-gti): implement unpark_from_ap_position + recovery actions

### DIFF
--- a/docs/plans/star-adventurer-gti-unpark-from-ap-position.md
+++ b/docs/plans/star-adventurer-gti-unpark-from-ap-position.md
@@ -1,10 +1,11 @@
 # Star Adventurer GTi: required `unpark_from_ap_position` + recovery actions
 
-## Status: design landed; implementation not started
+## Status: implemented (issue #249)
 
-Design captured in
+All six phases below landed under issue #249. Design captured in
 [`docs/services/star-adventurer-gti.md` §Unpark from AP position](../services/star-adventurer-gti.md#unpark-from-ap-position).
-Conversation log lives on issue #248 (the tracker for picking this up).
+Conversation log lives on issue #248 (the design tracker); issue #249
+tracked the implementation.
 
 ## Motivation
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -1376,7 +1376,12 @@ src/
                            re-exports of the park-persistence helpers
   mount_device/
     device.rs            — `impl Device for MountDevice` (connect /
-                           description / driver info)
+                           description / driver info, plus
+                           `SupportedActions` + `Action` dispatch)
+    actions.rs           — the three driver-specific ASCOM `Action`
+                           handlers (`SetUnparkFromApPosition`,
+                           `SetPreferredApPark`, `UnparkFromApPosition`)
+                           that `device.rs`'s `action` dispatches to
     telescope.rs         — `impl Telescope for MountDevice` (the ASCOM
                            surface: capability flags, coordinate reads,
                            slew / sync / park / side-of-pier / pulse-guide)
@@ -1384,7 +1389,7 @@ src/
                            between the trait impls: validation,
                            preconditions, motion-control wrappers,
                            post-connect lifecycle hooks
-                           (`seed_home_pose_after_connect`,
+                           (`seed_after_connect`, `reset_mount_encoders`,
                             `load_park_target_after_connect`),
                            the slew planner
                            (`execute_slew_with_explicit_side`),

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -306,7 +306,7 @@ impl FlipPolicy {
 /// for Park 4 (target on the meridian, anti-pole side) and at
 /// `mech_HA = 0` for Park 5 (target on the anti-meridian, pole side
 /// horizon), and the Dec encoder is past the celestial pole.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApPark {
     /// "Current position." No encoder seeding — the driver trusts the
     /// firmware encoder as-is on connect. The operator asserts they
@@ -315,7 +315,6 @@ pub enum ApPark {
     /// setups. Not a valid `preferred_ap_park` (it is not a slew
     /// target). The `codebase_*` accessors return [`None`] for this
     /// variant.
-    #[serde(rename = "ap_park_0")]
     ApPark0,
     /// AP Park 1. "RA horizontal" (Dec axis east-west horizontal,
     /// saddle on the *west* end, counterweight on the east end). OTA
@@ -326,7 +325,6 @@ pub enum ApPark {
     /// `(−90 − Latitude)` for south. Codebase reading:
     /// `mech_HA = 0`, `dec_encoder = ±(90 − |latitude|)` (sign matches
     /// the hemisphere).
-    #[serde(rename = "ap_park_1")]
     ApPark1,
     /// AP Park 2. "RA axis vertical, Dec = 0". OTA level facing the
     /// east horizon, counterweight shaft pointing down. The "RA
@@ -334,7 +332,6 @@ pub enum ApPark {
     /// at any latitude the codebase reading is `mech_HA = −6 h`
     /// (target on the east-rising celestial equator), `dec_encoder
     /// = 0`. Hemisphere-independent.
-    #[serde(rename = "ap_park_2")]
     ApPark2,
     /// AP Park 3 (also Sky-Watcher's power-on home). OTA along the
     /// polar axis pointing at the visible celestial pole — Polaris
@@ -344,7 +341,6 @@ pub enum ApPark {
     /// AP table: `Dec = 90` (visible pole). Codebase reading:
     /// `mech_HA = 0`, `dec_encoder = +90°` for north / `−90°` for
     /// south.
-    #[serde(rename = "ap_park_3")]
     ApPark3,
     /// AP Park 4. East-side / post-meridian-flip equivalent of Park 1:
     /// saddle on the *east* end of the Dec axis, counterweight shaft
@@ -359,7 +355,6 @@ pub enum ApPark {
     /// ∓(90 + |latitude|)`. Codebase reading: `mech_HA = −12 h`
     /// (= `+12 h` via the encoder wrap),
     /// `dec_encoder = ∓(90 + |latitude|)`.
-    #[serde(rename = "ap_park_4")]
     ApPark4,
     /// AP Park 5. East-side / post-meridian-flip equivalent of Park 1
     /// (mirror of Park 4 across the polar-axis plane): saddle on the
@@ -378,8 +373,82 @@ pub enum ApPark {
     /// (`Note: Park 5 shown below is only available in APCC and the
     /// AP V2 driver.` per the AP doc — it's an APCC extension, not on
     /// the keypad.)
-    #[serde(rename = "ap_park_5")]
     ApPark5,
+}
+
+impl ApPark {
+    /// The canonical `ap_park_N` token for this variant — the single
+    /// source of truth for the string form used in config JSON
+    /// (`Serialize`/`Deserialize` delegate here), ASCOM `Action`
+    /// parameters, and `Action` return values.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApPark0 => "ap_park_0",
+            Self::ApPark1 => "ap_park_1",
+            Self::ApPark2 => "ap_park_2",
+            Self::ApPark3 => "ap_park_3",
+            Self::ApPark4 => "ap_park_4",
+            Self::ApPark5 => "ap_park_5",
+        }
+    }
+}
+
+impl std::fmt::Display for ApPark {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ApPark {
+    type Err = ApParkParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "ap_park_0" => Ok(Self::ApPark0),
+            "ap_park_1" => Ok(Self::ApPark1),
+            "ap_park_2" => Ok(Self::ApPark2),
+            "ap_park_3" => Ok(Self::ApPark3),
+            "ap_park_4" => Ok(Self::ApPark4),
+            "ap_park_5" => Ok(Self::ApPark5),
+            other => Err(ApParkParseError(other.to_string())),
+        }
+    }
+}
+
+/// Error from parsing an unrecognised AP-park token via
+/// [`ApPark::from_str`]. Carries the offending token for the message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApParkParseError(pub String);
+
+impl std::fmt::Display for ApParkParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unknown AP park {:?}; expected one of ap_park_0..ap_park_5",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ApParkParseError {}
+
+impl Serialize for ApPark {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ApPark {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let token = String::deserialize(deserializer)?;
+        token.parse().map_err(serde::de::Error::custom)
+    }
 }
 
 impl ApPark {
@@ -822,6 +891,31 @@ mod tests {
             let got: ApPark = serde_json::from_str(json).expect(json);
             assert_eq!(got, expected, "json input {json}");
         }
+    }
+
+    #[test]
+    fn ap_park_as_str_and_from_str_are_the_canonical_token_mapping() {
+        for park in [
+            ApPark::ApPark0,
+            ApPark::ApPark1,
+            ApPark::ApPark2,
+            ApPark::ApPark3,
+            ApPark::ApPark4,
+            ApPark::ApPark5,
+        ] {
+            // `as_str` ↔ `FromStr` round-trip.
+            assert_eq!(park.as_str().parse::<ApPark>().unwrap(), park);
+            // serde delegates to the same mapping, so the JSON string
+            // form is exactly `as_str()` — the single source of truth.
+            assert_eq!(
+                serde_json::to_value(park).unwrap(),
+                serde_json::Value::String(park.as_str().to_string()),
+            );
+        }
+        assert_eq!(ApPark::ApPark3.as_str(), "ap_park_3");
+        // An unrecognised token is a parse error that names the offender.
+        let err = "ap_park_9".parse::<ApPark>().unwrap_err();
+        assert!(err.to_string().contains("ap_park_9"), "{err}");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -177,18 +177,41 @@ pub struct MountConfig {
     #[serde(default)]
     pub flip_policy: FlipPolicy,
 
-    /// Physical pose the mount is in at power-up.
+    /// Physical pose the operator powers the mount up in. **Required**
+    /// in spirit — the ship default is [`ApPark::ApPark0`] ("current
+    /// position, I will plate-solve"), the safest assumption for an
+    /// unknown or variable physical setup.
     ///
-    /// When `Some(ApPark*)`, the driver seeds the firmware encoder on
-    /// connect (no motion, just `:E1` / `:E2`) so the codebase's
-    /// celestial-coordinate math matches the operator's physical
-    /// pose. When `None` (the default), the driver does no seeding
-    /// and trusts the firmware encoder as-is — the codebase's
-    /// historical pre-Phase-6 behaviour. See [`HomePose`] for the
-    /// supported AP park positions and the wiring in
-    /// `MountDevice::seed_home_pose_after_connect`.
-    #[serde(default)]
-    pub home_pose: Option<HomePose>,
+    /// For `ap_park_1..ap_park_5` the driver seeds the firmware encoder
+    /// on the fresh-power-up connect (no motion, just `:E1` / `:E2`) so
+    /// the codebase's celestial-coordinate math matches the operator's
+    /// physical pose. For `ap_park_0` the driver does **no** seeding and
+    /// trusts the firmware encoder as-is — the operator has asserted
+    /// they will ground-truth the position via plate-solve + sync.
+    ///
+    /// The runtime `SetUnparkFromApPosition` Action persists a new value
+    /// here (applied on the next fresh-power-up). See [`ApPark`] for the
+    /// supported positions, the design doc's
+    /// [§Unpark from AP position](../../../docs/services/star-adventurer-gti.md#unpark-from-ap-position),
+    /// and the wiring in `MountDevice::seed_after_connect`.
+    #[serde(default = "default_unpark_from_ap_position")]
+    pub unpark_from_ap_position: ApPark,
+
+    /// AP park the standard ASCOM `Park()` slews to when no raw
+    /// `park_*_ticks` override is set. Defaults to [`ApPark::ApPark3`]
+    /// (Sky-Watcher's stock power-up pose along the polar axis).
+    ///
+    /// `ap_park_0` is rejected at deserialize time — "current position"
+    /// is not a slew target. The runtime `SetPreferredApPark` Action
+    /// persists a new value here. When both this and an explicit
+    /// `park_ra_ticks` / `park_dec_ticks` pair are set, the raw tick
+    /// pair wins (per-axis). See the design doc's
+    /// [§Custom Actions for runtime control](../../../docs/services/star-adventurer-gti.md#custom-actions-for-runtime-control).
+    #[serde(
+        default = "default_preferred_ap_park",
+        deserialize_with = "deserialize_preferred_ap_park"
+    )]
+    pub preferred_ap_park: ApPark,
 }
 
 /// Master switch + parameters for driver-planned meridian flips.
@@ -263,9 +286,11 @@ impl FlipPolicy {
 /// positions.
 ///
 /// The Sky-Watcher firmware resets its encoder counter to `(0, 0)`
-/// every power-up. When `home_pose: Some(ApPark*)`, the driver
-/// seeds the firmware encoder on connect so the codebase's coordinate
-/// math interprets that zero against the operator's physical pose.
+/// every power-up. For `ap_park_1..ap_park_5` the driver seeds the
+/// firmware encoder on connect so the codebase's coordinate math
+/// interprets that zero against the operator's physical pose. The
+/// [`ApPark::ApPark0`] variant means "no seed — trust the firmware
+/// encoder as-is"; its `codebase_*` accessors return [`None`].
 ///
 /// Each AP pose is mirror-symmetric between the Northern and Southern
 /// Hemispheres around the observer's local meridian — the
@@ -282,7 +307,16 @@ impl FlipPolicy {
 /// `mech_HA = 0` for Park 5 (target on the anti-meridian, pole side
 /// horizon), and the Dec encoder is past the celestial pole.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum HomePose {
+pub enum ApPark {
+    /// "Current position." No encoder seeding — the driver trusts the
+    /// firmware encoder as-is on connect. The operator asserts they
+    /// will plate-solve and `SyncToCoordinates` before any blind-
+    /// pointing slew. Safe ship default for unknown / variable physical
+    /// setups. Not a valid `preferred_ap_park` (it is not a slew
+    /// target). The `codebase_*` accessors return [`None`] for this
+    /// variant.
+    #[serde(rename = "ap_park_0")]
+    ApPark0,
     /// AP Park 1. "RA horizontal" (Dec axis east-west horizontal,
     /// saddle on the *west* end, counterweight on the east end). OTA
     /// tube level, pointing at the polar-side horizon — north horizon
@@ -348,10 +382,11 @@ pub enum HomePose {
     ApPark5,
 }
 
-impl HomePose {
+impl ApPark {
     /// Codebase-convention `mech_HA` (signed hours, `[−12, +12)`)
-    /// corresponding to firmware encoder `(0, 0)` at this home pose
-    /// for the configured latitude.
+    /// corresponding to firmware encoder `(0, 0)` at this AP park
+    /// for the configured latitude. [`None`] for [`ApPark::ApPark0`]
+    /// ("current position" has no fixed encoder mapping).
     ///
     /// AP defines each pose by the OTA pointing direction and which
     /// side of the mount the OTA tube is on (East or West, mechanical).
@@ -388,29 +423,31 @@ impl HomePose {
     ///   OTA reaches north horizon via natural-side dec rotation).
     /// - Parks 2 and 3 are hemisphere-neutral for mech_HA (`−6`,
     ///   saddle in the south-up direction, neither east nor west).
-    pub fn codebase_mech_ha_hours(&self, _latitude_deg: f64) -> f64 {
+    pub fn codebase_mech_ha_hours(&self, _latitude_deg: f64) -> Option<f64> {
         // We don't case-split on hemisphere for mech_HA: the saddle
         // east/west position is a function of the encoder alone,
         // which is hemisphere-independent. The dec encoder *is*
         // hemisphere-dependent — see [`codebase_dec_encoder_degrees`].
         match self {
+            // "Current position" has no fixed encoder mapping.
+            Self::ApPark0 => None,
             // Park 1: OTA west of mount → saddle west → mech_HA in
             // the (−6, +6) range. `mech_HA = 0` is the canonical
             // saddle-west position (dec axis east-west horizontal).
-            Self::ApPark1 => 0.0,
+            Self::ApPark1 => Some(0.0),
             // Park 2 and Park 3 share the same RA position ("RA axis
             // vertical" per the AP doc); only the dec rotation differs.
             // Both put the dec axis south-up out of east-west horizontal
             // (`mech_HA = −6`).
-            Self::ApPark2 => -6.0,
-            Self::ApPark3 => -6.0,
+            Self::ApPark2 => Some(-6.0),
+            Self::ApPark3 => Some(-6.0),
             // Park 4: OTA east of mount → saddle east → `mech_HA` in
             // the wrap region. `mech_HA = −12` is the canonical
             // saddle-east position.
-            Self::ApPark4 => -12.0,
+            Self::ApPark4 => Some(-12.0),
             // Park 5: OTA east of mount (same saddle side as Park 4,
             // different dec rotation) → `mech_HA = −12`.
-            Self::ApPark5 => -12.0,
+            Self::ApPark5 => Some(-12.0),
         }
     }
 
@@ -423,13 +460,15 @@ impl HomePose {
     /// hemispheres. The codebase dec_enc value is the rotation angle
     /// around the dec axis from the dec=0 reference (which itself is
     /// hemisphere-dependent at fixed mech_HA).
-    pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> f64 {
+    pub fn codebase_dec_encoder_degrees(&self, latitude_deg: f64) -> Option<f64> {
         let northern = latitude_deg >= 0.0;
         let lat_abs = latitude_deg.abs();
         // Magnitude common to Parks 1, 4, 5 — the celestial Dec at the
         // polar-side / anti-polar horizon at this latitude.
         let horizon_dec_mag = 90.0 - lat_abs;
         match self {
+            // "Current position" has no fixed encoder mapping.
+            Self::ApPark0 => None,
             // Park 1: saddle west (mech_HA=0). OTA at polar-side
             // horizon — north horizon for N (alt=0, az=0), south
             // horizon for S. From the saddle-west position at
@@ -437,47 +476,37 @@ impl HomePose {
             // a past-pole rotation: `dec_enc ≈ ±(90 + |lat|)` (sign
             // matches hemisphere; magnitude > 90 indicates the
             // past-pole encoding).
-            Self::ApPark1 => {
-                if northern {
-                    90.0 + lat_abs
-                } else {
-                    -(90.0 + lat_abs)
-                }
-            }
-            Self::ApPark2 => 0.0,
-            Self::ApPark3 => {
+            Self::ApPark1 => Some(if northern {
+                90.0 + lat_abs
+            } else {
+                -(90.0 + lat_abs)
+            }),
+            Self::ApPark2 => Some(0.0),
+            Self::ApPark3 => Some(
                 // OTA at the visible celestial pole. Both hemispheres
                 // encode this as `dec_enc = ±90°` (sign matches
                 // hemisphere — celestial pole at +Dec in N, −Dec
                 // in S).
-                if northern {
-                    90.0
-                } else {
-                    -90.0
-                }
-            }
+                if northern { 90.0 } else { -90.0 },
+            ),
             // Park 4: saddle east (mech_HA=-12). OTA at the anti-
             // polar horizon — south for N (alt=0, az=180), north
             // for S. Past-pole rotation gives `dec_enc = ∓(90+|lat|)`
             // (sign opposite hemisphere).
-            Self::ApPark4 => {
-                if northern {
-                    -(90.0 + lat_abs)
-                } else {
-                    90.0 + lat_abs
-                }
-            }
+            Self::ApPark4 => Some(if northern {
+                -(90.0 + lat_abs)
+            } else {
+                90.0 + lat_abs
+            }),
             // Park 5: saddle east (mech_HA=-12, same as Park 4) but
             // OTA at the polar-side horizon (180° around dec axis
             // from Park 4). `dec_enc = ±(90 − |lat|)` (natural-side
             // encoding; |dec_enc| < 90).
-            Self::ApPark5 => {
-                if northern {
-                    horizon_dec_mag
-                } else {
-                    -horizon_dec_mag
-                }
-            }
+            Self::ApPark5 => Some(if northern {
+                horizon_dec_mag
+            } else {
+                -horizon_dec_mag
+            }),
         }
     }
 }
@@ -527,6 +556,33 @@ fn default_flip_range_hours() -> f64 {
 }
 fn default_true() -> bool {
     true
+}
+fn default_unpark_from_ap_position() -> ApPark {
+    // Ship default: "current position" — the safest assumption for an
+    // unknown / variable physical setup. No encoder seed on connect.
+    ApPark::ApPark0
+}
+fn default_preferred_ap_park() -> ApPark {
+    // Sky-Watcher's stock power-up pose (OTA along the polar axis at
+    // the visible celestial pole) — a sensible default `Park()` target.
+    ApPark::ApPark3
+}
+
+/// Deserialize `preferred_ap_park`, rejecting [`ApPark::ApPark0`].
+/// "Current position" is not a slew target, so it cannot be the
+/// preferred `Park()` destination — surfacing the misconfiguration at
+/// config-load time rather than at the first `Park()` call.
+fn deserialize_preferred_ap_park<'de, D>(deserializer: D) -> std::result::Result<ApPark, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let park = ApPark::deserialize(deserializer)?;
+    if park == ApPark::ApPark0 {
+        return Err(serde::de::Error::custom(
+            "preferred_ap_park cannot be \"ap_park_0\" (\"current position\" is not a slew target)",
+        ));
+    }
+    Ok(park)
 }
 
 impl Default for UsbConfig {
@@ -587,7 +643,8 @@ impl Default for MountConfig {
             park_ra_ticks: None,
             park_dec_ticks: None,
             flip_policy: FlipPolicy::default(),
-            home_pose: None,
+            unpark_from_ap_position: default_unpark_from_ap_position(),
+            preferred_ap_park: default_preferred_ap_park(),
         }
     }
 }
@@ -736,31 +793,50 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_default_is_none_for_backward_compat() {
-        // `home_pose: None` means "no encoder seeding on connect" —
-        // the codebase's pre-Phase-6 behaviour. Operators powering up
-        // at an AP park position opt in by setting `home_pose:
-        // "ap_park_<n>"`.
+    fn unpark_from_ap_position_default_is_ap_park_0() {
+        // The ship default is `ap_park_0` ("current position") — the
+        // safest assumption: no encoder seed on connect. Operators with
+        // a permanent setup opt into a named park to get the auto-seed.
         let cfg = MountConfig::default();
-        assert_eq!(cfg.home_pose, None);
+        assert_eq!(cfg.unpark_from_ap_position, ApPark::ApPark0);
     }
 
     #[test]
-    fn home_pose_deserialises_from_snake_case() {
+    fn preferred_ap_park_default_is_ap_park_3() {
+        // The default `Park()` target is Sky-Watcher's stock power-up
+        // pose along the polar axis.
+        let cfg = MountConfig::default();
+        assert_eq!(cfg.preferred_ap_park, ApPark::ApPark3);
+    }
+
+    #[test]
+    fn ap_park_deserialises_from_snake_case() {
         for (json, expected) in [
-            (r#""ap_park_1""#, HomePose::ApPark1),
-            (r#""ap_park_2""#, HomePose::ApPark2),
-            (r#""ap_park_3""#, HomePose::ApPark3),
-            (r#""ap_park_4""#, HomePose::ApPark4),
-            (r#""ap_park_5""#, HomePose::ApPark5),
+            (r#""ap_park_0""#, ApPark::ApPark0),
+            (r#""ap_park_1""#, ApPark::ApPark1),
+            (r#""ap_park_2""#, ApPark::ApPark2),
+            (r#""ap_park_3""#, ApPark::ApPark3),
+            (r#""ap_park_4""#, ApPark::ApPark4),
+            (r#""ap_park_5""#, ApPark::ApPark5),
         ] {
-            let got: HomePose = serde_json::from_str(json).expect(json);
+            let got: ApPark = serde_json::from_str(json).expect(json);
             assert_eq!(got, expected, "json input {json}");
         }
     }
 
     #[test]
-    fn home_pose_ap_park_1_matches_ap_table_both_hemispheres() {
+    fn ap_park_0_has_no_codebase_encoder_mapping() {
+        // "Current position" has no fixed encoder mapping; both
+        // accessors return `None` so callers must handle the no-seed
+        // case explicitly rather than seeding to a sentinel.
+        for lat in [-45.0, 0.0, 32.7] {
+            assert_eq!(ApPark::ApPark0.codebase_mech_ha_hours(lat), None);
+            assert_eq!(ApPark::ApPark0.codebase_dec_encoder_degrees(lat), None);
+        }
+    }
+
+    #[test]
+    fn ap_park_1_matches_ap_table_both_hemispheres() {
         // AP Park 1: OTA on west side of mount, level, facing the
         // polar-side horizon (N: north horizon, S: south horizon).
         // Saddle is on the west end of the dec axis → mech_HA = 0
@@ -775,56 +851,65 @@ mod tests {
         let n = 32.7_f64;
         let s = -33.0_f64;
         assert!(
-            (HomePose::ApPark1.codebase_dec_encoder_degrees(n) - 122.7).abs() < 1e-9,
-            "Park 1 N dec_enc at 32.7°: got {}",
-            HomePose::ApPark1.codebase_dec_encoder_degrees(n)
+            (ApPark::ApPark1.codebase_dec_encoder_degrees(n).unwrap() - 122.7).abs() < 1e-9,
+            "Park 1 N dec_enc at 32.7°: got {:?}",
+            ApPark::ApPark1.codebase_dec_encoder_degrees(n)
         );
         assert!(
-            (HomePose::ApPark1.codebase_dec_encoder_degrees(s) - (-123.0)).abs() < 1e-9,
-            "Park 1 S dec_enc at −33°: got {}",
-            HomePose::ApPark1.codebase_dec_encoder_degrees(s)
+            (ApPark::ApPark1.codebase_dec_encoder_degrees(s).unwrap() - (-123.0)).abs() < 1e-9,
+            "Park 1 S dec_enc at −33°: got {:?}",
+            ApPark::ApPark1.codebase_dec_encoder_degrees(s)
         );
-        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(n), 0.0);
-        assert_eq!(HomePose::ApPark1.codebase_mech_ha_hours(s), 0.0);
+        assert_eq!(ApPark::ApPark1.codebase_mech_ha_hours(n), Some(0.0));
+        assert_eq!(ApPark::ApPark1.codebase_mech_ha_hours(s), Some(0.0));
     }
 
     #[test]
-    fn home_pose_ap_park_2_is_hemisphere_independent() {
+    fn ap_park_2_is_hemisphere_independent() {
         // Park 2: "RA axis vertical, Dec = 0", both hemispheres.
         // OTA at east-rising celestial equator → celestial HA = −6 h,
         // celestial dec = 0. Both hemispheres land on the natural side
         // (|dec_enc| = 0 ≤ 90), so encoder = celestial dec for both.
         for lat in [-89.0, -33.0, 0.0, 32.7, 89.0] {
             assert_eq!(
-                HomePose::ApPark2.codebase_mech_ha_hours(lat),
-                -6.0,
+                ApPark::ApPark2.codebase_mech_ha_hours(lat),
+                Some(-6.0),
                 "Park 2 mech_HA at lat {lat}"
             );
             assert_eq!(
-                HomePose::ApPark2.codebase_dec_encoder_degrees(lat),
-                0.0,
+                ApPark::ApPark2.codebase_dec_encoder_degrees(lat),
+                Some(0.0),
                 "Park 2 dec at lat {lat}"
             );
         }
     }
 
     #[test]
-    fn home_pose_ap_park_3_visible_pole_inverts_with_hemisphere() {
+    fn ap_park_3_visible_pole_inverts_with_hemisphere() {
         // Park 3 / Sky-Watcher home: OTA along polar axis at the
         // visible pole. Celestial dec = +90 (N) / −90 (S). Natural
         // side for both hemispheres → encoder = celestial dec.
         // Verified on hardware at lat 32.7°N (2026-05-15): mech_HA =
         // −6 h and dec_enc = +90 leaves the OTA pointing at the NCP.
-        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(32.7), 90.0);
-        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(-33.0), -90.0);
+        assert_eq!(
+            ApPark::ApPark3.codebase_dec_encoder_degrees(32.7),
+            Some(90.0)
+        );
+        assert_eq!(
+            ApPark::ApPark3.codebase_dec_encoder_degrees(-33.0),
+            Some(-90.0)
+        );
         // Boundary: lat = 0 falls into the "north" arm via `>= 0`.
-        assert_eq!(HomePose::ApPark3.codebase_dec_encoder_degrees(0.0), 90.0);
-        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(32.7), -6.0);
-        assert_eq!(HomePose::ApPark3.codebase_mech_ha_hours(-33.0), -6.0);
+        assert_eq!(
+            ApPark::ApPark3.codebase_dec_encoder_degrees(0.0),
+            Some(90.0)
+        );
+        assert_eq!(ApPark::ApPark3.codebase_mech_ha_hours(32.7), Some(-6.0));
+        assert_eq!(ApPark::ApPark3.codebase_mech_ha_hours(-33.0), Some(-6.0));
     }
 
     #[test]
-    fn home_pose_ap_park_4_dec_at_lat_32() {
+    fn ap_park_4_dec_at_lat_32() {
         // AP Park 4: OTA on east side of mount, level, facing the
         // anti-polar horizon (N: south horizon, S: north horizon).
         // Saddle east → mech_HA = −12. AP celestial dec:
@@ -834,21 +919,21 @@ mod tests {
         // reference at this mech_HA): `dec_enc = ∓(90 + |lat|)`
         // (sign opposite hemisphere).
         assert!(
-            (HomePose::ApPark4.codebase_dec_encoder_degrees(32.7) - (-122.7)).abs() < 1e-9,
-            "Park 4 N at 32.7°: got {}",
-            HomePose::ApPark4.codebase_dec_encoder_degrees(32.7)
+            (ApPark::ApPark4.codebase_dec_encoder_degrees(32.7).unwrap() - (-122.7)).abs() < 1e-9,
+            "Park 4 N at 32.7°: got {:?}",
+            ApPark::ApPark4.codebase_dec_encoder_degrees(32.7)
         );
         assert!(
-            (HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0) - 123.0).abs() < 1e-9,
-            "Park 4 S at −33°: got {}",
-            HomePose::ApPark4.codebase_dec_encoder_degrees(-33.0)
+            (ApPark::ApPark4.codebase_dec_encoder_degrees(-33.0).unwrap() - 123.0).abs() < 1e-9,
+            "Park 4 S at −33°: got {:?}",
+            ApPark::ApPark4.codebase_dec_encoder_degrees(-33.0)
         );
-        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(32.7), -12.0);
-        assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(-33.0), -12.0);
+        assert_eq!(ApPark::ApPark4.codebase_mech_ha_hours(32.7), Some(-12.0));
+        assert_eq!(ApPark::ApPark4.codebase_mech_ha_hours(-33.0), Some(-12.0));
     }
 
     #[test]
-    fn home_pose_ap_park_5_matches_ap_table_both_hemispheres() {
+    fn ap_park_5_matches_ap_table_both_hemispheres() {
         // AP Park 5 (APCC / AP V2 driver only): OTA on east side of
         // mount, level, facing the polar-side horizon (N: north,
         // S: south). Saddle east → mech_HA = −12. Natural-side dec
@@ -860,29 +945,35 @@ mod tests {
         // +461,815), saddle east, OTA at north horizon — matches AP
         // Park 5 N visually.
         assert!(
-            (HomePose::ApPark5.codebase_dec_encoder_degrees(32.7) - 57.3).abs() < 1e-9,
-            "Park 5 N at 32.7°: got {}",
-            HomePose::ApPark5.codebase_dec_encoder_degrees(32.7)
+            (ApPark::ApPark5.codebase_dec_encoder_degrees(32.7).unwrap() - 57.3).abs() < 1e-9,
+            "Park 5 N at 32.7°: got {:?}",
+            ApPark::ApPark5.codebase_dec_encoder_degrees(32.7)
         );
         assert!(
-            (HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0) - (-57.0)).abs() < 1e-9,
-            "Park 5 S at −33°: got {}",
-            HomePose::ApPark5.codebase_dec_encoder_degrees(-33.0)
+            (ApPark::ApPark5.codebase_dec_encoder_degrees(-33.0).unwrap() - (-57.0)).abs() < 1e-9,
+            "Park 5 S at −33°: got {:?}",
+            ApPark::ApPark5.codebase_dec_encoder_degrees(-33.0)
         );
-        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(32.7), -12.0);
-        assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(-33.0), -12.0);
+        assert_eq!(ApPark::ApPark5.codebase_mech_ha_hours(32.7), Some(-12.0));
+        assert_eq!(ApPark::ApPark5.codebase_mech_ha_hours(-33.0), Some(-12.0));
     }
 
     #[test]
-    fn home_pose_park1_park5_share_celestial_target_opposite_pier() {
+    fn ap_park_1_park5_share_celestial_target_opposite_pier() {
         // Park 1 (saddle west) and Park 5 (saddle east) point at the
         // same celestial coordinates (polar-side horizon) but on
         // opposite mechanical pier sides. The dec-encoder magnitudes
         // therefore differ by the "past the pole" offset:
         // `|natural| + |flipped| = |dec| + (180 − |dec|) = 180°`.
         for lat in [-45.0, -33.0, 32.7, 45.0] {
-            let p1 = HomePose::ApPark1.codebase_dec_encoder_degrees(lat).abs();
-            let p5 = HomePose::ApPark5.codebase_dec_encoder_degrees(lat).abs();
+            let p1 = ApPark::ApPark1
+                .codebase_dec_encoder_degrees(lat)
+                .unwrap()
+                .abs();
+            let p5 = ApPark::ApPark5
+                .codebase_dec_encoder_degrees(lat)
+                .unwrap()
+                .abs();
             assert!(
                 (p1 + p5 - 180.0).abs() < 1e-9,
                 "lat {lat}: |p1| {p1}, |p5| {p5}, sum {} (expected 180)",
@@ -892,7 +983,7 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_park4_and_park5_share_pier_opposite_celestial_dec() {
+    fn ap_park_4_and_park5_share_pier_opposite_celestial_dec() {
         // Park 4 (OTA facing anti-polar horizon) and Park 5 (OTA
         // facing polar-side horizon) are on the same mechanical pier
         // (East, `mech_HA = −12`), and their celestial Decs are equal
@@ -903,10 +994,16 @@ mod tests {
         // encoder values are equal in magnitude with opposite signs
         // iff one is past-pole and the other is not.
         for lat in [-45.0, -33.0, 32.7, 45.0] {
-            assert_eq!(HomePose::ApPark4.codebase_mech_ha_hours(lat), -12.0);
-            assert_eq!(HomePose::ApPark5.codebase_mech_ha_hours(lat), -12.0);
-            let p4_abs = HomePose::ApPark4.codebase_dec_encoder_degrees(lat).abs();
-            let p5_abs = HomePose::ApPark5.codebase_dec_encoder_degrees(lat).abs();
+            assert_eq!(ApPark::ApPark4.codebase_mech_ha_hours(lat), Some(-12.0));
+            assert_eq!(ApPark::ApPark5.codebase_mech_ha_hours(lat), Some(-12.0));
+            let p4_abs = ApPark::ApPark4
+                .codebase_dec_encoder_degrees(lat)
+                .unwrap()
+                .abs();
+            let p5_abs = ApPark::ApPark5
+                .codebase_dec_encoder_degrees(lat)
+                .unwrap()
+                .abs();
             assert!(
                 (p4_abs + p5_abs - 180.0).abs() < 1e-9,
                 "lat {lat}: |p4| {p4_abs}, |p5| {p5_abs}"
@@ -915,36 +1012,75 @@ mod tests {
     }
 
     #[test]
-    fn home_pose_round_trips_through_mount_config_json() {
-        // None round-trips as the missing/null field.
-        let cfg = MountConfig {
-            home_pose: None,
-            ..MountConfig::default()
-        };
-        let json = serde_json::to_string(&cfg).expect("serialise");
-        let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
-        assert_eq!(back.home_pose, None, "None round trip");
-
-        // Every AP park variant round-trips through Some(...).
+    fn unpark_from_ap_position_round_trips_through_mount_config_json() {
+        // Every AP park variant round-trips through the required field.
         for pose in [
-            HomePose::ApPark1,
-            HomePose::ApPark2,
-            HomePose::ApPark3,
-            HomePose::ApPark4,
-            HomePose::ApPark5,
+            ApPark::ApPark0,
+            ApPark::ApPark1,
+            ApPark::ApPark2,
+            ApPark::ApPark3,
+            ApPark::ApPark4,
+            ApPark::ApPark5,
         ] {
             let cfg = MountConfig {
-                home_pose: Some(pose),
+                unpark_from_ap_position: pose,
                 ..MountConfig::default()
             };
             let json = serde_json::to_string(&cfg).expect("serialise");
             let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
-            assert_eq!(back.home_pose, Some(pose), "round trip for {pose:?}");
+            assert_eq!(
+                back.unpark_from_ap_position, pose,
+                "round trip for {pose:?}"
+            );
         }
     }
 
     #[test]
-    fn mount_config_deserialises_missing_home_pose_as_none() {
+    fn preferred_ap_park_round_trips_each_slew_target() {
+        // `ap_park_0` is excluded — it is rejected at deserialize time
+        // (covered by `preferred_ap_park_rejects_ap_park_0`).
+        for pose in [
+            ApPark::ApPark1,
+            ApPark::ApPark2,
+            ApPark::ApPark3,
+            ApPark::ApPark4,
+            ApPark::ApPark5,
+        ] {
+            let cfg = MountConfig {
+                preferred_ap_park: pose,
+                ..MountConfig::default()
+            };
+            let json = serde_json::to_string(&cfg).expect("serialise");
+            let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(back.preferred_ap_park, pose, "round trip for {pose:?}");
+        }
+    }
+
+    #[test]
+    fn preferred_ap_park_rejects_ap_park_0() {
+        // "Current position" is not a slew target — `preferred_ap_park:
+        // "ap_park_0"` must fail at config-load time, not silently at
+        // the first `Park()`.
+        let json = r#"{
+            "name": "T",
+            "unique_id": "t-001",
+            "description": "T",
+            "site_latitude_deg": 0.0,
+            "site_longitude_deg": 0.0,
+            "preferred_ap_park": "ap_park_0"
+        }"#;
+        let err = serde_json::from_str::<MountConfig>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("ap_park_0"),
+            "error should name the rejected value: {err}"
+        );
+    }
+
+    #[test]
+    fn mount_config_deserialises_missing_unpark_fields_as_ship_defaults() {
+        // Pre-rename config files (and any file omitting the new keys)
+        // load cleanly: `unpark_from_ap_position` defaults to the safe
+        // `ap_park_0`, `preferred_ap_park` to `ap_park_3`.
         let json = r#"{
             "name": "T",
             "unique_id": "t-001",
@@ -953,7 +1089,8 @@ mod tests {
             "site_longitude_deg": 0.0
         }"#;
         let m: MountConfig = serde_json::from_str(json).expect("deserialise");
-        assert_eq!(m.home_pose, None);
+        assert_eq!(m.unpark_from_ap_position, ApPark::ApPark0);
+        assert_eq!(m.preferred_ap_park, ApPark::ApPark3);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -13,7 +13,7 @@ pub mod mount_device;
 pub mod transport;
 
 pub use config::{
-    load_config, Config, FlipPolicy, HomePose, MountConfig, ServerConfig, TrackingRateName,
+    load_config, ApPark, Config, FlipPolicy, MountConfig, ServerConfig, TrackingRateName,
     TransportConfig, UdpConfig, UsbConfig, MAX_FLIP_RANGE_HOURS,
 };
 pub use error::{Result, StarAdvError};

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -8,7 +8,11 @@
 //!
 //! ## Submodule layout
 //!
-//! - [`device`] — `impl Device for MountDevice` (connect/description).
+//! - [`actions`] — the three driver-specific ASCOM `Action` handlers
+//!   (`SetUnparkFromApPosition`, `SetPreferredApPark`,
+//!   `UnparkFromApPosition`) dispatched from `device`'s `action`.
+//! - [`device`] — `impl Device for MountDevice` (connect/description,
+//!   `SupportedActions` + `Action` dispatch).
 //! - [`telescope`] — `impl Telescope for MountDevice` (the ASCOM
 //!   surface: coordinate reads, slew/sync/park, side-of-pier,
 //!   pulse-guide).
@@ -34,6 +38,7 @@ use crate::codec::SkywatcherCodec;
 use crate::config::MountConfig;
 use crate::manager::MountManager;
 
+mod actions;
 mod device;
 mod inherent;
 mod park_persistence;

--- a/services/star-adventurer-gti/src/mount_device/actions.rs
+++ b/services/star-adventurer-gti/src/mount_device/actions.rs
@@ -1,0 +1,203 @@
+//! Driver-specific ASCOM `Action` handlers for [`MountDevice`].
+//!
+//! The standard ASCOM Telescope interface has no concept of an
+//! "unpark from a named physical pose," so the three operations that
+//! the design's [§Unpark from AP position] section defines are exposed
+//! as vendor `Action(name, parameters)` calls, advertised through
+//! `SupportedActions`. The `impl Device` block in [`super::device`]
+//! dispatches to the handlers here.
+//!
+//! All three take the single `parameters` string as an
+//! `ap_park_0..ap_park_5` token (see [`parse_ap_park`]). The two
+//! persisting Actions (`SetUnparkFromApPosition`, `SetPreferredApPark`)
+//! refuse when the driver was started without `--config`, mirroring the
+//! `SetPark` capability gate — there is nowhere to persist to. The
+//! recovery Action (`UnparkFromApPosition`) writes no config and does
+//! not need a config path.
+//!
+//! [§Unpark from AP position]: ../../../../docs/services/star-adventurer-gti.md#unpark-from-ap-position
+
+use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
+
+use crate::config::ApPark;
+
+use super::park_persistence::write_mount_fields_to_config;
+use super::MountDevice;
+
+/// `SupportedActions` entry: persist a new `unpark_from_ap_position`.
+pub(super) const ACTION_SET_UNPARK_FROM_AP_POSITION: &str = "SetUnparkFromApPosition";
+/// `SupportedActions` entry: persist a new `preferred_ap_park`.
+pub(super) const ACTION_SET_PREFERRED_AP_PARK: &str = "SetPreferredApPark";
+/// `SupportedActions` entry: recovery unpark from a named physical pose.
+pub(super) const ACTION_UNPARK_FROM_AP_POSITION: &str = "UnparkFromApPosition";
+
+/// The driver-specific Action names, in `SupportedActions` order.
+pub(super) const SUPPORTED_ACTIONS: [&str; 3] = [
+    ACTION_SET_UNPARK_FROM_AP_POSITION,
+    ACTION_SET_PREFERRED_AP_PARK,
+    ACTION_UNPARK_FROM_AP_POSITION,
+];
+
+/// Parse an `Action` parameter string into an [`ApPark`]. Accepts the
+/// six `ap_park_N` tokens (whitespace-trimmed); anything else is an
+/// `INVALID_VALUE`.
+fn parse_ap_park(parameter: &str) -> ASCOMResult<ApPark> {
+    match parameter.trim() {
+        "ap_park_0" => Ok(ApPark::ApPark0),
+        "ap_park_1" => Ok(ApPark::ApPark1),
+        "ap_park_2" => Ok(ApPark::ApPark2),
+        "ap_park_3" => Ok(ApPark::ApPark3),
+        "ap_park_4" => Ok(ApPark::ApPark4),
+        "ap_park_5" => Ok(ApPark::ApPark5),
+        other => Err(ASCOMError::new(
+            ASCOMErrorCode::INVALID_VALUE,
+            format!("unknown AP park {other:?}; expected one of ap_park_0..ap_park_5"),
+        )),
+    }
+}
+
+/// Canonical `ap_park_N` string for an [`ApPark`] — the persisted JSON
+/// value and the Action return string.
+fn ap_park_str(park: ApPark) -> &'static str {
+    match park {
+        ApPark::ApPark0 => "ap_park_0",
+        ApPark::ApPark1 => "ap_park_1",
+        ApPark::ApPark2 => "ap_park_2",
+        ApPark::ApPark3 => "ap_park_3",
+        ApPark::ApPark4 => "ap_park_4",
+        ApPark::ApPark5 => "ap_park_5",
+    }
+}
+
+impl MountDevice {
+    /// Persist `key = value` to the on-disk config via the atomic-rename
+    /// helper, off the async runtime. Both persisting Actions route
+    /// through here; the caller has already verified `config_file_path`
+    /// is `Some`.
+    async fn persist_mount_ap_park(&self, key: &'static str, park: ApPark) -> ASCOMResult<()> {
+        let path = self.config_file_path.as_ref().ok_or_else(|| {
+            ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                format!("{key} requires the driver to be started with --config <path>"),
+            )
+        })?;
+        let path = path.clone();
+        let value = serde_json::Value::String(ap_park_str(park).to_string());
+        tokio::task::spawn_blocking(move || write_mount_fields_to_config(&path, &[(key, value)]))
+            .await
+            .map_err(|e| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    format!("{key} write task join error: {e}"),
+                )
+            })?
+            .map_err(ASCOMError::from)
+    }
+
+    /// `SetUnparkFromApPosition(park)` — persist a new
+    /// `unpark_from_ap_position`. Lazy: the value takes effect on the
+    /// *next* fresh-power-up auto-seed (`seed_after_connect` re-reads it
+    /// from disk); the current session's encoder is left untouched.
+    /// Operators wanting an immediate apply use `UnparkFromApPosition`.
+    pub(super) async fn handle_set_unpark_from_ap_position(
+        &self,
+        parameter: &str,
+    ) -> ASCOMResult<String> {
+        let park = parse_ap_park(parameter)?;
+        self.persist_mount_ap_park("unpark_from_ap_position", park)
+            .await?;
+        tracing::debug!(
+            unpark_from_ap_position = ?park,
+            "SetUnparkFromApPosition persisted to config file"
+        );
+        Ok(ap_park_str(park).to_string())
+    }
+
+    /// `SetPreferredApPark(park)` — set the `Park()` target. Rejects
+    /// `ap_park_0` (not a slew target). Persists to config and, when
+    /// connected, re-resolves the live park target so the change applies
+    /// to the next `Park()` without a reconnect; an explicit raw
+    /// `park_*_ticks` override still wins per-axis.
+    pub(super) async fn handle_set_preferred_ap_park(
+        &self,
+        parameter: &str,
+    ) -> ASCOMResult<String> {
+        let park = parse_ap_park(parameter)?;
+        if park == ApPark::ApPark0 {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_VALUE,
+                "preferred AP park cannot be ap_park_0 (\"current position\" is not a slew target)",
+            ));
+        }
+        self.persist_mount_ap_park("preferred_ap_park", park)
+            .await?;
+        // Re-resolve the live park target when connected so the change
+        // applies this session. `load_park_target_after_connect` re-reads
+        // the (just-persisted) value plus any raw `park_*_ticks` override
+        // from disk, so the raw-ticks-win rule holds. When disconnected
+        // the next connect resolves it.
+        if self.session.read().await.is_some() {
+            self.load_park_target_after_connect().await?;
+        }
+        tracing::debug!(preferred_ap_park = ?park, "SetPreferredApPark persisted to config file");
+        Ok(ap_park_str(park).to_string())
+    }
+
+    /// `UnparkFromApPosition(park)` — recovery unpark. The operator
+    /// asserts the OTA is physically at `park`; the driver makes the
+    /// firmware encoder match, *regardless* of the current encoder
+    /// state, then clears `AtPark`.
+    ///
+    /// Refuses when disconnected (`NOT_CONNECTED`), not parked, or
+    /// slewing (`INVALID_OPERATION`). For `ap_park_0` ("current
+    /// position") there is no encoder change — it is the standard
+    /// `Unpark()` end state. For `ap_park_1..ap_park_5` it runs the
+    /// [`MountDevice::reset_mount_encoders`] safe-stop-then-seed
+    /// sequence before clearing `AtPark`.
+    pub(super) async fn handle_unpark_from_ap_position(
+        &self,
+        parameter: &str,
+    ) -> ASCOMResult<String> {
+        let park = parse_ap_park(parameter)?;
+        self.ensure_connected().await?;
+        {
+            let state = self.state.read().await;
+            if !state.at_park {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "UnparkFromApPosition refused: mount is not parked",
+                ));
+            }
+            if state.slew_in_progress {
+                return Err(ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    "UnparkFromApPosition refused: slew in progress",
+                ));
+            }
+        }
+        if park == ApPark::ApPark0 {
+            // "Current position": no encoder change — equivalent to a
+            // standard `Unpark()`. The operator will plate-solve + sync.
+            tracing::debug!("UnparkFromApPosition(ap_park_0): clearing AtPark, no encoder change");
+        } else {
+            // The operator-confirmed physical pose: make the firmware
+            // encoder match it regardless of current state.
+            let (ra_ticks, dec_ticks) = self
+                .ap_park_target_ticks(park)
+                .await
+                .ok_or(ASCOMError::NOT_CONNECTED)?;
+            let guard = self.session.read().await;
+            let session = guard.as_ref().ok_or(ASCOMError::NOT_CONNECTED)?;
+            self.reset_mount_encoders(session, ra_ticks, dec_ticks)
+                .await?;
+            tracing::info!(
+                unpark_from_ap_position = ?park,
+                seeded_ra_ticks = ra_ticks,
+                seeded_dec_ticks = dec_ticks,
+                "UnparkFromApPosition reset firmware encoder to the named AP park"
+            );
+        }
+        self.state.write().await.at_park = false;
+        Ok(ap_park_str(park).to_string())
+    }
+}

--- a/services/star-adventurer-gti/src/mount_device/actions.rs
+++ b/services/star-adventurer-gti/src/mount_device/actions.rs
@@ -24,49 +24,50 @@ use crate::config::ApPark;
 use super::park_persistence::write_mount_fields_to_config;
 use super::MountDevice;
 
-/// `SupportedActions` entry: persist a new `unpark_from_ap_position`.
-pub(super) const ACTION_SET_UNPARK_FROM_AP_POSITION: &str = "SetUnparkFromApPosition";
-/// `SupportedActions` entry: persist a new `preferred_ap_park`.
-pub(super) const ACTION_SET_PREFERRED_AP_PARK: &str = "SetPreferredApPark";
-/// `SupportedActions` entry: recovery unpark from a named physical pose.
-pub(super) const ACTION_UNPARK_FROM_AP_POSITION: &str = "UnparkFromApPosition";
+/// The driver-specific ASCOM vendor Actions. Owns its `SupportedActions`
+/// names and the name→variant parsing the `Action` dispatch in
+/// [`super::device`] uses, so the name set lives in exactly one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ApParkAction {
+    SetUnparkFromApPosition,
+    SetPreferredApPark,
+    UnparkFromApPosition,
+}
 
-/// The driver-specific Action names, in `SupportedActions` order.
-pub(super) const SUPPORTED_ACTIONS: [&str; 3] = [
-    ACTION_SET_UNPARK_FROM_AP_POSITION,
-    ACTION_SET_PREFERRED_AP_PARK,
-    ACTION_UNPARK_FROM_AP_POSITION,
-];
+impl ApParkAction {
+    /// Every variant, in `SupportedActions` order.
+    pub(super) const ALL: [Self; 3] = [
+        Self::SetUnparkFromApPosition,
+        Self::SetPreferredApPark,
+        Self::UnparkFromApPosition,
+    ];
 
-/// Parse an `Action` parameter string into an [`ApPark`]. Accepts the
-/// six `ap_park_N` tokens (whitespace-trimmed); anything else is an
-/// `INVALID_VALUE`.
-fn parse_ap_park(parameter: &str) -> ASCOMResult<ApPark> {
-    match parameter.trim() {
-        "ap_park_0" => Ok(ApPark::ApPark0),
-        "ap_park_1" => Ok(ApPark::ApPark1),
-        "ap_park_2" => Ok(ApPark::ApPark2),
-        "ap_park_3" => Ok(ApPark::ApPark3),
-        "ap_park_4" => Ok(ApPark::ApPark4),
-        "ap_park_5" => Ok(ApPark::ApPark5),
-        other => Err(ASCOMError::new(
-            ASCOMErrorCode::INVALID_VALUE,
-            format!("unknown AP park {other:?}; expected one of ap_park_0..ap_park_5"),
-        )),
+    /// The ASCOM action name.
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Self::SetUnparkFromApPosition => "SetUnparkFromApPosition",
+            Self::SetPreferredApPark => "SetPreferredApPark",
+            Self::UnparkFromApPosition => "UnparkFromApPosition",
+        }
+    }
+
+    /// Resolve an ASCOM action name; `None` for an unrecognised name
+    /// (the caller maps that to `ACTION_NOT_IMPLEMENTED`).
+    pub(super) fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|action| action.name() == name)
     }
 }
 
-/// Canonical `ap_park_N` string for an [`ApPark`] — the persisted JSON
-/// value and the Action return string.
-fn ap_park_str(park: ApPark) -> &'static str {
-    match park {
-        ApPark::ApPark0 => "ap_park_0",
-        ApPark::ApPark1 => "ap_park_1",
-        ApPark::ApPark2 => "ap_park_2",
-        ApPark::ApPark3 => "ap_park_3",
-        ApPark::ApPark4 => "ap_park_4",
-        ApPark::ApPark5 => "ap_park_5",
-    }
+/// Parse an `Action`'s single `parameters` string into an [`ApPark`]
+/// (whitespace-trimmed), mapping an unrecognised token to
+/// `INVALID_VALUE`. The token↔variant mapping itself is canonical on
+/// [`ApPark`] (`FromStr` / [`ApPark::as_str`]); this only adapts it to
+/// the ASCOM error type.
+fn parse_ap_park(parameter: &str) -> ASCOMResult<ApPark> {
+    parameter
+        .trim()
+        .parse::<ApPark>()
+        .map_err(|e| ASCOMError::new(ASCOMErrorCode::INVALID_VALUE, e.to_string()))
 }
 
 impl MountDevice {
@@ -82,7 +83,7 @@ impl MountDevice {
             )
         })?;
         let path = path.clone();
-        let value = serde_json::Value::String(ap_park_str(park).to_string());
+        let value = serde_json::Value::String(park.as_str().to_string());
         tokio::task::spawn_blocking(move || write_mount_fields_to_config(&path, &[(key, value)]))
             .await
             .map_err(|e| {
@@ -110,7 +111,7 @@ impl MountDevice {
             unpark_from_ap_position = ?park,
             "SetUnparkFromApPosition persisted to config file"
         );
-        Ok(ap_park_str(park).to_string())
+        Ok(park.as_str().to_string())
     }
 
     /// `SetPreferredApPark(park)` — set the `Park()` target. Rejects
@@ -141,7 +142,7 @@ impl MountDevice {
             self.load_park_target_after_connect(&cfg).await?;
         }
         tracing::debug!(preferred_ap_park = ?park, "SetPreferredApPark persisted to config file");
-        Ok(ap_park_str(park).to_string())
+        Ok(park.as_str().to_string())
     }
 
     /// `UnparkFromApPosition(park)` — recovery unpark. The operator
@@ -199,6 +200,6 @@ impl MountDevice {
             );
         }
         self.state.write().await.at_park = false;
-        Ok(ap_park_str(park).to_string())
+        Ok(park.as_str().to_string())
     }
 }

--- a/services/star-adventurer-gti/src/mount_device/actions.rs
+++ b/services/star-adventurer-gti/src/mount_device/actions.rs
@@ -132,12 +132,13 @@ impl MountDevice {
         self.persist_mount_ap_park("preferred_ap_park", park)
             .await?;
         // Re-resolve the live park target when connected so the change
-        // applies this session. `load_park_target_after_connect` re-reads
-        // the (just-persisted) value plus any raw `park_*_ticks` override
+        // applies this session. `read_connect_config` re-reads the
+        // (just-persisted) value plus any raw `park_*_ticks` override
         // from disk, so the raw-ticks-win rule holds. When disconnected
         // the next connect resolves it.
         if self.session.read().await.is_some() {
-            self.load_park_target_after_connect().await?;
+            let cfg = self.read_connect_config().await?;
+            self.load_park_target_after_connect(&cfg).await?;
         }
         tracing::debug!(preferred_ap_park = ?park, "SetPreferredApPark persisted to config file");
         Ok(ap_park_str(park).to_string())

--- a/services/star-adventurer-gti/src/mount_device/device.rs
+++ b/services/star-adventurer-gti/src/mount_device/device.rs
@@ -3,15 +3,19 @@
 //! Mostly trivial getters that pass through to [`MountConfig`]; the
 //! interesting method is `set_connected` which drives the shared
 //! transport's session refcount and, on a 0→1 transition, runs the
-//! post-acquire fallible hooks (`seed_home_pose_after_connect` then
+//! post-acquire fallible hooks (`seed_after_connect` then
 //! `load_park_target_after_connect`) with structural rollback via
 //! `session.close().await` on any error.
 
 use ascom_alpaca::api::Device;
-use ascom_alpaca::ASCOMResult;
+use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
 use async_trait::async_trait;
 use tracing::debug;
 
+use super::actions::{
+    ACTION_SET_PREFERRED_AP_PARK, ACTION_SET_UNPARK_FROM_AP_POSITION,
+    ACTION_UNPARK_FROM_AP_POSITION, SUPPORTED_ACTIONS,
+};
 use super::MountDevice;
 
 #[async_trait]
@@ -49,22 +53,19 @@ impl Device for MountDevice {
                     .await
                     .map_err(Self::ascom_session_err)?;
                 // Post-acquire fallible work. Order matters:
-                // `seed_home_pose_after_connect` runs FIRST so the
-                // snapshot reflects the home_pose's logical encoder
+                // `seed_after_connect` runs FIRST so the snapshot
+                // reflects the configured AP park's logical encoder
                 // values before `load_park_target_after_connect`
-                // picks its default park target from the snapshot.
-                // Otherwise the handshake's pre-seed reading (firmware
-                // zero on a fresh power-up) would become the park
-                // fallback. On any failure, `session.close().await`
-                // synchronously closes — propagating its result so
-                // the user sees a real error instead of a swallowed
-                // warning (the pre-migration "rollback-disconnect
-                // failed" log branch is gone).
-                if let Err(e) = self.seed_home_pose_after_connect(&session).await {
+                // resolves its park target. On any failure,
+                // `session.close().await` synchronously closes —
+                // propagating its result so the user sees a real error
+                // instead of a swallowed warning (the pre-migration
+                // "rollback-disconnect failed" log branch is gone).
+                if let Err(e) = self.seed_after_connect(&session).await {
                     session.close().await.map_err(Self::ascom_transport_err)?;
                     return Err(e);
                 }
-                if let Err(e) = self.load_park_target_after_connect(&session).await {
+                if let Err(e) = self.load_park_target_after_connect().await {
                     session.close().await.map_err(Self::ascom_transport_err)?;
                     return Err(e);
                 }
@@ -93,5 +94,32 @@ impl Device for MountDevice {
 
     async fn driver_version(&self) -> ASCOMResult<String> {
         Ok(env!("CARGO_PKG_VERSION").to_string())
+    }
+
+    /// The driver-specific vendor Actions. See [`super::actions`] and
+    /// the design doc's
+    /// [§Custom Actions for runtime control](../../../../docs/services/star-adventurer-gti.md#custom-actions-for-runtime-control).
+    async fn supported_actions(&self) -> ASCOMResult<Vec<String>> {
+        Ok(SUPPORTED_ACTIONS.iter().map(|s| (*s).to_string()).collect())
+    }
+
+    /// Dispatch a vendor `Action`. Each handler takes the single
+    /// `parameters` string as an `ap_park_0..ap_park_5` token. An
+    /// unrecognised name returns `ACTION_NOT_IMPLEMENTED` per the ASCOM
+    /// `Action` contract.
+    async fn action(&self, action: String, parameters: String) -> ASCOMResult<String> {
+        match action.as_str() {
+            ACTION_SET_UNPARK_FROM_AP_POSITION => {
+                self.handle_set_unpark_from_ap_position(&parameters).await
+            }
+            ACTION_SET_PREFERRED_AP_PARK => self.handle_set_preferred_ap_park(&parameters).await,
+            ACTION_UNPARK_FROM_AP_POSITION => {
+                self.handle_unpark_from_ap_position(&parameters).await
+            }
+            other => Err(ASCOMError::new(
+                ASCOMErrorCode::ACTION_NOT_IMPLEMENTED,
+                format!("unknown action {other:?}"),
+            )),
+        }
     }
 }

--- a/services/star-adventurer-gti/src/mount_device/device.rs
+++ b/services/star-adventurer-gti/src/mount_device/device.rs
@@ -52,20 +52,32 @@ impl Device for MountDevice {
                     .acquire()
                     .await
                     .map_err(Self::ascom_session_err)?;
-                // Post-acquire fallible work. Order matters:
-                // `seed_after_connect` runs FIRST so the snapshot
-                // reflects the configured AP park's logical encoder
-                // values before `load_park_target_after_connect`
-                // resolves its park target. On any failure,
-                // `session.close().await` synchronously closes —
-                // propagating its result so the user sees a real error
-                // instead of a swallowed warning (the pre-migration
-                // "rollback-disconnect failed" log branch is gone).
-                if let Err(e) = self.seed_after_connect(&session).await {
+                // Post-acquire fallible work. The connect-time config is
+                // read once here and threaded into both hooks so neither
+                // re-reads the file. Order matters: `seed_after_connect`
+                // runs FIRST so the snapshot reflects the configured AP
+                // park's logical encoder values before
+                // `load_park_target_after_connect` resolves its park
+                // target. On any failure, `session.close().await`
+                // synchronously closes — propagating its result so the
+                // user sees a real error instead of a swallowed warning
+                // (the pre-migration "rollback-disconnect failed" log
+                // branch is gone).
+                let connect_cfg = match self.read_connect_config().await {
+                    Ok(cfg) => cfg,
+                    Err(e) => {
+                        session.close().await.map_err(Self::ascom_transport_err)?;
+                        return Err(e);
+                    }
+                };
+                if let Err(e) = self
+                    .seed_after_connect(&session, connect_cfg.unpark_from_ap_position)
+                    .await
+                {
                     session.close().await.map_err(Self::ascom_transport_err)?;
                     return Err(e);
                 }
-                if let Err(e) = self.load_park_target_after_connect().await {
+                if let Err(e) = self.load_park_target_after_connect(&connect_cfg).await {
                     session.close().await.map_err(Self::ascom_transport_err)?;
                     return Err(e);
                 }

--- a/services/star-adventurer-gti/src/mount_device/device.rs
+++ b/services/star-adventurer-gti/src/mount_device/device.rs
@@ -12,10 +12,7 @@ use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
 use async_trait::async_trait;
 use tracing::debug;
 
-use super::actions::{
-    ACTION_SET_PREFERRED_AP_PARK, ACTION_SET_UNPARK_FROM_AP_POSITION,
-    ACTION_UNPARK_FROM_AP_POSITION, SUPPORTED_ACTIONS,
-};
+use super::actions::ApParkAction;
 use super::MountDevice;
 
 #[async_trait]
@@ -112,7 +109,10 @@ impl Device for MountDevice {
     /// the design doc's
     /// [§Custom Actions for runtime control](../../../../docs/services/star-adventurer-gti.md#custom-actions-for-runtime-control).
     async fn supported_actions(&self) -> ASCOMResult<Vec<String>> {
-        Ok(SUPPORTED_ACTIONS.iter().map(|s| (*s).to_string()).collect())
+        Ok(ApParkAction::ALL
+            .iter()
+            .map(|action| action.name().to_string())
+            .collect())
     }
 
     /// Dispatch a vendor `Action`. Each handler takes the single
@@ -120,17 +120,19 @@ impl Device for MountDevice {
     /// unrecognised name returns `ACTION_NOT_IMPLEMENTED` per the ASCOM
     /// `Action` contract.
     async fn action(&self, action: String, parameters: String) -> ASCOMResult<String> {
-        match action.as_str() {
-            ACTION_SET_UNPARK_FROM_AP_POSITION => {
+        match ApParkAction::from_name(&action) {
+            Some(ApParkAction::SetUnparkFromApPosition) => {
                 self.handle_set_unpark_from_ap_position(&parameters).await
             }
-            ACTION_SET_PREFERRED_AP_PARK => self.handle_set_preferred_ap_park(&parameters).await,
-            ACTION_UNPARK_FROM_AP_POSITION => {
+            Some(ApParkAction::SetPreferredApPark) => {
+                self.handle_set_preferred_ap_park(&parameters).await
+            }
+            Some(ApParkAction::UnparkFromApPosition) => {
                 self.handle_unpark_from_ap_position(&parameters).await
             }
-            other => Err(ASCOMError::new(
+            None => Err(ASCOMError::new(
                 ASCOMErrorCode::ACTION_NOT_IMPLEMENTED,
-                format!("unknown action {other:?}"),
+                format!("unknown action {action:?}"),
             )),
         }
     }

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -44,7 +44,7 @@ use crate::coordinates::{
 };
 use crate::error::StarAdvError;
 
-use super::park_persistence::{read_ap_park_field, read_park_from_config};
+use super::park_persistence::{read_connect_fields, MountConnectFields};
 use super::slew::{
     check_non_flip_ra_path, flip_slew_dec_delta, flip_slew_ra_delta, issue_slew_axis,
     stop_axis_and_wait, AXIS_STOP_TIMEOUT,
@@ -95,6 +95,21 @@ pub(super) fn validate_guide_rate(deg_per_sec: f64) -> ASCOMResult<f64> {
         ));
     }
     Ok(fraction)
+}
+
+/// Resolved connect-time config: the raw per-axis `park_*_ticks`
+/// overrides (`None` = fall through to the AP-park target) plus the
+/// effective `unpark_from_ap_position` / `preferred_ap_park` (the
+/// on-disk value, or the in-memory startup value when the key is absent
+/// or no config file is in use). Produced once per connect by
+/// [`MountDevice::read_connect_config`] and consumed by the seed +
+/// park-target hooks so neither re-reads the file.
+#[derive(Debug)]
+pub(super) struct ConnectConfig {
+    pub park_ra_ticks: Option<i32>,
+    pub park_dec_ticks: Option<i32>,
+    pub unpark_from_ap_position: ApPark,
+    pub preferred_ap_park: ApPark,
 }
 
 impl MountDevice {
@@ -324,32 +339,61 @@ impl MountDevice {
     /// malformed JSON, lost transport mid-load) can be rolled back by the
     /// caller without leaking the connection ref-count. See the design
     /// doc's §"Park lifecycle" for the resolution rules.
-    pub(super) async fn load_park_target_after_connect(&self) -> ASCOMResult<()> {
-        let (config_ra, config_dec) = if let Some(path) = self.config_file_path.clone() {
-            let result = tokio::task::spawn_blocking(move || read_park_from_config(&path))
-                .await
-                .map_err(|e| {
-                    ASCOMError::new(
-                        ASCOMErrorCode::INVALID_OPERATION,
-                        format!("park-config read task join error: {e}"),
-                    )
-                })?;
-            result.map_err(ASCOMError::from)?
-        } else {
-            (self.config.park_ra_ticks, self.config.park_dec_ticks)
+    /// Read the connect-time `mount.*` config fields in a single disk
+    /// read + parse (when started with `--config`), resolving each
+    /// AP-park field to the in-memory startup value when the key is
+    /// absent. For `Config::default()` runs (no config file) every field
+    /// comes straight from `self.config`. Called once per connect by
+    /// `set_connected` and re-used by both the seed and park-target
+    /// hooks; also re-run by `SetPreferredApPark` to re-resolve the live
+    /// target after a write.
+    pub(super) async fn read_connect_config(&self) -> ASCOMResult<ConnectConfig> {
+        let Some(path) = self.config_file_path.clone() else {
+            return Ok(ConnectConfig {
+                park_ra_ticks: self.config.park_ra_ticks,
+                park_dec_ticks: self.config.park_dec_ticks,
+                unpark_from_ap_position: self.config.unpark_from_ap_position,
+                preferred_ap_park: self.config.preferred_ap_park,
+            });
         };
+        let MountConnectFields {
+            park_ra_ticks,
+            park_dec_ticks,
+            unpark_from_ap_position,
+            preferred_ap_park,
+        } = tokio::task::spawn_blocking(move || read_connect_fields(&path))
+            .await
+            .map_err(|e| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    format!("connect-config read task join error: {e}"),
+                )
+            })?
+            .map_err(ASCOMError::from)?;
+        Ok(ConnectConfig {
+            park_ra_ticks,
+            park_dec_ticks,
+            unpark_from_ap_position: unpark_from_ap_position
+                .unwrap_or(self.config.unpark_from_ap_position),
+            preferred_ap_park: preferred_ap_park.unwrap_or(self.config.preferred_ap_park),
+        })
+    }
+
+    pub(super) async fn load_park_target_after_connect(
+        &self,
+        cfg: &ConnectConfig,
+    ) -> ASCOMResult<()> {
         // Fallback for any axis without a raw override: the
         // `preferred_ap_park` encoder pair, else (defensively) the live
         // snapshot. `seed_after_connect` ran first, so on a fresh
         // power-up the snapshot already reflects the seeded encoder.
-        let preferred = self.configured_preferred_ap_park().await?;
         let snap = self.manager.snapshot().await;
         let (fallback_ra, fallback_dec) = self
-            .ap_park_target_ticks(preferred)
+            .ap_park_target_ticks(cfg.preferred_ap_park)
             .await
             .unwrap_or((snap.ra.position_ticks, snap.dec.position_ticks));
-        let ra_target = config_ra.unwrap_or(fallback_ra);
-        let dec_target = config_dec.unwrap_or(fallback_dec);
+        let ra_target = cfg.park_ra_ticks.unwrap_or(fallback_ra);
+        let dec_target = cfg.park_dec_ticks.unwrap_or(fallback_dec);
         {
             let mut s = self.state.write().await;
             s.park_ra_ticks = Some(ra_target);
@@ -358,9 +402,9 @@ impl MountDevice {
         debug!(
             ra_target,
             dec_target,
-            from_config_ra = config_ra.is_some(),
-            from_config_dec = config_dec.is_some(),
-            preferred_ap_park = ?preferred,
+            from_config_ra = cfg.park_ra_ticks.is_some(),
+            from_config_dec = cfg.park_dec_ticks.is_some(),
+            preferred_ap_park = ?cfg.preferred_ap_park,
             from_file = self.config_file_path.is_some(),
             "park target loaded"
         );
@@ -438,50 +482,6 @@ impl MountDevice {
         Ok(())
     }
 
-    /// Resolve a `mount.<key>` AP-park field for use this connect.
-    ///
-    /// Read fresh from the on-disk config file when the driver was
-    /// started with `--config` (so a `SetUnparkFromApPosition` /
-    /// `SetPreferredApPark` write — or an operator hand-edit — applies
-    /// on the next connect without a driver restart), falling back to
-    /// `fallback` (the in-memory startup value) when the key is absent
-    /// or no config file is in use. Mirrors
-    /// [`Self::load_park_target_after_connect`]'s disk read.
-    async fn configured_ap_park(&self, key: &'static str, fallback: ApPark) -> ASCOMResult<ApPark> {
-        let Some(path) = self.config_file_path.clone() else {
-            return Ok(fallback);
-        };
-        let from_disk = tokio::task::spawn_blocking(move || read_ap_park_field(&path, key))
-            .await
-            .map_err(|e| {
-                ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    format!("{key} config read task join error: {e}"),
-                )
-            })?
-            .map_err(ASCOMError::from)?;
-        Ok(from_disk.unwrap_or(fallback))
-    }
-
-    /// The `unpark_from_ap_position` in effect for this connect (disk,
-    /// falling back to the startup value). Used by the fresh-power-up
-    /// auto-seed.
-    pub(super) async fn configured_unpark_from_ap_position(&self) -> ASCOMResult<ApPark> {
-        self.configured_ap_park(
-            "unpark_from_ap_position",
-            self.config.unpark_from_ap_position,
-        )
-        .await
-    }
-
-    /// The `preferred_ap_park` in effect for this connect (disk,
-    /// falling back to the startup value). Used as the `Park()` target
-    /// when no raw `park_*_ticks` override is set.
-    pub(super) async fn configured_preferred_ap_park(&self) -> ASCOMResult<ApPark> {
-        self.configured_ap_park("preferred_ap_park", self.config.preferred_ap_park)
-            .await
-    }
-
     /// Encoder `(ra, dec)` tick pair for an AP park, or [`None`] when
     /// the park has no codebase mapping (`ap_park_0`) or transport
     /// parameters are unavailable (not connected). Resolves against the
@@ -529,13 +529,13 @@ impl MountDevice {
     pub(super) async fn seed_after_connect(
         &self,
         session: &Session<SkywatcherCodec>,
+        unpark_from_ap_position: ApPark,
     ) -> ASCOMResult<()> {
-        let configured = self.configured_unpark_from_ap_position().await?;
         // `ap_park_0` ("current position") has no codebase encoder
         // mapping — trust the firmware encoder as-is and emit no logs.
         let (Some(mech_ha), Some(dec_deg)) = (
-            configured.codebase_mech_ha_hours(self.config.site_latitude_deg),
-            configured.codebase_dec_encoder_degrees(self.config.site_latitude_deg),
+            unpark_from_ap_position.codebase_mech_ha_hours(self.config.site_latitude_deg),
+            unpark_from_ap_position.codebase_dec_encoder_degrees(self.config.site_latitude_deg),
         ) else {
             return Ok(());
         };
@@ -548,7 +548,7 @@ impl MountDevice {
         info!(
             pre_seed_ra_ticks = snap.ra.position_ticks,
             pre_seed_dec_ticks = snap.dec.position_ticks,
-            unpark_from_ap_position = ?configured,
+            unpark_from_ap_position = ?unpark_from_ap_position,
             "pre-seed encoder snapshot at connect"
         );
         if snap.ra.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
@@ -570,7 +570,7 @@ impl MountDevice {
         info!(
             seeded_ra_ticks = ra_ticks,
             seeded_dec_ticks = dec_ticks,
-            unpark_from_ap_position = ?configured,
+            unpark_from_ap_position = ?unpark_from_ap_position,
             "seeded firmware encoder for unpark_from_ap_position"
         );
         Ok(())

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -19,7 +19,7 @@
 //!   (ASCOM-mapped wrapper over [`super::slew::stop_axis_and_wait`]),
 //!   [`MountDevice::await_slew_complete`] (synchronous-slew polling).
 //! - **Post-connect lifecycle**:
-//!   [`MountDevice::seed_home_pose_after_connect`],
+//!   [`MountDevice::seed_after_connect`],
 //!   [`MountDevice::load_park_target_after_connect`].
 //! - **Slew planner**:
 //!   [`MountDevice::execute_slew_with_explicit_side`] — the shared
@@ -36,6 +36,7 @@ use skywatcher_motor_protocol::{Axis, Command};
 use tracing::{debug, info};
 
 use crate::codec::SkywatcherCodec;
+use crate::config::ApPark;
 use crate::coordinates::{
     dec_degrees_to_ticks, fold_ha, fold_to_canonical_band, local_sidereal_time_hours,
     mechanical_ha_to_ra_ticks, ra_to_mechanical_ha, side_of_pier as side_of_pier_calc,
@@ -43,7 +44,7 @@ use crate::coordinates::{
 };
 use crate::error::StarAdvError;
 
-use super::park_persistence::read_park_from_config;
+use super::park_persistence::{read_ap_park_field, read_park_from_config};
 use super::slew::{
     check_non_flip_ra_path, flip_slew_dec_delta, flip_slew_ra_delta, issue_slew_axis,
     stop_axis_and_wait, AXIS_STOP_TIMEOUT,
@@ -60,8 +61,9 @@ use super::{pre_flip_side_for_latitude, MountDevice};
 const SYNC_SLEW_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Maximum absolute encoder reading at connect that
-/// [`MountDevice::seed_home_pose_after_connect`] still treats as
-/// "fresh power-up" and applies the `home_pose` seed to. The
+/// [`MountDevice::seed_after_connect`] still treats as
+/// "fresh power-up" and applies the `unpark_from_ap_position` seed to.
+/// The
 /// Sky-Watcher firmware does not always read exactly `0` after a
 /// power-cycle — empirically the validation GTi reports `dec = −1`
 /// on connect, a single-tick initialisation artifact (≈ 0.4″ at the
@@ -297,30 +299,32 @@ impl MountDevice {
     /// Post-connect park-target load. Source priority, per axis:
     ///
     /// 1. `mount.park_*_ticks` from the **on-disk** config file when one
-    ///    was supplied via `--config`. Reading fresh from disk on every
-    ///    connect means a successful `SetPark` followed by
-    ///    disconnect/reconnect picks up the new target, and an operator
-    ///    hand-edit between connects takes effect.
-    /// 2. `self.config.park_*_ticks` for `Config::default()` runs (no
-    ///    config file) — these never change in-process because
-    ///    `SetPark` is unreachable in that mode.
-    /// 3. The **current** firmware encoder reading from the snapshot
-    ///    when neither of the above provided a value.
-    ///    `seed_home_pose_after_connect` runs first in `set_connected`
-    ///    so the snapshot already reflects the home_pose's logical
-    ///    encoder values on a fresh power-up; a mid-session reconnect
-    ///    (firmware encoder non-zero) leaves the snapshot at the
-    ///    handshake reading, which is the "park where the OTA already
-    ///    is" semantic operators expect from a reconnect.
+    ///    was supplied via `--config` (or `self.config.park_*_ticks` for
+    ///    `Config::default()` runs). The raw-encoder override: an
+    ///    operator who pinned a specific tick pair via `SetPark` or a
+    ///    hand-edit. Per-axis — one axis can be pinned while the other
+    ///    falls through. Reading fresh from disk means a `SetPark`
+    ///    followed by disconnect/reconnect picks up the new target.
+    /// 2. The `preferred_ap_park` encoder pair (the design's `Park()`
+    ///    target), resolved from the configured AP park, the site
+    ///    latitude, and the handshake counts-per-revolution. This is the
+    ///    default for any install that hasn't pinned raw ticks;
+    ///    `preferred_ap_park` ships as `ap_park_3`.
+    /// 3. The current firmware encoder reading from the snapshot, as a
+    ///    defensive fallback only when `preferred_ap_park` has no
+    ///    encoder mapping (`ap_park_0`, which deserialize rejects) or
+    ///    transport parameters are somehow unavailable.
+    ///
+    /// `seed_after_connect` runs first in `set_connected`, so on a fresh
+    /// power-up the snapshot already reflects the seeded encoder; the
+    /// defensive snapshot fallback therefore still lands on the pose the
+    /// operator powered up at if it is ever reached.
     ///
     /// Extracted from `set_connected` so a failure here (file missing,
     /// malformed JSON, lost transport mid-load) can be rolled back by the
     /// caller without leaking the connection ref-count. See the design
     /// doc's §"Park lifecycle" for the resolution rules.
-    pub(super) async fn load_park_target_after_connect(
-        &self,
-        _session: &Session<SkywatcherCodec>,
-    ) -> ASCOMResult<()> {
+    pub(super) async fn load_park_target_after_connect(&self) -> ASCOMResult<()> {
         let (config_ra, config_dec) = if let Some(path) = self.config_file_path.clone() {
             let result = tokio::task::spawn_blocking(move || read_park_from_config(&path))
                 .await
@@ -334,16 +338,18 @@ impl MountDevice {
         } else {
             (self.config.park_ra_ticks, self.config.park_dec_ticks)
         };
-        // Read the live snapshot rather than `params.ra_at_handshake_ticks`:
-        // `seed_home_pose_after_connect` runs before this function and
-        // mutates the snapshot when the operator has configured a
-        // `home_pose`, so the snapshot is the source-of-truth for the
-        // post-seed encoder state. Using the pre-seed handshake reading
-        // would default the park target to firmware-zero (mech_HA = 0h,
-        // mech_dec = 0°) — not the home_pose the operator powered up at.
+        // Fallback for any axis without a raw override: the
+        // `preferred_ap_park` encoder pair, else (defensively) the live
+        // snapshot. `seed_after_connect` ran first, so on a fresh
+        // power-up the snapshot already reflects the seeded encoder.
+        let preferred = self.configured_preferred_ap_park().await?;
         let snap = self.manager.snapshot().await;
-        let ra_target = config_ra.unwrap_or(snap.ra.position_ticks);
-        let dec_target = config_dec.unwrap_or(snap.dec.position_ticks);
+        let (fallback_ra, fallback_dec) = self
+            .ap_park_target_ticks(preferred)
+            .await
+            .unwrap_or((snap.ra.position_ticks, snap.dec.position_ticks));
+        let ra_target = config_ra.unwrap_or(fallback_ra);
+        let dec_target = config_dec.unwrap_or(fallback_dec);
         {
             let mut s = self.state.write().await;
             s.park_ra_ticks = Some(ra_target);
@@ -354,48 +360,183 @@ impl MountDevice {
             dec_target,
             from_config_ra = config_ra.is_some(),
             from_config_dec = config_dec.is_some(),
+            preferred_ap_park = ?preferred,
             from_file = self.config_file_path.is_some(),
             "park target loaded"
         );
         Ok(())
     }
 
-    /// Post-connect encoder seed for the operator's configured `HomePose`.
+    /// Safe-stop-then-seed the firmware encoder counter to the given
+    /// `(ra, dec)` tick pair. Wraps the bare `:E1` / `:E2` writes in a
+    /// stop envelope so the operation is correct regardless of in-flight
+    /// firmware state (pending `:G` goto, active `:I` tracking):
+    ///
+    /// 1. `:K1` / `:K2` (stop both axes) + poll `:f1` / `:f2` until idle.
+    /// 2. `:E1` / `:E2` write the seed encoder values, publishing each
+    ///    to the cached snapshot so an immediate read reflects it.
+    /// 3. Clear the driver-internal slew / target / tracking-request
+    ///    flags so the just-written encoder is the source of truth.
+    ///
+    /// Invoked by [`Self::seed_after_connect`] (where the stops are
+    /// no-ops on a fresh-power-up mount — the motors are idle) and by
+    /// the `UnparkFromApPosition(ap_park_N)` recovery Action for
+    /// `N ≥ 1` (where the stops cancel whatever motion a crash left
+    /// running). The standard `Unpark()` flow does **not** call this —
+    /// writing the encoder there would silently destroy session state.
+    ///
+    /// Takes the session explicitly because the connect-time seed runs
+    /// *before* the session is stored in `self.session`. On a
+    /// `stop_axis_and_wait` failure the encoder writes are **not**
+    /// attempted — motion is still in flight and re-seeding then would
+    /// race the firmware.
+    pub(super) async fn reset_mount_encoders(
+        &self,
+        session: &Session<SkywatcherCodec>,
+        ra_target_ticks: i32,
+        dec_target_ticks: i32,
+    ) -> ASCOMResult<()> {
+        // 1. Stop both axes and wait for idle. A stop failure bails
+        //    before any `:E` so we never seed against a moving axis.
+        stop_axis_and_wait(&self.manager, session, Axis::Ra, AXIS_STOP_TIMEOUT)
+            .await
+            .map_err(ASCOMError::from)?;
+        stop_axis_and_wait(&self.manager, session, Axis::Dec, AXIS_STOP_TIMEOUT)
+            .await
+            .map_err(ASCOMError::from)?;
+        // 2. Write the seed encoder values and publish them to the
+        //    cached snapshot.
+        self.manager
+            .send(
+                session,
+                Command::SetPosition {
+                    axis: Axis::Ra,
+                    ticks: ra_target_ticks,
+                },
+            )
+            .await
+            .map_err(ASCOMError::from)?;
+        self.manager.seed_ra_position(ra_target_ticks).await;
+        self.manager
+            .send(
+                session,
+                Command::SetPosition {
+                    axis: Axis::Dec,
+                    ticks: dec_target_ticks,
+                },
+            )
+            .await
+            .map_err(ASCOMError::from)?;
+        self.manager.seed_dec_position(dec_target_ticks).await;
+        // 3. Clear driver-internal motion / target / tracking state so
+        //    the freshly written encoder is the source of truth.
+        let mut state = self.state.write().await;
+        state.slew_in_progress = false;
+        state.target_ra_hours = None;
+        state.target_dec_degrees = None;
+        state.tracking_requested = false;
+        Ok(())
+    }
+
+    /// Resolve a `mount.<key>` AP-park field for use this connect.
+    ///
+    /// Read fresh from the on-disk config file when the driver was
+    /// started with `--config` (so a `SetUnparkFromApPosition` /
+    /// `SetPreferredApPark` write — or an operator hand-edit — applies
+    /// on the next connect without a driver restart), falling back to
+    /// `fallback` (the in-memory startup value) when the key is absent
+    /// or no config file is in use. Mirrors
+    /// [`Self::load_park_target_after_connect`]'s disk read.
+    async fn configured_ap_park(&self, key: &'static str, fallback: ApPark) -> ASCOMResult<ApPark> {
+        let Some(path) = self.config_file_path.clone() else {
+            return Ok(fallback);
+        };
+        let from_disk = tokio::task::spawn_blocking(move || read_ap_park_field(&path, key))
+            .await
+            .map_err(|e| {
+                ASCOMError::new(
+                    ASCOMErrorCode::INVALID_OPERATION,
+                    format!("{key} config read task join error: {e}"),
+                )
+            })?
+            .map_err(ASCOMError::from)?;
+        Ok(from_disk.unwrap_or(fallback))
+    }
+
+    /// The `unpark_from_ap_position` in effect for this connect (disk,
+    /// falling back to the startup value). Used by the fresh-power-up
+    /// auto-seed.
+    pub(super) async fn configured_unpark_from_ap_position(&self) -> ASCOMResult<ApPark> {
+        self.configured_ap_park(
+            "unpark_from_ap_position",
+            self.config.unpark_from_ap_position,
+        )
+        .await
+    }
+
+    /// The `preferred_ap_park` in effect for this connect (disk,
+    /// falling back to the startup value). Used as the `Park()` target
+    /// when no raw `park_*_ticks` override is set.
+    pub(super) async fn configured_preferred_ap_park(&self) -> ASCOMResult<ApPark> {
+        self.configured_ap_park("preferred_ap_park", self.config.preferred_ap_park)
+            .await
+    }
+
+    /// Encoder `(ra, dec)` tick pair for an AP park, or [`None`] when
+    /// the park has no codebase mapping (`ap_park_0`) or transport
+    /// parameters are unavailable (not connected). Resolves against the
+    /// configured site latitude and the handshake-reported counts-per-
+    /// revolution.
+    pub(super) async fn ap_park_target_ticks(&self, park: ApPark) -> Option<(i32, i32)> {
+        let mech_ha = park.codebase_mech_ha_hours(self.config.site_latitude_deg)?;
+        let dec_deg = park.codebase_dec_encoder_degrees(self.config.site_latitude_deg)?;
+        let params = self.manager.parameters().await?;
+        Some((
+            mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra),
+            dec_degrees_to_ticks(dec_deg, params.cpr_dec),
+        ))
+    }
+
+    /// Post-connect encoder seed for the operator's configured
+    /// `unpark_from_ap_position`.
     ///
     /// The Sky-Watcher firmware's encoder counter resets to `(0, 0)`
-    /// every time the mount powers up. With `home_pose !=
-    /// OtaOnMeridianAtEquator`, the codebase's convention for `(0, 0)`
-    /// doesn't match the operator's physical pose, so we issue
-    /// `:E1` / `:E2` (no-motion encoder seed) right after connect to
-    /// align the firmware's encoder counter with the codebase's
-    /// convention for the configured pose.
+    /// every power-up. For `ap_park_1..ap_park_5` the codebase's
+    /// convention for `(0, 0)` doesn't match the operator's physical
+    /// pose, so we run [`Self::reset_mount_encoders`] right after connect
+    /// (on a fresh power-up the stop steps are no-ops; the `:E1` / `:E2`
+    /// encoder writes are the meaningful work) to align the firmware's
+    /// encoder counter with the codebase convention for the pose.
     ///
     /// Skipped when:
-    /// - The home pose is the codebase default (no offset needed).
-    /// - The firmware reports a non-zero encoder reading at connect
-    ///   time **beyond a small fresh-power-up tolerance**. That
-    ///   indicates the mount has already been slewed or synced this
-    ///   power cycle — re-seeding would clobber it. The tolerance
-    ///   exists because the Sky-Watcher firmware does not always
-    ///   read exactly `(0, 0)` after a power-cycle: on the validation
-    ///   GTi we observed `dec = −1` on fresh power-up, a 1-tick
-    ///   initialisation artifact (~0.4″) that obviously still
-    ///   represents the "just powered up" state.
+    /// - The configured pose is `ap_park_0` ("current position"): the
+    ///   operator asserts they will plate-solve and `SyncToCoordinates`
+    ///   themselves, so the driver does not touch the encoder. No
+    ///   `info!()` lines are emitted in this case.
+    /// - The firmware reports a non-zero encoder reading at connect time
+    ///   **beyond a small fresh-power-up tolerance**. That indicates the
+    ///   mount has already been slewed or synced this power cycle —
+    ///   re-seeding would clobber it. The tolerance absorbs the
+    ///   Sky-Watcher firmware's 1-tick fresh-power-up artifact
+    ///   (observed `dec = −1` on the validation GTi, ~0.4″).
     ///
-    /// Documented operator assumption: when `home_pose != default`,
-    /// the operator powers up the mount **at** the configured pose and
-    /// connects the driver before any slew or sync. Reconnecting
-    /// mid-session after a slew is safe (the non-zero-encoder guard
-    /// catches it — a real slew lands tens of thousands of ticks away
-    /// from zero, well outside the tolerance).
-    pub(super) async fn seed_home_pose_after_connect(
+    /// Documented operator assumption: when `unpark_from_ap_position`
+    /// is one of `ap_park_1..ap_park_5`, the operator powers up the
+    /// mount **at** the configured pose and connects the driver before
+    /// any slew or sync. Reconnecting mid-session after a slew is safe
+    /// (the non-zero-encoder guard catches it — a real slew lands tens
+    /// of thousands of ticks away from zero, well outside the tolerance).
+    pub(super) async fn seed_after_connect(
         &self,
         session: &Session<SkywatcherCodec>,
     ) -> ASCOMResult<()> {
-        let Some(home_pose) = self.config.home_pose else {
-            // No pose configured — trust the firmware encoder as-is.
-            // This is the codebase's historical (pre-Phase-6) behaviour
-            // and what existing pre-`home_pose` config files expect.
+        let configured = self.configured_unpark_from_ap_position().await?;
+        // `ap_park_0` ("current position") has no codebase encoder
+        // mapping — trust the firmware encoder as-is and emit no logs.
+        let (Some(mech_ha), Some(dec_deg)) = (
+            configured.codebase_mech_ha_hours(self.config.site_latitude_deg),
+            configured.codebase_dec_encoder_degrees(self.config.site_latitude_deg),
+        ) else {
             return Ok(());
         };
         let params = self
@@ -407,7 +548,7 @@ impl MountDevice {
         info!(
             pre_seed_ra_ticks = snap.ra.position_ticks,
             pre_seed_dec_ticks = snap.dec.position_ticks,
-            home_pose = ?home_pose,
+            unpark_from_ap_position = ?configured,
             "pre-seed encoder snapshot at connect"
         );
         if snap.ra.position_ticks.abs() > FRESH_POWER_UP_TICK_TOLERANCE
@@ -417,41 +558,20 @@ impl MountDevice {
                 ra = snap.ra.position_ticks,
                 dec = snap.dec.position_ticks,
                 tolerance = FRESH_POWER_UP_TICK_TOLERANCE,
-                "skipping home_pose encoder seed: firmware encoder is non-zero beyond tolerance"
+                "skipping unpark_from_ap_position encoder seed: firmware encoder \
+                 is non-zero beyond tolerance"
             );
             return Ok(());
         }
-        let mech_ha = home_pose.codebase_mech_ha_hours(self.config.site_latitude_deg);
-        let dec_deg = home_pose.codebase_dec_encoder_degrees(self.config.site_latitude_deg);
         let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
         let dec_ticks = dec_degrees_to_ticks(dec_deg, params.cpr_dec);
-        self.manager
-            .send(
-                session,
-                Command::SetPosition {
-                    axis: Axis::Ra,
-                    ticks: ra_ticks,
-                },
-            )
-            .await
-            .map_err(ASCOMError::from)?;
-        self.manager.seed_ra_position(ra_ticks).await;
-        self.manager
-            .send(
-                session,
-                Command::SetPosition {
-                    axis: Axis::Dec,
-                    ticks: dec_ticks,
-                },
-            )
-            .await
-            .map_err(ASCOMError::from)?;
-        self.manager.seed_dec_position(dec_ticks).await;
+        self.reset_mount_encoders(session, ra_ticks, dec_ticks)
+            .await?;
         info!(
             seeded_ra_ticks = ra_ticks,
             seeded_dec_ticks = dec_ticks,
-            home_pose = ?home_pose,
-            "seeded firmware encoder for home_pose"
+            unpark_from_ap_position = ?configured,
+            "seeded firmware encoder for unpark_from_ap_position"
         );
         Ok(())
     }

--- a/services/star-adventurer-gti/src/mount_device/park_persistence.rs
+++ b/services/star-adventurer-gti/src/mount_device/park_persistence.rs
@@ -11,6 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::config::ApPark;
 use crate::error::StarAdvError;
 
 /// Probe whether the parent directory of `config_path` can host the
@@ -167,6 +168,56 @@ fn extract_park_tick(
     }
 }
 
+/// Read a `mount.<key>` AP-park enum value from the on-disk config file
+/// (`mount.unpark_from_ap_position`, `mount.preferred_ap_park`).
+///
+/// - Absent or JSON `null` → `Ok(None)`; the caller falls back to the
+///   in-memory config value for that field.
+/// - A recognised `ap_park_N` string → `Ok(Some(park))`.
+/// - Anything else (unknown string, wrong type), a missing/malformed
+///   file, or a missing `mount` object → `Err(StarAdvError::Config)`.
+///   Loud failure on an operator typo mirrors [`extract_park_tick`].
+///
+/// Reading at point-of-use (connect-time seed, `Park()` target
+/// resolution) means a `SetUnparkFromApPosition` / `SetPreferredApPark`
+/// write — or an operator hand-edit between connects — takes effect
+/// without a driver restart, the same contract [`read_park_from_config`]
+/// gives the park-tick keys. The `ap_park_0` rejection that
+/// `preferred_ap_park` carries at full-config deserialize is **not**
+/// re-applied here; the caller treats an `ap_park_0` value as "no AP
+/// target" and falls back accordingly.
+///
+/// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
+pub(super) fn read_ap_park_field(
+    config_path: &Path,
+    key: &str,
+) -> crate::error::Result<Option<ApPark>> {
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|e| StarAdvError::Config(format!("read config {}: {e}", config_path.display())))?;
+    let root: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+        StarAdvError::Config(format!("parse config {}: {e}", config_path.display()))
+    })?;
+    let mount = root
+        .as_object()
+        .and_then(|o| o.get("mount"))
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| {
+            StarAdvError::Config(format!(
+                "config {} has no `mount` object",
+                config_path.display()
+            ))
+        })?;
+    match mount.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(v) => {
+            let park: ApPark = serde_json::from_value(v.clone()).map_err(|e| {
+                StarAdvError::Config(format!("`mount.{key}` is not a valid AP park: {e}"))
+            })?;
+            Ok(Some(park))
+        }
+    }
+}
+
 /// Patch the on-disk JSON config with the supplied park encoder pair.
 ///
 /// Read-as-`Value` + atomic-rename pattern: load the file as
@@ -197,6 +248,45 @@ pub(super) fn write_park_to_config(
     park_ra_ticks: i32,
     park_dec_ticks: i32,
 ) -> crate::error::Result<()> {
+    write_mount_fields_to_config(
+        config_path,
+        &[
+            ("park_ra_ticks", serde_json::Value::from(park_ra_ticks)),
+            ("park_dec_ticks", serde_json::Value::from(park_dec_ticks)),
+        ],
+    )
+}
+
+/// Patch the on-disk JSON config, setting each `mount.<key>` in
+/// `updates` to its paired value. The read-modify-write engine behind
+/// [`write_park_to_config`] and the `SetUnparkFromApPosition` /
+/// `SetPreferredApPark` Actions.
+///
+/// Read-as-`Value` + atomic-rename pattern: load the file as
+/// `serde_json::Value`, mutate **only** the listed `mount` keys,
+/// serialise pretty-printed, write via a `tempfile::NamedTempFile` in
+/// the same directory, `persist` to swap it in atomically. Every other
+/// field — known and unknown — is preserved as a JSON value. Operator
+/// formatting (key order, indentation) is not preserved byte-for-byte
+/// because the round-trip pretty-prints the whole document; the
+/// *semantic* content outside the listed keys is unchanged.
+///
+/// Durability: fsync the staged file before rename (`tempfile::persist`
+/// uses POSIX `rename(2)`), then fsync the parent directory after
+/// rename so the directory entry update is itself durable. Mirrors
+/// `services/rp/src/persistence/document.rs::write_sidecar_sync`.
+///
+/// The driver never re-serialises its in-memory typed `Config` here:
+/// doing so would round-trip CLI overrides (`--port`, `--baud`, etc.)
+/// back to disk and is structurally avoided. See the design doc's
+/// [§"Park persistence"](../../../../docs/services/star-adventurer-gti.md#park-persistence)
+/// for the contract this helper implements.
+///
+/// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
+pub(super) fn write_mount_fields_to_config(
+    config_path: &Path,
+    updates: &[(&str, serde_json::Value)],
+) -> crate::error::Result<()> {
     use std::io::Write;
 
     let content = std::fs::read_to_string(config_path)
@@ -214,14 +304,9 @@ pub(super) fn write_park_to_config(
                 config_path.display()
             ))
         })?;
-    mount.insert(
-        "park_ra_ticks".to_string(),
-        serde_json::Value::from(park_ra_ticks),
-    );
-    mount.insert(
-        "park_dec_ticks".to_string(),
-        serde_json::Value::from(park_dec_ticks),
-    );
+    for (key, value) in updates {
+        mount.insert((*key).to_string(), value.clone());
+    }
     let mut pretty = serde_json::to_string_pretty(&root)
         .map_err(|e| StarAdvError::Config(format!("serialise config: {e}")))?;
     // serde_json's pretty-printer omits a trailing newline; add one so

--- a/services/star-adventurer-gti/src/mount_device/park_persistence.rs
+++ b/services/star-adventurer-gti/src/mount_device/park_persistence.rs
@@ -148,7 +148,8 @@ pub(super) struct MountConnectFields {
 /// the next connect without a driver restart.
 ///
 /// Per-field decoding matches the single-field helpers: tick keys go
-/// through [`extract_park_tick`] (loud on a non-i24 value), AP-park keys
+/// through [`extract_park_tick`] (loud on a non-integer, or an integer
+/// outside the `i32` / signed-24-bit encoder range), AP-park keys
 /// through [`extract_ap_park`] (loud on an unrecognised string). A
 /// missing/malformed file or a missing `mount` object is a
 /// `StarAdvError::Config`. The `ap_park_0` rejection that

--- a/services/star-adventurer-gti/src/mount_device/park_persistence.rs
+++ b/services/star-adventurer-gti/src/mount_device/park_persistence.rs
@@ -85,47 +85,6 @@ pub fn warn_if_park_path_unwritable(config_path: &Path) {
     }
 }
 
-/// Read `mount.park_ra_ticks` / `mount.park_dec_ticks` from the on-disk
-/// config file. Each axis is returned independently — a `None` means
-/// the file did not set that key (or set it to JSON `null`), and the
-/// caller will fall back to the handshake-captured value for that axis.
-///
-/// A key that **is** present but holds something other than an integer
-/// inside `i32`'s range is surfaced as a `StarAdvError::Config` rather
-/// than silently treated as `None`. Operator typos (a string,
-/// an i64 too large to be encoder ticks, a float) should fail loudly so
-/// the misconfiguration is visible rather than masked by the handshake
-/// fallback. Other failures (file missing, malformed JSON, `mount` key
-/// missing or not an object) are also surfaced as `StarAdvError::Config`.
-///
-/// Reading the file only at connect time means an operator can
-/// hand-edit the park keys between connects and have the change take
-/// effect on reconnect, without restarting the driver.
-///
-/// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
-pub(super) fn read_park_from_config(
-    config_path: &Path,
-) -> crate::error::Result<(Option<i32>, Option<i32>)> {
-    let content = std::fs::read_to_string(config_path)
-        .map_err(|e| StarAdvError::Config(format!("read config {}: {e}", config_path.display())))?;
-    let root: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-        StarAdvError::Config(format!("parse config {}: {e}", config_path.display()))
-    })?;
-    let mount = root
-        .as_object()
-        .and_then(|o| o.get("mount"))
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| {
-            StarAdvError::Config(format!(
-                "config {} has no `mount` object",
-                config_path.display()
-            ))
-        })?;
-    let ra = extract_park_tick(mount.get("park_ra_ticks"), "mount.park_ra_ticks")?;
-    let dec = extract_park_tick(mount.get("park_dec_ticks"), "mount.park_dec_ticks")?;
-    Ok((ra, dec))
-}
-
 /// Decode an optional park-tick JSON value:
 ///
 /// - Absent (`None`) or explicit `Value::Null` → `Ok(None)` (caller
@@ -168,30 +127,37 @@ fn extract_park_tick(
     }
 }
 
-/// Read a `mount.<key>` AP-park enum value from the on-disk config file
-/// (`mount.unpark_from_ap_position`, `mount.preferred_ap_park`).
+/// The connect-time `mount.*` fields the driver re-reads from disk on
+/// every connect, read in a **single** parse. A `None` means the key was
+/// absent or JSON `null` on disk — the caller applies the in-memory
+/// startup fallback for that field.
+#[derive(Debug)]
+pub(super) struct MountConnectFields {
+    pub park_ra_ticks: Option<i32>,
+    pub park_dec_ticks: Option<i32>,
+    pub unpark_from_ap_position: Option<ApPark>,
+    pub preferred_ap_park: Option<ApPark>,
+}
+
+/// Read the four connect-time `mount.*` fields (`park_ra_ticks`,
+/// `park_dec_ticks`, `unpark_from_ap_position`, `preferred_ap_park`)
+/// from the on-disk config in one read + parse, so `set_connected`'s
+/// seed + park-target hooks don't each re-read the file. A
+/// `SetUnparkFromApPosition` / `SetPreferredApPark` / `SetPark` write —
+/// or an operator hand-edit between connects — therefore takes effect on
+/// the next connect without a driver restart.
 ///
-/// - Absent or JSON `null` → `Ok(None)`; the caller falls back to the
-///   in-memory config value for that field.
-/// - A recognised `ap_park_N` string → `Ok(Some(park))`.
-/// - Anything else (unknown string, wrong type), a missing/malformed
-///   file, or a missing `mount` object → `Err(StarAdvError::Config)`.
-///   Loud failure on an operator typo mirrors [`extract_park_tick`].
-///
-/// Reading at point-of-use (connect-time seed, `Park()` target
-/// resolution) means a `SetUnparkFromApPosition` / `SetPreferredApPark`
-/// write — or an operator hand-edit between connects — takes effect
-/// without a driver restart, the same contract [`read_park_from_config`]
-/// gives the park-tick keys. The `ap_park_0` rejection that
+/// Per-field decoding matches the single-field helpers: tick keys go
+/// through [`extract_park_tick`] (loud on a non-i24 value), AP-park keys
+/// through [`extract_ap_park`] (loud on an unrecognised string). A
+/// missing/malformed file or a missing `mount` object is a
+/// `StarAdvError::Config`. The `ap_park_0` rejection that
 /// `preferred_ap_park` carries at full-config deserialize is **not**
-/// re-applied here; the caller treats an `ap_park_0` value as "no AP
+/// re-applied here — the caller treats an `ap_park_0` value as "no AP
 /// target" and falls back accordingly.
 ///
 /// Blocking I/O; callers wrap in `tokio::task::spawn_blocking`.
-pub(super) fn read_ap_park_field(
-    config_path: &Path,
-    key: &str,
-) -> crate::error::Result<Option<ApPark>> {
+pub(super) fn read_connect_fields(config_path: &Path) -> crate::error::Result<MountConnectFields> {
     let content = std::fs::read_to_string(config_path)
         .map_err(|e| StarAdvError::Config(format!("read config {}: {e}", config_path.display())))?;
     let root: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
@@ -207,7 +173,26 @@ pub(super) fn read_ap_park_field(
                 config_path.display()
             ))
         })?;
-    match mount.get(key) {
+    Ok(MountConnectFields {
+        park_ra_ticks: extract_park_tick(mount.get("park_ra_ticks"), "mount.park_ra_ticks")?,
+        park_dec_ticks: extract_park_tick(mount.get("park_dec_ticks"), "mount.park_dec_ticks")?,
+        unpark_from_ap_position: extract_ap_park(
+            mount.get("unpark_from_ap_position"),
+            "unpark_from_ap_position",
+        )?,
+        preferred_ap_park: extract_ap_park(mount.get("preferred_ap_park"), "preferred_ap_park")?,
+    })
+}
+
+/// Decode an optional `mount.<key>` AP-park value: absent / `null` →
+/// `Ok(None)`; a recognised `ap_park_N` string → `Ok(Some(park))`;
+/// anything else → `Err(StarAdvError::Config)`. Loud failure on an
+/// operator typo mirrors [`extract_park_tick`].
+fn extract_ap_park(
+    value: Option<&serde_json::Value>,
+    key: &str,
+) -> crate::error::Result<Option<ApPark>> {
+    match value {
         None | Some(serde_json::Value::Null) => Ok(None),
         Some(v) => {
             let park: ApPark = serde_json::from_value(v.clone()).map_err(|e| {

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -339,6 +339,16 @@ fn fast_settle_device() -> MountDevice {
     // Disable the CW-exclusion zone check for this test.
     cfg.mount.binding_zone_min_hours = 24.0;
     cfg.mount.binding_zone_max_hours = 0.0;
+    // Pin the park target to the mock's start position (0, 0) so
+    // `park()` is a zero-distance, instant slew. The park-lifecycle
+    // tests using this helper exercise the watcher / AtPark flip, not
+    // park-target resolution; without the pin they would inherit the
+    // `preferred_ap_park` default (`ap_park_3`, ~907 k ticks away) and
+    // turn every `park()` into a multi-poll slew that races the tests'
+    // fixed settle sleeps. `preferred_ap_park` resolution is covered by
+    // the dedicated `park_target_*` tests.
+    cfg.mount.park_ra_ticks = Some(0);
+    cfg.mount.park_dec_ticks = Some(0);
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     MountDevice::new(cfg.mount, manager)
 }
@@ -369,6 +379,10 @@ async fn fast_settle_connected_narrow_envelope() -> MountDevice {
     cfg.mount.binding_zone_max_hours = 1.5;
     cfg.mount.dec_min_degrees = -5.0;
     cfg.mount.dec_max_degrees = 5.0;
+    // Pin the park target to (0, 0) — see `fast_settle_device` for why
+    // (keeps `park()` instant despite the `preferred_ap_park` default).
+    cfg.mount.park_ra_ticks = Some(0);
+    cfg.mount.park_dec_ticks = Some(0);
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
@@ -1618,28 +1632,29 @@ async fn set_park_persists_current_snapshot_and_updates_in_memory_target() {
 }
 
 #[tokio::test]
-async fn park_target_defaults_to_handshake_capture_when_config_has_no_values() {
-    // No config park values **and no `home_pose`** → driver falls
-    // back to the live snapshot, which on a fresh connect equals
-    // the handshake-captured encoder reading. The mock starts both
-    // axes at 0 and the home_pose seed is a no-op when none is
-    // configured, so park_ra_ticks / park_dec_ticks should be
-    // Some(0) after connect.
+async fn park_target_defaults_to_preferred_ap_park_when_no_raw_override() {
+    // No raw `park_*_ticks` override and the ship-default
+    // `unpark_from_ap_position = ap_park_0` (no seed) → the park
+    // target resolves to the `preferred_ap_park` default (`ap_park_3`).
+    // `device()` runs at latitude 0, so ap_park_3 → mech_HA = -6h
+    // (ra = -6/24 * cpr = -907,200) and dec_enc = +90° (northern arm
+    // via `>= 0`; dec = 90/360 * cpr = +907,200).
     let d = device();
     d.set_connected(true).await.unwrap();
     let s = d.state.read().await;
-    assert_eq!(s.park_ra_ticks, Some(0));
-    assert_eq!(s.park_dec_ticks, Some(0));
+    assert_eq!(s.park_ra_ticks, Some(-907_200));
+    assert_eq!(s.park_dec_ticks, Some(907_200));
 }
 
 #[tokio::test]
-async fn home_pose_seed_fires_when_firmware_reports_near_zero_encoder() {
-    // Sky-Watcher firmware does not always read exactly (0, 0)
-    // after a power-cycle: the validation GTi reports dec = -1 on
-    // fresh power-up. Without the FRESH_POWER_UP_TICK_TOLERANCE
-    // guard the strict `!= 0` check would skip the seed and the
-    // mount would silently end up with a wrong celestial mapping
-    // (and a wrong Park target via the snapshot fallback).
+async fn unpark_seed_fires_when_firmware_reports_near_zero_encoder() {
+    // Sky-Watcher firmware does not always read exactly (0, 0) after a
+    // power-cycle: the validation GTi reports dec = -1 on fresh
+    // power-up. Without the FRESH_POWER_UP_TICK_TOLERANCE guard the
+    // strict `!= 0` check would skip the seed and the mount would
+    // silently end up with a wrong celestial mapping. The seed is
+    // observed directly via the post-seed snapshot encoder — the park
+    // target no longer reflects the seed (it tracks preferred_ap_park).
     use crate::transport::mock::CapturingMockFactory;
     let factory = CapturingMockFactory::new();
     // Force the dec encoder to a 1-tick fresh-power-up artifact
@@ -1652,26 +1667,27 @@ async fn home_pose_seed_fires_when_firmware_reports_near_zero_encoder() {
     // Disable the CW-exclusion zone check for this test.
     cfg.mount.binding_zone_min_hours = 24.0;
     cfg.mount.binding_zone_max_hours = 0.0;
-    cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+    cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
     // ApPark3 N hemisphere with mock cpr = 0x375F00 = 3,628,800:
-    // expected seed → ra_ticks = -907,200, dec_ticks = +907,200.
-    // If the seed had been skipped, the park target would be
-    // (0, -1) (the pre-seed snapshot).
-    let s = d.state.read().await;
-    assert_eq!(s.park_ra_ticks, Some(-907200));
-    assert_eq!(s.park_dec_ticks, Some(907200));
+    // expected seed → ra_ticks = -907,200, dec_ticks = +907,200. The
+    // snapshot reflects the `:E` writes; if the seed had been skipped
+    // it would still read the pre-seed (0, -1).
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, -907_200);
+    assert_eq!(snap.dec.position_ticks, 907_200);
 }
 
 #[tokio::test]
-async fn home_pose_seed_skips_when_firmware_encoder_beyond_tolerance() {
-    // A real post-slew encoder is tens of thousands of ticks away
-    // from zero — well beyond FRESH_POWER_UP_TICK_TOLERANCE. The
-    // seed must skip in that case so a mid-session reconnect does
-    // not clobber the operator's slewed-to position.
+async fn unpark_seed_skips_when_firmware_encoder_beyond_tolerance() {
+    // A real post-slew encoder is tens of thousands of ticks away from
+    // zero — well beyond FRESH_POWER_UP_TICK_TOLERANCE. The seed must
+    // skip so a mid-session reconnect does not clobber the operator's
+    // slewed-to position: the snapshot stays at the pre-seed reading
+    // (no `:E` written).
     use crate::transport::mock::CapturingMockFactory;
     let factory = CapturingMockFactory::new();
     {
@@ -1682,21 +1698,19 @@ async fn home_pose_seed_skips_when_firmware_encoder_beyond_tolerance() {
     // Disable the CW-exclusion zone check for this test.
     cfg.mount.binding_zone_min_hours = 24.0;
     cfg.mount.binding_zone_max_hours = 0.0;
-    cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+    cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
-    // Seed skipped → park target falls back to the snapshot (the
-    // pre-seed handshake reading), so park_ra_ticks should equal
-    // the firmware's reported 50,000 (not -907,200).
-    let s = d.state.read().await;
-    assert_eq!(s.park_ra_ticks, Some(50_000));
-    assert_eq!(s.park_dec_ticks, Some(0));
+    // Seed skipped → snapshot unchanged from the fresh-power-up reading.
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, 50_000);
+    assert_eq!(snap.dec.position_ticks, 0);
 }
 
 #[tokio::test]
-async fn home_pose_seed_skips_just_above_fresh_power_up_tolerance() {
+async fn unpark_seed_skips_just_above_fresh_power_up_tolerance() {
     // Pins the tight 10-tick fresh-power-up floor. A reading of 50
     // ticks (~18″ at the GTi's CPR) is well above the single-tick
     // firmware artifact and indicates the operator has already moved
@@ -1712,45 +1726,282 @@ async fn home_pose_seed_skips_just_above_fresh_power_up_tolerance() {
     let mut cfg = Config::default();
     cfg.mount.binding_zone_min_hours = 24.0;
     cfg.mount.binding_zone_max_hours = 0.0;
-    cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+    cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
-    let s = d.state.read().await;
-    assert_eq!(s.park_ra_ticks, Some(50));
-    assert_eq!(s.park_dec_ticks, Some(0));
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, 50);
+    assert_eq!(snap.dec.position_ticks, 0);
 }
 
 #[tokio::test]
-async fn park_target_defaults_to_home_pose_encoder_when_home_pose_configured() {
-    // Operator configures `home_pose: ap_park_3` (Sky-Watcher's
-    // stock power-up pose) and leaves `park_*_ticks` null. After
-    // connect, `seed_home_pose_after_connect` writes the home_pose's
-    // logical encoder values to the firmware via `:E`, and the
-    // park-target fallback must pick those up from the snapshot —
-    // otherwise `Park` would slew the mount to firmware-encoder-
-    // zero (mech_HA = 0h, mech_dec = 0°) instead of the pose the
-    // operator powered up at. Regression test for the
-    // meridian-flip-phase hardware-validation observation that
-    // `Park` from `home_pose: ap_park_3` drove the OTA to
-    // meridian / celestial equator instead of NCP.
+async fn park_target_uses_preferred_ap_park_distinct_from_unpark_seed() {
+    // The fresh-power-up seed (`unpark_from_ap_position`) and the
+    // `Park()` target (`preferred_ap_park`) are independent. Configure
+    // a seed of ap_park_3 and a *different* preferred park of ap_park_2:
+    // the snapshot must reflect the ap_park_3 seed, while the park
+    // target resolves to the ap_park_2 encoder pair.
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
     cfg.mount.binding_zone_min_hours = 24.0;
     cfg.mount.binding_zone_max_hours = 0.0;
-    cfg.mount.home_pose = Some(crate::config::HomePose::ApPark3);
+    cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
+    cfg.mount.preferred_ap_park = crate::config::ApPark::ApPark2;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
-    // ApPark3 codebase convention: mech_HA = -6h, dec encoder = +90°
-    // (northern hemisphere). Mock cpr = 0x375F00 = 3,628,800 for
-    // both axes, so ra = -6/24 * cpr = -907,200 and
-    // dec = 90/360 * cpr = +907,200.
+    // ap_park_3 seed: mech_HA = -6h, dec_enc = +90° → snapshot
+    // (-907,200, +907,200).
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, -907_200);
+    assert_eq!(snap.dec.position_ticks, 907_200);
+    // ap_park_2 park target: mech_HA = -6h (ra = -907,200), dec_enc = 0°
+    // (dec = 0) — distinct from the seed on the dec axis.
     let s = d.state.read().await;
-    assert_eq!(s.park_ra_ticks, Some(-907200));
-    assert_eq!(s.park_dec_ticks, Some(907200));
+    assert_eq!(s.park_ra_ticks, Some(-907_200));
+    assert_eq!(s.park_dec_ticks, Some(0));
+}
+
+// ---- reset_mount_encoders helper (Phase B) ----
+
+#[tokio::test]
+async fn reset_mount_encoders_writes_encoder_and_clears_state() {
+    let d = connected_device().await;
+    // Dirty the in-memory motion/target/tracking state a reset clears.
+    {
+        let mut s = d.state.write().await;
+        s.slew_in_progress = true;
+        s.target_ra_hours = Some(5.0);
+        s.target_dec_degrees = Some(10.0);
+        s.tracking_requested = true;
+    }
+    {
+        let guard = d.session.read().await;
+        let session = guard.as_ref().expect("connected device holds a session");
+        d.reset_mount_encoders(session, 12_345, -6_789)
+            .await
+            .unwrap();
+    }
+    // The `:E` writes are published to the cached snapshot.
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, 12_345);
+    assert_eq!(snap.dec.position_ticks, -6_789);
+    // Driver-internal motion/target/tracking state is cleared.
+    let s = d.state.read().await;
+    assert!(!s.slew_in_progress);
+    assert_eq!(s.target_ra_hours, None);
+    assert_eq!(s.target_dec_degrees, None);
+    assert!(!s.tracking_requested);
+}
+
+#[tokio::test]
+async fn reset_mount_encoders_errors_when_axis_never_stops() {
+    // If stop-and-wait fails (the axis never reports idle), the reset
+    // bails before writing any encoder seed — motion is still in flight
+    // and re-seeding then would race the firmware.
+    let manager = Arc::new(MountManager::new(
+        Config::default(),
+        Arc::new(StuckAxisFactory),
+    ));
+    let session = manager.transport().acquire().await.unwrap();
+    let d = MountDevice::new(Config::default().mount, Arc::clone(&manager));
+    let err = d
+        .reset_mount_encoders(&session, 1_000, -1_000)
+        .await
+        .unwrap_err();
+    assert!(
+        err.message.contains("did not stop"),
+        "expected a stop-timeout error, got {err:?}"
+    );
+}
+
+// ---- Custom Actions (Phase D) ----
+
+#[tokio::test]
+async fn supported_actions_lists_the_three_vendor_actions() {
+    let d = device();
+    let actions = d.supported_actions().await.unwrap();
+    assert_eq!(
+        actions,
+        vec![
+            "SetUnparkFromApPosition".to_string(),
+            "SetPreferredApPark".to_string(),
+            "UnparkFromApPosition".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn action_with_unknown_name_returns_action_not_implemented() {
+    let d = device();
+    let err = d
+        .action("NoSuchAction".to_string(), String::new())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::ACTION_NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn set_unpark_from_ap_position_persists_to_config() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    seed_default_config(&path);
+    let d = device_with_path(path.clone());
+    d.set_connected(true).await.unwrap();
+    let ret = d
+        .action(
+            "SetUnparkFromApPosition".to_string(),
+            "ap_park_2".to_string(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ret, "ap_park_2");
+    let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        back.mount.unpark_from_ap_position,
+        crate::config::ApPark::ApPark2
+    );
+}
+
+#[tokio::test]
+async fn set_unpark_from_ap_position_without_config_is_refused() {
+    // No `--config` path → nowhere to persist; the Action refuses.
+    let d = device();
+    let err = d
+        .action(
+            "SetUnparkFromApPosition".to_string(),
+            "ap_park_2".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+}
+
+#[tokio::test]
+async fn set_unpark_from_ap_position_rejects_unknown_park() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    seed_default_config(&path);
+    let d = device_with_path(path);
+    let err = d
+        .action(
+            "SetUnparkFromApPosition".to_string(),
+            "ap_park_9".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+}
+
+#[tokio::test]
+async fn set_preferred_ap_park_rejects_ap_park_0() {
+    // "Current position" is not a slew target.
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    seed_default_config(&path);
+    let d = device_with_path(path);
+    let err = d
+        .action("SetPreferredApPark".to_string(), "ap_park_0".to_string())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_VALUE);
+}
+
+#[tokio::test]
+async fn set_preferred_ap_park_persists_and_updates_live_target() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    seed_default_config(&path);
+    let d = device_with_path(path.clone());
+    d.set_connected(true).await.unwrap();
+    let ret = d
+        .action("SetPreferredApPark".to_string(), "ap_park_2".to_string())
+        .await
+        .unwrap();
+    assert_eq!(ret, "ap_park_2");
+    // Persisted to disk.
+    let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(back.mount.preferred_ap_park, crate::config::ApPark::ApPark2);
+    // Live park target re-resolved without a reconnect. device_with_path
+    // runs at latitude 0; ap_park_2 → mech_HA = -6h (ra = -907,200),
+    // dec_enc = 0° (dec = 0).
+    let s = d.state.read().await;
+    assert_eq!(s.park_ra_ticks, Some(-907_200));
+    assert_eq!(s.park_dec_ticks, Some(0));
+}
+
+#[tokio::test]
+async fn unpark_from_ap_position_ap_park_0_clears_at_park_without_encoder_change() {
+    let d = connected_device().await;
+    // Set the parked flag directly — this test exercises the unpark path.
+    d.state.write().await.at_park = true;
+    let before = d.manager.snapshot().await;
+    let ret = d
+        .action("UnparkFromApPosition".to_string(), "ap_park_0".to_string())
+        .await
+        .unwrap();
+    assert_eq!(ret, "ap_park_0");
+    assert!(!d.at_park().await.unwrap());
+    // "Current position" leaves the encoder untouched (≡ standard Unpark).
+    let after = d.manager.snapshot().await;
+    assert_eq!(after.ra.position_ticks, before.ra.position_ticks);
+    assert_eq!(after.dec.position_ticks, before.dec.position_ticks);
+}
+
+#[tokio::test]
+async fn unpark_from_ap_position_named_park_resets_encoder_and_clears_at_park() {
+    // The operator asserts the OTA is physically at ap_park_3; the
+    // driver makes the firmware encoder match regardless of the stale
+    // current reading, then clears AtPark.
+    use crate::transport::mock::CapturingMockFactory;
+    let factory = CapturingMockFactory::new();
+    {
+        let mut state = factory.state.lock().await;
+        state.ra.position_ticks = 200_000;
+        state.dec.position_ticks = -50_000;
+    }
+    let mut cfg = Config::default();
+    cfg.mount.binding_zone_min_hours = 24.0;
+    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.site_latitude_deg = 32.7157;
+    let manager = MountManager::new(cfg.clone(), Arc::new(factory));
+    let d = MountDevice::new(cfg.mount, manager);
+    d.set_connected(true).await.unwrap();
+    d.state.write().await.at_park = true;
+    let ret = d
+        .action("UnparkFromApPosition".to_string(), "ap_park_3".to_string())
+        .await
+        .unwrap();
+    assert_eq!(ret, "ap_park_3");
+    // ap_park_3 at lat 32.7157: ra = -907,200, dec = +907,200.
+    let snap = d.manager.snapshot().await;
+    assert_eq!(snap.ra.position_ticks, -907_200);
+    assert_eq!(snap.dec.position_ticks, 907_200);
+    assert!(!d.at_park().await.unwrap());
+}
+
+#[tokio::test]
+async fn unpark_from_ap_position_refuses_when_not_parked() {
+    let d = connected_device().await;
+    // at_park is false (default).
+    let err = d
+        .action("UnparkFromApPosition".to_string(), "ap_park_3".to_string())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+}
+
+#[tokio::test]
+async fn unpark_from_ap_position_refuses_when_disconnected() {
+    let d = device();
+    let err = d
+        .action("UnparkFromApPosition".to_string(), "ap_park_0".to_string())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMError::NOT_CONNECTED.code);
 }
 
 #[tokio::test]
@@ -1808,9 +2059,11 @@ async fn reconnect_after_set_park_picks_up_persisted_values() {
 }
 
 #[tokio::test]
-async fn reconnect_with_partial_config_uses_handshake_for_missing_axis() {
-    // Per-axis fallback: if the config sets only park_ra_ticks,
-    // RA comes from the file and Dec comes from the handshake.
+async fn reconnect_with_partial_config_uses_preferred_ap_park_for_missing_axis() {
+    // Per-axis fallback: if the config pins only park_ra_ticks, RA
+    // comes from the file and Dec falls through to the
+    // `preferred_ap_park` encoder pair (the default `ap_park_3`), not
+    // the raw handshake reading.
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     // Hand-craft a JSON config that sets only park_ra_ticks
@@ -1824,8 +2077,9 @@ async fn reconnect_with_partial_config_uses_handshake_for_missing_axis() {
     d.set_connected(true).await.unwrap();
     let s = d.state.read().await;
     assert_eq!(s.park_ra_ticks, Some(1234));
-    // Mock handshake reports Dec at 0.
-    assert_eq!(s.park_dec_ticks, Some(0));
+    // device_with_path runs at latitude 0; ap_park_3 dec_enc = +90°
+    // → dec = 90/360 * cpr = 907,200.
+    assert_eq!(s.park_dec_ticks, Some(907_200));
 }
 
 #[test]
@@ -2302,7 +2556,9 @@ async fn pulse_guide_rejects_same_axis_while_one_in_flight() {
 
 #[tokio::test]
 async fn pulse_guide_refuses_while_parked() {
-    let d = connected_device().await;
+    // `fast_settle_connected` pins the park target to (0, 0), so the
+    // park completes in one poll — see `fast_settle_device`.
+    let d = fast_settle_connected().await;
     d.park().await.unwrap();
     // Wait for AtPark = true (park watcher).
     let deadline = std::time::Instant::now() + Duration::from_secs(5);

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -25,7 +25,7 @@ use crate::error::StarAdvError;
 use crate::manager::MountManager;
 use crate::transport::mock::MockTransportFactory;
 
-use super::park_persistence::{read_park_from_config, write_park_to_config};
+use super::park_persistence::{read_connect_fields, write_park_to_config};
 use super::slew::{
     canonical_path_crosses_pole, check_non_flip_ra_path, flip_slew_dec_delta, flip_slew_ra_delta,
     pickup_reslew_axis, stop_axis_and_wait,
@@ -1331,11 +1331,11 @@ fn write_park_to_config_fails_on_malformed_json() {
 }
 
 #[test]
-fn read_park_from_config_fails_on_malformed_json() {
+fn read_connect_fields_fails_on_malformed_json() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     std::fs::write(&path, "{ not valid json").unwrap();
-    let err = read_park_from_config(&path).unwrap_err();
+    let err = read_connect_fields(&path).unwrap_err();
     match err {
         StarAdvError::Config(msg) => assert!(msg.contains("parse config"), "{msg}"),
         other => panic!("expected Config error, got {other:?}"),
@@ -1506,7 +1506,7 @@ async fn set_connected_rolls_back_transport_when_park_load_fails() {
     // We trigger the failure path by handing `MountDevice` a
     // `config_file_path` that points to a non-existent file:
     // the handshake will succeed (mock transport is happy), but
-    // `read_park_from_config` will fail with a missing-file error.
+    // `read_connect_fields` will fail with a missing-file error.
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("does_not_exist.json");
     let d = device_with_path(path);
@@ -2005,6 +2005,67 @@ async fn unpark_from_ap_position_refuses_when_disconnected() {
 }
 
 #[tokio::test]
+async fn unpark_from_ap_position_refuses_while_slewing() {
+    let d = connected_device().await;
+    {
+        let mut s = d.state.write().await;
+        s.at_park = true;
+        s.slew_in_progress = true;
+    }
+    let err = d
+        .action("UnparkFromApPosition".to_string(), "ap_park_3".to_string())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+}
+
+#[tokio::test]
+async fn set_unpark_from_ap_position_round_trips_every_named_park() {
+    // Exercises parse + canonical-string round-trip for the AP parks
+    // the focused action tests don't otherwise touch (ap_park_1/4/5).
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    seed_default_config(&path);
+    let d = device_with_path(path.clone());
+    d.set_connected(true).await.unwrap();
+    for (token, expected) in [
+        ("ap_park_1", crate::config::ApPark::ApPark1),
+        ("ap_park_4", crate::config::ApPark::ApPark4),
+        ("ap_park_5", crate::config::ApPark::ApPark5),
+    ] {
+        let ret = d
+            .action("SetUnparkFromApPosition".to_string(), token.to_string())
+            .await
+            .unwrap();
+        assert_eq!(ret, token);
+        let back: Config = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(back.mount.unpark_from_ap_position, expected);
+    }
+}
+
+#[tokio::test]
+async fn ap_park_target_ticks_is_none_for_ap_park_0() {
+    // "Current position" has no codebase encoder mapping, so the
+    // resolver returns None regardless of connection state.
+    let d = device();
+    assert_eq!(
+        d.ap_park_target_ticks(crate::config::ApPark::ApPark0).await,
+        None
+    );
+}
+
+#[tokio::test]
+async fn ap_park_target_ticks_is_none_when_disconnected() {
+    // A named park has a codebase mapping, but the tick conversion
+    // needs the handshake CPR — unavailable until connected.
+    let d = device();
+    assert_eq!(
+        d.ap_park_target_ticks(crate::config::ApPark::ApPark3).await,
+        None
+    );
+}
+
+#[tokio::test]
 async fn park_target_prefers_config_values_over_handshake_capture() {
     // Config carries park values → driver should use them, not the
     // (zeroed) handshake fallback.
@@ -2067,7 +2128,7 @@ async fn reconnect_with_partial_config_uses_preferred_ap_park_for_missing_axis()
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     // Hand-craft a JSON config that sets only park_ra_ticks
-    // (park_dec_ticks absent, which `read_park_from_config`
+    // (park_dec_ticks absent, which `read_connect_fields`
     // must read as `None`).
     let mut cfg = Config::default();
     cfg.mount.park_ra_ticks = Some(1234);
@@ -2083,7 +2144,7 @@ async fn reconnect_with_partial_config_uses_preferred_ap_park_for_missing_axis()
 }
 
 #[test]
-fn read_park_from_config_returns_none_for_each_missing_key() {
+fn read_connect_fields_returns_none_for_each_missing_key() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     let json = serde_json::json!({
@@ -2092,36 +2153,43 @@ fn read_park_from_config_returns_none_for_each_missing_key() {
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let (ra, dec) = read_park_from_config(&path).unwrap();
-    assert_eq!(ra, None);
-    assert_eq!(dec, None);
+    let f = read_connect_fields(&path).unwrap();
+    assert_eq!(f.park_ra_ticks, None);
+    assert_eq!(f.park_dec_ticks, None);
+    assert_eq!(f.unpark_from_ap_position, None);
+    assert_eq!(f.preferred_ap_park, None);
 }
 
 #[test]
-fn read_park_from_config_parses_both_keys() {
+fn read_connect_fields_parses_all_keys() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     let json = serde_json::json!({
         "mount": {
             "park_ra_ticks": 1234,
             "park_dec_ticks": -5678,
+            "unpark_from_ap_position": "ap_park_1",
+            "preferred_ap_park": "ap_park_4",
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let (ra, dec) = read_park_from_config(&path).unwrap();
-    assert_eq!(ra, Some(1234));
-    assert_eq!(dec, Some(-5678));
+    let f = read_connect_fields(&path).unwrap();
+    assert_eq!(f.park_ra_ticks, Some(1234));
+    assert_eq!(f.park_dec_ticks, Some(-5678));
+    assert_eq!(
+        f.unpark_from_ap_position,
+        Some(crate::config::ApPark::ApPark1)
+    );
+    assert_eq!(f.preferred_ap_park, Some(crate::config::ApPark::ApPark4));
 }
 
 #[test]
-fn read_park_from_config_treats_explicit_null_as_none_per_axis() {
-    // Pins the doc-comment guarantee: a `None` return value means
-    // the file did not set that key OR set it to `null`, and the
-    // two axes are returned independently. Here `park_ra_ticks`
-    // is set to a real value while `park_dec_ticks` is explicitly
-    // JSON `null`; the helper must return `(Some(1234), None)`,
-    // and the caller (`set_connected`) will then fall back to the
-    // handshake-captured value for the Dec axis only.
+fn read_connect_fields_treats_explicit_null_as_none_per_axis() {
+    // Pins the doc-comment guarantee: a `None` field means the file
+    // did not set that key OR set it to `null`, returned per key.
+    // Here `park_ra_ticks` is a real value while `park_dec_ticks` is
+    // explicitly JSON `null`; the reader returns `(Some(1234), None)`,
+    // and the caller falls back to the AP-park target for the Dec axis.
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     let json = serde_json::json!({
@@ -2131,13 +2199,35 @@ fn read_park_from_config_treats_explicit_null_as_none_per_axis() {
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let (ra, dec) = read_park_from_config(&path).unwrap();
-    assert_eq!(ra, Some(1234));
-    assert_eq!(dec, None);
+    let f = read_connect_fields(&path).unwrap();
+    assert_eq!(f.park_ra_ticks, Some(1234));
+    assert_eq!(f.park_dec_ticks, None);
 }
 
 #[test]
-fn read_park_from_config_errors_on_wrong_type() {
+fn read_connect_fields_errors_on_invalid_ap_park() {
+    // Operator typo: an unrecognised AP-park string must fail loudly
+    // rather than silently fall back.
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    let json = serde_json::json!({
+        "mount": {
+            "unpark_from_ap_position": "ap_park_99",
+        }
+    });
+    std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+    let err = read_connect_fields(&path).unwrap_err();
+    match err {
+        StarAdvError::Config(msg) => {
+            assert!(msg.contains("unpark_from_ap_position"), "{msg}");
+            assert!(msg.contains("AP park"), "{msg}");
+        }
+        other => panic!("expected Config error, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_connect_fields_errors_on_wrong_type() {
     // Operator typo: park_ra_ticks declared as a string. Used to
     // be silently treated as None (fell back to handshake);
     // current contract is to surface the misconfiguration. Per
@@ -2151,7 +2241,7 @@ fn read_park_from_config_errors_on_wrong_type() {
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let err = read_park_from_config(&path).unwrap_err();
+    let err = read_connect_fields(&path).unwrap_err();
     match err {
         StarAdvError::Config(msg) => {
             assert!(msg.contains("park_ra_ticks"), "{msg}");
@@ -2162,7 +2252,7 @@ fn read_park_from_config_errors_on_wrong_type() {
 }
 
 #[test]
-fn read_park_from_config_errors_on_float_value() {
+fn read_connect_fields_errors_on_float_value() {
     // serde_json::Value::Number for 1.5 isn't representable as
     // i64; `as_i64()` returns None and we surface a Config error
     // rather than silently dropping the value.
@@ -2175,12 +2265,12 @@ fn read_park_from_config_errors_on_float_value() {
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let err = read_park_from_config(&path).unwrap_err();
+    let err = read_connect_fields(&path).unwrap_err();
     assert!(matches!(err, StarAdvError::Config(_)));
 }
 
 #[test]
-fn read_park_from_config_errors_on_out_of_i32_range() {
+fn read_connect_fields_errors_on_out_of_i32_range() {
     // A value that fits in i64 but not i32 — e.g. someone copied
     // a large encoder count from a higher-resolution mount, or
     // a typo added a digit. Either way we should fail loudly so
@@ -2195,7 +2285,7 @@ fn read_park_from_config_errors_on_out_of_i32_range() {
         }
     });
     std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
-    let err = read_park_from_config(&path).unwrap_err();
+    let err = read_connect_fields(&path).unwrap_err();
     match err {
         StarAdvError::Config(msg) => {
             assert!(msg.contains("park_ra_ticks"), "{msg}");
@@ -2298,11 +2388,11 @@ fn probe_park_file_writability_fails_on_a_read_only_directory() {
 }
 
 #[test]
-fn read_park_from_config_fails_when_mount_object_is_missing() {
+fn read_connect_fields_fails_when_mount_object_is_missing() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     std::fs::write(&path, "{}").unwrap();
-    let err = read_park_from_config(&path).unwrap_err();
+    let err = read_connect_fields(&path).unwrap_err();
     match err {
         StarAdvError::Config(msg) => assert!(msg.contains("mount"), "{msg}"),
         other => panic!("expected Config, got {other:?}"),

--- a/services/star-adventurer-gti/tests/bdd/steps/mod.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/mod.rs
@@ -9,3 +9,4 @@ pub mod side_of_pier_steps;
 pub mod slew_steps;
 pub mod sync_steps;
 pub mod tracking_steps;
+pub mod unpark_steps;

--- a/services/star-adventurer-gti/tests/bdd/steps/unpark_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/unpark_steps.rs
@@ -4,18 +4,13 @@ use crate::world::StarAdventurerWorld;
 use cucumber::{given, then, when};
 use std::time::Duration;
 
-/// Resolve an `ap_park_N` feature-file token to the typed [`ApPark`].
+/// Resolve an `ap_park_N` feature-file token to the typed [`ApPark`]
+/// via its canonical `FromStr`; a bad token fails the scenario.
 fn parse_ap_park(token: &str) -> star_adventurer_gti::ApPark {
-    use star_adventurer_gti::ApPark;
-    match token {
-        "ap_park_0" => ApPark::ApPark0,
-        "ap_park_1" => ApPark::ApPark1,
-        "ap_park_2" => ApPark::ApPark2,
-        "ap_park_3" => ApPark::ApPark3,
-        "ap_park_4" => ApPark::ApPark4,
-        "ap_park_5" => ApPark::ApPark5,
-        other => panic!("unknown AP park token {other:?}"),
-    }
+    token
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("invalid AP park token {token:?}: {e}"))
 }
 
 #[given(expr = "a star-adventurer service configured with unpark_from_ap_position {string}")]

--- a/services/star-adventurer-gti/tests/bdd/steps/unpark_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/unpark_steps.rs
@@ -1,0 +1,95 @@
+//! Steps for unpark_from_ap_position.feature.
+
+use crate::world::StarAdventurerWorld;
+use cucumber::{given, then, when};
+use std::time::Duration;
+
+/// Resolve an `ap_park_N` feature-file token to the typed [`ApPark`].
+fn parse_ap_park(token: &str) -> star_adventurer_gti::ApPark {
+    use star_adventurer_gti::ApPark;
+    match token {
+        "ap_park_0" => ApPark::ApPark0,
+        "ap_park_1" => ApPark::ApPark1,
+        "ap_park_2" => ApPark::ApPark2,
+        "ap_park_3" => ApPark::ApPark3,
+        "ap_park_4" => ApPark::ApPark4,
+        "ap_park_5" => ApPark::ApPark5,
+        other => panic!("unknown AP park token {other:?}"),
+    }
+}
+
+#[given(expr = "a star-adventurer service configured with unpark_from_ap_position {string}")]
+async fn configured_with_unpark(world: &mut StarAdventurerWorld, park: String) {
+    world.config_mut().mount.unpark_from_ap_position = parse_ap_park(&park);
+    world.start_service().await;
+}
+
+#[when(expr = "I run the SetUnparkFromApPosition action with {string}")]
+async fn run_set_unpark(world: &mut StarAdventurerWorld, park: String) {
+    world
+        .mount()
+        .action("SetUnparkFromApPosition".to_string(), park)
+        .await
+        .unwrap();
+}
+
+#[when(expr = "I run the UnparkFromApPosition action with {string}")]
+async fn run_unpark_action(world: &mut StarAdventurerWorld, park: String) {
+    world
+        .mount()
+        .action("UnparkFromApPosition".to_string(), park)
+        .await
+        .unwrap();
+}
+
+#[then("the mount should have received an encoder seed on both axes")]
+async fn received_encoder_seed_both_axes(world: &mut StarAdventurerWorld) {
+    // `:E1` / `:E2` (SetPosition) carry a hex payload, so match on the
+    // frame prefix. Poll because CI runners can lag behind the wire.
+    for _ in 0..60 {
+        let log = world.command_log().await;
+        let e1 = log.iter().any(|c| c.starts_with(":E1"));
+        let e2 = log.iter().any(|c| c.starts_with(":E2"));
+        if e1 && e2 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let log = world.command_log().await;
+    panic!("expected :E1 and :E2 encoder-seed frames; saw {log:?}");
+}
+
+#[then("the mount should not have received an encoder-seed command")]
+async fn no_encoder_seed(world: &mut StarAdventurerWorld) {
+    // `set_connected` is awaited, so any connect-time seed has already
+    // reached the mock log by now; absence is therefore reliable without
+    // polling. `:E` frames only come from a seed / sync / reset.
+    let log = world.command_log().await;
+    let seeds: Vec<&String> = log.iter().filter(|c| c.starts_with(":E")).collect();
+    assert!(
+        seeds.is_empty(),
+        "expected no :E encoder-seed frames, saw {seeds:?} in {log:?}"
+    );
+}
+
+#[then(expr = "the persisted config should have unpark_from_ap_position {string}")]
+async fn persisted_unpark(world: &mut StarAdventurerWorld, park: String) {
+    let cfg = world.read_persisted_config();
+    assert_eq!(cfg.mount.unpark_from_ap_position, parse_ap_park(&park));
+}
+
+#[then(expr = "SupportedActions should include {string}, {string}, and {string}")]
+async fn supported_actions_include(
+    world: &mut StarAdventurerWorld,
+    first: String,
+    second: String,
+    third: String,
+) {
+    let actions = world.mount().supported_actions().await.unwrap();
+    for want in [first, second, third] {
+        assert!(
+            actions.contains(&want),
+            "SupportedActions {actions:?} missing {want:?}"
+        );
+    }
+}

--- a/services/star-adventurer-gti/tests/features/park.feature
+++ b/services/star-adventurer-gti/tests/features/park.feature
@@ -1,13 +1,13 @@
 Feature: Park, unpark, and SetPark
   Park stops tracking, slews both axes to the in-memory park-target
   encoder pair, and sets AtPark when both axes report stopped. The park
-  target is loaded on connect from `mount.park_ra_ticks` /
-  `mount.park_dec_ticks` in the config, falling back to the encoder
-  positions captured during the init handshake when those values are
-  absent. Tracking remains disabled after Park (per ASCOM). Unpark clears
-  AtPark but does not auto-enable tracking. SetPark captures the current
-  encoder pair and writes it back into the running config file via
-  atomic rename.
+  target is loaded on connect, per axis, from the raw
+  `mount.park_ra_ticks` / `mount.park_dec_ticks` override when set,
+  otherwise from the `mount.preferred_ap_park` AP park (ship default
+  `ap_park_3`, Sky-Watcher's stock power-up pose). Tracking remains
+  disabled after Park (per ASCOM). Unpark clears AtPark but does not
+  auto-enable tracking. SetPark captures the current encoder pair and
+  writes it back into the running config file via atomic rename.
 
   Scenario: AtPark is false on first connect
     Given a running star-adventurer service
@@ -22,21 +22,15 @@ Feature: Park, unpark, and SetPark
     Then the mount should have received command :K1 before any :S1
     And Tracking should be false
 
-  Scenario: Park targets the handshake-captured encoder pair when the config has no park values
+  Scenario: Park targets the preferred AP park when the config has no raw park values
+    # Default config: latitude 0, preferred_ap_park = ap_park_3. ap_park_3
+    # → mech_HA = -6h (ra = -6/24 * cpr = -907200) and dec_enc = +90°
+    # (dec = 90/360 * cpr = +907200) at the GTi CPR of 3,628,800.
     Given a running star-adventurer service
-    And the RA-axis encoder reads 0 ticks
-    And the Dec-axis encoder reads 0 ticks
     When I connect the device
     And I park the mount
-    Then the mount should have received a :S1 command targeting encoder 0
-    And the mount should have received a :S2 command targeting encoder 0
-
-  Scenario: Park targets the Dec encoder position captured at handshake
-    Given a running star-adventurer service
-    And the Dec-axis encoder reads 12000 ticks
-    When I connect the device
-    And I park the mount
-    Then the mount should have received a :S2 command targeting encoder 12000
+    Then the mount should have received a :S1 command targeting encoder -907200
+    And the mount should have received a :S2 command targeting encoder 907200
 
   Scenario: Park targets the configured park_ra_ticks when present
     Given a star-adventurer service configured with park_ra_ticks 5000 and park_dec_ticks -7000

--- a/services/star-adventurer-gti/tests/features/unpark_from_ap_position.feature
+++ b/services/star-adventurer-gti/tests/features/unpark_from_ap_position.feature
@@ -1,0 +1,59 @@
+Feature: Unpark from AP position
+  The Sky-Watcher firmware resets its encoder counter to (0, 0) on every
+  power-up, so the driver must be told which physical pose the OTA is in.
+  `mount.unpark_from_ap_position` carries that assumption, named after the
+  Astro-Physics park positions ap_park_0..ap_park_5. The ship default
+  ap_park_0 ("current position") means "no seed — I will plate-solve and
+  sync"; ap_park_1..ap_park_5 seed the firmware encoder on the fresh
+  power-up connect so the driver's celestial math matches the physical
+  pose.
+
+  Three driver-specific ASCOM Actions expose runtime control:
+  SetUnparkFromApPosition persists a new value (applied on the next
+  fresh-power-up connect), SetPreferredApPark sets the Park() target, and
+  UnparkFromApPosition is a recovery operation that resets the firmware
+  encoder to a named park before clearing AtPark.
+
+  Scenario: Fresh power-up with ap_park_0 leaves the encoder untouched
+    Given a star-adventurer service configured with unpark_from_ap_position "ap_park_0"
+    When I connect the device
+    Then the mount should not have received an encoder-seed command
+
+  Scenario: Fresh power-up with ap_park_3 seeds the firmware encoder
+    Given a star-adventurer service configured with unpark_from_ap_position "ap_park_3"
+    When I connect the device
+    Then the mount should have received an encoder seed on both axes
+
+  Scenario: UnparkFromApPosition with a named park resets the encoder and unparks
+    Given a star-adventurer service configured with park_ra_ticks 0 and park_dec_ticks 0
+    When I connect the device
+    And I park the mount
+    And I run the UnparkFromApPosition action with "ap_park_3"
+    Then the mount should have received an encoder seed on both axes
+    And AtPark should be false
+
+  Scenario: UnparkFromApPosition with ap_park_0 clears AtPark without seeding
+    Given a star-adventurer service configured with park_ra_ticks 0 and park_dec_ticks 0
+    When I connect the device
+    And I park the mount
+    And I run the UnparkFromApPosition action with "ap_park_0"
+    Then AtPark should be false
+    And the mount should not have received an encoder-seed command
+
+  Scenario: SetUnparkFromApPosition persists the value to the config file
+    Given a running star-adventurer service
+    When I connect the device
+    And I run the SetUnparkFromApPosition action with "ap_park_2"
+    Then the persisted config should have unpark_from_ap_position "ap_park_2"
+
+  Scenario: SetUnparkFromApPosition applies on the next fresh-power-up connect
+    Given a running star-adventurer service
+    When I connect the device
+    And I run the SetUnparkFromApPosition action with "ap_park_3"
+    And I disconnect the device
+    And I connect the device
+    Then the mount should have received an encoder seed on both axes
+
+  Scenario: SupportedActions advertises the driver-specific actions
+    Given a running star-adventurer service
+    Then SupportedActions should include "SetUnparkFromApPosition", "SetPreferredApPark", and "UnparkFromApPosition"


### PR DESCRIPTION
Implements the design from PR #248. Closes #249.

Replaces the implicit `home_pose: Option<HomePose>` model with a required `unpark_from_ap_position: ApPark` field (ship default `ap_park_0` = "current position") and adds three driver-specific ASCOM Actions plus a `ResetMountEncoders` helper.

## Phases

- **A — Config schema**: rename `HomePose` → `ApPark`, add the `ap_park_0` variant, make `codebase_*` accessors return `Option<f64>` (`None` for `ap_park_0`). Replace `home_pose` with required `unpark_from_ap_position` (default `ap_park_0`) and add `preferred_ap_park` (default `ap_park_3`, rejects `ap_park_0` at deserialize).
- **B — `reset_mount_encoders`**: stop both axes → `:E1`/`:E2` → clear slew/target/tracking state. Bails before any `:E` if a stop fails.
- **C — `seed_after_connect`** (renamed from `seed_home_pose_after_connect`): short-circuits on `ap_park_0`; reads the configured pose fresh from disk so a `SetUnparkFromApPosition` write applies on the next fresh-power-up connect without a driver restart.
- **D — Custom Actions** (new `mount_device/actions.rs`): `SetUnparkFromApPosition`, `SetPreferredApPark`, `UnparkFromApPosition`, wired through `Device::action`/`supported_actions` (first service in the repo to implement these). Generalised the `SetPark` config write-back helper.
- **E — `Park()`**: target resolves per-axis as raw `park_*_ticks` override → `preferred_ap_park` → snapshot (defensive).
- **F — Docs + BDD**: new `unpark_from_ap_position.feature` (7 scenarios), updated `park.feature` for the new fallback, and a design-doc module-structure refresh.

No migration — the driver is unreleased; this is a hard rename.

## Design interpretations

- **Disk is the source of truth** for the runtime-mutable fields (read fresh on connect), mirroring the existing `SetPark` precedent — `self.config` can't be mutated through `&self`, and this is what makes "applies on next fresh-power-up" work without restarting the driver.
- **Per-axis** park resolution (a superset of the plan's "both set" framing) preserves the existing partial-override behavior; the affected unit test was updated.

## Verification

- 389 unit tests + 132 BDD scenarios pass.
- `cargo fmt --check`, `cargo clippy` clean; the pre-commit hook ran workspace-wide `cargo clippy --all --all-targets --all-features -- -D warnings` + `cargo fmt --all --check` (both green).
- No `Cargo.toml`/`Cargo.lock` changes (no new dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)