### PR TITLE
feat(star-adventurer-gti): tracking-time exclusion-zone safety guard (Part 1 of #259)

### DIFF
--- a/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
+++ b/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
@@ -1,0 +1,290 @@
+# ADR-006: Typed Physical Quantities for the Star Adventurer GTi Pointing Math
+
+## Status
+
+Proposed (2026-05-23).
+
+Origin: the review thread on the issue #259 tracking-guard work. Wiring
+`MountConfig::validate()` (which closed a pre-existing gap where
+`FlipPolicy::validate()` was dead code) surfaced the deeper question —
+every physical quantity in the driver is a bare `f64`, so units and
+reference frames are enforced only by field-name suffixes, doc comments,
+and runtime validation, never by the type system. This ADR proposes the
+type-level fix and sequences it as a **separate initiative** from the
+shipped #259 work, which stays self-contained.
+
+## Context
+
+The Star Adventurer GTi driver does a lot of pointing arithmetic, and
+all of it runs on bare primitives:
+
+- `coordinates.rs` exposes 20 public functions, nearly all taking or
+  returning bare `f64` "hours" or "degrees" (53 `f64` mentions in the
+  file). `mech_ha` alone appears ~196 times across `src/` as a bare
+  `f64`.
+- Config carries the same shape: `flip_range_hours`,
+  `binding_zone_min_hours`/`binding_zone_max_hours`,
+  `tracking_guard_margin_hours`, `dec_min_degrees`/`dec_max_degrees`,
+  `site_latitude_deg`/`site_longitude_deg` are all `f64`.
+- There are **no newtypes anywhere in the workspace** (a `grep` for
+  `struct X(f64|i32|u32)` across `crates/` and `services/` returns
+  nothing) and **no units crate** (`uom`/`dimensioned`). This ADR would
+  set the first such convention.
+
+### The bug class this is meant to prevent
+
+Two things masquerade as "hours" but are different physical frames:
+
+- **Mechanical HA** (`mech_HA`) — the encoder's view of where the polar
+  axis points, folded to `[−12, +12)`. This is what the CW exclusion
+  zone, the slew-path checks, and the new tracking guard reason about.
+- **Celestial HA** (`HA = LST − RA`), plus the related `RA`, `LST`, and
+  `Dec` quantities.
+
+Because they're all `f64`, the compiler accepts any mix of them. Today
+the code is correct, but the correctness is unchecked. Two adjacent
+lines in `coordinates.rs` make the hazard concrete:
+
+```rust
+// mechanical_ha_to_ra: LST minus *mechanical* HA  (frame: mechanical)
+(lst_hours - mech_ha).rem_euclid(24.0)
+// ra_to_mechanical_ha: LST minus RA = celestial HA (frame: celestial)
+fold_to_signed((lst_hours - ra_hours).rem_euclid(24.0), 24.0)
+```
+
+Both are `f64 - f64`. Swap `mech_ha` and `ra_hours`, or feed a celestial
+HA into a function expecting `mech_HA`, and it compiles and runs — and on
+this mount a frame error in the wrong place drives the counterweights
+toward the tripod. The flip math (`mech_ha + 12.0`) and the
+ticks↔hours↔degrees conversions (`* 24.0 / cpr`, `/ 15.0`) are the same
+story: unit- and frame-laden operations expressed as untyped float
+arithmetic.
+
+This is exactly the failure mode this driver already takes seriously
+mechanically (issue #252's zone widening, #259's tracking guard); the
+type system can make a whole category of it unrepresentable.
+
+### Goals
+
+1. Make unit errors (hours vs degrees vs ticks) and frame errors
+   (mechanical vs celestial HA) **compile errors**.
+2. Move config validation from a runtime `validate()` call to
+   **construct-time / deserialize-time** invariants (parse-don't-validate).
+3. Encode the domain conversions (fold-to-`[−12,12)`, `HA→mech` `+12`
+   fold, tick↔angle) as **named, type-checked operations** rather than
+   inline float math.
+
+### Non-goals
+
+- Rewriting other services. They use bare `f64` too, but the bug class
+  bites hardest in this mount's pointing math; workspace-wide adoption is
+  a later, separate question.
+- Adopting a general dimensional-analysis framework (`uom`) — see
+  Options.
+- Changing any observable behaviour. This is a representation change with
+  the existing tests as the oracle.
+
+## Options Considered
+
+### Option 1 — Status quo + runtime `validate()` (do nothing more)
+
+Keep bare `f64`; rely on the `MountConfig::validate()` just added and on
+test coverage. **Rejected** as the end state: it leaves the frame bug
+class entirely unguarded (validation checks ranges, not units/frames),
+and it's the situation that prompted the question. Retained only as the
+fallback if the migration is judged too risky.
+
+### Option 2 — Config-boundary newtypes only ("Scope A")
+
+Newtype just the config fields with validating constructors + serde
+`try_from`, unwrapping to `f64` for all math. **Good but insufficient
+alone**: it delivers parse-don't-validate for config (a real win, and it
+retires `validate()`), but the moment a value enters `coordinates.rs` it
+becomes an untyped `f64` again, so the frame bug class survives. Adopted
+here as **a phase of**, not an alternative to, the full change.
+
+### Option 3 — Semantic domain types across the pointing math (CHOSEN)
+
+Introduce a small set of types that carry both unit and frame, threaded
+through `coordinates.rs`, `slew.rs`, `inherent.rs`, the tracking guard,
+and config. Distinct types for `MechHa` vs `HourAngle` (celestial) vs
+`Ra` vs `Lst` make the frame errors unrepresentable; `Degrees`,
+`Hours`, `Ticks`/`Cpr` carry units. See [Decision](#decision).
+
+### Option 4 — A dimensional-analysis crate (`uom`)
+
+`uom` gives compile-time unit checking for SI-style quantities.
+**Rejected**: heavyweight generic machinery and serde-integration
+friction for what is, here, a handful of bespoke astronomical frames
+(`uom` models units, not "mechanical vs celestial hour angle"). The
+frame distinction — the part that actually bites us — isn't something
+`uom` expresses. It would also be the workspace's first big external
+type dependency for marginal benefit.
+
+### Option 5 — Phantom-typed `Angle<Unit, Frame>`
+
+One generic `Angle<U, F>` with `PhantomData` markers for unit and frame.
+**Elegant, deferred**: it minimises the number of concrete types but
+pushes complexity into the type signatures and the conversion impls, and
+it's harder to give each frame its own domain methods
+(`Lst::hour_angle_of(ra)`). Start with concrete newtypes (Option 3); a
+later consolidation to a phantom-typed core is possible without changing
+call sites if the concrete types are kept thin.
+
+## Decision
+
+Adopt **Option 3**: a `units` module of concrete newtypes, migrated in
+regression-safe phases, with no external units dependency.
+
+### Type design (intent, not final API)
+
+Unit-carrying base types:
+
+```rust
+/// Angle in hours (1 h = 15°). No frame meaning on its own.
+pub struct Hours(f64);
+/// Angle in degrees.
+pub struct Degrees(f64);
+/// Encoder counts and counts-per-revolution.
+pub struct Ticks(i32);
+pub struct Cpr(u32);
+```
+
+Frame-distinct hour-angle types — the part that kills the bug class:
+
+```rust
+/// Mechanical hour angle: encoder view of the polar axis, folded to
+/// [-12, +12) h. The quantity the CW exclusion zone and tracking guard
+/// reason about.
+pub struct MechHa(Hours);
+/// Celestial hour angle of a target: LST - RA, folded to [-12, +12) h.
+pub struct HourAngle(Hours);
+pub struct Ra(Hours);
+pub struct Lst(Hours);
+```
+
+The domain conversions become named, type-checked operations — the inline
+float math of today turned into methods that only accept the right frames:
+
+```rust
+impl Lst    { pub fn hour_angle_of(self, ra: Ra) -> HourAngle; }   // LST - RA, folded
+impl HourAngle { pub fn to_mech(self, side: PierSide) -> MechHa; } // +12 fold on the flipped side
+impl Ticks  { pub fn to_mech_ha(self, cpr: Cpr) -> MechHa; }
+impl MechHa { pub fn to_ticks(self, cpr: Cpr) -> Ticks; }
+impl MechHa { pub fn in_zone(self, zone: CwExclusionZone) -> bool; }
+```
+
+`fold_ha` / `fold_to_signed` / `rem_euclid(24.0)` collapse into a single
+`Hours::fold_ha()` (and the fold becomes idempotent-by-construction for
+the frame types). `derive_more` (already a dependency) supplies
+`Display`, `From`, and the arithmetic boilerplate where it's safe; the
+`feature` list grows from `["debug"]` to include `from`/`into`/`display`
+(and `add`/`sub` only where unrestricted arithmetic is actually correct
+— notably **not** across frames).
+
+### Config newtypes subsume `validate()`
+
+Config fields become validating newtypes; serde validates on
+deserialize, so an out-of-range value fails at `serde_json::from_str`
+with the field name attached — strictly better than the hand-rolled
+`MountConfig::validate()`, which is then retired:
+
+```rust
+#[derive(Serialize)]
+#[serde(try_from = "f64", into = "f64")]
+pub struct FlipRangeHours(Hours);
+
+impl TryFrom<f64> for FlipRangeHours {
+    type Error = String;
+    fn try_from(v: f64) -> Result<Self, String> { /* (0, 0.95] */ }
+}
+```
+
+The CW zone — two fields with a cross-field `min ≥ max = disabled` rule —
+becomes one `CwExclusionZone` type (`Active { min, max } | Disabled`),
+so the "disabled" sentinel is modelled rather than conventional.
+
+### No external units dependency
+
+Use `derive_more` only. Reject `uom` (Option 4).
+
+## Migration plan (regression-safe, phased; one commit per stage in a single PR)
+
+`coordinates.rs` is hardware-validated (Phase 4/6, lat 32.7°N) and
+safety-critical. The migration is structured so the existing tests are
+the oracle at every step and the suite stays green throughout. The whole
+refactor lands as **one PR with one commit per stage** below — each
+commit keeps the suite green, so the PR can be reviewed (and bisected)
+stage by stage rather than split across multiple PRs.
+
+- **Phase 1 — `src/units.rs` + tests, no production change.** Land the
+  types with exhaustive unit tests and property tests (tick↔angle
+  round-trips, `fold_ha` idempotence, `HA→mech→HA` round-trips). Pure
+  addition; nothing calls them yet.
+- **Phase 2 — migrate `coordinates.rs` internals.** Convert function
+  bodies to the typed operations while keeping the existing public `f64`
+  signatures as thin wrappers (wrap on entry, unwrap on exit). The
+  current `coordinates::tests` pin behaviour and must stay green
+  unchanged — they are the regression net.
+- **Phase 3 — propagate types outward + config.** Flip the public
+  signatures to typed; migrate `slew.rs`, `tracking_guard.rs`,
+  `inherent.rs`, and the `MountConfig` fields (the Scope A newtypes);
+  retire `MountConfig::validate()` in favour of construct-time
+  validation. The ASCOM boundary (`ascom-alpaca`'s `f64` RA/Dec API) and
+  the wire codec stay `f64`; the device layer wraps/unwraps there, and
+  that boundary is documented.
+- **Phase 4 — remove transitional shims.** Delete the f64 wrappers; the
+  pointing API is fully typed.
+
+BDD scenarios and ConformU are unchanged and serve as end-to-end
+regression checks across all phases.
+
+## Consequences
+
+- **Eliminates the frame bug class** in pointing math and makes config
+  invalid-states unrepresentable — the two things this initiative exists
+  for.
+- **Workspace precedent.** First newtypes in the repo. The `units`
+  module is written to be reusable, but adoption is scoped to
+  `star-adventurer-gti` here; other services are untouched. A future ADR
+  can promote it workspace-wide if it earns its keep.
+- **Friction at boundaries.** Every f64 site gains a wrap/unwrap or a
+  method call, and three boundaries stay `f64` by necessity — serde
+  input, the Sky-Watcher wire codec, and the `ascom-alpaca` trait API
+  (RA in hours, Dec in degrees). These are localised and documented;
+  the interior is typed.
+- **Migration risk is the main cost** — it rewrites validated pointing
+  code. Mitigated by the phased plan, the existing test oracle, and
+  keeping each stage a self-contained, green commit that is
+  independently reviewable within the one PR.
+- **No new external dependency.** `derive_more` feature flags grow; no
+  `uom`.
+- **`#259` is unaffected.** The shipped tracking guard and
+  `MountConfig::validate()` continue to work; Phase 3 later swaps
+  `validate()` for typed construction without changing behaviour.
+
+## Open questions
+
+1. **Frame granularity.** Start with concrete `MechHa`/`HourAngle`/
+   `Ra`/`Lst` (this ADR) vs a phantom-typed `Angle<Unit, Frame>`
+   (Option 5). Proposal: concrete first, revisit consolidation after
+   Phase 3 shows the real conversion surface.
+2. **Land Scope A first?** The config newtypes are low-risk and
+   immediately retire `validate()`. Option to ship them as Phase 1.5
+   (before the `coordinates.rs` migration) for an early win. Recommended.
+3. **Workspace-wide adoption.** Out of scope here; revisit once the
+   `units` module has proven itself in this service.
+
+## References
+
+- Issue #259 review thread — the validation work that surfaced this.
+- `services/star-adventurer-gti/src/coordinates.rs` — the math being
+  typed (the `lst - mech_ha` vs `lst - ra` frame hazard).
+- `services/star-adventurer-gti/src/config.rs` — `MountConfig::validate`
+  / `FlipPolicy::validate` (the runtime checks construct-time validation
+  would subsume).
+- `docs/services/star-adventurer-gti.md` §"Safety envelope" /
+  §"Tracking-time safety guard" — why frame correctness is a hardware
+  concern on this mount.
+- `docs/decisions/004-testing-strategy-for-http-client-error-paths.md` —
+  prior workspace-convention ADR; format reference.

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -841,6 +841,54 @@ The Dec envelope (`dec_min_degrees` / `dec_max_degrees`, defaults
 driver will accept, primarily a sanity check against client-side
 coordinate-math bugs.
 
+#### Tracking-time safety guard
+
+The safety envelope above is enforced at *slew* time. But `Tracking =
+true` issues `:G` + `:I` + `:J` on the RA axis and from that point the
+firmware advances the encoder autonomously — the driver sends no
+further wire commands and the slew-time path checks never re-run. A
+multi-hour session that begins at a safe negative `mech_HA` drifts up
+across the zone entry (`mech_HA = +0.95` by default) with no operator
+action: the same physical failure mode as a zone-crossing slew, reached
+via tracking drift instead of a slew command (issue #259).
+
+A per-connection background guard closes that gap. While `Tracking =
+true` it watches the live encoder `mech_HA` — read from the snapshot
+the background poll loop already refreshes, at `polling_interval`, so
+the guard adds no extra wire traffic. When `mech_HA` enters the band
+`(binding_zone_min_hours − margin, binding_zone_max_hours + margin)` —
+the CW exclusion zone widened by `tracking_guard_margin_hours` on each
+edge — the guard:
+
+1. issues `:K1` to stop the RA axis,
+2. clears the in-memory `Tracking` flag to match the wire, and
+3. emits a `warn!` explaining why.
+
+It does **not** pick a pier side or flip. Post-guard state is
+`Tracking = false`, `Slewing = false`, the encoder wherever it was when
+the guard fired (no automatic park). The operator — or higher-level
+automation — decides what to do next: flip via `SetSideOfPier`, slew
+elsewhere, or park.
+
+`tracking_guard_margin_hours` (default `0.05` h ≈ 45 s of sidereal
+drift) lets cautious operators stop *before* the zone entry rather than
+at it; `0.0` stops exactly at `binding_zone_min_hours`. A non-finite or
+negative value is treated as `0.0`. The guard is **independent of
+`flip_policy.enabled`**: it is the safety floor that keeps an
+unattended autoguided session from contacting hardware whether or not
+meridian-flip support is configured. It is disabled only when the zone
+itself is (`binding_zone_min_hours ≥ binding_zone_max_hours`). Because
+`slew_to_coordinates_async` clears `Tracking` for a slew's duration, the
+guard is naturally dormant during slews and resumes once the
+completion watcher re-engages tracking on the new pose.
+
+Driver-planned auto-flip during tracking (Phase 2.5) — flipping ahead
+of the zone instead of just stopping — is a separate, larger change
+tracked as Part 2 of issue #259 and remains
+[deferred](#deferred-not-in-mvp). When it lands, this guard stays as the
+belt-and-suspenders fallback for when an auto-flip can't find a safe
+path.
+
 #### Pier-side decision tree
 
 `DestinationSideOfPier(ra, dec)` and `SlewToCoordinatesAsync(ra,
@@ -1020,6 +1068,13 @@ function.
 JSON, deserialised with `serde` + `humantime-serde` for `Duration`
 fields. The transport block is a tagged enum: `usb` or `udp`.
 
+The mount block is validated at startup (`load_config` →
+`MountConfig::validate`): an out-of-range `flip_policy.flip_range_hours`,
+a non-finite binding zone or tracking-guard margin, a margin above
+`MAX_TRACKING_GUARD_MARGIN_HOURS` (1.0 h), or an inverted /
+out-of-hemisphere Dec range is rejected with a clear error rather than
+silently driving the mount with a bad parameter.
+
 ```json
 {
   "transport": {
@@ -1099,6 +1154,14 @@ Notes:
   (CW points into the ground beneath the pier, not above the mount
   head). Setting `min ≥ max` disables the check (used by tests and
   by operators whose mount geometry differs).
+- `tracking_guard_margin_hours` extends CW exclusion-zone enforcement
+  to *tracking* time: a background guard stops the mount (`:K1`) once
+  the live encoder `mech_HA` drifts into
+  `(binding_zone_min_hours − margin, binding_zone_max_hours + margin)`
+  while `Tracking = true`. Defaults `0.05` h (≈ 45 s of sidereal
+  drift); `0.0` stops exactly at the zone entry. Independent of
+  `flip_policy.enabled`. See
+  [§Tracking-time safety guard](#tracking-time-safety-guard).
 - `dec_min_degrees` / `dec_max_degrees` clip the celestial-Dec
   range the driver will accept on slew / sync. Defaults `[−90, +90]°`.
 - `park_ra_ticks` / `park_dec_ticks` are written by `SetPark` and read
@@ -1635,7 +1698,7 @@ as `qhy-focuser` and `ppba-driver`.)
 | **Phase A7 — PulseGuide** | landed (issue #206) — implements `PulseGuide` as a rate-shifted tracking burst on the targeted axis (no `:P`; that's the ST4-jack rate setter, not a pulse trigger), flips `CanPulseGuide` and `CanSetGuideRates` to `true`. Re-enabled `[package.metadata.conformu]` so the full two-phase ConformU integration ran again — but the `conformance` phase, which `alpacaprotocol`-only manual runs hadn't exercised, surfaced three failures that PR #206's review hadn't caught; see Phase A8. |
 | **Phase A8 — Nightly ConformU opt-out (#201)** | landed (issue #201) — removed `[package.metadata.conformu]` again. ConformU's `conformance` phase fails for three independent reasons that need driver work first: (a) `SideOfPierTests` slews to mech-HA ±9 h, which the safety envelope correctly rejects on hardware but which ConformU treats as a fatal CheckMethods-level exception that abandons the rest of the suite; (b) `SideOfPier` always returns `pierWest` for in-envelope targets (Dec-encoder convention) where ConformU asserts the ASCOM pointing-state convention; (c) PulseGuide Dec moves at full sidereal rate instead of `guide_rate_dec_fraction × sidereal`. See [§Running ConformU manually](#running-conformu-manually) and [§Expected ConformU report](#expected-conformu-report) for the failure details and reproduction steps. |
 | **Phase 5 — user-defined `SetPark` + persistence** | landed (issue #203) — park target now sourced from `mount.park_ra_ticks` / `mount.park_dec_ticks` in the config (fallback: encoder positions captured at handshake), `SetPark` writes the current encoder pair back into the running config file via atomic rename, `CanSetPark` flips on when `--config` is provided. See [§Park lifecycle](#park-lifecycle) and [§Park persistence](#park-persistence). |
-| **Phase 6 — meridian-flip support** | hardware-validated 2026-05-16 (lat 32.7°N) — adds `MountConfig::flip_policy` (`enabled` + `flip_range_hours`), the asymmetric CW exclusion zone safety envelope, CW-exclusion zone-path-aware through-wrap RA routing, visible-pole Dec routing, `SetSideOfPier`, and flip-aware `DestinationSideOfPier`. End-to-end AP Park 1–5 traversal (including the through-wrap saddle-east flip and its flip-back) ran clean; the flip-back from the saddle-east wrap caught a sign-blind heuristic in `flip_slew_ra_delta` that the path-aware check now handles. `flip_policy.enabled` still defaults `false` (operators opt in once they've replayed the validation locally). Auto-flip-during-tracking is intentionally deferred to a Phase 2.5 follow-up — the driver only flips on an explicit `SetSideOfPier` or a slew whose target requires the opposite side. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md). See [§Meridian flip](#meridian-flip). |
+| **Phase 6 — meridian-flip support** | hardware-validated 2026-05-16 (lat 32.7°N) — adds `MountConfig::flip_policy` (`enabled` + `flip_range_hours`), the asymmetric CW exclusion zone safety envelope, CW-exclusion zone-path-aware through-wrap RA routing, visible-pole Dec routing, `SetSideOfPier`, and flip-aware `DestinationSideOfPier`. End-to-end AP Park 1–5 traversal (including the through-wrap saddle-east flip and its flip-back) ran clean; the flip-back from the saddle-east wrap caught a sign-blind heuristic in `flip_slew_ra_delta` that the path-aware check now handles. `flip_policy.enabled` still defaults `false` (operators opt in once they've replayed the validation locally). The tracking-time CW-exclusion-zone safety guard (Part 1 of issue #259) has since landed — a background watcher stops tracking before the encoder `mech_HA` drifts into the zone (see [§Tracking-time safety guard](#tracking-time-safety-guard)). Driver-planned auto-flip-during-tracking (Phase 2.5 / Part 2 of #259) remains deferred — the driver only flips on an explicit `SetSideOfPier` or a slew whose target requires the opposite side. Plan: [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md). See [§Meridian flip](#meridian-flip). |
 
 #### Phase 4 findings (hardware bringup)
 
@@ -1905,7 +1968,7 @@ What's still outstanding from Phase 4:
 | Polar-alignment helpers, TPOINT, cone error | observational pointing model is the host's concern, not the driver's |
 | WiFi station mode (mount on a routed network) | AP-mode UDP is verified; station mode just changes the bind-address selection — straightforward to add once a station-mode test setup exists |
 | Multi-mount support on a single binary | `rp` assumes one mount per service; multi-mount is a separate concern |
-| Auto-flip during tracking (Phase 2.5: `flip_policy.auto_flip_during_tracking` + `auto_flip_at_meridian_offset_hours`) | hosts like NINA / SGP / `rp` own flip timing themselves; mid-exposure auto-flip is a footgun for astrophotography and a separate state machine. Phase 6 lands explicit `SetSideOfPier`-driven flips only |
+| Driver-planned auto-flip during tracking (Phase 2.5 / Part 2 of issue #259: `flip_policy.auto_flip_during_tracking` + `auto_flip_at_meridian_offset_hours`) | hosts like NINA / SGP / `rp` own flip timing themselves; mid-exposure auto-flip is a footgun for astrophotography and a separate state machine. The Part 1 tracking-time safety guard (stop-only, see [§Tracking-time safety guard](#tracking-time-safety-guard)) has landed; auto-flip would replace the stop with a flip slew and re-engage tracking on the new pier side |
 | Altitude-based safety floor (Phase 3 in [`docs/plans/star-adventurer-gti-meridian-flip.md`](../plans/star-adventurer-gti-meridian-flip.md)) | replaces the rectangular Dec envelope with an altitude floor; independent of Phase 6 and can land in either order |
 
 ## References

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -872,9 +872,11 @@ elsewhere, or park.
 
 `tracking_guard_margin_hours` (default `0.05` h ≈ 45 s of sidereal
 drift) lets cautious operators stop *before* the zone entry rather than
-at it; `0.0` stops exactly at `binding_zone_min_hours`. A non-finite or
-negative value is treated as `0.0`. The guard is **independent of
-`flip_policy.enabled`**: it is the safety floor that keeps an
+at it; `0.0` stops exactly at `binding_zone_min_hours`. A non-finite,
+negative, or over-cap (> 1.0 h) margin is rejected at config load
+(`load_config` → `MountConfig::validate`); the guard additionally treats
+a non-finite or negative value as `0.0` as defense-in-depth. The guard is
+**independent of `flip_policy.enabled`**: it is the safety floor that keeps an
 unattended autoguided session from contacting hardware whether or not
 meridian-flip support is configured. It is disabled only when the zone
 itself is (`binding_zone_min_hours ≥ binding_zone_max_hours`). Because

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -164,8 +164,11 @@ pub struct MountConfig {
     /// Independent of [`FlipPolicy::enabled`]: the guard is the safety
     /// floor and runs whenever the zone is active
     /// (`binding_zone_min_hours < binding_zone_max_hours`), regardless
-    /// of meridian-flip support. A non-finite or negative value is
-    /// treated as `0.0` by the guard.
+    /// of meridian-flip support. Validated on load: a non-finite,
+    /// negative, or over-cap value (> [`MAX_TRACKING_GUARD_MARGIN_HOURS`])
+    /// fails config loading. The guard additionally treats a non-finite or
+    /// negative value as `0.0` as defense-in-depth for construction paths
+    /// that bypass validation.
     #[serde(default = "default_tracking_guard_margin_hours")]
     pub tracking_guard_margin_hours: f64,
 
@@ -297,12 +300,23 @@ impl MountConfig {
 
         // CW exclusion zone. `min >= max` is the documented "disabled"
         // sentinel (used by tests and by operators whose geometry
-        // differs — see the field docs), so only finiteness is required
-        // here; the guard / slew checks treat an inverted interval as
-        // "no zone".
+        // differs — see the field docs), accepted as "no zone". An
+        // *active* zone (`min < max`) must live in the folded
+        // mechanical-HA domain `[-12, +12)` that the guard and slew
+        // checks assume (neither does 24 h wrap handling).
         if !self.binding_zone_min_hours.is_finite() || !self.binding_zone_max_hours.is_finite() {
             return Err(format!(
                 "binding_zone_min_hours / binding_zone_max_hours must be finite, got ({}, {})",
+                self.binding_zone_min_hours, self.binding_zone_max_hours
+            ));
+        }
+        if self.binding_zone_min_hours < self.binding_zone_max_hours
+            && (self.binding_zone_min_hours < -12.0 || self.binding_zone_max_hours > 12.0)
+        {
+            return Err(format!(
+                "an active CW exclusion zone must satisfy \
+                 -12 <= binding_zone_min_hours < binding_zone_max_hours <= 12 (folded mech_HA), \
+                 got ({}, {})",
                 self.binding_zone_min_hours, self.binding_zone_max_hours
             ));
         }
@@ -1184,6 +1198,20 @@ mod tests {
         }
         .validate()
         .unwrap_err();
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_active_zone_outside_folded_range() {
+        // An active zone (min < max) must stay within folded mech_HA
+        // [-12, +12); a max beyond +12 is out of the domain the guard
+        // and slew checks assume.
+        let m = MountConfig {
+            binding_zone_min_hours: 0.95,
+            binding_zone_max_hours: 20.0,
+            ..Default::default()
+        };
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("active CW exclusion zone"), "got {err}");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -149,6 +149,26 @@ pub struct MountConfig {
     #[serde(default = "default_binding_zone_max_hours")]
     pub binding_zone_max_hours: f64,
 
+    /// Slack added on both edges of the CW exclusion zone for the
+    /// **tracking-time safety guard** (see the design doc's
+    /// [§"Tracking-time safety guard"](../../../docs/services/star-adventurer-gti.md#tracking-time-safety-guard)).
+    ///
+    /// While `Tracking = true`, a background watcher stops the mount
+    /// (`:K1`) once the live encoder `mech_HA` enters
+    /// `(binding_zone_min_hours − margin, binding_zone_max_hours + margin)`,
+    /// before tracking drift can carry the counterweights into the
+    /// zone. The margin lets cautious operators stop early; `0.0`
+    /// stops exactly at zone entry. Defaults to `0.05` h (≈ 45 s of
+    /// sidereal drift).
+    ///
+    /// Independent of [`FlipPolicy::enabled`]: the guard is the safety
+    /// floor and runs whenever the zone is active
+    /// (`binding_zone_min_hours < binding_zone_max_hours`), regardless
+    /// of meridian-flip support. A non-finite or negative value is
+    /// treated as `0.0` by the guard.
+    #[serde(default = "default_tracking_guard_margin_hours")]
+    pub tracking_guard_margin_hours: f64,
+
     /// Safe Dec mechanical-degree envelope. Same enforcement and
     /// rationale as the RA limits. Defaults `[-90.0, +90.0]` — the
     /// observable hemisphere, plus the convention that
@@ -253,6 +273,71 @@ impl FlipPolicy {
                 self.flip_range_hours
             ));
         }
+        Ok(())
+    }
+}
+
+/// Outer bound on [`MountConfig::tracking_guard_margin_hours`]. The
+/// margin is operator-preference slack before the CW exclusion zone,
+/// not a mechanical limit; this cap only catches a misconfiguration
+/// (e.g. a value entered in degrees, or a unit mix-up) at startup. The
+/// shipped default is `0.05` h.
+pub const MAX_TRACKING_GUARD_MARGIN_HOURS: f64 = 1.0;
+
+impl MountConfig {
+    /// Validate the mount configuration after load. Returns
+    /// `Err(message)` on a bad value; [`load_config`] surfaces it as a
+    /// startup error so an out-of-range config fails fast instead of
+    /// silently driving the mount with a bad parameter.
+    ///
+    /// These fields are bare `f64` with no newtype guarantees, so this
+    /// method is the single place their documented ranges are enforced.
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        self.flip_policy.validate()?;
+
+        // CW exclusion zone. `min >= max` is the documented "disabled"
+        // sentinel (used by tests and by operators whose geometry
+        // differs — see the field docs), so only finiteness is required
+        // here; the guard / slew checks treat an inverted interval as
+        // "no zone".
+        if !self.binding_zone_min_hours.is_finite() || !self.binding_zone_max_hours.is_finite() {
+            return Err(format!(
+                "binding_zone_min_hours / binding_zone_max_hours must be finite, got ({}, {})",
+                self.binding_zone_min_hours, self.binding_zone_max_hours
+            ));
+        }
+
+        // Tracking-guard margin: finite, non-negative, capped to catch a
+        // misconfiguration. The guard also sanitises bad values at
+        // runtime, but a startup error is clearer to the operator.
+        if !self.tracking_guard_margin_hours.is_finite()
+            || self.tracking_guard_margin_hours < 0.0
+            || self.tracking_guard_margin_hours > MAX_TRACKING_GUARD_MARGIN_HOURS
+        {
+            return Err(format!(
+                "tracking_guard_margin_hours must be in [0, {MAX_TRACKING_GUARD_MARGIN_HOURS}] hours, got {}",
+                self.tracking_guard_margin_hours
+            ));
+        }
+
+        // Dec clip range: a real celestial-Dec interval within the
+        // observable hemisphere.
+        if !self.dec_min_degrees.is_finite() || !self.dec_max_degrees.is_finite() {
+            return Err(format!(
+                "dec_min_degrees / dec_max_degrees must be finite, got ({}, {})",
+                self.dec_min_degrees, self.dec_max_degrees
+            ));
+        }
+        if self.dec_min_degrees < -90.0
+            || self.dec_max_degrees > 90.0
+            || self.dec_min_degrees >= self.dec_max_degrees
+        {
+            return Err(format!(
+                "dec_min_degrees / dec_max_degrees must satisfy -90 <= min < max <= 90, got ({}, {})",
+                self.dec_min_degrees, self.dec_max_degrees
+            ));
+        }
+
         Ok(())
     }
 }
@@ -513,6 +598,9 @@ fn default_binding_zone_min_hours() -> f64 {
 fn default_binding_zone_max_hours() -> f64 {
     11.05
 }
+fn default_tracking_guard_margin_hours() -> f64 {
+    0.05
+}
 fn default_dec_min_degrees() -> f64 {
     -90.0
 }
@@ -582,6 +670,7 @@ impl Default for MountConfig {
             tracking_rate: TrackingRateName::Sidereal,
             binding_zone_min_hours: default_binding_zone_min_hours(),
             binding_zone_max_hours: default_binding_zone_max_hours(),
+            tracking_guard_margin_hours: default_tracking_guard_margin_hours(),
             dec_min_degrees: default_dec_min_degrees(),
             dec_max_degrees: default_dec_max_degrees(),
             park_ra_ticks: None,
@@ -596,6 +685,10 @@ impl Default for MountConfig {
 pub fn load_config(path: &Path) -> std::result::Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
     let config: Config = serde_json::from_str(&content)?;
+    config
+        .mount
+        .validate()
+        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidData, msg))?;
     Ok(config)
 }
 
@@ -991,6 +1084,153 @@ mod tests {
         let m: MountConfig = serde_json::from_str(json).expect("deserialise");
         assert!(!m.flip_policy.enabled);
         assert!((m.flip_policy.flip_range_hours - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mount_config_default_tracking_guard_margin_is_45s_of_drift() {
+        // 0.05 h ≈ 45 s of sidereal drift — the shipped default the
+        // design doc's §"Tracking-time safety guard" documents.
+        let cfg = MountConfig::default();
+        assert!(
+            (cfg.tracking_guard_margin_hours - 0.05).abs() < f64::EPSILON,
+            "got {}",
+            cfg.tracking_guard_margin_hours
+        );
+    }
+
+    #[test]
+    fn mount_config_deserialises_missing_tracking_guard_margin_as_default() {
+        // Configs written before the tracking-time safety guard landed
+        // do not carry `tracking_guard_margin_hours`; the driver must
+        // read them as the 0.05 h default rather than failing.
+        let json = r#"{
+            "name": "T",
+            "unique_id": "t-001",
+            "description": "T",
+            "site_latitude_deg": 0.0,
+            "site_longitude_deg": 0.0
+        }"#;
+        let m: MountConfig = serde_json::from_str(json).expect("deserialise");
+        assert!((m.tracking_guard_margin_hours - 0.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mount_config_validate_accepts_defaults() {
+        MountConfig::default().validate().unwrap();
+    }
+
+    #[test]
+    fn mount_config_validate_accepts_disabled_binding_zone() {
+        // `min >= max` is the documented disable sentinel — must pass.
+        MountConfig {
+            binding_zone_min_hours: 24.0,
+            binding_zone_max_hours: 0.0,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap();
+    }
+
+    #[test]
+    fn mount_config_validate_delegates_to_flip_policy() {
+        // Previously dead: an out-of-range flip_range_hours is now
+        // rejected because `load_config` calls `validate`.
+        let m = MountConfig {
+            flip_policy: FlipPolicy {
+                flip_range_hours: 5.0, // > MAX_FLIP_RANGE_HOURS
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("flip_range_hours"), "got {err}");
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_margin_above_cap() {
+        let m = MountConfig {
+            tracking_guard_margin_hours: MAX_TRACKING_GUARD_MARGIN_HOURS + 0.1,
+            ..Default::default()
+        };
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("tracking_guard_margin_hours"), "got {err}");
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_negative_margin() {
+        MountConfig {
+            tracking_guard_margin_hours: -0.01,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap_err();
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_non_finite_margin() {
+        MountConfig {
+            tracking_guard_margin_hours: f64::NAN,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap_err();
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_non_finite_binding_zone() {
+        MountConfig {
+            binding_zone_min_hours: f64::INFINITY,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap_err();
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_inverted_dec_range() {
+        let m = MountConfig {
+            dec_min_degrees: 10.0,
+            dec_max_degrees: -10.0,
+            ..Default::default()
+        };
+        let err = m.validate().unwrap_err();
+        assert!(err.contains("dec_"), "got {err}");
+    }
+
+    #[test]
+    fn mount_config_validate_rejects_out_of_range_dec() {
+        MountConfig {
+            dec_min_degrees: -100.0,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap_err();
+    }
+
+    #[test]
+    fn load_config_rejects_an_out_of_range_value() {
+        // End-to-end: validation is wired into `load_config`, so a bad
+        // value in the file fails the load rather than being silently
+        // accepted. flip_range_hours = 5.0 is out of (0, 0.95].
+        use std::io::Write;
+        let cfg = Config {
+            mount: MountConfig {
+                flip_policy: FlipPolicy {
+                    flip_range_hours: 5.0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialise config");
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(json.as_bytes()).expect("write temp config");
+        let err = load_config(f.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("flip_range_hours"),
+            "expected a flip_range_hours validation error, got: {err}"
+        );
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -19,6 +19,9 @@
 //!   sequence) and flip-aware delta geometry.
 //! - [`watchers`] — tokio tasks observing slew / park / pulse-guide
 //!   completion in the background.
+//! - [`tracking_guard`] — per-connection background task that stops
+//!   tracking before the encoder `mech_HA` drifts into the CW
+//!   exclusion zone (issue #259).
 //! - [`park_persistence`] — JSON config-file read/write for `SetPark`
 //!   and the boot-time writability probe.
 
@@ -39,6 +42,7 @@ mod inherent;
 mod park_persistence;
 mod slew;
 mod telescope;
+mod tracking_guard;
 mod watchers;
 
 #[cfg(all(test, feature = "mock"))]

--- a/services/star-adventurer-gti/src/mount_device/device.rs
+++ b/services/star-adventurer-gti/src/mount_device/device.rs
@@ -7,6 +7,8 @@
 //! `load_park_target_after_connect`) with structural rollback via
 //! `session.close().await` on any error.
 
+use std::sync::Arc;
+
 use ascom_alpaca::api::Device;
 use ascom_alpaca::ASCOMResult;
 use async_trait::async_trait;
@@ -69,6 +71,19 @@ impl Device for MountDevice {
                     return Err(e);
                 }
                 *slot = Some(session);
+                // Start the tracking-time CW-exclusion-zone safety
+                // guard for this connection. It reads the cached
+                // snapshot the background poll loop refreshes and
+                // self-terminates when `set_connected(false)` clears
+                // the slot below. See [`super::tracking_guard`] and
+                // issue #259.
+                super::tracking_guard::spawn_tracking_guard(
+                    Arc::clone(&self.state),
+                    Arc::clone(&self.manager),
+                    Arc::clone(&self.session),
+                    self.config.clone(),
+                    self.manager.polling_interval_for_watcher(),
+                );
             }
             (false, true) => {
                 if let Some(session) = slot.take() {

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -229,6 +229,92 @@ async fn tracking_guard_tick_is_noop_when_not_tracking() {
 }
 
 #[tokio::test]
+async fn tracking_guard_tick_is_noop_when_parameters_not_cached() {
+    // Before the handshake caches CPR, mech_HA can't be computed, so the
+    // guard must no-op even with tracking engaged. Build a device and
+    // never connect, so `parameters()` stays None.
+    let cfg = Config {
+        mount: MountConfig {
+            binding_zone_min_hours: 0.95,
+            binding_zone_max_hours: 11.05,
+            ..Default::default()
+        },
+        ..Config::default()
+    };
+    let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
+    let d = MountDevice::new(cfg.mount, manager);
+    d.state.write().await.tracking_requested = true;
+    assert!(d.manager.parameters().await.is_none());
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(!fired, "no cached CPR -> guard cannot act");
+    assert!(
+        d.state.read().await.tracking_requested,
+        "tracking must be left untouched"
+    );
+}
+
+#[tokio::test]
+async fn tracking_guard_tick_is_noop_when_session_closed_mid_tick() {
+    // Params cached and mech_HA in-band, but the device's session slot
+    // was cleared (a disconnect racing the tick) before the guard could
+    // issue :K1.
+    let factory = CapturingMockFactory::new();
+    let mock = Arc::clone(&factory.state);
+    let cfg = Config {
+        mount: MountConfig {
+            binding_zone_min_hours: 0.95,
+            binding_zone_max_hours: 11.05,
+            ..Default::default()
+        },
+        ..Config::default()
+    };
+    let manager = MountManager::new(cfg.clone(), Arc::new(factory));
+    let d = MountDevice::new(cfg.mount, manager);
+    // Acquire to run the handshake (caches CPR, keeps the transport alive)
+    // but leave the device's own session slot empty.
+    let _session = d.manager.transport().acquire().await.unwrap();
+    seed_mech_ha(&d, &mock, 6.0).await; // mid-zone -> would otherwise fire
+    d.state.write().await.tracking_requested = true;
+    assert!(d.session.read().await.is_none());
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(!fired, "no session -> nothing to stop");
+    assert!(
+        d.state.read().await.tracking_requested,
+        "tracking must be left set"
+    );
+    let log = mock.lock().await.command_log.clone();
+    assert!(!log_has_k1(&log), "no :K1 without a session, log: {log:?}");
+}
+
+#[tokio::test]
+async fn tracking_guard_tick_leaves_tracking_set_when_stop_fails() {
+    // If the :K1 stop fails on the wire, the guard must NOT clear Tracking
+    // (it keeps reporting the wire truth) and must report not-fired so the
+    // next tick retries while mech_HA stays in-band.
+    let (d, mock) = guard_device(0.05).await;
+    seed_mech_ha(&d, &mock, 6.0).await; // mid-zone -> would fire
+    mock.lock().await.fail_command = Some(b'K'); // make :K1 error
+    d.state.write().await.tracking_requested = true;
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(!fired, "a failed stop is not a successful fire");
+    assert!(
+        d.state.read().await.tracking_requested,
+        "Tracking must stay set when the wire stop fails"
+    );
+    let log = mock.lock().await.command_log.clone();
+    assert!(
+        log_has_k1(&log),
+        "the :K1 attempt should still reach the wire, log: {log:?}"
+    );
+}
+
+#[tokio::test]
 async fn set_connected_idempotent_within_a_session() {
     let d = device();
     d.set_connected(true).await.unwrap();

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -23,13 +23,14 @@ use crate::config::Config;
 use crate::coordinates::{fold_to_canonical_band, SIDEREAL_DEG_PER_SEC};
 use crate::error::StarAdvError;
 use crate::manager::MountManager;
-use crate::transport::mock::MockTransportFactory;
+use crate::transport::mock::{CapturingMockFactory, MockMountState, MockTransportFactory};
 
 use super::park_persistence::{read_park_from_config, write_park_to_config};
 use super::slew::{
     canonical_path_crosses_pole, check_non_flip_ra_path, flip_slew_dec_delta, flip_slew_ra_delta,
     pickup_reslew_axis, stop_axis_and_wait,
 };
+use super::tracking_guard::tracking_guard_tick;
 use super::watchers::{watcher_poll_with_retry, watcher_should_abort};
 use super::*;
 
@@ -134,6 +135,97 @@ async fn set_connected_drives_transport_connect_and_disconnect() {
     assert!(d.connected().await.unwrap());
     d.set_connected(false).await.unwrap();
     assert!(!d.connected().await.unwrap());
+}
+
+/// Build a device with the CW exclusion zone enabled and the given
+/// tracking-guard margin, then establish a session **directly** (not via
+/// `set_connected`, so the background guard task isn't spawned — these
+/// tests drive [`tracking_guard_tick`] by hand for determinism). Returns
+/// the shared mock state for encoder seeding and command-log assertions.
+async fn guard_device(margin_hours: f64) -> (MountDevice, Arc<tokio::sync::Mutex<MockMountState>>) {
+    let factory = CapturingMockFactory::new();
+    let mock = Arc::clone(&factory.state);
+    let mut cfg = Config::default();
+    cfg.mount.binding_zone_min_hours = 0.95;
+    cfg.mount.binding_zone_max_hours = 11.05;
+    cfg.mount.tracking_guard_margin_hours = margin_hours;
+    let manager = MountManager::new(cfg.clone(), Arc::new(factory));
+    let d = MountDevice::new(cfg.mount, manager);
+    let session = d.manager.transport().acquire().await.unwrap();
+    *d.session.write().await = Some(session);
+    (d, mock)
+}
+
+/// Seed both the mock encoder and the cached snapshot to the tick value
+/// for `mech_ha`, so a poll-loop refresh and a direct snapshot read
+/// agree on the same position regardless of timing.
+async fn seed_mech_ha(
+    d: &MountDevice,
+    mock: &Arc<tokio::sync::Mutex<MockMountState>>,
+    mech_ha: f64,
+) {
+    let cpr = d.manager.parameters().await.unwrap().cpr_ra;
+    let ticks = (mech_ha * cpr as f64 / 24.0) as i32;
+    mock.lock().await.ra.position_ticks = ticks;
+    d.manager.seed_ra_position(ticks).await;
+}
+
+fn log_has_k1(log: &[Vec<u8>]) -> bool {
+    log.iter().any(|f| f == b":K1\r")
+}
+
+#[tokio::test]
+async fn tracking_guard_tick_stops_tracking_inside_the_zone() {
+    let (d, mock) = guard_device(0.05).await;
+    seed_mech_ha(&d, &mock, 6.0).await; // mid-zone (mech_HA = +6 h)
+    d.state.write().await.tracking_requested = true;
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(fired, "guard should fire mid-zone");
+    assert!(
+        !d.tracking().await.unwrap(),
+        "Tracking must be cleared after the guard fires"
+    );
+    let log = mock.lock().await.command_log.clone();
+    assert!(log_has_k1(&log), "expected a :K1 stop, log: {log:?}");
+}
+
+#[tokio::test]
+async fn tracking_guard_tick_is_noop_far_from_the_zone() {
+    let (d, mock) = guard_device(0.05).await;
+    seed_mech_ha(&d, &mock, -3.0).await; // typical session start, well clear
+    d.state.write().await.tracking_requested = true;
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(!fired, "guard must not fire far from the zone");
+    assert!(
+        d.tracking().await.unwrap(),
+        "Tracking must stay engaged far from the zone"
+    );
+    let log = mock.lock().await.command_log.clone();
+    assert!(
+        !log_has_k1(&log),
+        "no stop expected far from the zone, log: {log:?}"
+    );
+}
+
+#[tokio::test]
+async fn tracking_guard_tick_is_noop_when_not_tracking() {
+    let (d, mock) = guard_device(0.05).await;
+    seed_mech_ha(&d, &mock, 6.0).await; // mid-zone, but tracking is off
+                                        // `tracking_requested` left false — the guard only acts while the
+                                        // client has tracking engaged.
+
+    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+
+    assert!(!fired, "guard only acts while tracking is engaged");
+    let log = mock.lock().await.command_log.clone();
+    assert!(
+        !log_has_k1(&log),
+        "no stop expected when not tracking, log: {log:?}"
+    );
 }
 
 #[tokio::test]

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -58,9 +58,11 @@ type SessionSlot = Arc<RwLock<Option<Session<SkywatcherCodec>>>>;
 /// An empty/inverted interval (`zone_min >= zone_max`) disables the
 /// guard — the same convention the slew-path binding-zone check uses.
 /// A non-finite or negative `margin` is treated as `0.0` (stop exactly
-/// at zone entry) so a bad config value fails safe rather than fails
-/// open: the field is not validated at startup today, so the guard
-/// sanitises its own input.
+/// at zone entry) so a bad value fails safe rather than open. Config-file
+/// margins are already rejected at load by
+/// [`crate::config::MountConfig::validate`]; this sanitisation is
+/// defense-in-depth for construction paths that bypass that check
+/// (programmatic configs, tests).
 pub(super) fn tracking_guard_breached(mech_ha: f64, zone: (f64, f64), margin: f64) -> bool {
     let (zone_min, zone_max) = zone;
     if zone_min >= zone_max {

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -1,0 +1,279 @@
+//! Tracking-time CW-exclusion-zone safety guard.
+//!
+//! The slew planner ([`super::slew`]) keeps the counterweights clear of
+//! the CW exclusion zone at *slew* time, but once `Tracking = true` the
+//! firmware advances the RA encoder autonomously and the driver issues
+//! no further wire commands. A multi-hour imaging session that starts
+//! at a safe negative `mech_HA` will drift up across the zone entry
+//! (`mech_HA = +0.95` by default) with no intervention — the same
+//! physical failure mode as a zone-crossing slew, just reached via
+//! tracking drift. See issue #259.
+//!
+//! This module closes that gap with a per-connection background task
+//! that watches the live encoder `mech_HA` while tracking and stops the
+//! mount (`:K1`) before it can drift into the zone. The guard does
+//! **not** pick a pier side or flip — it just stops, clears the
+//! in-memory `Tracking` flag to match, and emits a `warn!`. The
+//! operator (or higher-level automation) decides what to do next: flip
+//! via `SetSideOfPier`, slew elsewhere, or park.
+//!
+//! It reads the snapshot the background poll loop already refreshes (it
+//! does not poll the wire itself), so it is the "extension of the
+//! existing poll loop" issue #259 describes without crossing into the
+//! transport layer. It runs whenever the zone is active, independent of
+//! [`crate::config::FlipPolicy::enabled`] — it is the safety floor that
+//! keeps an unattended autoguided session from contacting hardware.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rusty_photon_shared_transport::Session;
+use skywatcher_motor_protocol::{Axis, Command};
+use tokio::sync::RwLock;
+use tokio::time::interval;
+use tracing::{debug, warn};
+
+use crate::codec::SkywatcherCodec;
+use crate::config::MountConfig;
+use crate::coordinates::ra_ticks_to_mechanical_ha;
+use crate::manager::MountManager;
+
+use super::DriverState;
+
+/// Device session slot, shared with the completion watchers. `Some`
+/// between `set_connected(true)` and `set_connected(false)`.
+type SessionSlot = Arc<RwLock<Option<Session<SkywatcherCodec>>>>;
+
+/// Does the instantaneous encoder `mech_HA` fall inside the guarded
+/// band — the CW exclusion zone `(zone_min, zone_max)` widened by
+/// `margin` on both edges, i.e. the open interval
+/// `(zone_min − margin, zone_max + margin)`?
+///
+/// The check is on a single folded `mech_HA` value (already in
+/// `[−12, +12)`), not a swept path, so unlike
+/// [`super::slew::canonical_path_crosses_binding_zone`] it needs no
+/// 24-hour-wrap handling: the realistic zone+margin stays well within
+/// the folded range.
+///
+/// An empty/inverted interval (`zone_min >= zone_max`) disables the
+/// guard — the same convention the slew-path binding-zone check uses.
+/// A non-finite or negative `margin` is treated as `0.0` (stop exactly
+/// at zone entry) so a bad config value fails safe rather than fails
+/// open: the field is not validated at startup today, so the guard
+/// sanitises its own input.
+pub(super) fn tracking_guard_breached(mech_ha: f64, zone: (f64, f64), margin: f64) -> bool {
+    let (zone_min, zone_max) = zone;
+    if zone_min >= zone_max {
+        return false;
+    }
+    let margin = if margin.is_finite() && margin >= 0.0 {
+        margin
+    } else {
+        0.0
+    };
+    mech_ha > zone_min - margin && mech_ha < zone_max + margin
+}
+
+/// One guard evaluation against the latest cached snapshot.
+///
+/// Returns `true` only when it stopped tracking. It is a no-op (returns
+/// `false`) when the client has not engaged tracking, a slew is in
+/// flight, the zone is disabled, the snapshot `mech_HA` is clear of the
+/// band, parameters aren't cached yet, or the session closed mid-tick.
+pub(super) async fn tracking_guard_tick(
+    state: &Arc<RwLock<DriverState>>,
+    manager: &MountManager,
+    session_slot: &SessionSlot,
+    zone: (f64, f64),
+    margin: f64,
+) -> bool {
+    // Cheap gate first: only intervene while the client has tracking
+    // engaged and no slew is in flight. `slew_to_coordinates_async`
+    // clears `tracking_requested` for the slew's duration, so gating on
+    // it already keeps the guard dormant during slews; the
+    // `slew_in_progress` check is belt-and-suspenders for the brief
+    // post-slew tracking-restart window.
+    {
+        let s = state.read().await;
+        if !s.tracking_requested || s.slew_in_progress {
+            return false;
+        }
+    }
+    // `mech_HA` needs the per-axis CPR captured at handshake.
+    let Some(params) = manager.parameters().await else {
+        return false;
+    };
+    let snap = manager.snapshot().await;
+    let mech_ha = ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
+    if !tracking_guard_breached(mech_ha, zone, margin) {
+        return false;
+    }
+
+    // Breached. Stop RA tracking on the wire FIRST, mirroring
+    // `set_tracking(false)` (`:K1`, then clear the flag), so the
+    // in-memory `Tracking` state never reports "off" while the motor is
+    // still commutating. Read the device's own session slot the same
+    // way `MountDevice::send` does.
+    let guard = session_slot.read().await;
+    let Some(session) = guard.as_ref() else {
+        // Disconnected between the gate and here — nothing to stop.
+        return false;
+    };
+    match manager.send(session, Command::StopMotion(Axis::Ra)).await {
+        Ok(_) => {
+            drop(guard);
+            state.write().await.tracking_requested = false;
+            warn!(
+                mech_ha,
+                zone_min = zone.0,
+                zone_max = zone.1,
+                margin,
+                "tracking-guard: encoder mech_HA entered the CW exclusion-zone margin while \
+                 tracking; stopped the mount (:K1). Tracking is now off — flip via SetSideOfPier, \
+                 slew elsewhere, or park before re-engaging."
+            );
+            true
+        }
+        Err(e) => {
+            // Leave `tracking_requested` set so `Tracking` keeps
+            // reporting the wire truth; the next tick retries while
+            // `mech_HA` stays in the band.
+            warn!(
+                error = %e,
+                mech_ha,
+                "tracking-guard: failed to stop tracking on zone approach; will retry next tick"
+            );
+            false
+        }
+    }
+}
+
+/// Spawn the per-connection tracking-time safety guard.
+///
+/// Called on the `set_connected(true)` 0→1 transition once the session
+/// slot is populated. The task ticks at `polling_interval` (reusing the
+/// background poll loop's cadence), reads the cached snapshot, and acts
+/// only when [`tracking_guard_tick`] finds tracking engaged and
+/// `mech_HA` inside the guarded band. It self-terminates when
+/// `set_connected(false)` clears the session slot — the same disconnect
+/// signal the completion watchers observe.
+pub(super) fn spawn_tracking_guard(
+    state: Arc<RwLock<DriverState>>,
+    manager: Arc<MountManager>,
+    session_slot: SessionSlot,
+    config: MountConfig,
+    polling_interval: Duration,
+) {
+    let zone = (config.binding_zone_min_hours, config.binding_zone_max_hours);
+    let margin = config.tracking_guard_margin_hours;
+    tokio::spawn(async move {
+        let mut ticker = interval(polling_interval);
+        // Skip the immediate first tick (matches the background poll
+        // loop): the handshake just seeded the snapshot.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if session_slot.read().await.is_none() {
+                debug!("tracking-guard: session closed, exiting");
+                return;
+            }
+            tracking_guard_tick(&state, &manager, &session_slot, zone, margin).await;
+        }
+    });
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::tracking_guard_breached;
+    use proptest::prelude::*;
+
+    // Default GTi zone for the example-based cases.
+    const ZONE: (f64, f64) = (0.95, 11.05);
+
+    #[test]
+    fn far_below_the_zone_is_not_breached() {
+        // A session starting at mech_HA = −3 h is well clear.
+        assert!(!tracking_guard_breached(-3.0, ZONE, 0.05));
+    }
+
+    #[test]
+    fn inside_the_hard_zone_is_breached_even_with_zero_margin() {
+        assert!(tracking_guard_breached(6.0, ZONE, 0.0));
+    }
+
+    #[test]
+    fn margin_stops_tracking_before_zone_entry() {
+        // mech_HA = 0.92 is below the 0.95 zone entry but inside the
+        // 0.05 h margin band (0.90, 11.10) — the guard fires early.
+        assert!(tracking_guard_breached(0.92, ZONE, 0.05));
+        // Without the margin (0.0) the same point is still clear.
+        assert!(!tracking_guard_breached(0.92, ZONE, 0.0));
+    }
+
+    #[test]
+    fn band_edges_are_exclusive() {
+        // The band is the open interval (zone_min − margin, zone_max + margin).
+        assert!(!tracking_guard_breached(0.95 - 0.05, ZONE, 0.05));
+        assert!(!tracking_guard_breached(11.05 + 0.05, ZONE, 0.05));
+    }
+
+    #[test]
+    fn just_inside_each_edge_is_breached() {
+        assert!(tracking_guard_breached(0.95 - 0.05 + 1e-6, ZONE, 0.05));
+        assert!(tracking_guard_breached(11.05 + 0.05 - 1e-6, ZONE, 0.05));
+    }
+
+    #[test]
+    fn disabled_zone_never_breaches() {
+        // The world's test config disables the zone with min > max.
+        assert!(!tracking_guard_breached(6.0, (24.0, 0.0), 0.05));
+        // An equal pair is also empty.
+        assert!(!tracking_guard_breached(6.0, (6.0, 6.0), 0.05));
+    }
+
+    #[test]
+    fn negative_margin_degrades_to_zero() {
+        // Treated as 0.0: the band collapses to the raw zone, so a
+        // point below zone entry is clear but one inside still fires.
+        assert!(!tracking_guard_breached(0.92, ZONE, -1.0));
+        assert!(tracking_guard_breached(6.0, ZONE, -1.0));
+    }
+
+    #[test]
+    fn non_finite_margin_degrades_to_zero() {
+        assert!(!tracking_guard_breached(0.92, ZONE, f64::NAN));
+        assert!(tracking_guard_breached(6.0, ZONE, f64::INFINITY));
+    }
+
+    #[test]
+    fn non_finite_mech_ha_is_not_breached() {
+        assert!(!tracking_guard_breached(f64::NAN, ZONE, 0.05));
+    }
+
+    proptest! {
+        /// Any point strictly inside the hard zone is breached for every
+        /// non-negative margin — widening the band can't exclude it.
+        #[test]
+        fn inside_hard_zone_always_breached(
+            x in 0.951f64..11.049,
+            margin in 0.0f64..2.0,
+        ) {
+            prop_assert!(tracking_guard_breached(x, ZONE, margin));
+        }
+
+        /// Increasing the margin never un-breaches a point: the guarded
+        /// band only grows.
+        #[test]
+        fn margin_widening_is_monotonic(
+            x in -12.0f64..12.0,
+            m1 in 0.0f64..1.0,
+            extra in 0.0f64..1.0,
+        ) {
+            if tracking_guard_breached(x, ZONE, m1) {
+                prop_assert!(tracking_guard_breached(x, ZONE, m1 + extra));
+            }
+        }
+    }
+}

--- a/services/star-adventurer-gti/src/transport/mock.rs
+++ b/services/star-adventurer-gti/src/transport/mock.rs
@@ -184,6 +184,12 @@ pub struct MockMountState {
     /// Every command frame received, in arrival order. Tests assert against
     /// this to verify the driver issued the expected wire commands.
     pub command_log: Vec<Vec<u8>>,
+    /// Test-only fault injection. When `Some(letter)`, any command whose
+    /// letter matches replies with a mount error (`!XX`) instead of its
+    /// normal response, so the driver's send path returns `Err`. Used to
+    /// exercise wire-failure branches (e.g. the tracking guard's
+    /// `:K1`-failed path). The request is still recorded in `command_log`.
+    pub fail_command: Option<u8>,
     /// Pending replies the next `recv_frame` call should drain. Every
     /// processed command appends one frame; the [`FrameTransport`] impl
     /// pulls from the front to deliver replies in order.
@@ -207,6 +213,7 @@ impl Default for MockMountState {
             high_speed_ratio_dec: 32,
             motor_board_version: 0x0003_300C,
             command_log: Vec::new(),
+            fail_command: None,
             pending_replies: std::collections::VecDeque::new(),
         }
     }
@@ -244,6 +251,14 @@ impl MockMountState {
         let cmd = request[1];
         let axis = request[2];
         let payload = &request[3..request.len() - 1];
+
+        // Test-only fault injection: reply with a mount error for the
+        // selected command letter so the driver's send path returns
+        // `Err` (see `MockMountState::fail_command`).
+        if self.fail_command == Some(cmd) {
+            self.pending_replies.push_back(err_reply(0));
+            return;
+        }
 
         // Inquiries (lowercase letters)
         let reply = match cmd {

--- a/services/star-adventurer-gti/tests/bdd/steps/mod.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/mod.rs
@@ -8,4 +8,5 @@ pub mod pulse_guide_steps;
 pub mod side_of_pier_steps;
 pub mod slew_steps;
 pub mod sync_steps;
+pub mod tracking_safety_steps;
 pub mod tracking_steps;

--- a/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
@@ -1,0 +1,64 @@
+//! Steps for tracking_safety.feature.
+
+use std::time::Duration;
+
+use crate::world::StarAdventurerWorld;
+use cucumber::{given, then};
+
+/// GTi counts-per-revolution on both axes (`0x375F00`) — the value the
+/// mock seeds and the driver caches at handshake. Used to convert a
+/// human-readable mech_HA into the encoder tick value the
+/// `/debug/v1/mock-state` seed endpoint expects:
+/// `ticks = mech_HA × CPR / 24`.
+const GTI_CPR: f64 = 3_628_800.0;
+
+#[given(
+    expr = "a star-adventurer service with the CW exclusion zone from {float} to {float} hours"
+)]
+async fn configured_zone(world: &mut StarAdventurerWorld, min_hours: f64, max_hours: f64) {
+    let cfg = world.config_mut();
+    cfg.mount.binding_zone_min_hours = min_hours;
+    cfg.mount.binding_zone_max_hours = max_hours;
+}
+
+#[given("a star-adventurer service with the CW exclusion zone disabled")]
+async fn configured_zone_disabled(world: &mut StarAdventurerWorld) {
+    // An inverted interval (min > max) switches the binding-zone check
+    // off — the convention the slew planner and the guard share.
+    let cfg = world.config_mut();
+    cfg.mount.binding_zone_min_hours = 24.0;
+    cfg.mount.binding_zone_max_hours = 0.0;
+}
+
+#[given(expr = "a tracking-guard margin of {float} hours")]
+async fn configured_margin(world: &mut StarAdventurerWorld, margin_hours: f64) {
+    world.config_mut().mount.tracking_guard_margin_hours = margin_hours;
+}
+
+#[given(expr = "the RA encoder is at mechanical HA {float} hours")]
+async fn ra_encoder_at_mech_ha(world: &mut StarAdventurerWorld, mech_ha: f64) {
+    let ticks = (mech_ha * GTI_CPR / 24.0).round() as i32;
+    world.queue_seed("ra_ticks", ticks.into()).await;
+}
+
+#[then(expr = "the mount should stop tracking within {int} ms")]
+async fn stop_tracking_within(world: &mut StarAdventurerWorld, ms: u64) {
+    let deadline = std::time::Instant::now() + Duration::from_millis(ms);
+    while std::time::Instant::now() < deadline {
+        if !world.mount().tracking().await.unwrap() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("the tracking guard did not stop tracking within {ms} ms");
+}
+
+#[then(expr = "the mount should still be tracking after {int} ms")]
+async fn still_tracking_after(world: &mut StarAdventurerWorld, ms: u64) {
+    // Give the guard several poll cycles to (wrongly) fire; it must not.
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+    assert!(
+        world.mount().tracking().await.unwrap(),
+        "tracking was stopped after {ms} ms but should have stayed engaged"
+    );
+}

--- a/services/star-adventurer-gti/tests/features/tracking_safety.feature
+++ b/services/star-adventurer-gti/tests/features/tracking_safety.feature
@@ -1,0 +1,56 @@
+Feature: Tracking-time exclusion-zone safety guard
+  While Tracking = true a background guard watches the live encoder
+  mech_HA and stops the mount (:K1) before tracking drift can carry the
+  counterweights into the CW exclusion zone (mech_HA inside
+  (binding_zone_min_hours, binding_zone_max_hours), default
+  (0.95, 11.05) h). The guard fires once mech_HA enters the band widened
+  by tracking_guard_margin_hours on each edge -- the configurable margin
+  (default 0.05 h, ~45 s of sidereal drift) lets cautious operators stop
+  before the zone entry rather than at it.
+
+  The guard does not pick a pier side or flip: it stops the mount,
+  clears the in-memory Tracking flag to match, and warns, leaving the
+  operator (or higher-level automation) to flip via SetSideOfPier, slew
+  elsewhere, or park. It is the safety floor and runs whenever the zone
+  is active, independent of meridian-flip support.
+
+  Scenario: Tracking drifting into the exclusion zone stops the mount
+    Given a star-adventurer service with the CW exclusion zone from 0.95 to 11.05 hours
+    And a tracking-guard margin of 0.05 hours
+    And the RA encoder is at mechanical HA 3.0 hours
+    And a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    Then the mount should stop tracking within 6000 ms
+    And the mount should have received command :K1
+    And Slewing should be false
+
+  Scenario: Tracking clear of the exclusion zone keeps running
+    Given a star-adventurer service with the CW exclusion zone from 0.95 to 11.05 hours
+    And a tracking-guard margin of 0.05 hours
+    And the RA encoder is at mechanical HA -3.0 hours
+    And a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    Then the mount should still be tracking after 1000 ms
+
+  Scenario: The margin stops tracking before the zone entry is reached
+    # mech_HA 0.92 is below the 0.95 zone entry but inside the 0.05 h
+    # margin band (0.90, 11.10), so the guard stops the mount early.
+    Given a star-adventurer service with the CW exclusion zone from 0.95 to 11.05 hours
+    And a tracking-guard margin of 0.05 hours
+    And the RA encoder is at mechanical HA 0.92 hours
+    And a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    Then the mount should stop tracking within 6000 ms
+    And the mount should have received command :K1
+
+  Scenario: The guard is inactive when the exclusion zone is disabled
+    Given a star-adventurer service with the CW exclusion zone disabled
+    And a tracking-guard margin of 0.05 hours
+    And the RA encoder is at mechanical HA 3.0 hours
+    And a running star-adventurer service
+    When I connect the device
+    And I enable tracking
+    Then the mount should still be tracking after 1000 ms


### PR DESCRIPTION
## Summary

Part 1 of #259 — the tracking-time CW exclusion-zone safety guard. While `Tracking = true`, a per-connection background guard watches the live encoder `mech_HA` and stops the mount (`:K1`) once it enters `(binding_zone_min − margin, binding_zone_max + margin)`, before tracking drift can carry the counterweights into the exclusion zone. It clears the in-memory `Tracking` flag and warns; it does **not** pick a pier side, flip, or park — the operator (or higher-level automation) decides what's next.

Addresses #259 (Part 1). **Part 2 (auto-flip during tracking) remains deferred.**

## What's in this PR

- **Safety guard** (`mount_device/tracking_guard.rs`): pure `tracking_guard_breached`, `tracking_guard_tick`, and `spawn_tracking_guard` (spawned on `set_connected(true)`, self-terminates on disconnect, reads the cached poll-loop snapshot — no extra wire traffic). New `MountConfig::tracking_guard_margin_hours` (default 0.05 h ≈ 45 s of sidereal drift), independent of `flip_policy.enabled`.
- **Config hardening**: `MountConfig::validate()` is now wired into `load_config`, so an out-of-range config fails fast at startup. This revives the previously-**dead** `FlipPolicy::flip_range_hours` range check and adds zone / margin / Dec-range validation.
- **ADR-006** (`docs/decisions/006-typed-physical-quantities-for-mount-pointing.md`): proposes replacing the driver's bare-`f64` pointing math with semantic newtypes (a mechanical-vs-celestial hour-angle split) so unit/frame errors become compile errors. Surfaced from the review of this work; **Status: Proposed**. The follow-on refactor is a separate single PR (one commit per stage).

## Tests

- 16 new unit/property tests for the guard decision logic + 10 config-validation tests (incl. an end-to-end `load_config` rejection test).
- 4 new BDD scenarios in `tracking_safety.feature` (enter-zone → stop, far → no-op, margin honoured, zone-disabled → inactive).
- Full gate green: `cargo rail run --profile commit`, clippy `-D warnings` (workspace), BDD 130/130.

## Docs

- New **Tracking-time safety guard** section in the design doc; `tracking_guard_margin_hours` config notes; Phase 6 + Deferred-table updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)