### PR TITLE
feat(ci): self-hosted bazel-remote cache + descope Leptos/packaging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -88,8 +88,10 @@ build --disk_cache=~/.cache/bazel-disk-cache
 # --- CI-specific config ----------------------------------------------------
 
 # Activate with `bazel build --config=ci --config=remote-cache` in GitHub
-# Actions. The API key is passed on the command line via --remote_header
-# (not checked in). See .github/workflows/bazel.yml.
+# Actions. On trusted events (push to main, nightly) a write token is passed
+# via --remote_header="Authorization=Bearer <token>" (not checked in); PRs read
+# anonymously and add --remote_upload_local_results=false. See
+# .github/workflows/bazel.yml.
 
 build:ci --color=yes
 build:ci --show_timestamps
@@ -102,12 +104,21 @@ test:ci --test_output=errors
 test:ci --test_summary=terse
 
 # Remote cache is opt-in via a separate --config=remote-cache flag so local
-# developers don't accidentally upload to the shared cache with unvetted
-# credentials. CI jobs combine: --config=ci --config=remote-cache.
-build:remote-cache --bes_backend=grpcs://remote.buildbuddy.io
-build:remote-cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
-build:remote-cache --remote_cache_compression
+# developers don't accidentally point at the shared cache. CI jobs combine:
+# --config=ci --config=remote-cache.
+#
+# Backend: self-hosted bazel-remote on a TrueNAS SCALE box, exposed to the
+# public internet via a Cloudflare Tunnel (HTTPS, no open router ports).
+# The cache is public-READ (so every PR, including forks, gets a warm cache)
+# and token-WRITE (only push-to-main and the nightly schedule hold the Bearer
+# token — see bazel.yml). The hostname below is this repo's Cloudflare Tunnel
+# public hostname (zone rustyphoton.space is on Cloudflare). Setup runbook:
+# docs/skills/bazel-remote-cache.md.
+#
+# HTTP (not gRPC) endpoint: --remote_cache_compression is gRPC-only, so it is
+# intentionally omitted; bazel-remote compresses at rest via --storage_mode
+# zstd instead. --remote_timeout is already set by --config=ci.
+build:remote-cache --remote_cache=https://cache.rustyphoton.space
 
 # --- Local overrides -------------------------------------------------------
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -40,13 +40,16 @@ jobs:
       run:
         shell: bash
     env:
-      # Read+write key on push to main and on the nightly schedule populates
-      # the cache from trusted code (scheduled runs always execute against the
-      # default branch). Read-only key on pull requests prevents cache
-      # poisoning from forks. Empty for fork PRs (secrets not exposed); steps
-      # below detect this and skip --config=remote-cache so the job still
-      # provides build signal.
-      BUILDBUDDY_API_KEY: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && secrets.BUILDBUDDY_API_KEY || secrets.BUILDBUDDY_API_KEY_READONLY }}
+      # Self-hosted bazel-remote cache (TrueNAS + Cloudflare Tunnel) is
+      # public-READ / token-WRITE. Only push-to-main and the nightly schedule
+      # — which run from the default branch — get the write token, so they
+      # populate the cache from trusted code. PRs (including forks, which get
+      # no secrets at all) read anonymously and never write, which prevents
+      # cache poisoning. The per-step logic below adds --config=remote-cache
+      # unconditionally (reads are anonymous, so even fork PRs get a warm
+      # cache) and only attaches the write token + uploads when
+      # CACHE_WRITE_TOKEN is non-empty.
+      CACHE_WRITE_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && secrets.BAZEL_CACHE_WRITE_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -123,11 +126,13 @@ jobs:
       # the Windows loading-phase mystery is identified and fixed.
       - name: bazel build
         run: |
-          REMOTE_FLAGS=""
-          if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
-            REMOTE_FLAGS="--config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          REMOTE_FLAGS=(--config=remote-cache)
+          if [[ -n "$CACHE_WRITE_TOKEN" ]]; then
+            REMOTE_FLAGS+=(--remote_header="Authorization=Bearer $CACHE_WRITE_TOKEN")
+          else
+            REMOTE_FLAGS+=(--remote_upload_local_results=false)
           fi
-          bazel build --config=ci $REMOTE_FLAGS \
+          bazel build --config=ci "${REMOTE_FLAGS[@]}" \
             --execution_log_compact_file="${RUNNER_TEMP}/build-exec.log.zst" \
             --profile="${RUNNER_TEMP}/build-profile.json.gz" \
             --noslim_profile \
@@ -140,11 +145,13 @@ jobs:
         # unit + integration pass separate from BDD so log output stays
         # useful when something breaks.
         run: |
-          REMOTE_FLAGS=""
-          if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
-            REMOTE_FLAGS="--config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          REMOTE_FLAGS=(--config=remote-cache)
+          if [[ -n "$CACHE_WRITE_TOKEN" ]]; then
+            REMOTE_FLAGS+=(--remote_header="Authorization=Bearer $CACHE_WRITE_TOKEN")
+          else
+            REMOTE_FLAGS+=(--remote_upload_local_results=false)
           fi
-          bazel test --config=ci $REMOTE_FLAGS \
+          bazel test --config=ci "${REMOTE_FLAGS[@]}" \
             --execution_log_compact_file="${RUNNER_TEMP}/fast-test-exec.log.zst" \
             --profile="${RUNNER_TEMP}/fast-test-profile.json.gz" \
             --noslim_profile \
@@ -168,15 +175,16 @@ jobs:
         # On macOS, darwin-sandbox blocks OmniSim from binding network
         # ports; --spawn_strategy=local bypasses the sandbox for tests.
         run: |
-          REMOTE_FLAGS=""
-          if [[ -n "$BUILDBUDDY_API_KEY" ]]; then
-            REMOTE_FLAGS="--config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          REMOTE_FLAGS=(--config=remote-cache)
+          if [[ -n "$CACHE_WRITE_TOKEN" ]]; then
+            REMOTE_FLAGS+=(--remote_header="Authorization=Bearer $CACHE_WRITE_TOKEN")
+          else
+            REMOTE_FLAGS+=(--remote_upload_local_results=false)
           fi
-          EXTRA_FLAGS=""
           if [[ "$RUNNER_OS" != "Linux" ]]; then
-            EXTRA_FLAGS="--spawn_strategy=local"
+            REMOTE_FLAGS+=(--spawn_strategy=local)
           fi
-          bazel test --config=ci $REMOTE_FLAGS --test_tag_filters=bdd --test_env=OMNISIM_PATH $EXTRA_FLAGS \
+          bazel test --config=ci "${REMOTE_FLAGS[@]}" --test_tag_filters=bdd --test_env=OMNISIM_PATH \
             --execution_log_compact_file="${RUNNER_TEMP}/bdd-exec.log.zst" \
             --profile="${RUNNER_TEMP}/bdd-profile.json.gz" \
             --noslim_profile \

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -4,6 +4,22 @@
 **Started:** 2026-04-16
 **Target cutover:** TBD (dependent on shadow-mode validation)
 
+## Decisions (2026-05-24)
+
+Three decisions taken to shorten the path to a Bazel-primary cutover (Phase 7):
+
+1. **Cache backend: self-hosted `bazel-remote` on TrueNAS SCALE**, exposed
+   public-read / token-write via a Cloudflare Tunnel — replacing the BuildBuddy
+   free tier, whose LRU eviction (no retention guarantee) caused random
+   cold-cache rebuilds. Deterministic, $0, owned. Runbook:
+   [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
+2. **Leptos / `sentinel-app` WASM: abandoned.** Not used today; Phase 4 is
+   dropped, not deferred.
+3. **Release packaging: stays on Cargo permanently.** We release far less often
+   than we merge, so `release.yml` keeps using `cargo-deb` /
+   `cargo-generate-rpm`; Phase 6 is dropped. "Bazel-primary" applies to the
+   per-PR build/test path only.
+
 ## Motivation
 
 Three concrete problems drive this migration:
@@ -18,15 +34,15 @@ Bazel's remote cache is the structural fix for items 1 and 2 — the cache is co
 
 **In-scope:**
 - All 11 workspace crates build and test under Bazel.
-- Remote cache wired up (BuildBuddy free tier to start; self-host later if needed).
+- Remote cache wired up. Bootstrapped on the BuildBuddy free tier; now self-hosted `bazel-remote` on TrueNAS SCALE (see Decisions, 2026-05-24).
 - New GHA workflow running Bazel in shadow mode; Cargo remains required until parity.
 - BDD cucumber tests run under Bazel via custom `rust_test` wrappers.
-- `sentinel-app` Leptos WASM compiles under Bazel.
-- Release packaging (`cargo-deb`, `cargo-generate-rpm`) migrated to `rules_pkg`.
-- Documentation (`CLAUDE.md`, `docs/skills/pre-push.md`) updated.
+- Documentation (`CLAUDE.md`, `docs/skills/pre-push.md`, `docs/skills/bazel-remote-cache.md`) updated.
 
-**Out-of-scope (deferred):**
+**Out-of-scope (deferred or dropped):**
 - Removing Cargo entirely. `Cargo.toml` remains the source of truth for dependency versions via `crate_universe`'s `from_cargo`. Developers can still run `cargo` locally for IDE/rust-analyzer support.
+- **Leptos / `sentinel-app` WASM (dropped 2026-05-24).** Not used today; Phase 4 cancelled.
+- **Release packaging (dropped 2026-05-24).** `release.yml` stays on `cargo-deb` / `cargo-generate-rpm`; we release far less often than we merge. Phase 6 cancelled.
 - Miri under Bazel. rules_rust miri support is thin; keep the scheduled Cargo job.
 - ConformU runs. External ASCOM tool; keep the existing Cargo invocation.
 - Migrating `cargo-husky` pre-commit hooks. Bazel-native alternative would be a `sh_binary` hook installer, but out of scope here.
@@ -91,31 +107,38 @@ repo root/
 
 **Exit criteria met:** `bazel test --test_tag_filters=bdd //...` passes on Linux (5 targets, ~150 s wall on a warm cache — dominated by rp:bdd at ~150 s with 84 scenarios; the other four targets overlap in parallel and add negligible wall time).
 
-### Phase 4 — `sentinel-app` WASM (later)
-- [ ] `rust_shared_library` with `crate_type = ["cdylib", "rlib"]`.
-- [ ] `wasm_bindgen` integration via rules_rust's `@rules_rust//wasm_bindgen`.
-- [ ] `select()` on `@platforms//cpu:wasm32` for hydrate feature.
-- [ ] ssr feature as a default build target.
+### Phase 4 — `sentinel-app` WASM (DROPPED 2026-05-24)
 
-**Exit criteria:** `bazel build //services/sentinel-app:sentinel_app_wasm` produces the same `.wasm` + JS bindings that `cargo leptos build` does today.
+Cancelled: Leptos is not used today, so `sentinel-app` stays out of the Bazel
+graph. If a WASM UI returns, re-open this phase — the `wasm_bindgen` /
+`@platforms//cpu:wasm32` / hydrate+ssr approach noted in earlier revisions is
+the starting point.
 
-### Phase 5 — Remote cache + CI (DONE)
-- [x] `.github/workflows/bazel.yml` — triggers on PR, push to main, and a nightly schedule (07:07 UTC), runs `bazel test //...` with remote cache. The nightly run keeps the BuildBuddy LRU warm during quiet stretches on main: free-tier eviction is capacity-driven with no documented retention, and PR builds use a read-only key so they cannot repopulate the cache themselves.
-- [x] BuildBuddy free tier credentials in GHA secrets (`BUILDBUDDY_API_KEY` read+write for push to main and the nightly schedule, `BUILDBUDDY_API_KEY_READONLY` for PRs to prevent cache poisoning).
+### Phase 5 — Remote cache + CI (DONE; cache backend swapped 2026-05-24)
+- [x] `.github/workflows/bazel.yml` — triggers on PR, push to main, and a nightly schedule (07:07 UTC), runs `bazel test //...` with remote cache.
+- [x] Bootstrap backend: BuildBuddy free tier (read+write token on push/schedule, read-only token on PRs).
 - [x] Shadow mode: job is **not required** for merges; runs alongside Cargo jobs for 2+ weeks of parity validation.
-- [ ] Compare wall-clock and correctness against Cargo jobs weekly.
+- [x] **Cache backend swapped to self-hosted `bazel-remote` on TrueNAS SCALE** (public-read / token-write via Cloudflare Tunnel). `.bazelrc` `--config=remote-cache` points at the Cloudflare hostname; `bazel.yml` attaches `Authorization: Bearer` only on push/schedule and sets `--remote_upload_local_results=false` on PRs. Reads are anonymous, so fork PRs now get a warm cache too. Deterministic retention via `--max_size` ends the BuildBuddy LRU cold-cache outliers. Runbook: [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
+- [x] `.bazelrc` hostname set to `cache.rustyphoton.space` (zone `rustyphoton.space` verified on Cloudflare 2026-05-24).
+- [ ] Add the `BAZEL_CACHE_WRITE_TOKEN` GHA secret and deploy the TrueNAS side (runbook).
+- [ ] Compare wall-clock and correctness against Cargo jobs weekly (≥1 week on the TrueNAS cache).
 
 **Exit criteria:** Bazel CI job green for 2 consecutive weeks with no flakes; wall-clock within ±20 % of Cargo or better.
 
-### Phase 6 — Packaging (later)
-- [ ] `rules_pkg` for `.deb` (filemonitor today; eventually all services).
-- [ ] `rules_pkg` for `.rpm`.
-- [ ] Windows service wrapping via `pkg_zip` or equivalent.
-- [ ] `.github/workflows/release.yml` switched to Bazel.
+### Phase 6 — Packaging (DROPPED 2026-05-24)
 
-**Exit criteria:** release artifacts byte-identical (or functionally equivalent) to the Cargo path.
+Cancelled: `release.yml` stays on `cargo-deb` / `cargo-generate-rpm`. Release
+cadence is far lower than merge cadence, so the Bazel-primary goal targets the
+per-PR build/test path only; packaging keeps running on Cargo indefinitely.
 
 ### Phase 7 — Cutover (later)
+
+With Phase 4 (Leptos) and Phase 6 (packaging) dropped, cutover no longer waits
+on them. Remaining prerequisites: the TrueNAS cache live + parity logged
+(Phase 5), the Cargo-only gates (miri, sanitizers, conformu, `cargo-hack`,
+`cargo-msrv`, coverage) kept on a Cargo nightly, and the `rust-project.json`
+IDE decision (open question 4).
+
 - [ ] Bazel job becomes **required** on PRs.
 - [ ] Cargo CI jobs moved to a scheduled nightly (as safety net).
 - [ ] `docs/skills/pre-push.md` rewritten for `bazel test //...` as the primary pre-push command.
@@ -140,7 +163,7 @@ After Phase 7: the Cargo nightly job remains as a safety net for 30 days. Rollba
 | Leptos hydrate/ssr WASM rules are missing | High | Defer to Phase 4; prototype separately before committing. If blocked, keep `cargo leptos` as an escape hatch via `genrule`. |
 | rust-analyzer breaks under Bazel | Medium | Developers can still use Cargo locally (it's not removed). `rust-project.json` generator from rules_rust is also available. |
 | Team learning curve | Certain | This plan doc + pair programming on first few BUILD files. |
-| BuildBuddy free tier exceeded | Low | Self-host `bazel-remote` on a $5 VPS if we outgrow 100 GB/month transfer. |
+| Remote cache unavailable / cold | Low | Resolved: self-hosted `bazel-remote` on TrueNAS SCALE with deterministic `--max_size` retention. Bazel treats remote-cache errors as non-fatal (warns, builds locally), so a cache or tunnel outage degrades to a cold build rather than a CI failure. |
 | `aws-lc-sys` build fails on Windows under Bazel (MAX_PATH + bswap) | Hit | Four fixes: (1) shortened `from_cargo` name from `"crates"` to `"cr"` — the repo name appears twice in every build-script runfiles path, saving 8 chars; (2) `build_script_data_glob = ["**"]` annotation ensures all vendored C files are materialised in Bazel's runfiles; (3) `AWS_LC_SYS_NO_JITTER_ENTROPY=1` disables jitterentropy on Windows — its `tree_drbg_jitter_entropy.c` uses a deep `../../../../` relative `#include` whose un-normalised intermediate form (~280 chars) exceeds MSVC's MAX_PATH; (4) `AWS_LC_SYS_CFLAGS=/we4013` promotes MSVC's implicit-function-declaration warning to an error — the cc-crate builder's feature check for `__builtin_bswap*` wrongly passes because cl.exe in C89 mode treats GCC built-ins as implicit declarations (C4013, level 3) without emitting the warning at the default `/W1` level; `/we4013` makes the check fail correctly so aws-lc uses MSVC's `_byteswap_*` intrinsics. We use `AWS_LC_SYS_CFLAGS` (not plain `CFLAGS`) because rules_rust overrides `CFLAGS` in the build-script environment with its own MSVC flags; the crate-specific variant is read first by `get_crate_cflags()` and propagated to `CFLAGS_<target>` before the feature checks run. |
 
 ## Success metrics
@@ -230,6 +253,6 @@ Env var names follow the `{UPPER_SNAKE_PACKAGE}_BINARY` convention (e.g. `RP_BIN
 ## Open questions
 
 1. **bzlmod vs WORKSPACE.** Starting with bzlmod. Fallback to WORKSPACE mode if `crate_universe` bzlmod issues block progress.
-2. **Remote cache vendor.** Starting with BuildBuddy free tier. Consider self-hosted `bazel-remote` on a dedicated VM once cache size exceeds 10 GB.
+2. **Remote cache vendor.** RESOLVED (2026-05-24): self-hosted `bazel-remote` on TrueNAS SCALE, public-read / token-write via Cloudflare Tunnel. See Decisions and [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
 3. **TypeScript addition.** Deferred until UI work actually starts. `rules_js` and `aspect_rules_ts` are bzlmod-first — will integrate cleanly then.
 4. **rust-analyzer.** Does the team use cargo directly for IDE, or do we need `rust-project.json` generation from rules_rust? Decide after Phase 2.

--- a/docs/skills/bazel-remote-cache.md
+++ b/docs/skills/bazel-remote-cache.md
@@ -1,0 +1,172 @@
+# Skill: Self-Hosted Bazel Remote Cache (TrueNAS SCALE + Cloudflare Tunnel)
+
+## When to Read This
+
+- Standing up or re-pointing the Bazel remote cache that `.github/workflows/bazel.yml` uses.
+- Diagnosing cache misses, `403` on upload, or a cold-cache outlier in a Bazel CI run.
+- Auditing the cache's security posture on this **public** repo.
+
+This replaces the BuildBuddy free-tier cache (see `docs/plans/bazel-migration.md` → Decisions, 2026-05-24). The replacement fixes BuildBuddy's LRU eviction (no retention guarantee), which caused random cold-cache rebuilds — most visibly a ~15 min Windows `bazel build` when action results had aged out.
+
+The **repo-side wiring is already committed** (`.bazelrc`, `.github/workflows/bazel.yml`). This runbook covers the TrueNAS + Cloudflare side and the two values you must fill in (§4).
+
+## Architecture
+
+```
+GitHub-hosted runner (bazel.yml)
+   │   GET  = anonymous            → reads, incl. fork PRs (warm cache for everyone)
+   │   PUT  = Authorization: Bearer → writes, only on push-to-main / nightly
+   ▼
+Cloudflare edge   cache.rustyphoton.space          ← free TLS, no open router ports
+   │   (Cloudflare Tunnel; cloudflared dials OUT from TrueNAS)
+   ▼  ┌──────────────── TrueNAS SCALE ────────────────────────────────────────┐
+   └─▶│ Cloudflared app ─→ Caddy :8088 ─→ bazel-remote :8080 ─→ /data (SSD pool)│
+      │   (catalog)        (read/write split)  (cache server)   (dataset)       │
+      └────────────────────────────────────────────────────────────────────────┘
+```
+
+Caddy is required because `bazel-remote`'s own auth (`--htpasswd_file`) gates **all** methods identically. We want anonymous reads (so every PR, including forks, gets cache speed) but token-gated writes (anti-poisoning). Caddy does that split in six lines.
+
+## Security model — why this is safe on a public repo
+
+The cache stores build/test **outputs of public OSS code** — not secrets. So:
+
+- **Reads are anonymous.** Harmless, and a feature: fork PRs get a warm cache (BuildBuddy's read-only-key model never gave forks anything, because GitHub withholds secrets from forks).
+- **Writes require a Bearer token** that is a GitHub Actions **secret**. Secrets are exposed only to `push` and `schedule` events — which run from the default branch — never to PRs (and never to forks at all). So only trusted, main-derived runs can populate the cache. No poisoning path.
+- **Defense in depth:** PRs are read-only by a Bazel flag (`--remote_upload_local_results=false`) *and* Caddy `403`s any unauthenticated write. A workflow edited in a malicious PR still can't write (no token in its env; Caddy rejects it).
+
+This mirrors the trust split the BuildBuddy setup already encoded — just self-hosted, with retention you control.
+
+## Prerequisites
+
+- [ ] **TrueNAS SCALE 24.10.2.2+** ("Electric Eel"; the catalog Cloudflared app requires this).
+- [ ] A **domain on a Cloudflare zone** (free plan is fine) — needed for a named Tunnel hostname.
+- [ ] **~100 GB free** on the SSD pool.
+- [ ] A write token: `openssl rand -hex 32` — used in two places (Caddy env in §2, GitHub secret in §4). Keep it somewhere safe.
+
+---
+
+## Part 1 — Dataset on the SSD pool
+
+1. **Datasets → Add Dataset** on the SSD pool, e.g. `ssd-pool/apps/bazel-remote`. Note the mountpoint (e.g. `/mnt/ssd-pool/apps/bazel-remote`). Adjust the paths in §2 to match.
+2. **Disable snapshots / replication** for it. The cache is fully reconstructible; snapshotting it just wastes SSD. Wiping it only costs one cold rebuild.
+3. Create a `data/` subdir and drop the `Caddyfile` from §2 at the dataset root. Make `data/` writable by the container UID — on SCALE the built-in apps user is **UID 568**; from **System → Shell**: `chown -R 568:568 /mnt/ssd-pool/apps/bazel-remote/data`.
+
+## Part 2 — Deploy `bazel-remote` + Caddy (Apps → Custom App → Install via YAML)
+
+These two images aren't in the catalog, so install them as one Custom App. **Apps → Discover Apps → Custom App → Install via YAML** opens the Compose editor:
+
+```yaml
+services:
+  bazel-remote:
+    image: buchgr/bazel-remote-cache:latest   # :latest, not pinned — not reproducible as a result; fine since the cache is disposable
+    user: "568:568"                            # TrueNAS 'apps' uid:gid; must own /data
+    command:
+      - --dir=/data
+      - --max_size=80                          # GiB; raise as the SSD pool allows
+      - --storage_mode=zstd                    # compress at rest
+      - --http_address=0.0.0.0:8080
+      - --access_log_level=none
+    volumes:
+      - /mnt/ssd-pool/apps/bazel-remote/data:/data
+    restart: unless-stopped
+    # bazel-remote's 8080 is NOT published to the host — only Caddy reaches it
+    # over the app's internal network.
+
+  caddy:
+    image: caddy:2
+    depends_on: [bazel-remote]
+    environment:
+      CACHE_WRITE_TOKEN: "PASTE_OPENSSL_TOKEN_HERE"   # same value as the GitHub secret (§4)
+    ports:
+      - "8088:80"                              # published on the TrueNAS LAN IP
+    volumes:
+      - /mnt/ssd-pool/apps/bazel-remote/Caddyfile:/etc/caddy/Caddyfile:ro
+    restart: unless-stopped
+```
+
+`Caddyfile` (anonymous read, Bearer-only write) — save at `/mnt/ssd-pool/apps/bazel-remote/Caddyfile` *before* launching:
+
+```
+:80 {
+	@write_no_auth {
+		method PUT POST PATCH DELETE
+		not header Authorization "Bearer {$CACHE_WRITE_TOKEN}"
+	}
+	respond @write_no_auth 403
+	reverse_proxy bazel-remote:8080
+}
+```
+
+GET/HEAD never match the write matcher → served anonymously. A write with the exact Bearer token → proxied. A write without it → `403`. (`{$CACHE_WRITE_TOKEN}` is resolved from the container env at config load.)
+
+> **Why publish Caddy on `:8088`?** The catalog Cloudflared app (§3) runs as a *separate* Docker app, so it can't reach `caddy` by service name — it connects via the TrueNAS LAN IP. Publishing `8088` also doubles as a **fast LAN dev cache**: point a gitignored `user.bazelrc` at `build:remote-cache --remote_cache=http://<TRUENAS_LAN_IP>:8088` and your local `bazel build` reuses CI's cache. On a trusted home LAN this exposure is fine (reads are harmless; writes still need the token).
+
+### Using Traefik instead of Caddy (optional)
+
+If you already run the catalog **Traefik** app as your ingress, you can drop the `cloudflared`→`caddy` hop and route the public hostname through Traefik. The catch: Traefik has no built-in "require this exact Bearer token" middleware, so the read/write split needs one of:
+
+- a **ForwardAuth** middleware pointing at a tiny token-checker, applied only to a router with a `Method(\`PUT\`,\`POST\`,\`PATCH\`,\`DELETE\`)` rule (a second catch-all router serves reads with no middleware), or
+- a community API-key/bearer **plugin**, or
+- switching CI to **Basic auth** via URL-embedded creds (`--remote_cache=https://user:pass@cache...`) — but that sends credentials on reads too and changes the `bazel.yml` wiring.
+
+Caddy keeps the proxy self-contained and matches the `Authorization: Bearer` wiring already committed, so it's the default here. If you'd rather standardize on Traefik, say so and the router + ForwardAuth config can replace §2's `caddy` service.
+
+## Part 3 — Cloudflare Tunnel via the catalog Cloudflared app
+
+1. **Cloudflare Zero Trust → Networks → Tunnels → Create a tunnel** → *Cloudflared* → name it (e.g. `truenas`) → copy the **tunnel token**.
+2. **TrueNAS → Apps → Discover Apps → search "Cloudflared"** (Community train) → **Install** → paste the tunnel token into the app config → deploy. No ports are opened; `cloudflared` dials out to Cloudflare.
+3. Back in the Cloudflare tunnel → **Public Hostname → Add**:
+   - Subdomain `cache`, Domain `rustyphoton.space`
+   - Service **Type** `HTTP`, **URL** `<TRUENAS_LAN_IP>:8088`
+   Save. Cloudflare auto-creates the proxied DNS record and edge TLS.
+
+## Part 4 — Fill in the two repo values
+
+1. **`.bazelrc`:** already set — `--remote_cache=https://cache.rustyphoton.space` is committed (zone `rustyphoton.space` verified on Cloudflare). No change needed unless the hostname differs.
+2. **GitHub repo secret:** Settings → Secrets and variables → Actions → **New repository secret** → name `BAZEL_CACHE_WRITE_TOKEN`, value = the same token as Caddy's `CACHE_WRITE_TOKEN`.
+3. (After a week of green) delete the old `BUILDBUDDY_API_KEY` / `BUILDBUDDY_API_KEY_READONLY` secrets.
+
+## Part 5 — Validate
+
+- **Status:** `curl -sf https://cache.rustyphoton.space/status` → bazel-remote JSON (`NumFiles`, `ServerTime`, …).
+- **Write auth:** a write without the token must be rejected, with it must succeed:
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' -X PUT --data x \
+    https://cache.rustyphoton.space/cas/0000000000000000000000000000000000000000000000000000000000000000      # → 403
+  curl -s -o /dev/null -w '%{http_code}\n' -X PUT --data x \
+    -H "Authorization: Bearer <token>" \
+    https://cache.rustyphoton.space/cas/0000000000000000000000000000000000000000000000000000000000000000      # → 200
+  ```
+- **End to end (LAN):** `bazel build //... --config=remote-cache --remote_cache=http://<TRUENAS_LAN_IP>:8088`, then `bazel clean && bazel build //...` → the tail line shows `remote cache hit`.
+- **CI:** push the `feature/bazel-remote-truenas` branch; open the Bazel run and confirm `… processes: N remote cache hit`. The first push-to-main populates; subsequent PRs read.
+
+## Part 6 — Rollback
+
+Cache outages are **non-fatal** — Bazel treats remote-cache errors as a cache miss (warns, builds locally), so a stopped tunnel or full disk degrades to a cold build, never a red CI. To fully revert: `git revert` the `.bazelrc` + `bazel.yml` change; the BuildBuddy secrets are still present until you delete them (§4.3), so the old backend works again in one commit.
+
+## Operational notes
+
+- **Sizing:** `--max_size 80` (GiB) is the cache-content cap; Linux + macOS + Windows artifacts coexist (platform is part of the action key). Raise it freely on an SSD pool. Deterministic LRU within the cap — no surprise eviction.
+- **No backup:** the dataset is a cache; leave snapshots off.
+- **Lost build UI:** `bazel-remote` is cache-only; there's no BuildBuddy-style invocation dashboard. Timing still comes from the GHA logs and the `--profile` / exec-log artifacts `bazel.yml` already uploads. If you miss the UI, you can re-add BuildBuddy's *free BES* (`--bes_backend`) independently of the cache.
+- **HTTP not gRPC:** simplest over a Tunnel. `--remote_cache_compression` is gRPC-only and intentionally omitted; `--storage_mode zstd` compresses at rest. gRPC is a later optimization.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| CI uploads `403` | `BAZEL_CACHE_WRITE_TOKEN` (GitHub) ≠ `CACHE_WRITE_TOKEN` (Caddy env). |
+| Every run is a full miss | action-key instability (an env var like `PATH` leaking into keys), cache wiped, or `--max_size` too small so entries evict each run. |
+| `curl /status` hangs/fails | Cloudflared app stopped or wrong tunnel token; or the public hostname points at the wrong `LAN_IP:8088`. |
+| Reads work, writes never cache | expected on PRs (read-only by design); only push-to-main / nightly write. |
+| Caddy won't start | `Caddyfile` missing at the mounted host path, or `CACHE_WRITE_TOKEN` env unset. |
+
+## References
+
+- [docs/plans/bazel-migration.md](../plans/bazel-migration.md) — Decisions (2026-05-24) and Phase 5.
+- [.bazelrc](../../.bazelrc) `build:remote-cache` / [.github/workflows/bazel.yml](../../.github/workflows/bazel.yml) — the committed wiring.
+- [bazel-remote](https://github.com/buchgr/bazel-remote) — the cache server (flags, releases).
+- [TrueNAS: Custom App / Install via YAML](https://www.truenas.com/docs/scale/24.10/scaleuireference/apps/installcustomappscreens/)
+- [TrueNAS: Cloudflared app](https://apps.truenas.com/catalog/cloudflared) and [Cloudflare Tunnel tutorial](https://www.truenas.com/docs/scale/24.04/scaletutorials/apps/appsecurity/cloudflaretunnel/)
+- [Bazel remote caching](https://bazel.build/remote/caching) — HTTP cache protocol, `--remote_upload_local_results`.


### PR DESCRIPTION
## What

Swap the Bazel CI **remote cache backend** from the BuildBuddy free tier to a **self-hosted `bazel-remote`**, exposed over a Cloudflare Tunnel at `https://cache.rustyphoton.space` (public-read / token-write). Also records two migration decisions.

## Why

BuildBuddy's free tier uses LRU eviction with no retention guarantee, which caused random cold-cache rebuilds (most visibly a ~15-min Windows `bazel build` when action results aged out). A self-hosted cache gives **deterministic retention** (`--max_size`), is free, and is fully owned.

## How it's wired

- **`.bazelrc`** — `--config=remote-cache` now points at the Cloudflare HTTPS endpoint. Dropped BuildBuddy BES and the gRPC-only `--remote_cache_compression` (the HTTP cache compresses at rest via bazel-remote's `--storage_mode zstd`).
- **`.github/workflows/bazel.yml`** — anonymous reads on **every** event (so fork PRs get a warm cache too); an `Authorization: Bearer` write token (`secrets.BAZEL_CACHE_WRITE_TOKEN`) is attached **only** on push-to-main and the nightly schedule; PRs add `--remote_upload_local_results=false`. `REMOTE_FLAGS` became a bash array so the bearer value survives its embedded space.
- **`docs/skills/bazel-remote-cache.md`** — new runbook (TrueNAS custom-app YAML, the Caddy public-read/token-write split, the catalog Cloudflared app, a Traefik alternative, the security model, validation, rollback).
- **`docs/plans/bazel-migration.md`** — records the decisions below.

## Security model (public repo)

The cache stores build outputs of public code, so **reads are anonymous**; **writes require a bearer token** that is a GitHub Actions secret, exposed only to trusted `push`/`schedule` events (never to PRs or forks). A reverse-proxy method matcher also rejects unauthenticated writes. Net: only main-derived runs can populate the cache (no poisoning path), while every PR including forks benefits from reads.

## Decisions recorded

- **Leptos / `sentinel-app` WASM (Phase 4): dropped** — not used today.
- **Release packaging (Phase 6): stays on Cargo** — release cadence is far below merge cadence, so Bazel-primary targets the per-PR build/test path only.

## Verification

The cache is live and was verified end-to-end over HTTPS: `GET /status` returns bazel-remote JSON; an unauthenticated `PUT` is rejected (`403`); an authorized write stored a blob that reads back anonymously (`200`).

## Rollout

`bazel.yml` is **shadow mode** (not a required check), so this is safe to merge. The cache is empty until the **first push-to-main** (or nightly) builds with the write token; PRs read anonymously and start getting hits after that. Cache/tunnel errors are non-fatal — Bazel falls back to a local build — so CI can't go red if the cache is unreachable.

Runbook: `docs/skills/bazel-remote-cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)