### PR TITLE
ci: add Bazel/Cargo target-parity check (found 3 crates missing from Bazel)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,38 @@
+# Bazel/Cargo target-parity gate.
+#
+# Ensures every Cargo workspace member has a Bazel rust target, so that
+# "Bazel green" means Bazel builds what Cargo builds (hand-written BUILD.bazel
+# files can otherwise drift from the workspace). Runs during the Phase 7 soak
+# and after — on PRs, push-to-main, and nightly — so drift is caught the moment
+# a crate is added without a BUILD.bazel.
+#
+# See scripts/check-bazel-cargo-parity.sh and docs/plans/bazel-migration.md.
+permissions:
+  contents: read
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "45 6 * * *"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: parity
+jobs:
+  bazel-cargo-parity:
+    runs-on: ubuntu-latest
+    name: bazel/cargo target parity
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Setup bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+        with:
+          bazelisk-version: 1.28.1
+      # Query-only: cargo metadata + bazel query, no build. jq is preinstalled
+      # on ubuntu-latest.
+      - name: Check Bazel/Cargo target parity
+        run: ./scripts/check-bazel-cargo-parity.sh

--- a/scripts/check-bazel-cargo-parity.sh
+++ b/scripts/check-bazel-cargo-parity.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Bazel/Cargo target-parity check.
+#
+# Ensures every Cargo workspace member has at least one Bazel rust target, so
+# that "Bazel green" actually means Bazel builds what Cargo builds. Hand-written
+# BUILD.bazel files can silently drift from the Cargo workspace — a crate added
+# to Cargo.toml can go without a BUILD.bazel and escape the Bazel gate entirely.
+# This guards against that. See docs/plans/bazel-migration.md.
+#
+# A Cargo member is "covered" if its directory contains any rust_* Bazel rule
+# (rust_library / rust_binary / rust_proc_macro / rust_shared_library / ...).
+# The script FAILS on a Cargo member with no Bazel target that is not in the
+# documented EXPECTED_GAPS allowlist below — which doubles as the pre-cutover
+# TODO list. Empty that list before making Bazel the required PR gate.
+#
+# Requires: cargo, bazel (bazelisk), jq, git.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# --- Cargo members deliberately not (yet) in the Bazel graph ----------------
+# Each line is a crate the Bazel gate does NOT cover. Remove an entry the
+# moment its BUILD.bazel lands; the cutover (docs/plans/bazel-migration.md
+# Phase 7) should not flip until this list is empty. Inline "# reason"
+# comments are allowed and stripped before comparison.
+read -r -d '' EXPECTED_GAPS <<'GAPS' || true
+crates/skywatcher-motor-protocol  # plain library; BUILD.bazel pending (cutover prereq)
+services/dsd-fp2                   # CoverCalibrator service; BUILD.bazel pending
+services/star-adventurer-gti       # mount service; BUILD.bazel pending
+GAPS
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Cargo workspace member directories, relative to the workspace root.
+root=$(cargo metadata --format-version 1 | jq -r '.workspace_root')
+cargo metadata --no-deps --format-version 1 \
+  | jq -r --arg root "$root/" '.packages[].manifest_path | ltrimstr($root) | rtrimstr("/Cargo.toml")' \
+  | sort -u > "$tmp/cargo.txt"
+
+# Bazel packages (directories) containing any rust_* rule. --output=package
+# yields the directory, e.g. "services/rp".
+bazel query 'kind("rust_.*", //...)' --output=package 2>/dev/null \
+  | sort -u > "$tmp/bazel.txt"
+
+# Strip inline/full-line "# comments", trailing whitespace, and blank lines.
+printf '%s\n' "$EXPECTED_GAPS" | sed 's/#.*//; s/[[:space:]]*$//; /^[[:space:]]*$/d' | sort -u > "$tmp/allow.txt"
+
+# Cargo members with no Bazel target.
+comm -23 "$tmp/cargo.txt" "$tmp/bazel.txt" > "$tmp/gaps.txt"
+# New (not allowlisted) => failure. Closed (allowlisted but now covered) => nudge.
+comm -23 "$tmp/gaps.txt" "$tmp/allow.txt" > "$tmp/new.txt"
+comm -13 "$tmp/gaps.txt" "$tmp/allow.txt" > "$tmp/closed.txt"
+
+echo "::group::Bazel/Cargo target parity"
+echo "Cargo workspace members  : $(wc -l < "$tmp/cargo.txt")"
+echo "Covered by a Bazel target: $(comm -12 "$tmp/cargo.txt" "$tmp/bazel.txt" | wc -l)"
+echo "Current gaps             :"
+sed 's/^/    /' "$tmp/gaps.txt"
+echo "::endgroup::"
+
+status=0
+if [ -s "$tmp/new.txt" ]; then
+  echo "::error::Cargo member(s) with no Bazel target and not allowlisted. Add a BUILD.bazel (preferred), or — if the omission is intentional — add the path to EXPECTED_GAPS in scripts/check-bazel-cargo-parity.sh with a reason:"
+  sed 's/^/    /' "$tmp/new.txt"
+  status=1
+fi
+if [ -s "$tmp/closed.txt" ]; then
+  echo "::warning::These allowlisted gaps now HAVE Bazel targets — remove them from EXPECTED_GAPS:"
+  sed 's/^/    /' "$tmp/closed.txt"
+fi
+
+if [ "$status" -eq 0 ]; then
+  remaining=$(wc -l < "$tmp/allow.txt")
+  if [ "$remaining" -gt 0 ]; then
+    echo "Parity OK (no new gaps). $remaining crate(s) still need a BUILD.bazel before the Bazel-required cutover."
+  else
+    echo "Parity OK — Bazel builds every Cargo workspace member."
+  fi
+fi
+exit "$status"


### PR DESCRIPTION
## What

A **Bazel/Cargo target-parity check** — guards that every Cargo workspace member has a Bazel rust target, so that "Bazel green" means Bazel actually builds what Cargo builds. This is the assumption behind the Phase 7 cutover (`docs/plans/bazel-migration.md`); hand-written `BUILD.bazel` files can silently drift from the workspace.

## It already found real drift

Running it surfaced **3 Cargo crates with no Bazel target at all** — Bazel does not build or test these today:

| crate | kind |
|---|---|
| `crates/skywatcher-motor-protocol` | library |
| `services/dsd-fp2` | **service** (CoverCalibrator) |
| `services/star-adventurer-gti` | **service** (mount) |

They're allowlisted in `EXPECTED_GAPS` (which doubles as the pre-cutover TODO list), so the check passes today (no *new* gaps). But **these need `BUILD.bazel` files before Bazel becomes the required gate** — otherwise PRs touching them would pass the Bazel gate without Bazel ever building them.

## How it works

- `scripts/check-bazel-cargo-parity.sh` — diffs `cargo metadata` workspace members against `bazel query 'kind("rust_.*", //...)' --output=package`. Fails on a non-allowlisted Cargo member with no Bazel target; warns (so you trim the list) when an allowlisted gap gains a target.
- `.github/workflows/parity.yml` — runs it on **PR + push-to-main + nightly + workflow_dispatch**. Query-only (`cargo metadata` + `bazel query`, no build), so it's fast (~1–2 min).

Merging now means the parity signal is collected throughout the 2-week soak and any new drift is caught immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)