### PR TITLE
ci(bazel): prepare Phase 7 cutover — Bazel primary, Cargo → safety net (draft, do not merge until soak)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,22 +1,22 @@
-# Shadow-mode Bazel build/test. Runs alongside the canonical Cargo jobs
-# during the migration described in docs/plans/bazel-migration.md.
+# Primary CI: Bazel build + test on ubuntu/macos/windows (cutover per
+# docs/plans/bazel-migration.md Phase 7). These are the REQUIRED PR checks;
+# the Cargo workflows (check.yml/test.yml) now run on push-to-main + nightly
+# as the safety net for gates Bazel doesn't cover (miri, sanitizers, conformu,
+# cargo-hack, cargo-msrv, coverage).
 #
-# This workflow is NOT required for merge. Its purpose is to build
-# confidence that Bazel produces parity results before cutting over.
-# Add it to required checks once the migration plan's phase-7 exit
-# criteria are met.
+# NOTE: marking these jobs "required" is a branch-protection setting applied
+# at cutover time — merging this workflow change alone does not enforce it.
 permissions:
   contents: read
 on:
   push:
     branches: [main]
   pull_request:
-  # Nightly run from main keeps the BuildBuddy remote cache warm.
-  # BuildBuddy uses LRU eviction on a shared free-tier cache with no
-  # documented retention guarantee, so quiet stretches on main let
-  # action results age out and PRs pay the full uncached cost. A daily
-  # main-equivalent build refreshes last-used timestamps and re-uploads
-  # anything that did get evicted.
+  # Nightly run from main keeps the self-hosted bazel-remote cache populated
+  # and current during quiet stretches (it holds the write token, like
+  # push-to-main). With deterministic --max_size retention there is no LRU
+  # eviction to outrun; the nightly mainly guards against a long quiet gap
+  # leaving the cache cold for the next PR. See docs/skills/bazel-remote-cache.md.
   schedule:
     - cron: "7 7 * * *"
 concurrency:
@@ -31,7 +31,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    name: bazel build + test (shadow) / ${{ matrix.os }}
+    name: bazel build + test / ${{ matrix.os }}
     # Action-graph change detection replaces cargo-rail. Bazel figures out
     # which targets actually changed and only rebuilds those; everything
     # else is a cache hit.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,19 +1,18 @@
-# This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
-# several checks:
-# - fmt: checks that the code is formatted according to rustfmt
-# - clippy: checks that the code does not contain any clippy warnings
-# - doc: checks that the code can be documented without errors
-# - hack: check combinations of feature flags
-# - msrv: check that the msrv specified in the workspace is correct
+# Cargo quality gates: fmt, clippy, doc, hack (feature powerset), msrv.
+#
+# Post Bazel cutover (docs/plans/bazel-migration.md Phase 7): Bazel is the
+# required PR gate, so these Cargo checks no longer run per-PR. They run on
+# push-to-main (every merge — fast safety-net feedback) and nightly, catching
+# anything the Bazel graph doesn't cover. Trigger on demand via
+# workflow_dispatch.
 permissions:
   contents: read
-# This configuration allows maintainers of this repo to create a branch and pull request based on
-# the new branch. Restricting the push trigger to the main branch ensures that the PR only gets
-# built once.
 on:
   push:
     branches: [main]
-  pull_request:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 # If new code is pushed to a PR branch, then cancel in progress workflows for that PR. Ensures that
 # we don't waste CI time, and returns results quicker https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -11,7 +11,6 @@ permissions:
 on:
   push:
     branches: [main]
-  pull_request:
   schedule:
     - cron: "17 7 * * *"
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,21 @@
-# This is the main CI workflow that runs the test suite on all pushes to main and all pull requests.
-# It runs the following jobs:
-# - required: runs the test suite on ubuntu with the stable rust toolchain
-# - os-check: runs the test suite on mac and windows (workspace-level)
-#   On Windows, BDD tests are split into per-service parallel jobs to avoid
-#   the ~10m sequential wall-clock from per-scenario process spawn overhead.
-# - coverage: runs the test suite and collects per-package coverage information
-# See check.yml for information about how the concurrency cancellation and workflow triggering works
+# Cargo test suite: ubuntu/macos/windows nextest, per-service Windows BDD,
+# and coverage. (Windows BDD is split per-service to avoid the ~10m sequential
+# wall-clock from per-scenario process spawn overhead.)
+#
+# Post Bazel cutover (docs/plans/bazel-migration.md Phase 7): Bazel is the
+# required PR gate, so this suite no longer runs per-PR. It runs on
+# push-to-main (every merge) and nightly as the cross-platform safety net;
+# trigger on demand via workflow_dispatch. cargo-rail still scopes the push
+# runs to changed crates; the nightly exercises the full workspace. (Removing
+# cargo-rail outright is the post-cutover cleanup tracked in Phase 7.)
 permissions:
   contents: read
 on:
   push:
     branches: [main]
-  pull_request:
+  schedule:
+    - cron: "30 6 * * *"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,7 @@
 
    If `cargo-rail` is not available, fall back to `cargo build --all --all-targets --all-features --locked --quiet --color never` and `cargo nextest run --locked --all-features --all-targets --color never`. See docs/skills/pre-push.md for the full CI quality-gate suite.
 
-   A Bazel build system is being introduced alongside Cargo (see `docs/plans/bazel-migration.md`). Cargo remains the canonical build during the migration; Bazel runs in shadow mode and is not a required pre-push step yet. If you want to exercise it, `bazel test //...` runs all non-`requires-cargo`, non-BDD targets.
+   **Cutover (`docs/plans/bazel-migration.md` Phase 7): Bazel is now the primary, required CI gate**, which supersedes the cargo-first instruction above *for the PR gate*. Before pushing, run `bazel test //...` (fast targets) and `bazel test //... --test_tag_filters=bdd` (BDD), plus `cargo fmt`. The Cargo gates are NOT removed: `cargo fmt` stays mandatory, and the Cargo workflows (check.yml/test.yml — clippy, feature-powerset, msrv, coverage, the OS + BDD matrix) plus sanitizers/miri/ConformU now run on push-to-main + nightly as the safety net for what Bazel doesn't cover — use `cargo rail`/the Cargo suite to reproduce one of those locally. `bazel test //...` excludes `requires-cargo` and (by default) `bdd` targets; the BDD filter above adds them back.
 
 5. You MUST NEVER commit to the main branch of the git repository. ALL work MUST happen on a branch. Before making any code changes, verify you are on a feature branch. If on main, create and switch to an appropriate feature branch first. Use appropriate naming for branches such as `feature/new_feature_name` or `chore/update_dependency_x`.
 

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -120,7 +120,7 @@ the starting point.
 - [x] Shadow mode: job is **not required** for merges; runs alongside Cargo jobs for 2+ weeks of parity validation.
 - [x] **Cache backend swapped to self-hosted `bazel-remote` on TrueNAS SCALE** (public-read / token-write via Cloudflare Tunnel). `.bazelrc` `--config=remote-cache` points at the Cloudflare hostname; `bazel.yml` attaches `Authorization: Bearer` only on push/schedule and sets `--remote_upload_local_results=false` on PRs. Reads are anonymous, so fork PRs now get a warm cache too. Deterministic retention via `--max_size` ends the BuildBuddy LRU cold-cache outliers. Runbook: [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
 - [x] `.bazelrc` hostname set to `cache.rustyphoton.space` (zone `rustyphoton.space` verified on Cloudflare 2026-05-24).
-- [ ] Add the `BAZEL_CACHE_WRITE_TOKEN` GHA secret and deploy the TrueNAS side (runbook).
+- [x] `BAZEL_CACHE_WRITE_TOKEN` GHA secret added + TrueNAS side deployed; cache verified populating from push-to-main (2026-05-24).
 - [ ] Compare wall-clock and correctness against Cargo jobs weekly (≥1 week on the TrueNAS cache).
 
 **Exit criteria:** Bazel CI job green for 2 consecutive weeks with no flakes; wall-clock within ±20 % of Cargo or better.
@@ -139,11 +139,14 @@ on them. Remaining prerequisites: the TrueNAS cache live + parity logged
 `cargo-msrv`, coverage) kept on a Cargo nightly, and the `rust-project.json`
 IDE decision (open question 4).
 
-- [ ] Bazel job becomes **required** on PRs.
-- [ ] Cargo CI jobs moved to a scheduled nightly (as safety net).
-- [ ] `docs/skills/pre-push.md` rewritten for `bazel test //...` as the primary pre-push command.
-- [ ] `cargo-rail` dependency removed from CI (the 50-LOC upstream PR becomes moot).
-- [ ] `.config/rail.toml` deleted.
+Prepared in the cutover PR (do **not** merge until the Phase 5 soak passes —
+Bazel green for 2 consecutive weeks, wall-clock within ±20 % of Cargo):
+
+- [x] Cargo CI moved off PRs to push-to-main + nightly (check.yml/test.yml/safety.yml triggers) as the safety net.
+- [x] `docs/skills/pre-push.md` + `CLAUDE.md` rule 4 reframed — `bazel test //...` is the primary pre-push; Cargo covers the safety-net gates.
+- [x] `bazel.yml` jobs renamed (dropped "(shadow)").
+- [ ] **Bazel jobs made required on PRs** — branch-protection setting, applied manually at cutover (merging the workflow change alone does not enforce it).
+- [ ] `cargo-rail` removed from CI + `.config/rail.toml` deleted — deferred to a post-cutover cleanup PR (keeps reworking rail's BDD-discovery machinery off the trigger change).
 
 **Exit criteria:** 30 days of required-Bazel CI with zero reverts to Cargo jobs.
 

--- a/docs/skills/pre-push.md
+++ b/docs/skills/pre-push.md
@@ -36,10 +36,26 @@
 
 ## Procedure
 
-### Step 1: Run the full CI suite via `act` (recommended)
+### Step 1: Run Bazel — the required PR gate (recommended)
 
-The easiest way to run all quality gates locally is with `act`, which executes
-the actual GitHub Actions workflows in Docker containers.
+Since the Phase 7 cutover (`docs/plans/bazel-migration.md`), the **Bazel jobs
+are the required PR checks**, so reproduce those first:
+
+```bash
+bazel test //...                          # fast unit + integration targets
+bazel test //... --test_tag_filters=bdd   # BDD (cucumber) targets
+```
+
+These use the shared remote cache (`--config=remote-cache` in `.bazelrc`), so
+they are usually fast. Green here ≈ green on the required PR checks.
+
+### Step 2: Reproduce the Cargo safety-net gates via `act`
+
+The Cargo workflows no longer gate PRs — they run on push-to-main + nightly as
+the safety net for what Bazel doesn't cover (clippy, feature-powerset, msrv,
+coverage, sanitizers, miri, ConformU). Run them locally with `act` when a
+push-to-main / nightly Cargo job fails, or before a change touching those
+areas. `act` executes the actual GitHub Actions workflows in Docker containers.
 
 ```bash
 # Run all independent checks in parallel
@@ -67,7 +83,7 @@ act workflow_dispatch -W .github/workflows/conformu.yml -j plan -j conformu  # n
 > (macOS/Windows) is skipped locally. Multi-OS `conformu` jobs run the ubuntu
 > variant only.
 
-### Step 2 (fallback): Raw `cargo` commands
+### Step 3 (fallback): Raw `cargo` commands
 
 When Docker or `act` is unavailable, use these cargo commands directly.
 


### PR DESCRIPTION
## What

Prepares the **Phase 7 cutover** (`docs/plans/bazel-migration.md`): makes Bazel the primary/required PR gate and moves the Cargo suite off PRs to **push-to-main + nightly** as the safety net.

> [!WARNING]
> **Draft — do not merge yet.** Merge only after the Phase 5 soak passes (Bazel CI green for 2 consecutive weeks, wall-clock within ±20% of Cargo) **and** branch protection is flipped to require the bazel checks.

## Changes

- **`check.yml` / `test.yml`** — drop the `pull_request` trigger; run on `push:[main]` + nightly (`06:00` / `06:30` UTC) + `workflow_dispatch`. All gates preserved (fmt, clippy, doc, hack/feature-powerset, msrv, the ubuntu/macos/windows matrix, per-service Windows BDD, coverage) — now the post-cutover safety net rather than per-PR gates.
- **`safety.yml`** — drop the now-dead `pull_request` trigger (the sanitizer job already skipped PRs via its `if`).
- **`bazel.yml`** — drop "(shadow)" from job names; rewrite the header for the primary-gate role; fix a stale BuildBuddy comment on the nightly trigger (it's the self-hosted bazel-remote cache now).
- **`docs/skills/pre-push.md` + `CLAUDE.md` (rule 4)** — `bazel test //...` is now the primary pre-push command; Cargo reframed as the safety-net gates (`cargo fmt` still mandatory).
- **`docs/plans/bazel-migration.md`** — Phase 5 secret/deploy item checked off; Phase 7 checklist updated.

## Safety-net model

Bazel gates PRs. The Cargo suite runs on every merge to main + nightly, so anything Bazel's action graph doesn't cover (clippy lints, feature-powerset, msrv, coverage, sanitizers, miri, ConformU) is still caught — just post-merge. The 2-week soak before merging is what proves Bazel catches what matters before we lean on that net.

## Deliberately NOT in this PR

- **Making the bazel checks "required"** — branch-protection setting (Settings → Branches), applied manually at cutover. Merging this workflow change alone does not enforce it.
- **Removing `cargo-rail` + `.config/rail.toml`** — deferred to a post-cutover cleanup PR, because cleanly removing rail also means reworking the BDD-package discovery its `plan` job feeds the Windows BDD matrix. Keeping that separate de-risks both.

## Note on this PR's own CI

Since `check.yml`/`test.yml` no longer trigger on `pull_request`, **the Cargo checks won't run on this PR** — only the bazel jobs (+ CodeQL etc.). That's the new world working as intended; the restructured Cargo workflows first run for real on push-to-main after merge, and can be smoke-tested beforehand via `workflow_dispatch` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)