### PR TITLE
ci(bazel): add BUILD.bazel for the 3 crates missing from Bazel (closes parity gaps)

### DIFF
--- a/crates/skywatcher-motor-protocol/BUILD.bazel
+++ b/crates/skywatcher-motor-protocol/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@cr//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+exports_files(["Cargo.toml"], visibility = ["//visibility:public"])
+
+rust_library(
+    name = "skywatcher-motor-protocol",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = aliases(),
+    crate_name = "skywatcher_motor_protocol",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "skywatcher-motor-protocol_unit_test",
+    size = "small",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate = ":skywatcher-motor-protocol",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+# tests/property_tests.rs — proptest-based wire-protocol round-trip checks.
+rust_test(
+    name = "property_tests",
+    srcs = ["tests/property_tests.rs"],
+    size = "small",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_root = "tests/property_tests.rs",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [":skywatcher-motor-protocol"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/scripts/check-bazel-cargo-parity.sh
+++ b/scripts/check-bazel-cargo-parity.sh
@@ -23,10 +23,11 @@ cd "$(git rev-parse --show-toplevel)"
 # moment its BUILD.bazel lands; the cutover (docs/plans/bazel-migration.md
 # Phase 7) should not flip until this list is empty. Inline "# reason"
 # comments are allowed and stripped before comparison.
+#
+# This list is now EMPTY: every Cargo workspace member has a Bazel target
+# (Gate B closed). Only re-add an entry if you intentionally land a Cargo crate
+# without a BUILD.bazel — with a reason.
 read -r -d '' EXPECTED_GAPS <<'GAPS' || true
-crates/skywatcher-motor-protocol  # plain library; BUILD.bazel pending (cutover prereq)
-services/dsd-fp2                   # CoverCalibrator service; BUILD.bazel pending
-services/star-adventurer-gti       # mount service; BUILD.bazel pending
 GAPS
 
 tmp=$(mktemp -d)

--- a/services/dsd-fp2/BUILD.bazel
+++ b/services/dsd-fp2/BUILD.bazel
@@ -1,0 +1,118 @@
+load("@cr//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+
+exports_files(["Cargo.toml"], visibility = ["//visibility:public"])
+
+_INTRA_WORKSPACE_DEPS = [
+    "//crates/rp-auth:rp-auth",
+    "//crates/rp-tls:rp-tls",
+    "//crates/rusty-photon-service-lifecycle:rusty-photon-service-lifecycle",
+    "//crates/rusty-photon-shared-transport:rusty-photon-shared-transport",
+]
+
+rust_library(
+    name = "dsd-fp2_lib",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
+    aliases = aliases(),
+    crate_name = "dsd_fp2",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_binary(
+    name = "dsd-fp2",
+    srcs = ["src/main.rs"],
+    aliases = aliases(),
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    # Pin CARGO_PKG_NAME to the Cargo package name (rules_rust defaults it to
+    # the Bazel target name); keeps anything that reads env!("CARGO_PKG_NAME")
+    # consistent with Cargo, and identical to the _mock binary below.
+    rustc_env = {"CARGO_PKG_NAME": "dsd-fp2"},
+    visibility = ["//visibility:public"],
+    deps = [":dsd-fp2_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "dsd-fp2_unit_test",
+    size = "small",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate = ":dsd-fp2_lib",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+# conformu_integration: cfg(feature = "conformu"); deferred (run under Cargo).
+
+# BDD cucumber tests spawn a mock-feature binary. Features are a compile-time
+# concept, so the mock binary needs its own lib+bin compiled with
+# crate_features = ["mock"].
+rust_library(
+    name = "dsd-fp2_lib_mock",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
+    aliases = aliases(),
+    crate_features = ["mock"],
+    crate_name = "dsd_fp2",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_binary(
+    name = "dsd-fp2_mock",
+    srcs = ["src/main.rs"],
+    aliases = aliases(),
+    crate_features = ["mock"],
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    rustc_env = {"CARGO_PKG_NAME": "dsd-fp2"},
+    deps = [":dsd-fp2_lib_mock"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "bdd",
+    srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
+    # BDD spawns a service process per scenario; give it a generous timeout.
+    size = "large",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_root = "tests/bdd.rs",
+    data = [
+        ":dsd-fp2_mock",
+        "Cargo.toml",
+    ] + glob(["tests/features/**"]),
+    edition = "2021",
+    env = {
+        "BDD_PACKAGE_DIR": "services/dsd-fp2",
+        "DSD_FP2_BINARY": "$(rootpath :dsd-fp2_mock)",
+    },
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
+    # be the service name (rules_rust would otherwise use the crate name "bdd").
+    rustc_env = {"CARGO_PKG_NAME": "dsd-fp2"},
+    tags = ["bdd"],
+    use_libtest_harness = False,
+    deps = [
+        ":dsd-fp2_lib",
+        "//crates/bdd-infra:bdd-infra",
+    ] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/services/star-adventurer-gti/BUILD.bazel
+++ b/services/star-adventurer-gti/BUILD.bazel
@@ -1,0 +1,138 @@
+load("@cr//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+
+exports_files(["Cargo.toml"], visibility = ["//visibility:public"])
+
+_INTRA_WORKSPACE_DEPS = [
+    "//crates/rp-auth:rp-auth",
+    "//crates/rp-tls:rp-tls",
+    "//crates/rusty-photon-service-lifecycle:rusty-photon-service-lifecycle",
+    "//crates/rusty-photon-shared-transport:rusty-photon-shared-transport",
+    "//crates/skywatcher-motor-protocol:skywatcher-motor-protocol",
+]
+
+rust_library(
+    name = "star-adventurer-gti_lib",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
+    aliases = aliases(),
+    crate_name = "star_adventurer_gti",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_binary(
+    name = "star-adventurer-gti",
+    srcs = ["src/main.rs"],
+    aliases = aliases(),
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    rustc_env = {"CARGO_PKG_NAME": "star-adventurer-gti"},
+    visibility = ["//visibility:public"],
+    deps = [":star-adventurer-gti_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "star-adventurer-gti_unit_test",
+    size = "small",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate = ":star-adventurer-gti_lib",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+# tests/test_lib.rs exercises the server end-to-end behind the `mock` feature
+# (it serializes server start/stop via a Mutex). Like the BDD targets, it needs
+# the mock-feature lib variant.
+rust_test(
+    name = "test_lib",
+    srcs = ["tests/test_lib.rs"],
+    size = "medium",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_features = ["mock"],
+    crate_root = "tests/test_lib.rs",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [":star-adventurer-gti_lib_mock"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+# conformu_integration: cfg(feature = "conformu"); deferred (run under Cargo).
+
+# BDD cucumber tests spawn a mock-feature binary — separate lib+bin compiled
+# with crate_features = ["mock"] (features are compile-time, not per-target).
+rust_library(
+    name = "star-adventurer-gti_lib_mock",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs"]),
+    aliases = aliases(),
+    crate_features = ["mock"],
+    crate_name = "star_adventurer_gti",
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_binary(
+    name = "star-adventurer-gti_mock",
+    srcs = ["src/main.rs"],
+    aliases = aliases(),
+    crate_features = ["mock"],
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    rustc_env = {"CARGO_PKG_NAME": "star-adventurer-gti"},
+    deps = [":star-adventurer-gti_lib_mock"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+rust_test(
+    name = "bdd",
+    srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
+    # 130+ scenarios, each spawning a service process; generous timeout.
+    size = "large",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_root = "tests/bdd.rs",
+    data = [
+        ":star-adventurer-gti_mock",
+        "Cargo.toml",
+    ] + glob(["tests/features/**"]),
+    edition = "2021",
+    env = {
+        "BDD_PACKAGE_DIR": "services/star-adventurer-gti",
+        "STAR_ADVENTURER_GTI_BINARY": "$(rootpath :star-adventurer-gti_mock)",
+    },
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME.
+    rustc_env = {"CARGO_PKG_NAME": "star-adventurer-gti"},
+    tags = ["bdd"],
+    use_libtest_harness = False,
+    deps = [
+        ":star-adventurer-gti_lib",
+        "//crates/bdd-infra:bdd-infra",
+    ] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)


### PR DESCRIPTION
## What

Adds `BUILD.bazel` for the **3 Cargo crates that had no Bazel target** — the parity gaps found by #311. With these, Bazel builds/tests the full workspace, closing **Gate B** of the Phase 7 cutover.

- **`crates/skywatcher-motor-protocol`** — `rust_library` + unit test + `property_tests`.
- **`services/dsd-fp2`** & **`services/star-adventurer-gti`** — full service shape (matching `ppba-driver`): `rust_library` + `rust_binary` + `mock`-feature lib/bin variants + unit test + `bdd` (cucumber, `tags=["bdd"]`, spawns the `_mock` binary via `{SERVICE}_BINARY`). `star-adventurer-gti` also gets its mock-gated `tests/test_lib.rs`. `conformu_integration` is deferred (run under Cargo), as in the other services.

Also **empties `EXPECTED_GAPS`** in `scripts/check-bazel-cargo-parity.sh`: these three were the last allowlisted gaps, so the `bazel/cargo target parity` check now passes clean — **25/25 Cargo workspace members covered, 0 gaps**, no warning. **Gate B is closed.**

## Merged `main` into the branch

Brings in #311 (parity check), #313, #316 (Bazel cloud cache), and #310. Because #311 now lives on this branch, the `EXPECTED_GAPS` cleanup lands here rather than as a separate follow-up. Conflict-free merge — the only files this PR touches are the three new `BUILD.bazel` files plus the parity script.

## Validated locally

- `scripts/check-bazel-cargo-parity.sh` → **25/25 members covered, 0 gaps**, exit 0 (also green in CI).
- `cargo rail run --profile commit` after the merge → **562 tests pass** on the three affected crates.
- `bazel build` of all three packages → **16 targets, build OK**.
- `bazel test` of the 5 non-BDD targets → **5/5 pass** (including `star-adventurer-gti`'s mock-gated `test_lib`).
- BDD targets compile; their runs are exercised by this PR's `bazel` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
