### PR TITLE
fix(rp): surface failed camera exposures instead of hanging do_capture

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -23,6 +23,11 @@ jobs:
   sanitizers:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # Explicit timeout — see test.yml's plan job. The sanitizer `cargo test`
+    # step runs the same BDD scenarios that intermittently hang; without a
+    # cap GitHub's 360 min default let `ubuntu / nightly / address` burn a
+    # full 6 h. 40 min sits ~2x above the ~19 min healthy sanitizer run.
+    timeout-minutes: 40
     name: ubuntu / nightly / ${{ matrix.sanitizer }}
     strategy:
       fail-fast: false
@@ -73,6 +78,7 @@ jobs:
     needs: sanitizers
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,6 +19,11 @@ jobs:
   nightly:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # Explicit timeout — see test.yml's plan job. The `cargo test --test bdd`
+    # step intermittently hangs; without a cap GitHub's 360 min default let
+    # the `scheduled / ubuntu / beta*` jobs burn a full 6 h. 30 min is ~2x
+    # the ~12-15 min healthy run.
+    timeout-minutes: 30
     name: scheduled / ubuntu / nightly
     steps:
       - uses: actions/checkout@v5
@@ -46,6 +51,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Discover Miri Services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       services: ${{ steps.find.outputs.services }}
       has_services: ${{ steps.find.outputs.has_services }}
@@ -76,6 +82,7 @@ jobs:
     if: github.event_name != 'pull_request' && needs.discover-miri.outputs.has_services == 'true'
     needs: discover-miri
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: scheduled / ubuntu / miri / ${{ matrix.service.name }}
     strategy:
       fail-fast: false
@@ -105,6 +112,7 @@ jobs:
     # Cargo semver rules (i.e cargo does not update to a new major version unless explicitly told
     # to).
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: scheduled / ubuntu / beta / updated
     # There's no point running this if no Cargo.lock was checked in in the first place, since we'd
     # just redo what happened in the regular test job. Unfortunately, hashFiles only works in if on
@@ -143,6 +151,7 @@ jobs:
   beta:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: scheduled / ubuntu / beta
     steps:
       - uses: actions/checkout@v5
@@ -179,6 +188,7 @@ jobs:
     needs: [nightly, discover-miri, miri, update, beta]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,14 @@ name: test
 jobs:
   plan:
     runs-on: ubuntu-latest
+    # Explicit job timeout. Without one, GitHub's default is 360 min (6 h):
+    # a BDD hang in `cargo test --test bdd` silently burned a full 6 h per
+    # job before being killed, blocking the runner queue overnight. The root
+    # cause (rp's `do_capture` looping forever on a failed sky-survey-camera
+    # exposure) is fixed at the source; these caps are defense-in-depth so no
+    # future hang can ever burn 6 h again. Values sit ~2x above the observed
+    # healthy max so cold-cache/load variance won't false-positive.
+    timeout-minutes: 15
     name: plan
     outputs:
       test: ${{ steps.rail.outputs.test }}
@@ -76,6 +84,8 @@ jobs:
     needs: plan
     if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: ubuntu-latest
+    # See the plan job for why these caps exist (6 h BDD-hang backstop).
+    timeout-minutes: 30
     name: ubuntu / stable
     steps:
       - uses: actions/checkout@v5
@@ -128,6 +138,7 @@ jobs:
     needs: plan
     if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: macos-latest
+    timeout-minutes: 30
     name: macos-latest
     steps:
       - uses: actions/checkout@v5
@@ -168,6 +179,7 @@ jobs:
     needs: plan
     if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: windows-latest
+    timeout-minutes: 30
     name: windows / nextest
     steps:
       - uses: actions/checkout@v5
@@ -204,6 +216,7 @@ jobs:
     # BDD-only PRs (#186) from the windows-bdd matrix.
     if: needs.plan.outputs.has-bdd == 'true'
     runs-on: windows-latest
+    timeout-minutes: 30
     name: windows / bdd / ${{ matrix.package }}
     strategy:
       fail-fast: false
@@ -253,6 +266,7 @@ jobs:
     needs: plan
     if: needs.plan.outputs.test == 'true' || needs.plan.outputs.infra == 'true' || needs.plan.outputs.has-bdd == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: coverage
     steps:
       - uses: actions/checkout@v5

--- a/crates/bdd-infra/src/rp_harness/mcp_client.rs
+++ b/crates/bdd-infra/src/rp_harness/mcp_client.rs
@@ -5,10 +5,29 @@
 //! reused for all tool calls within that scenario — mirroring how a real
 //! MCP client (e.g. calibrator-flats) works.
 
+use std::time::Duration;
+
 use rmcp::model::CallToolRequestParams;
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ServiceExt;
 use serde_json::Value;
+
+/// Upper bound on a single MCP request (`call_tool` / `list_tools`).
+///
+/// rmcp's `Peer::call_tool` has no built-in client timeout: if an rp tool
+/// handler never returns, the `await` here hangs *forever*. That is what ran
+/// CI's closed-loop centering BDD to GitHub's 6 h job cap — rp's `do_capture`
+/// looped indefinitely on a failed `sky-survey-camera` exposure (root-caused
+/// and fixed in `services/rp/src/mcp/internals.rs::do_capture`). This timeout
+/// is a defense-in-depth backstop: any future handler hang fails the scenario
+/// fast and legibly here, rather than hanging the BDD binary until the CI
+/// job's `timeout-minutes` kills it.
+///
+/// 360 s sits comfortably above rp's worst-case single blocking operation
+/// (the 300 s slew/park deadlines), so a genuinely slow-but-progressing call
+/// still completes and a *server-produced* error still propagates with its
+/// real message; only a true hang trips this bound.
+const MCP_CALL_TIMEOUT: Duration = Duration::from_secs(360);
 
 /// A persistent MCP client backed by a single rmcp session.
 pub struct McpTestClient {
@@ -36,10 +55,16 @@ impl McpTestClient {
             params.arguments = Some(obj.clone());
         }
 
-        let result = self
-            .peer
-            .call_tool(params)
+        let result = tokio::time::timeout(MCP_CALL_TIMEOUT, self.peer.call_tool(params))
             .await
+            .map_err(|_| {
+                format!(
+                    "{}: MCP call timed out after {}s with no response — the rp MCP \
+                     transport was almost certainly torn down mid-request (see MCP_CALL_TIMEOUT)",
+                    tool_name,
+                    MCP_CALL_TIMEOUT.as_secs()
+                )
+            })?
             .map_err(|e| format!("{}: {}", tool_name, e))?;
 
         if result.is_error.unwrap_or(false) {
@@ -64,10 +89,15 @@ impl McpTestClient {
 
     /// List all available MCP tools and return their names.
     pub async fn list_tools(&self) -> Result<Vec<String>, String> {
-        let tools = self
-            .peer
-            .list_all_tools()
+        let tools = tokio::time::timeout(MCP_CALL_TIMEOUT, self.peer.list_all_tools())
             .await
+            .map_err(|_| {
+                format!(
+                    "list_tools: MCP call timed out after {}s with no response (see \
+                     MCP_CALL_TIMEOUT)",
+                    MCP_CALL_TIMEOUT.as_secs()
+                )
+            })?
             .map_err(|e| format!("list_tools: {}", e))?;
 
         Ok(tools.into_iter().map(|t| t.name.to_string()).collect())

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -420,7 +420,14 @@ test spawns `rp` alongside OmniSim and/or an orchestrator plugin:
   `sibling_service_dir` — launch helpers.
 - `WebhookReceiver`, `TestOrchestrator`, `OrchestratorBehavior` — in-process
   plugin stand-ins.
-- `McpTestClient` — persistent rmcp client for calling rp's MCP tools.
+- `McpTestClient` — persistent rmcp client for calling rp's MCP tools. Each
+  `call_tool` / `list_tools` request is bounded by `MCP_CALL_TIMEOUT` (360 s):
+  rmcp has no built-in client timeout, so if an rp tool handler hangs the
+  `await` would otherwise block forever. (A `do_capture` loop that span
+  indefinitely on a failed `sky-survey-camera` exposure burned a full 6 h per
+  CI job this way before it was fixed at the source.) The bound is a backstop
+  so any future handler hang fails the scenario fast rather than running the
+  job to its `timeout-minutes` cap.
 
 Turn the feature on **only** for tests that actually spawn rp. Services whose
 BDD tests only need `ServiceHandle` (filemonitor, qhy-focuser, ppba-driver,

--- a/services/rp/src/imaging/tools/center_on_target.rs
+++ b/services/rp/src/imaging/tools/center_on_target.rs
@@ -22,6 +22,15 @@
 //! slew traverse a small distance even under heavy CI load. See
 //! `services/rp/tests/features/center_on_target.feature` for the
 //! worked numbers.
+//!
+//! Note: the 6 h CI hangs in the closed-loop centering BDD (May 2026)
+//! were *not* this slew/keep-alive race. They traced to `do_capture`
+//! looping forever on a **failed** `sky-survey-camera` exposure — its
+//! follow-mode mount read timed out under load, so `ImageReady` never
+//! went true and the capture poll spun indefinitely. Fixed at the
+//! source in `mcp/internals.rs::do_capture` (treat `CameraState::Error`
+//! as terminal + a readout deadline). CI job `timeout-minutes` and the
+//! BDD client's `MCP_CALL_TIMEOUT` are independent backstops.
 
 use async_trait::async_trait;
 use serde::Serialize;

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -12,6 +12,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ascom_alpaca::api::camera::CameraState;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -19,6 +20,17 @@ use crate::imaging::{self, BackgroundStats, DetectionParams, Star};
 use crate::persistence::{self, CachedImage, CachedPixels, ExposureDocument};
 
 use super::handler::McpHandler;
+
+/// Backstop grace added to the requested exposure `duration` to bound
+/// `do_capture`'s readout wait. An Alpaca camera can *fail* an exposure
+/// — transition `CameraState` to `Error` and leave `ImageReady` false
+/// (e.g. `sky-survey-camera` when its follow-mode mount read or survey
+/// fetch times out) — or, more rarely, wedge in `Exposing`. The poll
+/// loop treats `Error` as terminal; this grace caps the wait even when a
+/// camera never reports either readiness or error. 120 s mirrors
+/// `do_move_focuser_blocking`'s deadline and comfortably covers real
+/// readout/download latency on top of the exposure itself.
+const CAPTURE_READOUT_GRACE: Duration = Duration::from_secs(120);
 
 // ---------------------------------------------------------------------------
 // Private helper types shared across imaging tool bodies. All
@@ -446,11 +458,42 @@ impl McpHandler {
             .await
             .map_err(|e| format!("failed to start exposure: {}", e))?;
 
+        // Poll until the frame is ready — but a not-ready camera is not
+        // necessarily still exposing. An Alpaca camera that *fails* an
+        // exposure transitions to `CameraState::Error` and leaves
+        // `ImageReady` false forever; polling `ImageReady` alone treats
+        // that as "still exposing" and loops indefinitely. That is the
+        // bug that ran CI's closed-loop centering BDD to GitHub's 6 h job
+        // cap: `sky-survey-camera`'s follow-mode mount read timed out
+        // under load, the exposure failed, and `do_capture` span here
+        // forever. Treat `Error` as terminal (surfacing the camera's
+        // stored reason via `image_array`), and cap the total wait with a
+        // deadline as a backstop for a camera wedged in `Exposing`.
+        let deadline = tokio::time::Instant::now() + duration + CAPTURE_READOUT_GRACE;
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
             match cam.image_ready().await {
                 Ok(true) => break,
-                Ok(false) => continue,
+                Ok(false) => {
+                    // A transient `camera_state` read error is non-fatal —
+                    // `ImageReady` stays the primary signal and the deadline
+                    // below still bounds the wait.
+                    if let Ok(CameraState::Error) = cam.camera_state().await {
+                        let detail = cam
+                            .image_array()
+                            .await
+                            .err()
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| "camera reported error state".to_string());
+                        return Err(format!("exposure failed: {}", detail));
+                    }
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(format!(
+                            "timeout waiting for image_ready after {:?}",
+                            duration + CAPTURE_READOUT_GRACE
+                        ));
+                    }
+                }
                 Err(e) => return Err(format!("error checking image ready: {}", e)),
             }
         }

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -79,6 +79,13 @@ struct MockCamera {
     /// `0` ⇒ default 65535. Any other value is returned verbatim — set
     /// to `> u16::MAX` to exercise the I32 cache-insert path.
     max_adu_value: u32,
+    /// When set, `image_ready` reports `false` forever — simulating a
+    /// camera that never completes (a failed or wedged exposure).
+    never_ready: bool,
+    /// When set, `camera_state` reports `Error` — simulating a camera
+    /// that failed an exposure (e.g. sky-survey-camera's mount read
+    /// timing out). Drives the `do_capture` failed-exposure path.
+    report_error_state: bool,
 }
 
 impl_mock_device!(MockCamera);
@@ -100,7 +107,18 @@ impl ascom_alpaca::api::Camera for MockCamera {
         if self.fail_image_ready {
             return Err(ASCOMError::invalid_operation("readout failed"));
         }
-        Ok(true)
+        Ok(!self.never_ready)
+    }
+
+    async fn camera_state(
+        &self,
+    ) -> ascom_alpaca::ASCOMResult<ascom_alpaca::api::camera::CameraState> {
+        use ascom_alpaca::api::camera::CameraState;
+        Ok(if self.report_error_state {
+            CameraState::Error
+        } else {
+            CameraState::Idle
+        })
     }
 
     async fn image_array(
@@ -863,6 +881,56 @@ async fn test_capture_image_array_fails() {
         }))
         .await;
     assert_tool_error(result, "failed to download image array");
+}
+
+#[tokio::test]
+async fn test_capture_failed_exposure_surfaces_error_not_hang() {
+    // Regression for the 6 h CI hang: a camera that *fails* an exposure
+    // reports `CameraState::Error` and leaves `ImageReady` false forever.
+    // `do_capture` must surface that as an error rather than polling
+    // `ImageReady` indefinitely. `fail_image_array` makes `image_array`
+    // carry the stored failure detail, mirroring sky-survey-camera after a
+    // follow-mode mount-read timeout. The outer `timeout` guard fails the
+    // test loudly (rather than hanging the suite) if the loop regresses.
+    let cam = MockCamera {
+        never_ready: true,
+        report_error_state: true,
+        fail_image_array: true,
+        ..Default::default()
+    };
+    let handler = test_handler(camera_registry(Arc::new(cam)));
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        handler.capture(Parameters(CaptureParams {
+            camera_id: "cam".into(),
+            duration: Duration::from_millis(100),
+        })),
+    )
+    .await
+    .expect("do_capture hung on a failed exposure instead of returning an error");
+    assert_tool_error(result, "exposure failed");
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_capture_times_out_when_camera_never_ready() {
+    // Backstop: a camera wedged not-ready *without* signalling an Error
+    // state must still not hang forever — the `duration + CAPTURE_READOUT_
+    // GRACE` deadline ends the loop. `start_paused` auto-advances tokio's
+    // clock so the ~120 s deadline is reached without real waiting.
+    let cam = MockCamera {
+        never_ready: true,
+        // report_error_state defaults false → camera_state == Idle, so the
+        // Error branch never trips and only the deadline can end the loop.
+        ..Default::default()
+    };
+    let handler = test_handler(camera_registry(Arc::new(cam)));
+    let result = handler
+        .capture(Parameters(CaptureParams {
+            camera_id: "cam".into(),
+            duration: Duration::from_millis(100),
+        }))
+        .await;
+    assert_tool_error(result, "timeout waiting for image_ready");
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Overnight CI on `main` repeatedly ran for **~6 hours** and was cancelled (GitHub's 360 min hard per-job cap), blocking the runner queue. First seen **~May 18**, then on essentially every scheduled `rolling`/`safety` run, plus the May 25 `test` push.

## Real root cause

> ⚠️ My first pass wrongly blamed a `do_slew_blocking` / rmcp keep-alive race. A reviewer pushed back — *a tiny OmniSim slew never takes 300 s* — which was correct. Re-investigated; the 300 s in the logs is just the HTTP transport giving up (a symptom). Here's the actual cause.

The hung step is always `cargo test --test bdd`, and all three captured failures (`ubuntu / stable`, `ubuntu / nightly / address`, scheduled `beta`) hang on the **identical** closed-loop centering example, right when `center_on_target` is called. At kill time `rp`, `sky-survey-camera`, and `ascom.alpaca.simulators` are **all still alive** — nothing crashed; rp's handler just never returns and logs nothing for the full 5 minutes.

rp's `do_capture` poll loop (`services/rp/src/mcp/internals.rs`):

```rust
loop {
    tokio::time::sleep(Duration::from_millis(100)).await;
    match cam.image_ready().await {
        Ok(true)  => break,
        Ok(false) => continue,   // ← a FAILED exposure looks identical to "still exposing", forever
        Err(e)    => return Err(...),
    }
}
```

It polls **only `ImageReady`** — no deadline, and no check of `CameraState`. But an Alpaca camera that *fails* an exposure transitions to `CameraState::Error` and **leaves `ImageReady` false**. So a failed exposure = infinite spin.

The trigger: in the `@e2e-centering` BDD the real `sky-survey-camera` follows OmniSim, and its follow-mode mount read has a **2 s** timeout (`sky_survey_camera_steps.rs:50`). Under heavy parallel-OmniSim CI load that read intermittently exceeds 2 s → the camera's exposure task fails (`last_error` set, `image_ready` stays false) → rp's `do_capture` spins forever → `center_on_target` never returns → the MCP call hangs → the BDD job runs to the 6 h cap.

No relevant code changed in the regression window (May 16–18 was all `star-adventurer-gti`/`pa-falcon-rotator`); this is a **latent bug** that a GitHub runner-image/load shift around May 18 started tripping. The focuser path right next door (`do_move_focuser_blocking`) already had a deadline + state check; `do_capture` didn't.

## Fix (at the source)

`do_capture` now:
- treats **`CameraState::Error` as terminal**, surfacing the camera's stored failure detail via `image_array` (e.g. `exposure failed: survey request timed out`); and
- bounds the readout wait with a **`duration + CAPTURE_READOUT_GRACE` (120 s)** deadline as a backstop for a camera wedged in `Exposing`.

Two regression tests added (`tests.rs`): a failed exposure now returns an error within ~0.1 s (not a hang), and a never-ready camera trips the deadline (verified with `start_paused`).

## Defense-in-depth (kept from the first pass, reframed)

So that no future hang — whatever its cause — can burn 6 h again:
- **`.github/workflows/{test,safety,scheduled}.yml`**: explicit per-job `timeout-minutes` (15–40, ~2× the observed healthy max). Previously the implicit 360 min default.
- **`crates/bdd-infra/.../mcp_client.rs`**: bound `call_tool`/`list_tools` with a 360 s `MCP_CALL_TIMEOUT` so a hung handler fails the scenario fast and legibly instead of hanging the BDD binary.

## Verification

- `cargo rail run --profile commit -q` → **1801 passed, 9 skipped** (was 1799; +2 new tests).
- New tests: `test_capture_failed_exposure_surfaces_error_not_hang`, `test_capture_times_out_when_camera_never_ready`.
- pre-commit hook: `cargo clippy --all --all-targets --all-features -- -D warnings` + `cargo fmt --all --check` → clean.
- All three workflow YAMLs validated; every job carries a job-level `timeout-minutes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)