### PR TITLE
fix(star-adventurer-gti): SetPark reads encoder fresh from wire (#308)

### DIFF
--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -574,7 +574,20 @@ argument). No separate state file. Concretely:
    `INVALID_OPERATION`) when the device is disconnected or while a
    slew / park is in progress — the "current encoder pair" wouldn't be
    stable otherwise.
-3. **Read-as-`Value`, write only park keys.** The driver reads the
+3. **Fresh encoder read.** The encoder pair (and the per-axis running
+   flag the in-progress refusal checks) is read **live from the wire** —
+   a synchronous `:j` / `:f` poll on both axes via the connected
+   session — not from the background poll snapshot, which lags the wire
+   by up to one `polling_interval`. Reading live means `SetPark`
+   persists the true current encoder even if the operator moved the
+   mount out-of-band immediately before the call, and removes a
+   connect/poll timing race that made the BDD persistence scenario flaky
+   on slow CI (issue #308): the eager service-start handshake seeds the
+   snapshot before the test sets the encoder, and the user's connect is
+   a refcount bump rather than a fresh handshake. (The write itself is
+   fully `fsync`'d and atomically renamed before the call returns — see
+   step 5 — so the persisted file is durable, not fire-and-forget.)
+4. **Read-as-`Value`, write only park keys.** The driver reads the
    on-disk JSON via `serde_json::Value`, mutates *only*
    `mount.park_ra_ticks` and `mount.park_dec_ticks`, and serialises the
    result pretty-printed. Any field the driver doesn't recognise
@@ -588,7 +601,7 @@ argument). No separate state file. Concretely:
    in-memory typed `Config`** to disk — that path would round-trip the
    CLI overrides (`--port`, `--baud`, `--server-port`, `--transport`)
    back into the file and is structurally avoided here.
-4. **Atomic rename via `tempfile::NamedTempFile`.** The temp file is
+5. **Atomic rename via `tempfile::NamedTempFile`.** The temp file is
    created in the **same directory** as the destination (required for
    `persist` to use POSIX `rename` rather than copy-and-delete),
    `sync_all`'d (fsync the file data) so a crash after rename can't
@@ -598,10 +611,10 @@ argument). No separate state file. Concretely:
    [`services/rp/src/persistence/document.rs::write_sidecar_sync`](../../services/rp/src/persistence/document.rs).
    On any error path the temp file auto-deletes via `Drop`, so a
    panic mid-write doesn't leave a `*.tmp` artifact behind.
-5. **Blocking I/O on the blocking pool.** The whole read+parse+stage+
+6. **Blocking I/O on the blocking pool.** The whole read+parse+stage+
    fsync+rename sequence runs inside `tokio::task::spawn_blocking` so
    the async runtime isn't held up. Same pattern as `write_sidecar`.
-6. **In-memory update follows disk.** The in-memory park target is
+7. **In-memory update follows disk.** The in-memory park target is
    updated only after the file write succeeds. If the file write
    fails, the in-memory park is unchanged and the caller sees an
    ASCOM error — there is no "partial success" state.

--- a/services/star-adventurer-gti/src/mount_device/telescope.rs
+++ b/services/star-adventurer-gti/src/mount_device/telescope.rs
@@ -761,21 +761,39 @@ impl Telescope for MountDevice {
         //      slew_to_coordinates_async() now set this *before*
         //      issuing motion (with rollback-on-error), so the
         //      flag observation here is reliable.
-        //   2. The latest wire snapshot's `running` flag: defense
-        //      in depth against an axis that's running for any
-        //      reason the in-memory flag wouldn't capture (a
-        //      tracking pulse, an external `:J` from a future
-        //      out-of-band path, a flag-set racing the wire send).
-        //      The snapshot is updated by the background poller at
-        //      `polling_interval`; the window where snapshot lags
-        //      reality is bounded by that interval.
+        //   2. A fresh wire read of each axis' `running` flag (below):
+        //      defense in depth against an axis that's running for any
+        //      reason the in-memory flag wouldn't capture (a tracking
+        //      pulse, an external `:J` from a future out-of-band path,
+        //      a flag-set racing the wire send).
         if self.state.read().await.slew_in_progress {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_OPERATION,
                 "SetPark refused while slew or park is in progress",
             ));
         }
-        let snap = self.manager.snapshot().await;
+        // Read the encoder pair **fresh** from the wire, not from the
+        // background poll snapshot. SetPark captures the *current*
+        // encoder pair, but the cached snapshot lags the wire by up to
+        // one `polling_interval` — reading it could persist a stale
+        // position when the operator moved the mount out-of-band just
+        // before SetPark. The lag also made the BDD persistence scenario
+        // flaky on slow CI (issue #308): the eager service-start
+        // handshake seeds the snapshot *before* the test sets the
+        // encoder, and the user's connect is a refcount bump rather than
+        // a fresh handshake, so the captured position hinged on a
+        // background poll landing in that gap. A synchronous
+        // `poll_axes_now` removes the timing dependency (and refreshes
+        // the cache as a side effect). Same session-read idiom as
+        // `set_tracking` / `stop_and_wait`.
+        let snap = {
+            let guard = self.session.read().await;
+            let session = guard.as_ref().ok_or(ASCOMError::NOT_CONNECTED)?;
+            self.manager
+                .poll_axes_now(session)
+                .await
+                .map_err(ASCOMError::from)?
+        };
         if snap.ra.running || snap.dec.running {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_OPERATION,

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -1802,7 +1802,7 @@ async fn set_park_refuses_when_wire_snapshot_reports_axis_running() {
 }
 
 #[tokio::test]
-async fn set_park_persists_current_snapshot_and_updates_in_memory_target() {
+async fn set_park_persists_current_wire_position_and_updates_in_memory_target() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     seed_default_config(&path);

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -1385,6 +1385,25 @@ fn device_with_path(path: PathBuf) -> MountDevice {
     MountDevice::with_config_file_path(cfg.mount, manager, Some(path))
 }
 
+/// Like [`device_with_path`] but backed by a [`CapturingMockFactory`] so
+/// the test can seed the mock's **wire** encoder state. `SetPark` reads
+/// the live encoder via `poll_axes_now`, so seeding the cached snapshot
+/// (`seed_ra_position`) is not enough — the value must be on the wire
+/// for a fresh `:j` poll to capture it.
+fn device_with_path_and_mock(
+    path: PathBuf,
+) -> (MountDevice, Arc<tokio::sync::Mutex<MockMountState>>) {
+    let factory = CapturingMockFactory::new();
+    let mock = Arc::clone(&factory.state);
+    let mut cfg = Config::default();
+    // Disable the CW-exclusion zone check for these tests.
+    cfg.mount.binding_zone_min_hours = 24.0;
+    cfg.mount.binding_zone_max_hours = 0.0;
+    let manager = MountManager::new(cfg.clone(), Arc::new(factory));
+    let d = MountDevice::with_config_file_path(cfg.mount, manager, Some(path));
+    (d, mock)
+}
+
 /// Helper: write a default `Config` to `path` as pretty JSON. Used as
 /// the seed file for SetPark round-trip tests.
 fn seed_default_config(path: &Path) {
@@ -1787,13 +1806,16 @@ async fn set_park_persists_current_snapshot_and_updates_in_memory_target() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     seed_default_config(&path);
-    let d = device_with_path(path.clone());
+    let (d, mock) = device_with_path_and_mock(path.clone());
     d.set_connected(true).await.unwrap();
-    // Seed the snapshot directly — the polling loop won't overwrite
-    // a stationary mock axis (`advance_one_step` bails on
-    // `!running`), so these values stick.
-    d.manager.seed_ra_position(8000).await;
-    d.manager.seed_dec_position(-3000).await;
+    // Seed the mock's *wire* encoder: SetPark reads the live position
+    // via `poll_axes_now`, so the value must be on the wire (a
+    // stationary axis won't be advanced by `:j` polling).
+    {
+        let mut s = mock.lock().await;
+        s.ra.position_ticks = 8000;
+        s.dec.position_ticks = -3000;
+    }
 
     d.set_park().await.unwrap();
 
@@ -2274,10 +2296,14 @@ async fn reconnect_after_set_park_picks_up_persisted_values() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     seed_default_config(&path);
-    let d = device_with_path(path.clone());
+    let (d, mock) = device_with_path_and_mock(path.clone());
     d.set_connected(true).await.unwrap();
-    d.manager.seed_ra_position(8000).await;
-    d.manager.seed_dec_position(-3000).await;
+    // Seed the mock *wire* encoder; SetPark reads it via `poll_axes_now`.
+    {
+        let mut s = mock.lock().await;
+        s.ra.position_ticks = 8000;
+        s.dec.position_ticks = -3000;
+    }
     d.set_park().await.unwrap();
 
     // Disconnect: in-memory park state is cleared.
@@ -2285,11 +2311,14 @@ async fn reconnect_after_set_park_picks_up_persisted_values() {
     assert_eq!(d.state.read().await.park_ra_ticks, None);
     assert_eq!(d.state.read().await.park_dec_ticks, None);
 
-    // Reset the mock encoders so reconnect's handshake fallback
-    // would be (0, 0) — proves the re-read picked up SetPark's
-    // values rather than just re-reading handshake.
-    d.manager.seed_ra_position(0).await;
-    d.manager.seed_dec_position(0).await;
+    // Reset the mock *wire* encoders so reconnect's handshake `:j`
+    // fallback would be (0, 0) — proves the re-read picked up SetPark's
+    // persisted values rather than just re-reading the handshake.
+    {
+        let mut s = mock.lock().await;
+        s.ra.position_ticks = 0;
+        s.dec.position_ticks = 0;
+    }
 
     d.set_connected(true).await.unwrap();
     let s = d.state.read().await;


### PR DESCRIPTION
## Summary

Fixes #308 — the flaky (macOS-only) `star-adventurer-gti` BDD scenario *"SetPark writes the current encoder ticks back to the config file."*

The issue hypothesized a **persistence flush race** (the async config write hadn't flushed when the assertion fired). That is **not** the mechanism. `set_park` `await`s a `spawn_blocking` that does write → `sync_all` → atomic `persist` (rename) → parent-dir fsync, all *before* it returns its HTTP response, and the test reads the file only *after* that response. The file is fully durable and atomically renamed before the assertion runs — the persisted file was never fire-and-forget.

The real cause is a **captured-value race**: `set_park` persisted the *wrong* value.

## Root cause

- `set_park` captured the park-encoder pair from the **background-poll snapshot** (`manager.snapshot()`), which lags the live wire by up to one `polling_interval`.
- Since #302 (service-lifetime transport), the handshake that seeds that snapshot from `:j` runs **eagerly at service start** — *before* the BDD test POSTs its `8000/−3000` encoder seed — so the snapshot is seeded to the mock's default `0/0`. The user's `Connected = true` is a refcount 1→2 bump that runs **no fresh handshake**, so the snapshot only reaches `8000/−3000` via the background poll loop.
- If `set_park` reads the snapshot before that poll lands, it persists the stale `0`. macOS CI loses this 50 ms race occasionally.

In production this is benign (the mount is stationary during SetPark, so the ≤1-poll-stale snapshot is accurate), but the BDD scenario mutates the encoder out-of-band via the mock-state endpoint and then immediately connects + calls SetPark, exposing the lag.

## Fix

`set_park` now reads the encoder pair — and the per-axis `running` flag its in-progress refusal checks — **fresh from the wire** via a synchronous `poll_axes_now(session)`, using the same `session.read()` idiom as `set_tracking` / `stop_and_wait`. This captures the true current encoder regardless of poll timing and is faithful to SetPark's "capture the *current* encoder pair" contract (also correct if an operator nudged the mount out-of-band just before SetPark).

## Verification

Proven deterministically on Linux by forcing `polling_interval` to 30 s (permanently stale snapshot):

- **Old code:** fails with `park_ra_ticks mismatch — left: Some(0), right: Some(8000)` (exactly the issue's symptom).
- **With the fix:** passes.

Other checks:
- 8 `set_park` unit tests pass (two success-path tests reworked to seed the mock **wire** encoder — a fresh `:j` reads the wire, so seeding only the cached snapshot no longer suffices).
- Full star-adventurer BDD suite: `136 scenarios (136 passed)`.
- `cargo rail run --profile commit`: `425 passed, 1 skipped`.
- `cargo fmt` clean.

## Files changed

- `services/star-adventurer-gti/src/mount_device/telescope.rs` — fresh-read in `set_park`.
- `services/star-adventurer-gti/src/mount_device/tests.rs` — two SetPark success-path tests reworked + `device_with_path_and_mock` helper.
- `docs/services/star-adventurer-gti.md` — §Park persistence documents the fresh read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
