### PR TITLE
fix(pa-falcon-rotator): parse signed step counter as i32

### DIFF
--- a/docs/services/falcon-rotator.md
+++ b/docs/services/falcon-rotator.md
@@ -100,12 +100,20 @@ Field types:
 
 | Field | Type | Notes |
 |---|---|---|
-| `position_in_steps` | unsigned integer | Internal step counter |
-| `position_in_deg` | `f64`, two decimals | Authoritative for `MechanicalPosition` |
+| `position_in_steps` | **signed** integer (`i32`) | Step counter relative to the 0° home; **negative for positions CCW of home**. Informational only — the driver derives all positions from `position_in_deg`. |
+| `position_in_deg` | `f64`, two decimals | Authoritative for `MechanicalPosition`; always wrapped to `[0, 360)` |
 | `is_moving` | `0` / `1` | Drives `IsMoving` |
 | `limit_detect` | `0` / `1` | Driver logs `warn!` on edge transitions, does not raise |
 | `do_derotation` | `0` / `1` | MVP keeps this `0` (see [De-rotation](#de-rotation)) |
 | `motor_reverse` | `0` / `1` | Drives `Reverse` |
+
+> **Signed step counter (validated on real hardware, firmware 1.5, ConformU).**
+> A target beyond the 220° CW limit is reached the long way round — CCW past the
+> 0° home — where `position_in_steps` goes **negative** (e.g. `FR_OK:-2838:327.24:1:0:0:0`)
+> while `position_in_deg` stays wrapped to `[0, 360)`. Parsing the step field as
+> unsigned previously aborted every status read in that region with
+> `INVALID_OPERATION: FA position_steps: invalid digit found in string`; it is
+> now parsed as `i32`. The degree field is unaffected, so positions stay correct.
 
 ### Commands the driver does **not** send
 

--- a/docs/services/falcon-rotator.md
+++ b/docs/services/falcon-rotator.md
@@ -123,6 +123,17 @@ Field types:
 
 The Falcon has a single physical-angle concept. ASCOM's `IRotatorV3+` separates *mechanical* angle from *sky* angle joined by a `Sync` offset. The driver implements that separation in software.
 
+The two frames and their bridge are distinct types in `units.rs` — `MechanicalDegrees`, `SkyDegrees`, and the `SyncOffset` that joins them — so the offset arithmetic in the table below is checked at compile time rather than by convention. The whole algebra is three operators plus one rotation:
+
+| Relation | Typed form |
+|---|---|
+| `Position` = mech + offset | `MechanicalDegrees + SyncOffset → SkyDegrees` |
+| `MoveAbsolute`: mech = sky − offset | `SkyDegrees − SyncOffset → MechanicalDegrees` |
+| `Sync`: offset = sky − mech | `SkyDegrees − MechanicalDegrees → SyncOffset` |
+| `Move(delta)`: mech.rotate(delta) | relative rotation, stays mechanical |
+
+A sky angle therefore can't be used where a mechanical one is expected, and the offset can't be silently dropped, without a compile error. All three angle types normalise to `[0, 360)` on construction (see [Position normalisation](#position-normalisation)); non-finite inputs are rejected at the ASCOM boundary before a value is constructed. `Steps` (the signed `FA`/`FP` counter) is a fourth type, but since the driver derives every position from the degree field it is informational on the wire — only the mock converts between `Steps` and `MechanicalDegrees` (× 86.6).
+
 | ASCOM Property/Method | Implementation |
 |---|---|
 | `CanReverse` | `true` (always) |
@@ -311,7 +322,8 @@ services/pa-falcon-rotator/
 │   ├── serial.rs           # FalconTransportFactory (TransportFactory over tokio-serial)
 │   ├── mock.rs             # MockFalconTransportFactory (feature = "mock")
 │   ├── protocol.rs         # Command enum + response parsers + validate_echo
-│   └── manager.rs          # FalconManager wrapping SharedTransport<FalconCodec> + driver-side state
+│   ├── manager.rs          # FalconManager wrapping SharedTransport<FalconCodec> + driver-side state
+│   └── units.rs            # SkyDegrees / MechanicalDegrees / SyncOffset / Steps + frame algebra
 ├── tests/
 │   ├── bdd.rs              # cucumber entry point (harness = false)
 │   ├── bdd/

--- a/services/pa-falcon-rotator/src/codec.rs
+++ b/services/pa-falcon-rotator/src/codec.rs
@@ -38,8 +38,9 @@ pub enum FalconResponse {
     FirmwareVersion(String),
     /// `FD:nn.nn` — the `FD` position-in-degrees reply.
     PositionDeg(f64),
-    /// `FP:n..` — the `FP` position-in-steps reply.
-    PositionSteps(u32),
+    /// `FP:n..` — the `FP` signed position-in-steps reply (negative CCW of
+    /// the 0° home; see [`crate::protocol::FalconStatus::position_steps`]).
+    PositionSteps(i32),
     /// `VS:n..` — the `VS` raw input-voltage reply.
     Voltage(u32),
     /// `FR:0` / `FR:1` — the `FR` is-running reply.
@@ -284,6 +285,23 @@ mod tests {
     fn decode_position_steps() {
         let resp = FalconCodec.decode(b"FP:4332\n").unwrap();
         assert_eq!(resp, FalconResponse::PositionSteps(4332));
+    }
+
+    #[test]
+    fn decode_position_steps_accepts_negative_below_home() {
+        // Real hardware (firmware 1.5) reports negative steps CCW of the 0°
+        // home; the codec must decode them rather than abort the frame.
+        let resp = FalconCodec.decode(b"FP:-1784\n").unwrap();
+        assert_eq!(resp, FalconResponse::PositionSteps(-1784));
+    }
+
+    #[test]
+    fn decode_full_status_accepts_negative_steps_below_home() {
+        let resp = FalconCodec.decode(b"FR_OK:-2838:327.24:1:0:0:0\n").unwrap();
+        match resp {
+            FalconResponse::Status(s) => assert_eq!(s.position_steps, -2838),
+            other => panic!("expected Status, got {other:?}"),
+        }
     }
 
     #[test]

--- a/services/pa-falcon-rotator/src/codec.rs
+++ b/services/pa-falcon-rotator/src/codec.rs
@@ -22,6 +22,7 @@ use crate::protocol::{
     parse_firmware_version, parse_full_status, parse_is_running, parse_position_deg,
     parse_position_steps, parse_voltage_raw, Command, FalconStatus,
 };
+use crate::units::{MechanicalDegrees, Steps};
 
 /// Decoded response frame from the device.
 ///
@@ -37,10 +38,10 @@ pub enum FalconResponse {
     /// `FV:n.n` — the `FV` firmware-version reply.
     FirmwareVersion(String),
     /// `FD:nn.nn` — the `FD` position-in-degrees reply.
-    PositionDeg(f64),
+    PositionDeg(MechanicalDegrees),
     /// `FP:n..` — the `FP` signed position-in-steps reply (negative CCW of
     /// the 0° home; see [`crate::protocol::FalconStatus::position_steps`]).
-    PositionSteps(i32),
+    PositionSteps(Steps),
     /// `VS:n..` — the `VS` raw input-voltage reply.
     Voltage(u32),
     /// `FR:0` / `FR:1` — the `FR` is-running reply.
@@ -233,7 +234,7 @@ mod tests {
 
     #[test]
     fn encode_move_deg_uses_two_decimal_places() {
-        let bytes = FalconCodec.encode(&Command::MoveDeg(45.0));
+        let bytes = FalconCodec.encode(&Command::MoveDeg(MechanicalDegrees::new(45.0)));
         assert_eq!(&bytes, b"MD:45.00\n");
     }
 
@@ -260,8 +261,8 @@ mod tests {
             FalconResponse::Status(s) => s,
             other => panic!("expected Status, got {other:?}"),
         };
-        assert_eq!(status.position_steps, 4332);
-        assert!((status.position_deg - 50.0).abs() < 1e-9);
+        assert_eq!(status.position_steps, Steps(4332));
+        assert!((status.position_deg.value() - 50.0).abs() < 1e-9);
         assert!(!status.is_moving);
     }
 
@@ -278,13 +279,13 @@ mod tests {
             FalconResponse::PositionDeg(v) => v,
             other => panic!("expected PositionDeg, got {other:?}"),
         };
-        assert!((v - 142.30).abs() < 1e-9);
+        assert!((v.value() - 142.30).abs() < 1e-9);
     }
 
     #[test]
     fn decode_position_steps() {
         let resp = FalconCodec.decode(b"FP:4332\n").unwrap();
-        assert_eq!(resp, FalconResponse::PositionSteps(4332));
+        assert_eq!(resp, FalconResponse::PositionSteps(Steps(4332)));
     }
 
     #[test]
@@ -292,14 +293,14 @@ mod tests {
         // Real hardware (firmware 1.5) reports negative steps CCW of the 0°
         // home; the codec must decode them rather than abort the frame.
         let resp = FalconCodec.decode(b"FP:-1784\n").unwrap();
-        assert_eq!(resp, FalconResponse::PositionSteps(-1784));
+        assert_eq!(resp, FalconResponse::PositionSteps(Steps(-1784)));
     }
 
     #[test]
     fn decode_full_status_accepts_negative_steps_below_home() {
         let resp = FalconCodec.decode(b"FR_OK:-2838:327.24:1:0:0:0\n").unwrap();
         match resp {
-            FalconResponse::Status(s) => assert_eq!(s.position_steps, -2838),
+            FalconResponse::Status(s) => assert_eq!(s.position_steps, Steps(-2838)),
             other => panic!("expected Status, got {other:?}"),
         }
     }
@@ -365,8 +366,8 @@ mod tests {
         assert!(codec.matches(
             &Command::FullStatus,
             &FalconResponse::Status(FalconStatus {
-                position_steps: 0,
-                position_deg: 0.0,
+                position_steps: Steps(0),
+                position_deg: MechanicalDegrees::new(0.0),
                 is_moving: false,
                 limit_detect: false,
                 do_derotation: false,
@@ -384,7 +385,7 @@ mod tests {
     fn matches_pairs_echo_commands_with_echo_variant() {
         let codec = FalconCodec;
         assert!(codec.matches(
-            &Command::MoveDeg(180.0),
+            &Command::MoveDeg(MechanicalDegrees::new(180.0)),
             &FalconResponse::Echo("MD:180.00".to_string())
         ));
         assert!(codec.matches(&Command::Halt, &FalconResponse::Echo("FH:1".to_string())));
@@ -409,7 +410,10 @@ mod tests {
             &Command::FullStatus,
             &FalconResponse::Echo("MD:0.00".to_string())
         ));
-        assert!(!codec.matches(&Command::MoveDeg(0.0), &FalconResponse::IsRunning(true)));
+        assert!(!codec.matches(
+            &Command::MoveDeg(MechanicalDegrees::new(0.0)),
+            &FalconResponse::IsRunning(true)
+        ));
     }
 
     // ---- FalconCodecError::from_protocol --------------------------------

--- a/services/pa-falcon-rotator/src/lib.rs
+++ b/services/pa-falcon-rotator/src/lib.rs
@@ -21,6 +21,7 @@ pub mod protocol;
 pub mod rotator_device;
 pub mod serial;
 pub mod switch_device;
+pub mod units;
 
 pub use codec::{FalconCodec, FalconCodecError, FalconResponse};
 pub use config::{load_config, Config, RotatorConfig, SerialConfig, ServerConfig, SwitchConfig};
@@ -29,6 +30,7 @@ pub use manager::FalconManager;
 pub use rotator_device::FalconRotatorDevice;
 pub use serial::FalconTransportFactory;
 pub use switch_device::FalconStatusSwitchDevice;
+pub use units::{MechanicalDegrees, SkyDegrees, Steps, SyncOffset};
 
 #[cfg(feature = "mock")]
 pub use mock::MockFalconTransportFactory;

--- a/services/pa-falcon-rotator/src/manager.rs
+++ b/services/pa-falcon-rotator/src/manager.rs
@@ -35,26 +35,7 @@ use tracing::{debug, info, warn};
 use crate::codec::{FalconCodec, FalconCodecError, FalconResponse};
 use crate::error::{FalconRotatorError, Result};
 use crate::protocol::{validate_echo, Command, FalconStatus};
-
-/// Normalise a degree value into `[0.0, 360.0)`.
-///
-/// Handles negative deltas (e.g. from `Move(delta < 0)`) by adding a full
-/// turn before the second modulo so the result is always non-negative.
-fn normalise_deg(deg: f64) -> f64 {
-    ((deg % 360.0) + 360.0) % 360.0
-}
-
-/// Quantise a degree value to the `MD:nn.nn` wire precision (1/100°) by
-/// rounding to two decimal places.
-///
-/// Without this step, `format!("{:.2}", 359.999)` rounds up to `"360.00"`,
-/// which violates the documented `[0, 360)` wire range. Quantising first
-/// produces `360.00` as an `f64`, which the subsequent `normalise_deg`
-/// call wraps back to `0.0` before formatting — keeping the wire output
-/// inside the documented range.
-fn quantise_to_wire(deg: f64) -> f64 {
-    (deg * 100.0).round() / 100.0
-}
+use crate::units::{MechanicalDegrees, SkyDegrees, SyncOffset};
 
 /// Manager wrapping the shared transport plus driver-side Falcon state.
 ///
@@ -63,8 +44,8 @@ fn quantise_to_wire(deg: f64) -> f64 {
 /// hold their own `Option<Session<FalconCodec>>`.
 pub struct FalconManager {
     transport: Arc<SharedTransport<FalconCodec>>,
-    sync_offset: Mutex<f64>,
-    target_position: Mutex<Option<f64>>,
+    sync_offset: Mutex<SyncOffset>,
+    target_position: Mutex<Option<SkyDegrees>>,
     last_limit_detected: Arc<Mutex<Option<bool>>>,
 }
 
@@ -90,7 +71,7 @@ impl FalconManager {
         let transport = SharedTransport::new(factory, FalconCodec, hooks);
         Arc::new(Self {
             transport,
-            sync_offset: Mutex::new(0.0),
+            sync_offset: Mutex::new(SyncOffset::ZERO),
             target_position: Mutex::new(None),
             last_limit_detected,
         })
@@ -164,10 +145,11 @@ impl FalconManager {
 
     /// Move to a mechanical angle on the caller's session.
     ///
-    /// The caller has already applied any sync offset; this method
-    /// validates finiteness, quantises to the `MD:nn.nn` wire precision,
-    /// normalises into `[0, 360)`, emits the command, and returns the
-    /// actual wire-quantised mechanical value that was sent.
+    /// The caller has already applied any sync offset (the
+    /// [`MechanicalDegrees`] type carries a normalised, finite angle by
+    /// construction). This method quantises to the `MD:nn.nn` wire precision
+    /// — which also re-normalises into `[0, 360)` — emits the command, and
+    /// returns the actual wire-quantised mechanical value that was sent.
     ///
     /// Returning the wire-quantised value matters because a near-boundary
     /// input (e.g. `359.999`) becomes `MD:0.00` on the wire; callers that
@@ -177,22 +159,17 @@ impl FalconManager {
     pub async fn move_mechanical(
         &self,
         session: &Session<FalconCodec>,
-        target_mech_deg: f64,
-    ) -> Result<f64> {
-        if !target_mech_deg.is_finite() {
-            return Err(FalconRotatorError::InvalidValue(format!(
-                "move target must be finite, got {target_mech_deg}"
-            )));
-        }
-        let wire_deg = normalise_deg(quantise_to_wire(target_mech_deg));
-        let cmd = Command::MoveDeg(wire_deg);
+        target: MechanicalDegrees,
+    ) -> Result<MechanicalDegrees> {
+        let wire = target.quantise_to_wire();
+        let cmd = Command::MoveDeg(wire);
         let resp = session
             .request(cmd.clone())
             .await
             .map_err(FalconRotatorError::from)?;
         let echo = expect_echo(resp, "MD")?;
         validate_echo(&cmd, &echo)?;
-        Ok(wire_deg)
+        Ok(wire)
     }
 
     /// Issue `FH`, validate the `FH:1` echo, and clear the stored target.
@@ -243,28 +220,31 @@ impl FalconManager {
                 "sync target must be finite, got {sky_deg}"
             )));
         }
+        let sky = SkyDegrees::new(sky_deg);
         let mech = self.read_status(session).await?.position_deg;
-        let offset = normalise_deg(sky_deg - mech);
+        let offset = sky - mech;
         *self.sync_offset.lock().await = offset;
         debug!(
             "sync: sky={:.4} mech={:.4} → sync_offset={:.4}",
-            sky_deg, mech, offset
+            sky.value(),
+            mech.value(),
+            offset.value()
         );
         Ok(())
     }
 
     /// Read the current driver-side sync offset.
-    pub async fn sync_offset(&self) -> f64 {
+    pub async fn sync_offset(&self) -> SyncOffset {
         *self.sync_offset.lock().await
     }
 
     /// Store the last-requested sky-coordinate target.
-    pub async fn set_target_position(&self, sky_deg: f64) {
-        *self.target_position.lock().await = Some(sky_deg);
+    pub async fn set_target_position(&self, target: SkyDegrees) {
+        *self.target_position.lock().await = Some(target);
     }
 
     /// Read the last-requested sky-coordinate target.
-    pub async fn target_position(&self) -> Option<f64> {
+    pub async fn target_position(&self) -> Option<SkyDegrees> {
         *self.target_position.lock().await
     }
 
@@ -273,7 +253,7 @@ impl FalconManager {
     /// from a clean slate (`sync_offset = 0`, no target, no remembered
     /// limit edge).
     pub async fn clear_session_state(&self) {
-        *self.sync_offset.lock().await = 0.0;
+        *self.sync_offset.lock().await = SyncOffset::ZERO;
         *self.target_position.lock().await = None;
         *self.last_limit_detected.lock().await = None;
     }
@@ -362,60 +342,6 @@ async fn handshake(
     Ok(())
 }
 
-#[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
-mod tests {
-    use super::*;
-
-    // ---- normalise_deg ---------------------------------------------------
-
-    #[test]
-    fn normalise_deg_zero_is_zero() {
-        assert!((normalise_deg(0.0)).abs() < 1e-9);
-    }
-
-    #[test]
-    fn normalise_deg_under_360_passthrough() {
-        assert!((normalise_deg(180.0) - 180.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn normalise_deg_wraps_positive_overflow() {
-        assert!((normalise_deg(370.0) - 10.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn normalise_deg_wraps_negative_into_positive() {
-        assert!((normalise_deg(-10.0) - 350.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn normalise_deg_handles_two_turn_overflow() {
-        assert!((normalise_deg(720.0)).abs() < 1e-9);
-    }
-
-    // ---- quantise_to_wire ------------------------------------------------
-
-    #[test]
-    fn quantise_to_wire_rounds_up_to_360_from_just_below() {
-        assert!((quantise_to_wire(359.999) - 360.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn quantise_to_wire_preserves_two_decimal_values() {
-        assert!((quantise_to_wire(123.45) - 123.45).abs() < 1e-9);
-    }
-
-    #[test]
-    fn quantise_to_wire_then_normalise_keeps_wire_in_range() {
-        let v = normalise_deg(quantise_to_wire(359.999));
-        assert!((v).abs() < 1e-9, "expected 0.0, got {v}");
-        let formatted = format!("{v:.2}");
-        assert_eq!(formatted, "0.00");
-    }
-}
-
 /// Mock-backed integration tests for the manager.
 ///
 /// Exercises the handshake + protocol API against the deterministic
@@ -502,18 +428,18 @@ mod mock_tests {
         let (manager, factory) = make_manager();
         let session = acquire_session(&manager).await;
 
-        manager.set_target_position(123.45).await;
+        manager.set_target_position(SkyDegrees::new(123.45)).await;
         factory.set_limit_detect(true).await;
         let _ = manager.read_status(&session).await.unwrap();
         factory.set_mech_position_deg(45.0).await;
         manager.sync(&session, 90.0).await.unwrap();
-        assert!((manager.sync_offset().await - 45.0).abs() < 1e-9);
+        assert!((manager.sync_offset().await.value() - 45.0).abs() < 1e-9);
 
         session.close().await.unwrap();
         manager.clear_session_state().await;
 
         assert_eq!(manager.target_position().await, None);
-        assert!((manager.sync_offset().await).abs() < 1e-9);
+        assert!((manager.sync_offset().await.value()).abs() < 1e-9);
         assert_eq!(*manager.last_limit_detected.lock().await, None);
     }
 
@@ -526,7 +452,7 @@ mod mock_tests {
         let session = acquire_session(&manager).await;
 
         let status = manager.read_status(&session).await.unwrap();
-        assert!((status.position_deg - 50.0).abs() < 1e-9);
+        assert!((status.position_deg.value() - 50.0).abs() < 1e-9);
         assert!(!status.is_moving);
     }
 
@@ -547,29 +473,17 @@ mod mock_tests {
         let session = acquire_session(&manager).await;
         factory.clear_command_log().await;
 
-        manager.move_mechanical(&session, -30.0).await.unwrap(); // → 330°
+        manager
+            .move_mechanical(&session, MechanicalDegrees::new(-30.0))
+            .await
+            .unwrap(); // → 330°
         let log = factory.command_log().await;
         assert_eq!(log, vec!["MD:330.00".to_string()]);
     }
 
-    #[tokio::test]
-    async fn move_mechanical_rejects_non_finite() {
-        let (manager, factory) = make_manager();
-        let session = acquire_session(&manager).await;
-        factory.clear_command_log().await;
-
-        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-            let err = manager.move_mechanical(&session, bad).await.unwrap_err();
-            assert!(
-                matches!(err, FalconRotatorError::InvalidValue(_)),
-                "expected InvalidValue for {bad}, got {err:?}"
-            );
-        }
-        assert!(
-            factory.command_log().await.is_empty(),
-            "no command should reach the wire for non-finite targets"
-        );
-    }
+    // Non-finite rejection now lives at the ASCOM boundary (the
+    // `MechanicalDegrees` argument is finite by construction); see the
+    // `move_*_rejects_non_finite` tests in `rotator_device`.
 
     #[tokio::test]
     async fn move_mechanical_wraps_just_under_360_to_zero() {
@@ -577,7 +491,10 @@ mod mock_tests {
         let session = acquire_session(&manager).await;
         factory.clear_command_log().await;
 
-        manager.move_mechanical(&session, 359.999).await.unwrap();
+        manager
+            .move_mechanical(&session, MechanicalDegrees::new(359.999))
+            .await
+            .unwrap();
         assert_eq!(factory.command_log().await, vec!["MD:0.00".to_string()]);
     }
 
@@ -587,16 +504,24 @@ mod mock_tests {
         let session = acquire_session(&manager).await;
         factory.clear_command_log().await;
 
-        let wire = manager.move_mechanical(&session, 359.999).await.unwrap();
+        let wire = manager
+            .move_mechanical(&session, MechanicalDegrees::new(359.999))
+            .await
+            .unwrap();
         assert!(
-            (wire - 0.0).abs() < 1e-9,
-            "expected wire-quantised 0.0, got {wire}"
+            (wire.value() - 0.0).abs() < 1e-9,
+            "expected wire-quantised 0.0, got {}",
+            wire.value()
         );
 
-        let wire = manager.move_mechanical(&session, 123.456).await.unwrap();
+        let wire = manager
+            .move_mechanical(&session, MechanicalDegrees::new(123.456))
+            .await
+            .unwrap();
         assert!(
-            (wire - 123.46).abs() < 1e-9,
-            "expected wire-quantised 123.46, got {wire}"
+            (wire.value() - 123.46).abs() < 1e-9,
+            "expected wire-quantised 123.46, got {}",
+            wire.value()
         );
     }
 
@@ -606,7 +531,10 @@ mod mock_tests {
         let session = acquire_session(&manager).await;
         factory.clear_command_log().await;
 
-        manager.move_mechanical(&session, 360.0).await.unwrap();
+        manager
+            .move_mechanical(&session, MechanicalDegrees::new(360.0))
+            .await
+            .unwrap();
         assert_eq!(factory.command_log().await, vec!["MD:0.00".to_string()]);
     }
 
@@ -614,7 +542,7 @@ mod mock_tests {
     async fn halt_sends_fh_and_clears_target() {
         let (manager, factory) = make_manager();
         let session = acquire_session(&manager).await;
-        manager.set_target_position(180.0).await;
+        manager.set_target_position(SkyDegrees::new(180.0)).await;
         factory.clear_command_log().await;
 
         manager.halt(&session).await.unwrap();
@@ -661,7 +589,7 @@ mod mock_tests {
 
         // mech = 120°, sync to 30° → offset = (30 - 120) mod 360 = 270.
         manager.sync(&session, 30.0).await.unwrap();
-        let offset = manager.sync_offset().await;
+        let offset = manager.sync_offset().await.value();
         assert!(
             (offset - 270.0).abs() < 1e-9,
             "expected offset 270.0, got {offset}"
@@ -672,7 +600,7 @@ mod mock_tests {
     async fn sync_rejects_non_finite() {
         let (manager, _factory) = make_manager();
         let session = acquire_session(&manager).await;
-        let starting_offset = manager.sync_offset().await;
+        let starting_offset = manager.sync_offset().await.value();
 
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             let err = manager.sync(&session, bad).await.unwrap_err();
@@ -681,7 +609,7 @@ mod mock_tests {
                 "expected InvalidValue for {bad}, got {err:?}"
             );
         }
-        assert!((manager.sync_offset().await - starting_offset).abs() < 1e-9);
+        assert!((manager.sync_offset().await.value() - starting_offset).abs() < 1e-9);
     }
 
     // ---- limit_detect edge log -----------------------------------------
@@ -872,7 +800,7 @@ mod mock_tests {
 
         fail_switch.store(true, Ordering::SeqCst);
         let err = manager
-            .move_mechanical(&session, 180.0)
+            .move_mechanical(&session, MechanicalDegrees::new(180.0))
             .await
             .expect_err("move_mechanical should propagate the transport failure");
         assert!(
@@ -890,7 +818,7 @@ mod mock_tests {
         let (manager, factory) = make_injectable_manager();
         let fail_switch = factory.fail_next_send();
         let session = acquire_session(&manager).await;
-        manager.set_target_position(180.0).await;
+        manager.set_target_position(SkyDegrees::new(180.0)).await;
 
         fail_switch.store(true, Ordering::SeqCst);
         let err = manager
@@ -903,7 +831,7 @@ mod mock_tests {
         );
         assert_eq!(
             manager.target_position().await,
-            Some(180.0),
+            Some(SkyDegrees::new(180.0)),
             "halt's target-clearing side effect must NOT fire on transport failure"
         );
     }
@@ -915,7 +843,7 @@ mod mock_tests {
         let (manager, factory) = make_injectable_manager();
         let fail_switch = factory.fail_next_send();
         let session = acquire_session(&manager).await;
-        let starting_offset = manager.sync_offset().await;
+        let starting_offset = manager.sync_offset().await.value();
 
         fail_switch.store(true, Ordering::SeqCst);
         let err = manager
@@ -926,7 +854,7 @@ mod mock_tests {
             matches!(err, FalconRotatorError::Communication(_)),
             "expected Communication, got {err:?}"
         );
-        assert!((manager.sync_offset().await - starting_offset).abs() < 1e-9);
+        assert!((manager.sync_offset().await.value() - starting_offset).abs() < 1e-9);
     }
 
     #[tokio::test]
@@ -955,7 +883,7 @@ mod mock_tests {
         );
 
         assert!(!manager.is_available());
-        assert!((manager.sync_offset().await).abs() < 1e-9);
+        assert!((manager.sync_offset().await.value()).abs() < 1e-9);
         assert_eq!(manager.target_position().await, None);
     }
 }

--- a/services/pa-falcon-rotator/src/mock.rs
+++ b/services/pa-falcon-rotator/src/mock.rs
@@ -28,6 +28,12 @@ use tracing::debug;
 /// Steps per degree (vendor product page).
 const STEPS_PER_DEGREE: f64 = 86.6;
 
+/// Firmware-enforced CW soft limit, in degrees. A target beyond this is only
+/// reachable the long way round (CCW past the 0° home), which the firmware
+/// reports as a *negative* signed step count. Modelled here so the mock
+/// reproduces the real-hardware behaviour ConformU exercises (firmware 1.5).
+const FALCON_CW_LIMIT_DEG: f64 = 220.0;
+
 /// Default raw ADC voltage reading returned by `VS`.
 const DEFAULT_VOLTAGE_RAW: u32 = 800;
 
@@ -42,8 +48,11 @@ const UNKNOWN_COMMAND_RESPONSE: &str = "ERR:UNKNOWN";
 /// Simulated Falcon Rotator device state.
 #[derive(Debug, Clone)]
 struct MockDeviceState {
-    /// Current mechanical position in degrees (normalised to `[0, 360)`).
-    mech_position_deg: f64,
+    /// Signed mechanical position as a step count relative to the 0° home,
+    /// mirroring the real Falcon encoder (negative CCW of home). The normalised
+    /// `[0, 360)` angle is derived from this via
+    /// [`MockDeviceState::mech_position_deg`].
+    mech_steps: i32,
     /// `true` until the next `FA` clears the flag (best-effort BDD model).
     is_moving: bool,
     /// Mirrors the `FN:b` setting; persists across commands.
@@ -61,7 +70,7 @@ struct MockDeviceState {
 impl Default for MockDeviceState {
     fn default() -> Self {
         Self {
-            mech_position_deg: 0.0,
+            mech_steps: 0,
             is_moving: false,
             motor_reverse: false,
             do_derotation: false,
@@ -73,15 +82,21 @@ impl Default for MockDeviceState {
 }
 
 impl MockDeviceState {
-    fn position_steps(&self) -> u32 {
-        (self.mech_position_deg * STEPS_PER_DEGREE).round() as u32
+    fn position_steps(&self) -> i32 {
+        self.mech_steps
+    }
+
+    /// Normalised `[0, 360)` mechanical angle derived from the signed step
+    /// counter — what the firmware reports for `FD` and the `FA` degree field.
+    fn mech_position_deg(&self) -> f64 {
+        normalise_deg(f64::from(self.mech_steps) / STEPS_PER_DEGREE)
     }
 
     fn full_status_response(&self) -> String {
         format!(
             "FR_OK:{}:{:.2}:{}:{}:{}:{}",
             self.position_steps(),
-            self.mech_position_deg,
+            self.mech_position_deg(),
             bit(self.is_moving),
             bit(self.limit_detect),
             bit(self.do_derotation),
@@ -100,6 +115,20 @@ fn bit(b: bool) -> u8 {
 
 fn normalise_deg(deg: f64) -> f64 {
     ((deg % 360.0) + 360.0) % 360.0
+}
+
+/// Map a commanded degree to the Falcon's *signed* step counter, modelling the
+/// 220° CW soft limit: a target beyond 220° is only reachable the long way
+/// round (CCW past the 0° home), which the firmware represents as a negative
+/// step count (`deg - 360`). Mirrors real-hardware capture (firmware 1.5).
+fn signed_target_steps(deg: f64) -> i32 {
+    let d = normalise_deg(deg);
+    let signed = if d > FALCON_CW_LIMIT_DEG {
+        d - 360.0
+    } else {
+        d
+    };
+    (signed * STEPS_PER_DEGREE).round() as i32
 }
 
 /// In-memory Falcon state plus a queue of pending response frames.
@@ -131,7 +160,7 @@ impl MockState {
                 resp
             }
             "FV" => format!("FV:{}", self.device_state.firmware_version),
-            "FD" => format!("FD:{:.2}", self.device_state.mech_position_deg),
+            "FD" => format!("FD:{:.2}", self.device_state.mech_position_deg()),
             "FP" => format!("FP:{}", self.device_state.position_steps()),
             "VS" => format!("VS:{}", self.device_state.voltage_raw),
             "FH" => {
@@ -172,7 +201,7 @@ impl MockState {
         let value = command.strip_prefix("MD:").unwrap_or("");
         match value.parse::<f64>() {
             Ok(deg) if deg.is_finite() => {
-                self.device_state.mech_position_deg = normalise_deg(deg);
+                self.device_state.mech_steps = signed_target_steps(deg);
                 self.device_state.is_moving = true;
                 // Echo the command literally so the driver's echo
                 // validation sees what it sent regardless of mock precision.
@@ -186,8 +215,9 @@ impl MockState {
         let value = command.strip_prefix("MS:").unwrap_or("");
         match value.parse::<u32>() {
             Ok(steps) => {
-                let deg = f64::from(steps) / STEPS_PER_DEGREE;
-                self.device_state.mech_position_deg = normalise_deg(deg);
+                // MS commands an absolute (unsigned) step target; store it as
+                // the signed counter directly.
+                self.device_state.mech_steps = steps as i32;
                 self.device_state.is_moving = true;
                 format!("MS:{steps}")
             }
@@ -263,14 +293,14 @@ impl TransportFactory for MockFalconTransportFactory {
 impl MockFalconTransportFactory {
     /// Seed the mock's mechanical position before opening a connection.
     pub async fn set_mech_position_deg(&self, value: f64) {
-        self.state.lock().await.device_state.mech_position_deg = normalise_deg(value);
+        self.state.lock().await.device_state.mech_steps = signed_target_steps(value);
     }
 
     /// Read the mock's current mechanical position. Used by tests that
     /// verify a code path *did not* mutate the device counter (e.g. ASCOM
     /// Sync, which must leave MechanicalPosition untouched).
     pub async fn mech_position_deg(&self) -> f64 {
-        self.state.lock().await.device_state.mech_position_deg
+        self.state.lock().await.device_state.mech_position_deg()
     }
 
     /// Seed the mock's `motor_reverse` flag (mirrors EEPROM persistence).
@@ -495,6 +525,29 @@ mod tests {
         assert_eq!(&deg, b"FD:50.00\n");
         // 50 * 86.6 = 4330
         assert_eq!(&steps, b"FP:4330\n");
+    }
+
+    #[tokio::test]
+    async fn move_past_cw_limit_reports_negative_steps() {
+        // Real hardware (firmware 1.5): a target beyond the 220° CW soft limit
+        // is reached the long way round (CCW past the 0° home), so the signed
+        // step counter goes negative even though position_deg wraps into
+        // [0, 360). This is the case the u32→i32 parse fix must survive — and
+        // exactly what the real-hardware ConformU run tripped on.
+        let factory = MockFalconTransportFactory::default();
+        let mut t = open(&factory).await;
+        let _ = round_trip(&mut t, b"MD:300.00\n").await;
+
+        // 300° > 220° CW limit → signed -60° → -60 * 86.6 = -5196 steps.
+        let fp = round_trip(&mut t, b"FP\n").await;
+        assert_eq!(std::str::from_utf8(&fp).unwrap().trim(), "FP:-5196");
+
+        let fa = round_trip(&mut t, b"FA\n").await;
+        let fa_text = std::str::from_utf8(&fa).unwrap();
+        assert!(
+            fa_text.starts_with("FR_OK:-5196:300.00:"),
+            "expected negative steps with wrapped degrees: {fa_text}"
+        );
     }
 
     #[tokio::test]

--- a/services/pa-falcon-rotator/src/mock.rs
+++ b/services/pa-falcon-rotator/src/mock.rs
@@ -25,8 +25,7 @@ use rusty_photon_shared_transport::{FrameTransport, TransportError, TransportFac
 use tokio::sync::Mutex;
 use tracing::debug;
 
-/// Steps per degree (vendor product page).
-const STEPS_PER_DEGREE: f64 = 86.6;
+use crate::units::{MechanicalDegrees, Steps, STEPS_PER_DEGREE};
 
 /// Firmware-enforced CW soft limit, in degrees. A target beyond this is only
 /// reachable the long way round (CCW past the 0° home), which the firmware
@@ -48,11 +47,12 @@ const UNKNOWN_COMMAND_RESPONSE: &str = "ERR:UNKNOWN";
 /// Simulated Falcon Rotator device state.
 #[derive(Debug, Clone)]
 struct MockDeviceState {
-    /// Signed mechanical position as a step count relative to the 0° home,
-    /// mirroring the real Falcon encoder (negative CCW of home). The normalised
-    /// `[0, 360)` angle is derived from this via
-    /// [`MockDeviceState::mech_position_deg`].
-    mech_steps: i32,
+    /// Mechanical position the device currently holds, in its own frame.
+    /// The signed `FA`/`FP` step counter is *derived* from this via
+    /// [`signed_target_steps`] (negative CCW of the 0° home, for targets past
+    /// the 220° CW limit), mirroring how the real Falcon reports a step count
+    /// alongside the authoritative degree field.
+    mech: MechanicalDegrees,
     /// `true` until the next `FA` clears the flag (best-effort BDD model).
     is_moving: bool,
     /// Mirrors the `FN:b` setting; persists across commands.
@@ -70,7 +70,7 @@ struct MockDeviceState {
 impl Default for MockDeviceState {
     fn default() -> Self {
         Self {
-            mech_steps: 0,
+            mech: MechanicalDegrees::new(0.0),
             is_moving: false,
             motor_reverse: false,
             do_derotation: false,
@@ -82,20 +82,23 @@ impl Default for MockDeviceState {
 }
 
 impl MockDeviceState {
-    fn position_steps(&self) -> i32 {
-        self.mech_steps
+    /// The signed step counter the device reports for `FP` and the `FA` step
+    /// field, derived from the mechanical angle (negative CCW of the 0° home;
+    /// see [`signed_target_steps`]).
+    fn position_steps(&self) -> Steps {
+        signed_target_steps(self.mech)
     }
 
-    /// Normalised `[0, 360)` mechanical angle derived from the signed step
-    /// counter — what the firmware reports for `FD` and the `FA` degree field.
+    /// The `[0, 360)` mechanical angle the firmware reports for `FD` and the
+    /// `FA` degree field.
     fn mech_position_deg(&self) -> f64 {
-        normalise_deg(f64::from(self.mech_steps) / STEPS_PER_DEGREE)
+        self.mech.value()
     }
 
     fn full_status_response(&self) -> String {
         format!(
             "FR_OK:{}:{:.2}:{}:{}:{}:{}",
-            self.position_steps(),
+            self.position_steps().value(),
             self.mech_position_deg(),
             bit(self.is_moving),
             bit(self.limit_detect),
@@ -113,22 +116,18 @@ fn bit(b: bool) -> u8 {
     }
 }
 
-fn normalise_deg(deg: f64) -> f64 {
-    ((deg % 360.0) + 360.0) % 360.0
-}
-
-/// Map a commanded degree to the Falcon's *signed* step counter, modelling the
+/// Map a mechanical angle to the Falcon's *signed* step counter, modelling the
 /// 220° CW soft limit: a target beyond 220° is only reachable the long way
 /// round (CCW past the 0° home), which the firmware represents as a negative
 /// step count (`deg - 360`). Mirrors real-hardware capture (firmware 1.5).
-fn signed_target_steps(deg: f64) -> i32 {
-    let d = normalise_deg(deg);
+fn signed_target_steps(mech: MechanicalDegrees) -> Steps {
+    let d = mech.value();
     let signed = if d > FALCON_CW_LIMIT_DEG {
         d - 360.0
     } else {
         d
     };
-    (signed * STEPS_PER_DEGREE).round() as i32
+    Steps((signed * STEPS_PER_DEGREE).round() as i32)
 }
 
 /// In-memory Falcon state plus a queue of pending response frames.
@@ -161,7 +160,7 @@ impl MockState {
             }
             "FV" => format!("FV:{}", self.device_state.firmware_version),
             "FD" => format!("FD:{:.2}", self.device_state.mech_position_deg()),
-            "FP" => format!("FP:{}", self.device_state.position_steps()),
+            "FP" => format!("FP:{}", self.device_state.position_steps().value()),
             "VS" => format!("VS:{}", self.device_state.voltage_raw),
             "FH" => {
                 self.device_state.is_moving = false;
@@ -201,7 +200,7 @@ impl MockState {
         let value = command.strip_prefix("MD:").unwrap_or("");
         match value.parse::<f64>() {
             Ok(deg) if deg.is_finite() => {
-                self.device_state.mech_steps = signed_target_steps(deg);
+                self.device_state.mech = MechanicalDegrees::new(deg);
                 self.device_state.is_moving = true;
                 // Echo the command literally so the driver's echo
                 // validation sees what it sent regardless of mock precision.
@@ -213,11 +212,12 @@ impl MockState {
 
     fn process_move_steps(&mut self, command: &str) -> String {
         let value = command.strip_prefix("MS:").unwrap_or("");
-        match value.parse::<u32>() {
+        // The encoder is signed relative to the 0° home, so parse the target
+        // as i32 (no lossy u32→i32 cast) and store the equivalent mechanical
+        // angle; the FA/FP step field is re-derived from it.
+        match value.parse::<i32>() {
             Ok(steps) => {
-                // MS commands an absolute (unsigned) step target; store it as
-                // the signed counter directly.
-                self.device_state.mech_steps = steps as i32;
+                self.device_state.mech = MechanicalDegrees::from(Steps(steps));
                 self.device_state.is_moving = true;
                 format!("MS:{steps}")
             }
@@ -293,7 +293,7 @@ impl TransportFactory for MockFalconTransportFactory {
 impl MockFalconTransportFactory {
     /// Seed the mock's mechanical position before opening a connection.
     pub async fn set_mech_position_deg(&self, value: f64) {
-        self.state.lock().await.device_state.mech_steps = signed_target_steps(value);
+        self.state.lock().await.device_state.mech = MechanicalDegrees::new(value);
     }
 
     /// Read the mock's current mechanical position. Used by tests that
@@ -348,16 +348,6 @@ mod tests {
     }
 
     // ---- Helpers ---------------------------------------------------------
-
-    #[test]
-    fn normalise_deg_wraps_positive_overflow() {
-        assert!((normalise_deg(370.0) - 10.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn normalise_deg_wraps_negative_into_positive() {
-        assert!((normalise_deg(-10.0) - 350.0).abs() < 1e-9);
-    }
 
     #[test]
     fn bit_maps_true_and_false() {

--- a/services/pa-falcon-rotator/src/protocol.rs
+++ b/services/pa-falcon-rotator/src/protocol.rs
@@ -99,9 +99,15 @@ impl Command {
 /// Parsed Falcon `FA` full-status response.
 ///
 /// Wire format: `FR_OK:position_in_steps:position_in_deg:is_moving:limit_detect:do_derotation:motor_reverse`
+///
+/// `position_steps` is **signed**: the Falcon's step counter is referenced to
+/// the 0° home and reads negative for positions reached CCW of home — which
+/// happens whenever a target beyond the 220° CW soft limit is reached the long
+/// way round. `position_deg` is always normalised to `[0, 360)`. Captured on
+/// real hardware (firmware 1.5); see `parse_full_status` tests.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FalconStatus {
-    pub position_steps: u32,
+    pub position_steps: i32,
     pub position_deg: f64,
     pub is_moving: bool,
     pub limit_detect: bool,
@@ -143,7 +149,10 @@ pub fn parse_full_status(response: &str) -> Result<FalconStatus> {
             fields.len()
         )));
     }
-    let position_steps: u32 = fields[0]
+    // Signed: negative for positions CCW of the 0° home (e.g. a target past
+    // the 220° CW limit reached the long way round). Parsing as u32 here is
+    // the bug that broke every status read whenever steps went negative.
+    let position_steps: i32 = fields[0]
         .parse()
         .map_err(|e| FalconRotatorError::ParseError(format!("FA position_steps: {e}")))?;
     let position_deg: f64 = fields[1]
@@ -194,7 +203,10 @@ pub fn parse_position_deg(response: &str) -> Result<f64> {
 }
 
 /// Parse the `FP:n..` steps response.
-pub fn parse_position_steps(response: &str) -> Result<u32> {
+///
+/// Signed: the step counter is referenced to the 0° home and reads negative
+/// for positions CCW of home (real hardware, firmware 1.5).
+pub fn parse_position_steps(response: &str) -> Result<i32> {
     let rest = strip_known_prefix(response, "FP:")?;
     rest.parse()
         .map_err(|e| FalconRotatorError::ParseError(format!("FP: {e}")))
@@ -490,6 +502,21 @@ mod tests {
         assert!(matches!(err, FalconRotatorError::ParseError(_)));
     }
 
+    #[test]
+    fn parse_full_status_accepts_negative_steps_below_home() {
+        // Real-hardware capture (firmware 1.5): driving past the 220° CW limit
+        // sends the rotator the long way round — CCW past the 0° home — where
+        // the signed step counter goes negative while position_deg wraps into
+        // [0, 360). Parsing field 0 as i32 (not u32) is what keeps status reads
+        // alive across that region; the u32 parse here used to abort the read
+        // with "FA position_steps: invalid digit found in string".
+        let status = parse_full_status("FR_OK:-2838:327.24:1:0:0:0").unwrap();
+        assert_eq!(status.position_steps, -2838);
+        assert!((status.position_deg - 327.24).abs() < 1e-9);
+        assert!(status.is_moving);
+        assert!(!status.limit_detect);
+    }
+
     // ---- parse_firmware_version -------------------------------------------
 
     #[test]
@@ -570,11 +597,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_position_steps_rejects_negative() {
-        assert!(matches!(
-            parse_position_steps("FP:-1").unwrap_err(),
-            FalconRotatorError::ParseError(_)
-        ));
+    fn parse_position_steps_accepts_negative_below_home() {
+        // The Falcon step counter is signed relative to the 0° home: positions
+        // CCW of home report negative steps. Captured on real hardware
+        // (firmware 1.5), e.g. `FP:-1784` observed at 339.96° while traversing
+        // past the 220° CW limit the long way round.
+        assert_eq!(parse_position_steps("FP:-1784").unwrap(), -1784);
     }
 
     // ---- parse_voltage_raw ------------------------------------------------

--- a/services/pa-falcon-rotator/src/protocol.rs
+++ b/services/pa-falcon-rotator/src/protocol.rs
@@ -5,6 +5,7 @@
 //! command table.
 
 use crate::error::{FalconRotatorError, Result};
+use crate::units::{MechanicalDegrees, Steps};
 
 /// Commands the driver issues to the Falcon Rotator.
 ///
@@ -39,10 +40,10 @@ pub enum Command {
     DerotationOff,
     /// `DR:<ms>` — enable de-rotation at `ms` ms/step.
     DerotationRate(u32),
-    /// `MD:<deg>` — move to absolute degrees.
-    MoveDeg(f64),
+    /// `MD:<deg>` — move to absolute (mechanical) degrees.
+    MoveDeg(MechanicalDegrees),
     /// `MS:<steps>` — move to absolute steps.
-    MoveSteps(u32),
+    MoveSteps(Steps),
     /// `FH` — halt. Expect `FH:1`.
     Halt,
     /// `FR` — is running. Expect `FR:1` or `FR:0`.
@@ -68,8 +69,8 @@ impl Command {
             Command::Voltage => "VS".to_string(),
             Command::DerotationOff => "DR:0".to_string(),
             Command::DerotationRate(ms) => format!("DR:{ms}"),
-            Command::MoveDeg(deg) => format!("MD:{deg:.2}"),
-            Command::MoveSteps(steps) => format!("MS:{steps}"),
+            Command::MoveDeg(deg) => format!("MD:{:.2}", deg.value()),
+            Command::MoveSteps(steps) => format!("MS:{}", steps.value()),
             Command::Halt => "FH".to_string(),
             Command::IsRunning => "FR".to_string(),
             Command::SetReverse(on) => format!("FN:{}", if *on { 1 } else { 0 }),
@@ -77,18 +78,20 @@ impl Command {
     }
 
     /// Reject command instances that would serialise to an invalid wire
-    /// payload — currently just non-finite `MoveDeg(f64)`, which would
-    /// emit `MD:NaN` / `MD:inf` / `MD:-inf`.
+    /// payload — currently just a `MoveDeg` whose `MechanicalDegrees` holds a
+    /// non-finite value, which would emit `MD:NaN` / `MD:inf` / `MD:-inf`.
     ///
-    /// `SerialManager::move_mechanical` already validates before constructing
-    /// the variant, so this is defence-in-depth for callers that route
-    /// through the public `SerialManager::send_command` entry point with a
-    /// hand-built `Command`. `to_command_string` stays infallible.
+    /// The ASCOM boundary rejects non-finite move targets before a
+    /// `MechanicalDegrees` is ever constructed, so this is defence-in-depth
+    /// for callers that hand-build a `Command` and route it through the
+    /// public `send_command` entry point. `to_command_string` stays
+    /// infallible.
     pub fn validate(&self) -> Result<()> {
         if let Command::MoveDeg(deg) = self {
-            if !deg.is_finite() {
+            if !deg.value().is_finite() {
                 return Err(FalconRotatorError::InvalidValue(format!(
-                    "MoveDeg target must be finite, got {deg}"
+                    "MoveDeg target must be finite, got {}",
+                    deg.value()
                 )));
             }
         }
@@ -107,8 +110,8 @@ impl Command {
 /// real hardware (firmware 1.5); see `parse_full_status` tests.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FalconStatus {
-    pub position_steps: i32,
-    pub position_deg: f64,
+    pub position_steps: Steps,
+    pub position_deg: MechanicalDegrees,
     pub is_moving: bool,
     pub limit_detect: bool,
     pub do_derotation: bool,
@@ -152,17 +155,19 @@ pub fn parse_full_status(response: &str) -> Result<FalconStatus> {
     // Signed: negative for positions CCW of the 0° home (e.g. a target past
     // the 220° CW limit reached the long way round). Parsing as u32 here is
     // the bug that broke every status read whenever steps went negative.
-    let position_steps: i32 = fields[0]
+    let steps_raw: i32 = fields[0]
         .parse()
         .map_err(|e| FalconRotatorError::ParseError(format!("FA position_steps: {e}")))?;
-    let position_deg: f64 = fields[1]
+    let deg_raw: f64 = fields[1]
         .parse()
         .map_err(|e| FalconRotatorError::ParseError(format!("FA position_deg: {e}")))?;
-    if !position_deg.is_finite() {
+    if !deg_raw.is_finite() {
         return Err(FalconRotatorError::ParseError(format!(
-            "FA position_deg: non-finite value {position_deg} in {response:?}"
+            "FA position_deg: non-finite value {deg_raw} in {response:?}"
         )));
     }
+    let position_steps = Steps(steps_raw);
+    let position_deg = MechanicalDegrees::new(deg_raw);
     let is_moving = parse_bool(fields[2], "FA is_moving")?;
     let limit_detect = parse_bool(fields[3], "FA limit_detect")?;
     let do_derotation = parse_bool(fields[4], "FA do_derotation")?;
@@ -189,7 +194,7 @@ pub fn parse_firmware_version(response: &str) -> Result<String> {
 }
 
 /// Parse the `FD:nn.nn` degrees response.
-pub fn parse_position_deg(response: &str) -> Result<f64> {
+pub fn parse_position_deg(response: &str) -> Result<MechanicalDegrees> {
     let rest = strip_known_prefix(response, "FD:")?;
     let value: f64 = rest
         .parse()
@@ -199,16 +204,17 @@ pub fn parse_position_deg(response: &str) -> Result<f64> {
             "FD: non-finite value {value} in {response:?}"
         )));
     }
-    Ok(value)
+    Ok(MechanicalDegrees::new(value))
 }
 
 /// Parse the `FP:n..` steps response.
 ///
 /// Signed: the step counter is referenced to the 0° home and reads negative
 /// for positions CCW of home (real hardware, firmware 1.5).
-pub fn parse_position_steps(response: &str) -> Result<i32> {
+pub fn parse_position_steps(response: &str) -> Result<Steps> {
     let rest = strip_known_prefix(response, "FP:")?;
     rest.parse()
+        .map(Steps)
         .map_err(|e| FalconRotatorError::ParseError(format!("FP: {e}")))
 }
 
@@ -328,18 +334,30 @@ mod tests {
 
     #[test]
     fn command_move_deg_uses_two_decimal_places() {
-        assert_eq!(Command::MoveDeg(284.8).to_command_string(), "MD:284.80");
+        assert_eq!(
+            Command::MoveDeg(MechanicalDegrees::new(284.8)).to_command_string(),
+            "MD:284.80"
+        );
     }
 
     #[test]
     fn command_move_deg_pads_to_two_decimal_places() {
-        assert_eq!(Command::MoveDeg(0.0).to_command_string(), "MD:0.00");
-        assert_eq!(Command::MoveDeg(45.0).to_command_string(), "MD:45.00");
+        assert_eq!(
+            Command::MoveDeg(MechanicalDegrees::new(0.0)).to_command_string(),
+            "MD:0.00"
+        );
+        assert_eq!(
+            Command::MoveDeg(MechanicalDegrees::new(45.0)).to_command_string(),
+            "MD:45.00"
+        );
     }
 
     #[test]
     fn command_move_steps_includes_count() {
-        assert_eq!(Command::MoveSteps(31_192).to_command_string(), "MS:31192");
+        assert_eq!(
+            Command::MoveSteps(Steps(31_192)).to_command_string(),
+            "MS:31192"
+        );
     }
 
     #[test]
@@ -356,16 +374,26 @@ mod tests {
 
     #[test]
     fn validate_accepts_finite_move_deg() {
-        Command::MoveDeg(180.0).validate().unwrap();
-        Command::MoveDeg(0.0).validate().unwrap();
-        Command::MoveDeg(-90.0).validate().unwrap();
-        Command::MoveDeg(359.99).validate().unwrap();
+        Command::MoveDeg(MechanicalDegrees::new(180.0))
+            .validate()
+            .unwrap();
+        Command::MoveDeg(MechanicalDegrees::new(0.0))
+            .validate()
+            .unwrap();
+        Command::MoveDeg(MechanicalDegrees::new(-90.0))
+            .validate()
+            .unwrap();
+        Command::MoveDeg(MechanicalDegrees::new(359.99))
+            .validate()
+            .unwrap();
     }
 
     #[test]
     fn validate_rejects_non_finite_move_deg() {
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-            let err = Command::MoveDeg(bad).validate().unwrap_err();
+            let err = Command::MoveDeg(MechanicalDegrees::new(bad))
+                .validate()
+                .unwrap_err();
             assert!(
                 matches!(err, FalconRotatorError::InvalidValue(_)),
                 "expected InvalidValue for {bad}, got {err:?}"
@@ -385,7 +413,7 @@ mod tests {
         Command::Voltage.validate().unwrap();
         Command::DerotationOff.validate().unwrap();
         Command::DerotationRate(50).validate().unwrap();
-        Command::MoveSteps(31_192).validate().unwrap();
+        Command::MoveSteps(Steps(31_192)).validate().unwrap();
         Command::Halt.validate().unwrap();
         Command::IsRunning.validate().unwrap();
         Command::SetReverse(true).validate().unwrap();
@@ -407,8 +435,8 @@ mod tests {
     #[test]
     fn parse_full_status_happy_path() {
         let status = parse_full_status("FR_OK:4332:50.00:0:0:0:0").unwrap();
-        assert_eq!(status.position_steps, 4332);
-        assert!((status.position_deg - 50.0).abs() < 1e-9);
+        assert_eq!(status.position_steps, Steps(4332));
+        assert!((status.position_deg.value() - 50.0).abs() < 1e-9);
         assert!(!status.is_moving);
         assert!(!status.limit_detect);
         assert!(!status.do_derotation);
@@ -418,13 +446,13 @@ mod tests {
     #[test]
     fn parse_full_status_with_trailing_newline() {
         let status = parse_full_status("FR_OK:4332:50.00:0:0:0:0\n").unwrap();
-        assert_eq!(status.position_steps, 4332);
+        assert_eq!(status.position_steps, Steps(4332));
     }
 
     #[test]
     fn parse_full_status_with_trailing_crlf() {
         let status = parse_full_status("FR_OK:4332:50.00:0:0:0:0\r\n").unwrap();
-        assert_eq!(status.position_steps, 4332);
+        assert_eq!(status.position_steps, Steps(4332));
     }
 
     #[test]
@@ -511,8 +539,8 @@ mod tests {
         // alive across that region; the u32 parse here used to abort the read
         // with "FA position_steps: invalid digit found in string".
         let status = parse_full_status("FR_OK:-2838:327.24:1:0:0:0").unwrap();
-        assert_eq!(status.position_steps, -2838);
-        assert!((status.position_deg - 327.24).abs() < 1e-9);
+        assert_eq!(status.position_steps, Steps(-2838));
+        assert!((status.position_deg.value() - 327.24).abs() < 1e-9);
         assert!(status.is_moving);
         assert!(!status.limit_detect);
     }
@@ -546,7 +574,7 @@ mod tests {
     #[test]
     fn parse_position_deg_basic() {
         let v = parse_position_deg("FD:142.30").unwrap();
-        assert!((v - 142.30).abs() < 1e-9);
+        assert!((v.value() - 142.30).abs() < 1e-9);
     }
 
     #[test]
@@ -593,7 +621,7 @@ mod tests {
 
     #[test]
     fn parse_position_steps_basic() {
-        assert_eq!(parse_position_steps("FP:12345").unwrap(), 12345);
+        assert_eq!(parse_position_steps("FP:12345").unwrap(), Steps(12345));
     }
 
     #[test]
@@ -602,7 +630,7 @@ mod tests {
         // CCW of home report negative steps. Captured on real hardware
         // (firmware 1.5), e.g. `FP:-1784` observed at 339.96° while traversing
         // past the 220° CW limit the long way round.
-        assert_eq!(parse_position_steps("FP:-1784").unwrap(), -1784);
+        assert_eq!(parse_position_steps("FP:-1784").unwrap(), Steps(-1784));
     }
 
     // ---- parse_voltage_raw ------------------------------------------------
@@ -693,17 +721,25 @@ mod tests {
 
     #[test]
     fn validate_echo_move_deg_matches() {
-        validate_echo(&Command::MoveDeg(180.0), "MD:180.00").unwrap();
+        validate_echo(
+            &Command::MoveDeg(MechanicalDegrees::new(180.0)),
+            "MD:180.00",
+        )
+        .unwrap();
     }
 
     #[test]
     fn validate_echo_move_deg_matches_with_trailing_newline() {
-        validate_echo(&Command::MoveDeg(180.0), "MD:180.00\n").unwrap();
+        validate_echo(
+            &Command::MoveDeg(MechanicalDegrees::new(180.0)),
+            "MD:180.00\n",
+        )
+        .unwrap();
     }
 
     #[test]
     fn validate_echo_move_steps_matches() {
-        validate_echo(&Command::MoveSteps(15_000), "MS:15000").unwrap();
+        validate_echo(&Command::MoveSteps(Steps(15_000)), "MS:15000").unwrap();
     }
 
     #[test]
@@ -739,7 +775,11 @@ mod tests {
 
     #[test]
     fn validate_echo_rejects_mismatch() {
-        let err = validate_echo(&Command::MoveDeg(180.0), "MD:181.00").unwrap_err();
+        let err = validate_echo(
+            &Command::MoveDeg(MechanicalDegrees::new(180.0)),
+            "MD:181.00",
+        )
+        .unwrap_err();
         assert!(matches!(err, FalconRotatorError::InvalidResponse(_)));
     }
 

--- a/services/pa-falcon-rotator/src/rotator_device.rs
+++ b/services/pa-falcon-rotator/src/rotator_device.rs
@@ -25,11 +25,7 @@ use crate::codec::FalconCodec;
 use crate::config::RotatorConfig;
 use crate::error::FalconRotatorError;
 use crate::manager::FalconManager;
-
-/// Normalise a degree value into `[0.0, 360.0)`.
-fn normalise_deg(deg: f64) -> f64 {
-    ((deg % 360.0) + 360.0) % 360.0
-}
+use crate::units::{MechanicalDegrees, SkyDegrees};
 
 /// Guard macro that returns NOT_CONNECTED if the device is not connected.
 ///
@@ -176,7 +172,7 @@ impl Rotator for FalconRotatorDevice {
         let offset = self.manager.sync_offset().await;
         self.with_session(async |session| {
             let status = self.manager.read_status(session).await?;
-            Ok(normalise_deg(status.position_deg + offset))
+            Ok((status.position_deg + offset).value())
         })
         .await
     }
@@ -185,7 +181,7 @@ impl Rotator for FalconRotatorDevice {
         ensure_connected!(self);
         self.with_session(async |session| {
             let status = self.manager.read_status(session).await?;
-            Ok(normalise_deg(status.position_deg))
+            Ok(status.position_deg.value())
         })
         .await
     }
@@ -193,14 +189,14 @@ impl Rotator for FalconRotatorDevice {
     async fn target_position(&self) -> ASCOMResult<f64> {
         ensure_connected!(self);
         if let Some(target) = self.manager.target_position().await {
-            return Ok(target);
+            return Ok(target.value());
         }
         // No move outstanding: fall back to current Position. Matches the
         // design doc's TargetPosition row and the dominant ASCOM convention.
         let offset = self.manager.sync_offset().await;
         self.with_session(async |session| {
             let status = self.manager.read_status(session).await?;
-            Ok(normalise_deg(status.position_deg + offset))
+            Ok((status.position_deg + offset).value())
         })
         .await
     }
@@ -247,7 +243,7 @@ impl Rotator for FalconRotatorDevice {
                 // position is (mech + offset) + delta, and the mechanical
                 // wire value is therefore (mech + offset + delta) - offset
                 // = mech + delta.
-                let target_mech = normalise_deg(status.position_deg + position);
+                let target_mech = status.position_deg.rotate(position);
                 // Set TargetPosition only after the MD command has been
                 // accepted — a failed echo on the wire must NOT leave a
                 // stale target the client could read back via
@@ -258,7 +254,7 @@ impl Rotator for FalconRotatorDevice {
                 self.manager.move_mechanical(session, target_mech).await
             })
             .await?;
-        let target_sky = normalise_deg(wire_mech + offset);
+        let target_sky = wire_mech + offset;
         self.manager.set_target_position(target_sky).await;
         Ok(())
     }
@@ -272,11 +268,11 @@ impl Rotator for FalconRotatorDevice {
             .to_ascom_error());
         }
         let offset = self.manager.sync_offset().await;
-        let target_mech = normalise_deg(position - offset);
+        let target_mech = SkyDegrees::new(position) - offset;
         let wire_mech = self
             .with_session(async |session| self.manager.move_mechanical(session, target_mech).await)
             .await?;
-        let target_sky = normalise_deg(wire_mech + offset);
+        let target_sky = wire_mech + offset;
         self.manager.set_target_position(target_sky).await;
         Ok(())
     }
@@ -298,11 +294,11 @@ impl Rotator for FalconRotatorDevice {
         let wire_mech = self
             .with_session(async |session| {
                 self.manager
-                    .move_mechanical(session, normalise_deg(position))
+                    .move_mechanical(session, MechanicalDegrees::new(position))
                     .await
             })
             .await?;
-        let target_sky = normalise_deg(wire_mech + offset);
+        let target_sky = wire_mech + offset;
         self.manager.set_target_position(target_sky).await;
         Ok(())
     }
@@ -717,7 +713,7 @@ mod mock_tests {
         switch.set_connected(true).await.unwrap();
         factory.set_mech_position_deg(120.0).await;
         rotator.sync(30.0).await.unwrap();
-        let offset_before = manager.sync_offset().await;
+        let offset_before = manager.sync_offset().await.value();
         assert!(
             (offset_before - 270.0).abs() < 1e-9,
             "offset_before={offset_before}"
@@ -731,7 +727,7 @@ mod mock_tests {
             manager.is_available(),
             "switch still holds a session — transport must stay open"
         );
-        let offset_after = manager.sync_offset().await;
+        let offset_after = manager.sync_offset().await.value();
         assert!(
             (offset_after - offset_before).abs() < 1e-9,
             "sync_offset must not be cleared while another device still holds a session; \

--- a/services/pa-falcon-rotator/src/units.rs
+++ b/services/pa-falcon-rotator/src/units.rs
@@ -1,0 +1,296 @@
+//! Typed angular and step quantities for the Falcon Rotator.
+//!
+//! The Falcon exposes a single physical angle. ASCOM's `IRotatorV3+` splits
+//! that into a **mechanical** frame (the device's own zero) and a **sky**
+//! frame (the client's coordinate), joined by a driver-side [`SyncOffset`] —
+//! see the design doc's
+//! [ASCOM Rotator Mapping](../../../docs/services/falcon-rotator.md#ascom-rotator-mapping)
+//! and
+//! [Sync semantics](../../../docs/services/falcon-rotator.md#sync-semantics--why-driver-side-not-sd)
+//! sections. These newtypes make the frame explicit at the type level so the
+//! offset arithmetic can't be written wrong: you cannot add two sky angles,
+//! or cross between frames without applying the offset, without a compile
+//! error.
+//!
+//! The whole algebra is four operations, mirroring the four relations the
+//! driver computes:
+//!
+//! ```text
+//! Position       mech + offset = sky     MechanicalDegrees + SyncOffset -> SkyDegrees
+//! MoveAbsolute   sky  - offset = mech    SkyDegrees - SyncOffset        -> MechanicalDegrees
+//! Sync           sky  - mech   = offset  SkyDegrees - MechanicalDegrees -> SyncOffset
+//! Move(delta)    mech.rotate(delta)      relative rotation, stays mechanical
+//! ```
+//!
+//! [`Steps`] is the Falcon's signed encoder count (negative CCW of the 0°
+//! home). The driver derives every position from the degree field, so on the
+//! wire `Steps` is informational; it earns its keep in the mock, which models
+//! the device's signed counter via the [`STEPS_PER_DEGREE`] conversion.
+
+use std::ops::{Add, Sub};
+
+/// Steps per degree (vendor product page). The mock converts between its
+/// signed step counter and a mechanical angle with this; the driver itself
+/// works in degrees and never converts.
+pub const STEPS_PER_DEGREE: f64 = 86.6;
+
+/// Normalise a degree value into `[0.0, 360.0)`.
+///
+/// The standard `((x % 360) + 360) % 360` so negative inputs (a
+/// `Move(delta < 0)`, or a `sky - mech` that goes negative) wrap up into the
+/// canonical range. Every constructor below funnels through this, so each
+/// angle type holds a normalised value by construction.
+fn normalise_deg(deg: f64) -> f64 {
+    ((deg % 360.0) + 360.0) % 360.0
+}
+
+/// A mechanical angle in `[0, 360)` — the Falcon's own frame: the `FA`/`FD`
+/// degree field, the `MD:` wire target, and ASCOM `MechanicalPosition`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MechanicalDegrees(f64);
+
+/// A sky angle in `[0, 360)` — the ASCOM client's frame: `Position`, the
+/// `MoveAbsolute` / `Sync` targets, and `TargetPosition`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SkyDegrees(f64);
+
+/// The driver-side `Sync` offset (`sky - mech`), in `[0, 360)`. Bridges the
+/// two frames: `mech + offset = sky` and `sky - offset = mech`.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct SyncOffset(f64);
+
+impl MechanicalDegrees {
+    /// Construct from a degree value, normalising into `[0, 360)`.
+    ///
+    /// Callers must reject non-finite input first (the ASCOM boundary and the
+    /// wire parsers both do); a non-finite value would propagate as `NaN`.
+    pub fn new(deg: f64) -> Self {
+        Self(normalise_deg(deg))
+    }
+
+    /// The underlying degree value in `[0, 360)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Quantise to the `MD:nn.nn` wire precision (1/100°), then re-normalise
+    /// so a near-boundary value like `359.999` becomes `0.00` rather than the
+    /// out-of-range `360.00`.
+    pub fn quantise_to_wire(self) -> Self {
+        Self::new((self.0 * 100.0).round() / 100.0)
+    }
+
+    /// Apply a relative rotation (degrees, may be negative), staying in the
+    /// mechanical frame. Models the target of ASCOM `Move(delta)`.
+    pub fn rotate(self, delta: f64) -> Self {
+        Self::new(self.0 + delta)
+    }
+}
+
+impl SkyDegrees {
+    /// Construct from a degree value, normalising into `[0, 360)`. See
+    /// [`MechanicalDegrees::new`] for the non-finite precondition.
+    pub fn new(deg: f64) -> Self {
+        Self(normalise_deg(deg))
+    }
+
+    /// The underlying degree value in `[0, 360)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl SyncOffset {
+    /// A zero offset — the unsynced state, and what `clear_session_state`
+    /// resets to on disconnect.
+    pub const ZERO: SyncOffset = SyncOffset(0.0);
+
+    /// Construct from a degree value, normalising into `[0, 360)`. See
+    /// [`MechanicalDegrees::new`] for the non-finite precondition.
+    pub fn new(deg: f64) -> Self {
+        Self(normalise_deg(deg))
+    }
+
+    /// The underlying offset value in `[0, 360)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// `mech + offset = sky` — lift a mechanical angle into the sky frame.
+impl Add<SyncOffset> for MechanicalDegrees {
+    type Output = SkyDegrees;
+
+    fn add(self, offset: SyncOffset) -> SkyDegrees {
+        SkyDegrees::new(self.0 + offset.0)
+    }
+}
+
+/// `sky - offset = mech` — drop a sky angle into the mechanical frame.
+impl Sub<SyncOffset> for SkyDegrees {
+    type Output = MechanicalDegrees;
+
+    fn sub(self, offset: SyncOffset) -> MechanicalDegrees {
+        MechanicalDegrees::new(self.0 - offset.0)
+    }
+}
+
+/// `sky - mech = offset` — the `Sync` operation: the offset that makes the
+/// current mechanical angle read as `sky`.
+impl Sub<MechanicalDegrees> for SkyDegrees {
+    type Output = SyncOffset;
+
+    fn sub(self, mech: MechanicalDegrees) -> SyncOffset {
+        SyncOffset::new(self.0 - mech.0)
+    }
+}
+
+/// The Falcon's signed step counter relative to the 0° home (negative CCW of
+/// home), as reported in the `FA` step field and by `FP`. Informational on
+/// the wire — the driver derives all positions from the degree field — but
+/// the mock models the device's counter with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Steps(pub i32);
+
+impl Steps {
+    /// The underlying signed step count.
+    pub fn value(self) -> i32 {
+        self.0
+    }
+}
+
+/// A step count maps to exactly one mechanical angle (`steps / 86.6`,
+/// normalised). The reverse direction is device-specific — the past-limit
+/// sign convention lives in the mock — so it is deliberately not a `From`.
+impl From<Steps> for MechanicalDegrees {
+    fn from(steps: Steps) -> Self {
+        MechanicalDegrees::new(f64::from(steps.0) / STEPS_PER_DEGREE)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-9;
+
+    // ---- Construction / normalisation ------------------------------------
+
+    #[test]
+    fn mechanical_new_passes_through_in_range() {
+        assert!((MechanicalDegrees::new(142.30).value() - 142.30).abs() < EPS);
+    }
+
+    #[test]
+    fn mechanical_new_wraps_positive_overflow() {
+        assert!((MechanicalDegrees::new(370.0).value() - 10.0).abs() < EPS);
+    }
+
+    #[test]
+    fn mechanical_new_wraps_negative_into_positive() {
+        assert!((MechanicalDegrees::new(-10.0).value() - 350.0).abs() < EPS);
+    }
+
+    #[test]
+    fn sky_new_wraps() {
+        assert!((SkyDegrees::new(720.5).value() - 0.5).abs() < EPS);
+    }
+
+    #[test]
+    fn offset_new_wraps_negative() {
+        // 37.5 - 142.3 = -104.8 → +360 = 255.2
+        assert!((SyncOffset::new(-104.8).value() - 255.2).abs() < EPS);
+    }
+
+    #[test]
+    fn offset_zero_is_zero() {
+        assert!((SyncOffset::ZERO.value()).abs() < EPS);
+        assert_eq!(SyncOffset::default(), SyncOffset::ZERO);
+    }
+
+    // ---- quantise_to_wire ------------------------------------------------
+
+    #[test]
+    fn quantise_rounds_to_two_decimals() {
+        // 142.29792… (the integer-step round-trip of 142.30) → 142.30
+        assert!(
+            (MechanicalDegrees::new(142.297_921)
+                .quantise_to_wire()
+                .value()
+                - 142.30)
+                .abs()
+                < EPS
+        );
+    }
+
+    #[test]
+    fn quantise_wraps_boundary_to_zero() {
+        // 359.999 would format as 360.00 (out of range); quantise + normalise
+        // yields 0.00 instead.
+        assert!(MechanicalDegrees::new(359.999).quantise_to_wire().value() < EPS);
+    }
+
+    // ---- rotate ----------------------------------------------------------
+
+    #[test]
+    fn rotate_positive_wraps() {
+        assert!((MechanicalDegrees::new(350.0).rotate(20.0).value() - 10.0).abs() < EPS);
+    }
+
+    #[test]
+    fn rotate_negative_wraps() {
+        assert!((MechanicalDegrees::new(10.0).rotate(-30.0).value() - 340.0).abs() < EPS);
+    }
+
+    // ---- Frame algebra ---------------------------------------------------
+
+    #[test]
+    fn mech_plus_offset_is_sky() {
+        // 142.30 + 255.20 = 397.50 → 37.50
+        let sky = MechanicalDegrees::new(142.30) + SyncOffset::new(255.20);
+        assert!((sky.value() - 37.50).abs() < EPS);
+    }
+
+    #[test]
+    fn sky_minus_offset_is_mech() {
+        // 180.00 - 255.20 = -75.20 → 284.80
+        let mech = SkyDegrees::new(180.0) - SyncOffset::new(255.20);
+        assert!((mech.value() - 284.80).abs() < EPS);
+    }
+
+    #[test]
+    fn sky_minus_mech_is_offset() {
+        // 37.50 - 142.30 = -104.80 → 255.20
+        let offset = SkyDegrees::new(37.50) - MechanicalDegrees::new(142.30);
+        assert!((offset.value() - 255.20).abs() < EPS);
+    }
+
+    #[test]
+    fn lifting_then_dropping_round_trips() {
+        let mech = MechanicalDegrees::new(142.30);
+        let offset = SyncOffset::new(255.20);
+        let back = (mech + offset) - offset;
+        assert!((back.value() - mech.value()).abs() < EPS);
+    }
+
+    // ---- Steps ↔ degrees -------------------------------------------------
+
+    #[test]
+    fn steps_to_mechanical_positive() {
+        // 50° * 86.6 = 4330 steps; 4330 / 86.6 = 50°
+        assert!((MechanicalDegrees::from(Steps(4330)).value() - 50.0).abs() < EPS);
+    }
+
+    #[test]
+    fn negative_steps_below_home_wrap_into_range() {
+        // -5196 / 86.6 = -60° → 300° (a target past the 220° CW limit).
+        assert!((MechanicalDegrees::from(Steps(-5196)).value() - 300.0).abs() < EPS);
+    }
+
+    #[test]
+    fn steps_value_round_trips() {
+        assert_eq!(Steps(-2838).value(), -2838);
+    }
+}

--- a/services/pa-falcon-rotator/tests/property_tests.rs
+++ b/services/pa-falcon-rotator/tests/property_tests.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 
 use pa_falcon_rotator::protocol::{parse_full_status, FalconStatus};
+use pa_falcon_rotator::{MechanicalDegrees, Steps};
 use proptest::prelude::*;
 
 proptest! {
@@ -33,8 +34,8 @@ proptest! {
         );
         let parsed = parse_full_status(&wire).unwrap();
         prop_assert_eq!(parsed, FalconStatus {
-            position_steps: steps,
-            position_deg: deg,
+            position_steps: Steps(steps),
+            position_deg: MechanicalDegrees::new(deg),
             is_moving,
             limit_detect,
             do_derotation,

--- a/services/pa-falcon-rotator/tests/property_tests.rs
+++ b/services/pa-falcon-rotator/tests/property_tests.rs
@@ -13,7 +13,10 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn full_status_wire_format_round_trips(
-        steps in 0u32..1_000_000,
+        // Signed range: the Falcon step counter goes negative CCW of the 0°
+        // home (real hardware, firmware 1.5), so the round-trip must hold for
+        // negative steps too.
+        steps in -1_000_000i32..1_000_000,
         deg_cents in 0u32..36_000,
         is_moving in any::<bool>(),
         limit_detect in any::<bool>(),


### PR DESCRIPTION
## Summary

Fixes a Pegasus Falcon Rotator driver bug found during **hardware** ConformU validation. `position_steps` is a *signed* encoder count (negative when the rotator is CCW of the 0° home), but the driver parsed it as `u32`. Any target past the **220° CW cable-wrap limit** is reached the long way round (CCW past 0°), where the step counter goes negative and every status read aborted with:

```
ASCOM error INVALID_OPERATION: Parse error: FA position_steps: invalid digit found in string
```

failing ConformU with **7 issues**. The degrees field is unaffected, so the fix is contained.

## Root cause (captured on real hardware, firmware 1.5)

```
FA='FR_OK:466:5.38:1:0:0:0'      (just above home, steps +)
FA='FR_OK:-85:359.02:1:0:0:0'    ← steps NEGATIVE, degrees wrap to 359
FA='FR_OK:-2838:327.24:1:0:0:0'
```

`position_steps` is signed relative to home (≈86.6 steps/°); `deg = normalize(steps / 86.6)`. The 220° CW limit is the ASCOM-mandated cable-wrap guard, so the device reaches all angles — some only via negative steps. This was invisible to the mock (which only ever emitted positive steps), so it surfaced only against real hardware.

## Changes

- **`protocol.rs`, `codec.rs`**: `position_steps` `u32 → i32` (informational field; `Position`/`MechanicalPosition` derive from the degrees field).
- **`mock.rs`**: model the signed counter + 220° CW limit (`signed_target_steps`) so targets past the limit emit negative steps — the mock ConformU test now **reproduces and guards** the bug it previously missed.
- Regression tests built from the real captured frames (`FR_OK:-2838:327.24:…`, `FP:-1784`); property-test step range widened to signed; new mock test for the past-limit case.
- **`docs/services/falcon-rotator.md`**: corrected the `position_in_steps` field type + added a validated note.

## Validation

- `cargo fmt` clean, `cargo rail --profile commit` → **298 passed**, clippy clean (`-D warnings`).
- Mock ConformU → **both suites pass**, now exercising the negative-steps path.
- **Real-hardware ConformU rotator (firmware 1.5) → PASS, 0 issues** — previously failed at `MoveAbsolute 225`; ConformU drove the full suite and auto-restored the device to 152°.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
