### PR TITLE
feat(star-adventurer-gti): typed physical quantities for pointing math (ADR-006)

### DIFF
--- a/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
+++ b/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
@@ -221,8 +221,8 @@ with the field name attached — strictly better than the hand-rolled
 `MountConfig::validate()` / `FlipPolicy::validate()`, which are retired:
 
 ```rust
-#[derive(Serialize, derive_more::Into)]      // Into generates From<_> for f64
-#[serde(try_from = "f64", into = "f64")]
+#[derive(Serialize, Deserialize)]            // From<_>/Into hand-rolled (no derive_more feature)
+#[serde(try_from = "f64", into = "f64")]     // JSON stays a bare number
 pub struct FlipRangeHours(f64);
 
 impl TryFrom<f64> for FlipRangeHours {
@@ -231,9 +231,21 @@ impl TryFrom<f64> for FlipRangeHours {
 }
 ```
 
-The CW zone — two fields with a cross-field `min ≥ max = disabled` rule —
-becomes one `CwExclusionZone` type (`Active { min, max } | Disabled`),
-so the "disabled" sentinel is modelled rather than conventional.
+The scalar fields (`FlipRangeHours`, `TrackingGuardMarginHours`) keep a
+bare-number JSON form. The CW zone becomes one `CwExclusionZone`
+(`Active(ActiveZone) | Disabled`), modelled as `Option<ActiveZone>` on
+the wire — an `{ min_hours, max_hours }` object, or `null` for disabled —
+so the "disabled" state is explicit rather than the old `min ≥ max`
+convention; `ActiveZone` validates `-12 ≤ min < max ≤ 12`. `DecLimits`
+is the analogous `{ min_degrees, max_degrees }` type. Defaults live on
+the types (`Default` impls), so the fields use bare `#[serde(default)]`.
+
+As-built notes: because there are no operators yet, the config JSON
+**schema changed** to this cleaner nested form rather than preserving the
+old flat `binding_zone_min/max_hours` / `dec_min/max_degrees` keys (no
+backwards-compatibility constraint). `derive_more` stays at `["debug"]`;
+the handful of `From` impls are hand-rolled rather than growing its
+feature set.
 
 ### No external units dependency
 

--- a/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
+++ b/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Proposed (2026-05-23).
+Accepted (2026-05-24). Implemented on the `feature/sag-typed-units` branch
+as a single PR (see [Migration plan](#migration-plan)).
 
 Origin: the review thread on the issue #259 tracking-guard work. Wiring
 `MountConfig::validate()` (which closed a pre-existing gap where
@@ -26,10 +27,13 @@ all of it runs on bare primitives:
   `binding_zone_min_hours`/`binding_zone_max_hours`,
   `tracking_guard_margin_hours`, `dec_min_degrees`/`dec_max_degrees`,
   `site_latitude_deg`/`site_longitude_deg` are all `f64`.
-- There are **no newtypes anywhere in the workspace** (a `grep` for
-  `struct X(f64|i32|u32)` across `crates/` and `services/` returns
-  nothing) and **no units crate** (`uom`/`dimensioned`). This ADR would
-  set the first such convention.
+- The workspace's **first frame-distinct newtypes** landed concurrently
+  in `pa-falcon-rotator/src/units.rs` (#304, 2026-05-24): `MechanicalDegrees`
+  vs `SkyDegrees`, bridged by a `SyncOffset`, hand-rolled over `f64` with
+  no external units crate. That establishes the convention; this ADR makes
+  `star-adventurer-gti` the **second adopter** and extends it to a richer
+  set of astronomical frames. There is still **no units crate**
+  (`uom`/`dimensioned`) in the workspace, and none is added here.
 
 ### The bug class this is meant to prevent
 
@@ -55,10 +59,13 @@ fold_to_signed((lst_hours - ra_hours).rem_euclid(24.0), 24.0)
 Both are `f64 - f64`. Swap `mech_ha` and `ra_hours`, or feed a celestial
 HA into a function expecting `mech_HA`, and it compiles and runs — and on
 this mount a frame error in the wrong place drives the counterweights
-toward the tripod. The flip math (`mech_ha + 12.0`) and the
-ticks↔hours↔degrees conversions (`* 24.0 / cpr`, `/ 15.0`) are the same
-story: unit- and frame-laden operations expressed as untyped float
-arithmetic.
+toward the tripod. The same hazard exists on the **Dec axis**: the
+encoder's mechanical declination (`[−180, +180)`, runs past the pole) and
+the celestial declination (`[−90, +90]`) are both bare degree `f64`s,
+related by a `sign·(180 − |d|)` through-the-pole reflection on the flipped
+side. The flip math (`mech_ha + 12.0`) and the ticks↔hours↔degrees
+conversions (`* 24.0 / cpr`, `/ 15.0`) are the same story: unit- and
+frame-laden operations expressed as untyped float arithmetic.
 
 This is exactly the failure mode this driver already takes seriously
 mechanically (issue #252's zone widening, #259's tracking guard); the
@@ -67,12 +74,13 @@ type system can make a whole category of it unrepresentable.
 ### Goals
 
 1. Make unit errors (hours vs degrees vs ticks) and frame errors
-   (mechanical vs celestial HA) **compile errors**.
+   (mechanical vs celestial HA, mechanical vs celestial Dec, RA-axis vs
+   Dec-axis ticks) **compile errors**.
 2. Move config validation from a runtime `validate()` call to
    **construct-time / deserialize-time** invariants (parse-don't-validate).
 3. Encode the domain conversions (fold-to-`[−12,12)`, `HA→mech` `+12`
-   fold, tick↔angle) as **named, type-checked operations** rather than
-   inline float math.
+   fold, through-the-pole Dec reflection, tick↔angle) as **named,
+   type-checked operations** rather than inline float math.
 
 ### Non-goals
 
@@ -82,7 +90,8 @@ type system can make a whole category of it unrepresentable.
 - Adopting a general dimensional-analysis framework (`uom`) — see
   Options.
 - Changing any observable behaviour. This is a representation change with
-  the existing tests as the oracle.
+  the existing tests (`coordinates::tests`, `mount_device::tests`, the BDD
+  suite, ConformU) as the oracle.
 
 ## Options Considered
 
@@ -101,15 +110,17 @@ Newtype just the config fields with validating constructors + serde
 alone**: it delivers parse-don't-validate for config (a real win, and it
 retires `validate()`), but the moment a value enters `coordinates.rs` it
 becomes an untyped `f64` again, so the frame bug class survives. Adopted
-here as **a phase of**, not an alternative to, the full change.
+here as **part of**, not an alternative to, the full change.
 
 ### Option 3 — Semantic domain types across the pointing math (CHOSEN)
 
 Introduce a small set of types that carry both unit and frame, threaded
 through `coordinates.rs`, `slew.rs`, `inherent.rs`, the tracking guard,
 and config. Distinct types for `MechHa` vs `HourAngle` (celestial) vs
-`Ra` vs `Lst` make the frame errors unrepresentable; `Degrees`,
-`Hours`, `Ticks`/`Cpr` carry units. See [Decision](#decision).
+`Ra` vs `Lst`, and `MechDec` vs `Dec`, make the frame errors
+unrepresentable; `Cpr`, `RaTicks`/`DecTicks` carry units and axis. See
+[Decision](#decision). `pa-falcon-rotator` shipped this exact shape for
+its (simpler) two-frame problem, which de-risks it.
 
 ### Option 4 — A dimensional-analysis crate (`uom`)
 
@@ -124,75 +135,95 @@ type dependency for marginal benefit.
 ### Option 5 — Phantom-typed `Angle<Unit, Frame>`
 
 One generic `Angle<U, F>` with `PhantomData` markers for unit and frame.
-**Elegant, deferred**: it minimises the number of concrete types but
-pushes complexity into the type signatures and the conversion impls, and
-it's harder to give each frame its own domain methods
-(`Lst::hour_angle_of(ra)`). Start with concrete newtypes (Option 3); a
-later consolidation to a phantom-typed core is possible without changing
-call sites if the concrete types are kept thin.
+**Rejected for readability.** It minimises the number of concrete types
+but pushes complexity into the type signatures (`Angle<Hours, Mechanical>`
+instead of `MechHa`, with the expanded form leaking into compiler
+diagnostics), splits the impls between "generic over `F`" and
+"one specific `(U,F)`" blocks, and makes per-frame domain methods
+(`Lst::hour_angle_of`) awkward. The payoff — writing the uniform
+operations (e.g. the fold) once — is small here because the frame set is
+tiny and closed and most operations are bespoke cross-frame conversions.
+Concrete newtypes (Option 3) read better, which is the priority, and
+match the rotator's choice.
 
 ## Decision
 
-Adopt **Option 3**: a `units` module of concrete newtypes, migrated in
-regression-safe phases, with no external units dependency.
+Adopt **Option 3**: a `units` module of concrete newtypes, no external
+units dependency, hand-rolled in the style `pa-falcon-rotator`
+established.
 
-### Type design (intent, not final API)
+### Type design (as built — `src/units.rs`)
 
-Unit-carrying base types:
+Each newtype holds an `f64`/`i32`/`u32` directly (no inner unit wrapper —
+the frame type *is* the unit) and is canonical by construction: every
+constructor funnels through a fold/normalise helper. Conversions are the
+**only** way to cross a frame boundary, and each is a named, total method.
 
-```rust
-/// Angle in hours (1 h = 15°). No frame meaning on its own.
-pub struct Hours(f64);
-/// Angle in degrees.
-pub struct Degrees(f64);
-/// Encoder counts and counts-per-revolution.
-pub struct Ticks(i32);
-pub struct Cpr(u32);
-```
-
-Frame-distinct hour-angle types — the part that kills the bug class:
+RA axis (hours):
 
 ```rust
-/// Mechanical hour angle: encoder view of the polar axis, folded to
-/// [-12, +12) h. The quantity the CW exclusion zone and tracking guard
-/// reason about.
-pub struct MechHa(Hours);
-/// Celestial hour angle of a target: LST - RA, folded to [-12, +12) h.
-pub struct HourAngle(Hours);
-pub struct Ra(Hours);
-pub struct Lst(Hours);
+pub struct Lst(f64);        // local sidereal time, [0, 24)
+pub struct Ra(f64);         // right ascension, [0, 24)
+pub struct HourAngle(f64);  // celestial HA = LST - RA, [-12, +12)
+pub struct MechHa(f64);     // mechanical (encoder) HA, [-12, +12)
+pub struct RaTicks(i32);    // RA-axis encoder counts
 ```
+
+Dec axis (degrees):
+
+```rust
+pub struct Dec(f64);        // celestial declination (not clamped; through-pole detectable)
+pub struct MechDec(f64);    // mechanical (encoder) dec, [-180, +180)
+pub struct DecTicks(i32);   // Dec-axis encoder counts
+```
+
+Shared: `pub struct Cpr(u32);` (per-axis counts-per-revolution; `Cpr(0)`
+models "parameters not yet populated" and the conversions degrade to a
+zero quantity rather than dividing by zero).
 
 The domain conversions become named, type-checked operations — the inline
 float math of today turned into methods that only accept the right frames:
 
 ```rust
-impl Lst    { pub fn hour_angle_of(self, ra: Ra) -> HourAngle; }   // LST - RA, folded
-impl HourAngle { pub fn to_mech(self, side: PierSide) -> MechHa; } // +12 fold on the flipped side
-impl Ticks  { pub fn to_mech_ha(self, cpr: Cpr) -> MechHa; }
-impl MechHa { pub fn to_ticks(self, cpr: Cpr) -> Ticks; }
-impl MechHa { pub fn in_zone(self, zone: CwExclusionZone) -> bool; }
+impl Lst       { pub fn hour_angle_of(self, ra: Ra) -> HourAngle; }  // LST - RA, folded
+impl HourAngle { pub fn to_mech(self) -> MechHa; }                   // pre-flip (value preserved)
+impl MechHa    { pub fn flipped(self) -> MechHa;                     // post-flip mirror (+12 fold)
+                 pub fn to_ticks(self, cpr: Cpr) -> RaTicks;
+                 pub fn to_ra(self, lst: Lst) -> Ra;                 // pre-flip
+                 pub fn to_ra_flipped(self, lst: Lst) -> Ra; }       // post-flip (+12)
+impl RaTicks   { pub fn to_mech_ha(self, cpr: Cpr) -> MechHa;
+                 pub fn fold_to_canonical_band(self, cpr: Cpr) -> RaTicks; }
+impl Dec       { pub fn to_mech(self) -> MechDec;                    // pre-flip
+                 pub fn to_mech_flipped(self) -> MechDec; }          // through the pole
+impl MechDec   { pub fn to_dec(self) -> Dec;                         // pre-flip
+                 pub fn to_dec_flipped(self) -> Dec;                 // through the pole (self-inverse)
+                 pub fn to_ticks(self, cpr: Cpr) -> DecTicks; }
+impl DecTicks  { pub fn to_mech_dec(self, cpr: Cpr) -> MechDec;
+                 pub fn fold_to_canonical_band(self, cpr: Cpr) -> DecTicks; }
 ```
 
-`fold_ha` / `fold_to_signed` / `rem_euclid(24.0)` collapse into a single
-`Hours::fold_ha()` (and the fold becomes idempotent-by-construction for
-the frame types). `derive_more` (already a dependency) supplies
-`Display`, `From`, and the arithmetic boilerplate where it's safe; the
-`feature` list grows from `["debug"]` to include `from`/`into`/`display`
-(and `add`/`sub` only where unrestricted arithmetic is actually correct
-— notably **not** across frames).
+**Hand-rolled, no `derive_more` arithmetic.** The operations are
+cross-frame (distinct `Output` types), require post-op normalisation, and
+— critically — same-frame arithmetic (`MechHa + MechHa`, two absolute
+angles summed) is *meaningless* and must stay a compile error. A blanket
+`#[derive(Add)]` would skip the fold and re-open exactly the bug class the
+newtypes exist to close, so hand-rolling the valid conversions is both
+safer and (because the only derivable thing, `Into` to replace `value()`,
+would bloat the consuming math) no more code. `derive_more` stays at the
+`["debug"]` feature; its `Into` derive earns its keep only on the config
+newtypes below.
 
 ### Config newtypes subsume `validate()`
 
 Config fields become validating newtypes; serde validates on
 deserialize, so an out-of-range value fails at `serde_json::from_str`
 with the field name attached — strictly better than the hand-rolled
-`MountConfig::validate()`, which is then retired:
+`MountConfig::validate()` / `FlipPolicy::validate()`, which are retired:
 
 ```rust
-#[derive(Serialize)]
+#[derive(Serialize, derive_more::Into)]      // Into generates From<_> for f64
 #[serde(try_from = "f64", into = "f64")]
-pub struct FlipRangeHours(Hours);
+pub struct FlipRangeHours(f64);
 
 impl TryFrom<f64> for FlipRangeHours {
     type Error = String;
@@ -206,83 +237,93 @@ so the "disabled" sentinel is modelled rather than conventional.
 
 ### No external units dependency
 
-Use `derive_more` only. Reject `uom` (Option 4).
+Use `derive_more` only (and only its `["debug"]` feature plus `Into` on
+the config newtypes). Reject `uom` (Option 4).
 
-## Migration plan (regression-safe, phased; one commit per stage in a single PR)
+## Migration plan
 
-`coordinates.rs` is hardware-validated (Phase 4/6, lat 32.7°N) and
-safety-critical. The migration is structured so the existing tests are
-the oracle at every step and the suite stays green throughout. The whole
-refactor lands as **one PR with one commit per stage** below — each
-commit keeps the suite green, so the PR can be reviewed (and bisected)
-stage by stage rather than split across multiple PRs.
+The whole change lands as **one PR**, committed at green checkpoints (the
+ADR's earlier draft proposed four reviewable phases with transitional
+`f64` shims that were then deleted; landing in one PR makes the
+shim-then-remove ceremony unnecessary — signatures flip straight to
+typed). `coordinates.rs` is hardware-validated (Phase 4/6, lat 32.7°N)
+and safety-critical, so the existing tests are the oracle at every
+checkpoint and the suite stays green throughout. Checkpoints:
 
-- **Phase 1 — `src/units.rs` + tests, no production change.** Land the
-  types with exhaustive unit tests and property tests (tick↔angle
-  round-trips, `fold_ha` idempotence, `HA→mech→HA` round-trips). Pure
-  addition; nothing calls them yet.
-- **Phase 2 — migrate `coordinates.rs` internals.** Convert function
-  bodies to the typed operations while keeping the existing public `f64`
-  signatures as thin wrappers (wrap on entry, unwrap on exit). The
-  current `coordinates::tests` pin behaviour and must stay green
-  unchanged — they are the regression net.
-- **Phase 3 — propagate types outward + config.** Flip the public
-  signatures to typed; migrate `slew.rs`, `tracking_guard.rs`,
-  `inherent.rs`, and the `MountConfig` fields (the Scope A newtypes);
-  retire `MountConfig::validate()` in favour of construct-time
-  validation. The ASCOM boundary (`ascom-alpaca`'s `f64` RA/Dec API) and
-  the wire codec stay `f64`; the device layer wraps/unwraps there, and
-  that boundary is documented.
-- **Phase 4 — remove transitional shims.** Delete the f64 wrappers; the
-  pointing API is fully typed.
+1. **`src/units.rs` + tests** — the types with exhaustive unit + property
+   tests (tick↔angle round-trips, `fold` idempotence, `HA→mech→HA` and
+   through-pole round-trips). Pure addition; nothing calls them yet.
+   *(landed: commit `b00364a`.)*
+2. **`coordinates.rs` migrated** — public signatures flipped to typed; the
+   `coordinates::tests` call sites updated to construct/extract types with
+   their assertions (expected values) unchanged, so they remain the
+   regression net.
+3. **Consumers migrated** — `slew.rs`, `tracking_guard.rs`, `inherent.rs`,
+   `telescope.rs`, `watchers.rs`, `device.rs`, and `mount_device::tests`
+   construct types at the `f64` boundaries and unwrap results back to
+   `f64` where they meet the ASCOM trait API (`ascom-alpaca`'s `f64`
+   RA/Dec), the Sky-Watcher wire codec, and serde — the three boundaries
+   that stay `f64` by necessity, each documented.
+4. **Config Scope A** — the validating newtypes; `MountConfig::validate()`
+   / `FlipPolicy::validate()` retired in favour of construct-time
+   validation; the `validate()` test sites migrated to deserialize/
+   construct assertions.
 
-BDD scenarios and ConformU are unchanged and serve as end-to-end
-regression checks across all phases.
+(2)–(4) may be grouped into fewer commits where flipping a signature
+forces its callers to change atomically. BDD scenarios and ConformU are
+unchanged and serve as end-to-end regression checks across all checkpoints.
 
 ## Consequences
 
-- **Eliminates the frame bug class** in pointing math and makes config
-  invalid-states unrepresentable — the two things this initiative exists
-  for.
-- **Workspace precedent.** First newtypes in the repo. The `units`
-  module is written to be reusable, but adoption is scoped to
-  `star-adventurer-gti` here; other services are untouched. A future ADR
-  can promote it workspace-wide if it earns its keep.
-- **Friction at boundaries.** Every f64 site gains a wrap/unwrap or a
+- **Eliminates the frame bug class** in pointing math (RA *and* Dec axes)
+  and makes config invalid-states unrepresentable — the two things this
+  initiative exists for.
+- **Second adopter, shared convention.** `pa-falcon-rotator` established
+  the hand-rolled-newtype convention; this service adopts and extends it.
+  The convention (newtype-per-quantity, parse-don't-validate config) is
+  recorded in `docs/skills/development-workflow.md`. The `units` types
+  themselves stay service-local; a future ADR can promote a shared
+  `rusty-photon-units` crate if a third pointing device earns it.
+- **Friction at boundaries.** Every `f64` site gains a wrap/unwrap or a
   method call, and three boundaries stay `f64` by necessity — serde
   input, the Sky-Watcher wire codec, and the `ascom-alpaca` trait API
   (RA in hours, Dec in degrees). These are localised and documented;
   the interior is typed.
 - **Migration risk is the main cost** — it rewrites validated pointing
-  code. Mitigated by the phased plan, the existing test oracle, and
-  keeping each stage a self-contained, green commit that is
-  independently reviewable within the one PR.
-- **No new external dependency.** `derive_more` feature flags grow; no
-  `uom`.
-- **`#259` is unaffected.** The shipped tracking guard and
-  `MountConfig::validate()` continue to work; Phase 3 later swaps
-  `validate()` for typed construction without changing behaviour.
+  code. Mitigated by the existing test oracle and keeping each checkpoint
+  a green commit.
+- **No new external dependency.** `derive_more` stays at `["debug"]` (plus
+  its `Into` derive on config newtypes); no `uom`.
+- **`#259` is unaffected.** The shipped tracking guard kept working; its
+  `validate()` was swapped for typed construction without behaviour
+  change.
 
-## Open questions
+## Resolved questions
 
-1. **Frame granularity.** Start with concrete `MechHa`/`HourAngle`/
-   `Ra`/`Lst` (this ADR) vs a phantom-typed `Angle<Unit, Frame>`
-   (Option 5). Proposal: concrete first, revisit consolidation after
-   Phase 3 shows the real conversion surface.
-2. **Land Scope A first?** The config newtypes are low-risk and
-   immediately retire `validate()`. Option to ship them as Phase 1.5
-   (before the `coordinates.rs` migration) for an early win. Recommended.
-3. **Workspace-wide adoption.** Out of scope here; revisit once the
-   `units` module has proven itself in this service.
+1. **Frame granularity** — concrete `MechHa`/`HourAngle`/`Ra`/`Lst`,
+   `MechDec`/`Dec`, `RaTicks`/`DecTicks` (this ADR), **not** a
+   phantom-typed `Angle<Unit, Frame>` (Option 5). Decided on readability;
+   the rotator's concrete choice is the precedent. The RA/Dec axes are
+   treated symmetrically, and RA-axis vs Dec-axis ticks are distinct types.
+2. **Scope A** — the config newtypes land in the same single PR (not a
+   separate earlier phase), and fully retire `validate()`.
+3. **Workspace-wide adoption** — out of scope here; the *convention* is
+   documented now, the *types* stay service-local, and the rotator +
+   this service are the two precedents a future promotion would build on.
 
 ## References
 
 - Issue #259 review thread — the validation work that surfaced this.
+- `services/pa-falcon-rotator/src/units.rs` — the workspace's first
+  frame-distinct newtypes (#304); the style this ADR matches.
+- `services/star-adventurer-gti/src/units.rs` — the types this ADR adds.
 - `services/star-adventurer-gti/src/coordinates.rs` — the math being
   typed (the `lst - mech_ha` vs `lst - ra` frame hazard).
 - `services/star-adventurer-gti/src/config.rs` — `MountConfig::validate`
   / `FlipPolicy::validate` (the runtime checks construct-time validation
-  would subsume).
+  subsumes).
+- `docs/skills/development-workflow.md` — the newtype / parse-don't-validate
+  convention.
 - `docs/services/star-adventurer-gti.md` §"Safety envelope" /
   §"Tracking-time safety guard" — why frame correctness is a hardware
   concern on this mount.

--- a/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
+++ b/docs/decisions/006-typed-physical-quantities-for-mount-pointing.md
@@ -210,8 +210,9 @@ angles summed) is *meaningless* and must stay a compile error. A blanket
 newtypes exist to close, so hand-rolling the valid conversions is both
 safer and (because the only derivable thing, `Into` to replace `value()`,
 would bloat the consuming math) no more code. `derive_more` stays at the
-`["debug"]` feature; its `Into` derive earns its keep only on the config
-newtypes below.
+`["debug"]` feature throughout — the config newtypes below validate via
+serde's `into`/`try_from` with hand-rolled `From` impls, not a
+`derive_more` derive.
 
 ### Config newtypes subsume `validate()`
 

--- a/docs/services/star-adventurer-gti.md
+++ b/docs/services/star-adventurer-gti.md
@@ -801,10 +801,10 @@ the negative-mech_HA half puts the CW into the floor beneath the
 pier rather than above the mount head, so no mirror zone applies.
 
 The driver enforces this as a single interval on the **chosen-side
-encoder mech_HA**, in `MountConfig::binding_zone_min_hours` and
-`binding_zone_max_hours` (defaults `0.95` and `11.05` — the wide
-zone derived from the 0.95 h rule and hardware-verified at lat
-32.7°N):
+encoder mech_HA**, in `MountConfig::cw_exclusion_zone` — an active
+`{ min_hours, max_hours }` interval (defaults `0.95` and `11.05` — the
+wide zone derived from the 0.95 h rule and hardware-verified at lat
+32.7°N), or `null` to disable:
 
 - A slew or sync's *target* mech_HA inside the interval is rejected
   with `INVALID_VALUE` before any motion (the destination check).
@@ -820,10 +820,10 @@ zone derived from the 0.95 h rule and hardware-verified at lat
   signed into `[−12, +12)`).
 - For flipped-side targets, `target_mech_HA = celestial_HA + 12 h`
   (folded).
-- Setting `binding_zone_min ≥ binding_zone_max` (an empty interval)
-  disables both the destination and path checks — used by BDD
-  scenarios that pass hardcoded celestial coords whose computed
-  mech_HA depends on wallclock LST.
+- Setting `cw_exclusion_zone` to `null` (disabled) turns off both the
+  destination and path checks — used by BDD scenarios that pass
+  hardcoded celestial coords whose computed mech_HA depends on
+  wallclock LST.
 
 Historical note: a narrower `(+6.95, +11.05)` zone was used before
 2026-05-17. That captured only the *outer* portion of the exclusion
@@ -840,10 +840,10 @@ pattern. The operator's `park_ra_ticks` / `park_dec_ticks` are
 assumed to have been validated against the zone at the time of
 configuration.
 
-The Dec envelope (`dec_min_degrees` / `dec_max_degrees`, defaults
-`[−90, +90]°`) is independent — it bounds the celestial Dec the
-driver will accept, primarily a sanity check against client-side
-coordinate-math bugs.
+The Dec envelope (`dec_limits`, default
+`{ min_degrees: -90, max_degrees: 90 }`) is independent — it bounds the
+celestial Dec the driver will accept, primarily a sanity check against
+client-side coordinate-math bugs.
 
 #### Tracking-time safety guard
 
@@ -860,8 +860,8 @@ A per-connection background guard closes that gap. While `Tracking =
 true` it watches the live encoder `mech_HA` — read from the snapshot
 the background poll loop already refreshes, at `polling_interval`, so
 the guard adds no extra wire traffic. When `mech_HA` enters the band
-`(binding_zone_min_hours − margin, binding_zone_max_hours + margin)` —
-the CW exclusion zone widened by `tracking_guard_margin_hours` on each
+`(min_hours − margin, max_hours + margin)` — the active
+`cw_exclusion_zone` widened by `tracking_guard_margin_hours` on each
 edge — the guard:
 
 1. issues `:K1` to stop the RA axis,
@@ -876,14 +876,14 @@ elsewhere, or park.
 
 `tracking_guard_margin_hours` (default `0.05` h ≈ 45 s of sidereal
 drift) lets cautious operators stop *before* the zone entry rather than
-at it; `0.0` stops exactly at `binding_zone_min_hours`. A non-finite,
-negative, or over-cap (> 1.0 h) margin is rejected at config load
-(`load_config` → `MountConfig::validate`); the guard additionally treats
-a non-finite or negative value as `0.0` as defense-in-depth. The guard is
-**independent of `flip_policy.enabled`**: it is the safety floor that keeps an
-unattended autoguided session from contacting hardware whether or not
-meridian-flip support is configured. It is disabled only when the zone
-itself is (`binding_zone_min_hours ≥ binding_zone_max_hours`). Because
+at it; `0.0` stops exactly at the zone's `min_hours`. A non-finite,
+negative, or over-cap (> 1.0 h) margin is rejected at config load by the
+`TrackingGuardMarginHours` newtype's deserialize; the guard additionally
+treats a non-finite or negative value as `0.0` as defense-in-depth. The
+guard is **independent of `flip_policy.enabled`**: it is the safety floor
+that keeps an unattended autoguided session from contacting hardware
+whether or not meridian-flip support is configured. It is disabled only
+when `cw_exclusion_zone` is `null` (`Disabled`). Because
 `slew_to_coordinates_async` clears `Tracking` for a slew's duration, the
 guard is naturally dormant during slews and resumes once the
 completion watcher re-engages tracking on the new pose.
@@ -1074,12 +1074,15 @@ function.
 JSON, deserialised with `serde` + `humantime-serde` for `Duration`
 fields. The transport block is a tagged enum: `usb` or `udp`.
 
-The mount block is validated at startup (`load_config` →
-`MountConfig::validate`): an out-of-range `flip_policy.flip_range_hours`,
-a non-finite binding zone or tracking-guard margin, a margin above
-`MAX_TRACKING_GUARD_MARGIN_HOURS` (1.0 h), or an inverted /
-out-of-hemisphere Dec range is rejected with a clear error rather than
-silently driving the mount with a bad parameter.
+The mount block is **validated at deserialize** (parse-don't-validate):
+the range-carrying fields are newtypes whose `serde` `try_from` rejects an
+out-of-range value during `load_config`, with the offending field named,
+so a bad config fails at startup rather than mid-session. `flip_range_hours`
+must be `(0, 0.95]`; `tracking_guard_margin_hours` `[0, 1.0]`; an active
+`cw_exclusion_zone` must satisfy `-12 ≤ min_hours < max_hours ≤ 12`;
+`dec_limits` must satisfy `-90 ≤ min_degrees < max_degrees ≤ 90`. (This
+replaced the former runtime `MountConfig::validate` / `FlipPolicy::validate`
+— see [ADR-006](../decisions/006-typed-physical-quantities-for-mount-pointing.md).)
 
 ```json
 {
@@ -1106,6 +1109,9 @@ silently driving the mount with a bad parameter.
     "site_elevation_m": 0.0,
     "settle_after_slew": "2s",
     "tracking_rate": "sidereal",
+    "cw_exclusion_zone": { "min_hours": 0.95, "max_hours": 11.05 },
+    "tracking_guard_margin_hours": 0.05,
+    "dec_limits": { "min_degrees": -90.0, "max_degrees": 90.0 },
     "park_ra_ticks": null,
     "park_dec_ticks": null,
     "flip_policy": {
@@ -1147,29 +1153,32 @@ Notes:
   WGS84 degrees, `+E`. (ASCOM convention.)
 - `tracking_rate` accepts `"sidereal"` only in MVP. Field is reserved
   for future expansion.
-- `binding_zone_min_hours` / `binding_zone_max_hours` define the
-  CW exclusion interval in encoder `mech_HA` (signed
-  hours folded `[−12, +12)`). Slews / syncs whose chosen-side
-  `mech_HA` falls inside the interval are rejected with
-  `INVALID_VALUE`; flip slews and non-flip slews additionally check
-  that their swept path doesn't cross the zone (`INVALID_OPERATION`
-  if so — see [§Safety envelope](#safety-envelope-cw-exclusion-zone)).
-  Defaults `(0.95, 11.05)` for the GTi — the one-sided arc where
-  the CW shaft rises more than 0.95 h above horizontal, peaking at
-  `mech_HA = +6 h`. The negative-mech_HA side is *not* a CW exclusion zone
-  (CW points into the ground beneath the pier, not above the mount
-  head). Setting `min ≥ max` disables the check (used by tests and
-  by operators whose mount geometry differs).
+- `cw_exclusion_zone` defines the CW exclusion interval in encoder
+  `mech_HA` (signed hours folded `[−12, +12)`) as either an active
+  `{ "min_hours": .., "max_hours": .. }` object or `null` (disabled).
+  Slews / syncs whose chosen-side `mech_HA` falls inside the interval
+  are rejected with `INVALID_VALUE`; flip slews and non-flip slews
+  additionally check that their swept path doesn't cross the zone
+  (`INVALID_OPERATION` if so — see
+  [§Safety envelope](#safety-envelope-cw-exclusion-zone)).
+  Default `{ "min_hours": 0.95, "max_hours": 11.05 }` for the GTi — the
+  one-sided arc where the CW shaft rises more than 0.95 h above
+  horizontal, peaking at `mech_HA = +6 h`. The negative-mech_HA side is
+  *not* a CW exclusion zone (CW points into the ground beneath the pier,
+  not above the mount head). An active zone must satisfy
+  `-12 ≤ min_hours < max_hours ≤ 12`; use `null` to disable (tests, or
+  mounts whose geometry differs).
 - `tracking_guard_margin_hours` extends CW exclusion-zone enforcement
   to *tracking* time: a background guard stops the mount (`:K1`) once
-  the live encoder `mech_HA` drifts into
-  `(binding_zone_min_hours − margin, binding_zone_max_hours + margin)`
-  while `Tracking = true`. Defaults `0.05` h (≈ 45 s of sidereal
-  drift); `0.0` stops exactly at the zone entry. Independent of
-  `flip_policy.enabled`. See
+  the live encoder `mech_HA` drifts into the active zone widened by
+  `margin` on each edge, while `Tracking = true`. Defaults `0.05` h
+  (≈ 45 s of sidereal drift); `0.0` stops exactly at the zone entry;
+  valid range `[0, 1.0]`. Independent of `flip_policy.enabled`. See
   [§Tracking-time safety guard](#tracking-time-safety-guard).
-- `dec_min_degrees` / `dec_max_degrees` clip the celestial-Dec
-  range the driver will accept on slew / sync. Defaults `[−90, +90]°`.
+- `dec_limits` (`{ "min_degrees": .., "max_degrees": .. }`) clips the
+  celestial-Dec range the driver accepts on slew / sync. Default
+  `{ "min_degrees": -90.0, "max_degrees": 90.0 }`; must satisfy
+  `-90 ≤ min_degrees < max_degrees ≤ 90`.
 - `park_ra_ticks` / `park_dec_ticks` are written by `SetPark` and read
   on every connect; absent (or `null`) at first run, populated once
   `SetPark` is called. Operators may set them by hand to pin a known
@@ -1894,10 +1903,11 @@ In addition to the codec fixes:
   counterweight-up region with ConformU's pier-flip tests stalled
   the motor against a hard stop while the encoder counter kept
   advancing (audible motor noise, OTA stationary). `MountConfig`
-  now carries `binding_zone_min_hours` /
-  `binding_zone_max_hours` (the asymmetric mech_HA interval where
-  the CW binds against the pier) plus `dec_min_degrees` /
-  `dec_max_degrees`. `SyncToCoordinates` and
+  carries the asymmetric mech_HA interval where the CW binds against
+  the pier (`cw_exclusion_zone`) plus the Dec envelope (`dec_limits`) —
+  both later wrapped as validated newtypes per
+  [ADR-006](../decisions/006-typed-physical-quantities-for-mount-pointing.md).
+  `SyncToCoordinates` and
   `SlewToCoordinatesAsync` reject targets whose chosen-side
   `mech_HA` falls inside the CW exclusion zone with `INVALID_VALUE`
   before any wire motion; `Park` writes the target encoder ticks

--- a/docs/skills/development-workflow.md
+++ b/docs/skills/development-workflow.md
@@ -209,6 +209,45 @@ area at a time.
 
 ---
 
+## Conventions
+
+### Typed physical quantities (newtypes over bare `f64`/`i32`)
+
+When a service does unit- or frame-laden arithmetic (angles, encoder
+ticks, sync offsets), wrap the quantity in a newtype that carries its
+unit and reference frame rather than threading a bare `f64`/`i32`.
+Distinct types make unit and frame mix-ups **compile errors** instead of
+silent runtime faults, and conversions between frames become named,
+type-checked methods rather than inline float math.
+
+Precedents:
+
+- `services/pa-falcon-rotator/src/units.rs` — `MechanicalDegrees` vs
+  `SkyDegrees`, bridged by a `SyncOffset`.
+- `services/star-adventurer-gti/src/units.rs` — `MechHa` vs `HourAngle`/
+  `Ra`/`Lst`, `MechDec` vs `Dec`, and `RaTicks`/`DecTicks`/`Cpr`.
+
+Style: hand-roll the constructors (which normalise/fold) and only the
+operations that are *valid*. Do **not** derive blanket same-type
+arithmetic (`derive_more`'s `Add`/`Sub`) — it skips normalisation and
+re-admits meaningless operations (e.g. summing two absolute angles).
+Keep the types service-local until a second device needs them; no
+external units crate (`uom`). See
+[ADR-006](../decisions/006-typed-physical-quantities-for-mount-pointing.md).
+
+### Parse-don't-validate for config
+
+Config invariants belong in the field *types*, checked at deserialize —
+not in a runtime `validate()` pass. A field with a range or a cross-field
+rule becomes a newtype (or a small grouped type) with a `serde`
+`try_from` that rejects a bad value during `serde_json::from_str`, with
+the offending field named, so a bad config fails at **load** (startup)
+rather than mid-session. `star-adventurer-gti`'s `config.rs`
+(`FlipRangeHours`, `CwExclusionZone`, `DecLimits`, …) is the reference; it
+retired a hand-rolled `MountConfig::validate`.
+
+---
+
 ## Example: rp Service Timeline
 
 The rp service followed this workflow. The full commit history

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -115,8 +115,8 @@ pub struct MountConfig {
 
     /// CW exclusion zone in encoder `mech_HA` (signed
     /// hours, folded to `[−12, +12)`). Slews / syncs whose chosen
-    /// pier side's `mech_HA` falls inside
-    /// `(binding_zone_min_hours, binding_zone_max_hours)` are
+    /// pier side's `mech_HA` falls inside the active zone's open
+    /// interval `(min_hours, max_hours)` are
     /// rejected with `INVALID_VALUE` and never reach the wire. Flip
     /// slews additionally check that the *path swept* by the polar
     /// axis stays clear of the zone — see [`flip_slew_ra_delta`].
@@ -139,9 +139,10 @@ pub struct MountConfig {
     /// which the OTA contacted the tripod during the 2026-05-17
     /// session.
     ///
-    /// Set `binding_zone_min_hours = binding_zone_max_hours` (or any
-    /// non-overlapping pair) to disable the check entirely; only do
-    /// this for tests or for mounts whose CW exclusion arc is known to
+    /// JSON form is the active object `{ "min_hours": .., "max_hours": .. }`
+    /// (validated at deserialize time), or `null` to disable the check
+    /// entirely (deserialises to [`CwExclusionZone::Disabled`]); only
+    /// disable for tests or for mounts whose CW exclusion arc is known to
     /// be elsewhere. See the design doc's
     /// [§Per-pier safety envelopes](../../../docs/services/star-adventurer-gti.md#per-pier-safety-envelopes).
     #[serde(default)]
@@ -152,21 +153,22 @@ pub struct MountConfig {
     /// [§"Tracking-time safety guard"](../../../docs/services/star-adventurer-gti.md#tracking-time-safety-guard)).
     ///
     /// While `Tracking = true`, a background watcher stops the mount
-    /// (`:K1`) once the live encoder `mech_HA` enters
-    /// `(binding_zone_min_hours − margin, binding_zone_max_hours + margin)`,
+    /// (`:K1`) once the live encoder `mech_HA` enters the active zone
+    /// widened by the margin — `(min_hours − margin, max_hours + margin)` —
     /// before tracking drift can carry the counterweights into the
     /// zone. The margin lets cautious operators stop early; `0.0`
     /// stops exactly at zone entry. Defaults to `0.05` h (≈ 45 s of
     /// sidereal drift).
     ///
     /// Independent of [`FlipPolicy::enabled`]: the guard is the safety
-    /// floor and runs whenever the zone is active
-    /// (`binding_zone_min_hours < binding_zone_max_hours`), regardless
-    /// of meridian-flip support. Validated on load: a non-finite,
-    /// negative, or over-cap value (> [`MAX_TRACKING_GUARD_MARGIN_HOURS`])
-    /// fails config loading. The guard additionally treats a non-finite or
-    /// negative value as `0.0` as defense-in-depth for construction paths
-    /// that bypass validation.
+    /// floor and runs whenever `cw_exclusion_zone` is
+    /// [`Active`](CwExclusionZone::Active), regardless of meridian-flip
+    /// support. Validated at deserialize time by
+    /// [`TrackingGuardMarginHours`]: a non-finite, negative, or over-cap
+    /// value (> [`MAX_TRACKING_GUARD_MARGIN_HOURS`]) fails config loading.
+    /// The guard additionally treats a non-finite or negative value as
+    /// `0.0` as defense-in-depth for construction paths that bypass
+    /// validation.
     #[serde(default)]
     pub tracking_guard_margin_hours: TrackingGuardMarginHours,
 
@@ -299,10 +301,25 @@ pub const MAX_TRACKING_GUARD_MARGIN_HOURS: f64 = 1.0;
 pub struct FlipRangeHours(f64);
 
 impl FlipRangeHours {
-    /// Construct without validation — for defaults and trusted internal
-    /// callers. The validating boundary is serde deserialize (`try_from`).
-    pub const fn new(hours: f64) -> Self {
+    /// Unchecked `const` constructor, `pub(crate)` so the public API
+    /// cannot bypass validation — it exists only for `Default` and
+    /// in-crate callers with compile-time-known-good values (and tests
+    /// that deliberately build out-of-range values). External and
+    /// runtime-valued callers use [`try_new`](Self::try_new) or serde.
+    pub(crate) const fn new(hours: f64) -> Self {
         Self(hours)
+    }
+    /// Validating constructor: the single source of truth for the
+    /// invariant, which serde's `try_from` and any programmatic caller
+    /// funnel through. `Err` (with the field named) unless `hours` is in
+    /// `(0, MAX_FLIP_RANGE_HOURS]`.
+    pub fn try_new(hours: f64) -> std::result::Result<Self, String> {
+        if !hours.is_finite() || hours <= 0.0 || hours > MAX_FLIP_RANGE_HOURS {
+            return Err(format!(
+                "flip_policy.flip_range_hours must be in (0, {MAX_FLIP_RANGE_HOURS}] hours, got {hours}"
+            ));
+        }
+        Ok(Self(hours))
     }
     /// The underlying value in hours.
     pub fn value(self) -> f64 {
@@ -313,12 +330,7 @@ impl FlipRangeHours {
 impl TryFrom<f64> for FlipRangeHours {
     type Error = String;
     fn try_from(v: f64) -> std::result::Result<Self, String> {
-        if !v.is_finite() || v <= 0.0 || v > MAX_FLIP_RANGE_HOURS {
-            return Err(format!(
-                "flip_policy.flip_range_hours must be in (0, {MAX_FLIP_RANGE_HOURS}] hours, got {v}"
-            ));
-        }
-        Ok(Self(v))
+        Self::try_new(v)
     }
 }
 
@@ -335,9 +347,19 @@ impl From<FlipRangeHours> for f64 {
 pub struct TrackingGuardMarginHours(f64);
 
 impl TrackingGuardMarginHours {
-    /// Construct without validation — see [`FlipRangeHours::new`].
-    pub const fn new(hours: f64) -> Self {
+    /// Unchecked `const` constructor — see [`FlipRangeHours::new`].
+    pub(crate) const fn new(hours: f64) -> Self {
         Self(hours)
+    }
+    /// Validating constructor — see [`FlipRangeHours::try_new`]. `Err`
+    /// unless `hours` is in `[0, MAX_TRACKING_GUARD_MARGIN_HOURS]`.
+    pub fn try_new(hours: f64) -> std::result::Result<Self, String> {
+        if !hours.is_finite() || !(0.0..=MAX_TRACKING_GUARD_MARGIN_HOURS).contains(&hours) {
+            return Err(format!(
+                "tracking_guard_margin_hours must be in [0, {MAX_TRACKING_GUARD_MARGIN_HOURS}] hours, got {hours}"
+            ));
+        }
+        Ok(Self(hours))
     }
     /// The underlying value in hours.
     pub fn value(self) -> f64 {
@@ -348,12 +370,7 @@ impl TrackingGuardMarginHours {
 impl TryFrom<f64> for TrackingGuardMarginHours {
     type Error = String;
     fn try_from(v: f64) -> std::result::Result<Self, String> {
-        if !v.is_finite() || !(0.0..=MAX_TRACKING_GUARD_MARGIN_HOURS).contains(&v) {
-            return Err(format!(
-                "tracking_guard_margin_hours must be in [0, {MAX_TRACKING_GUARD_MARGIN_HOURS}] hours, got {v}"
-            ));
-        }
-        Ok(Self(v))
+        Self::try_new(v)
     }
 }
 
@@ -380,12 +397,39 @@ struct ActiveZoneWire {
 }
 
 impl ActiveZone {
-    /// Construct without validation — see [`FlipRangeHours::new`].
-    pub const fn new(min_hours: f64, max_hours: f64) -> Self {
+    /// Unchecked `const` constructor — see [`FlipRangeHours::new`].
+    pub(crate) const fn new(min_hours: f64, max_hours: f64) -> Self {
         Self {
             min_hours,
             max_hours,
         }
+    }
+    /// Validating constructor — see [`FlipRangeHours::try_new`]. `Err`
+    /// unless `-12 <= min_hours < max_hours <= 12` (folded mech_HA);
+    /// `null`/[`CwExclusionZone::Disabled`] is how a zone is turned off,
+    /// so an inverted interval is rejected rather than silently disabling.
+    pub fn try_new(min_hours: f64, max_hours: f64) -> std::result::Result<Self, String> {
+        if !min_hours.is_finite() || !max_hours.is_finite() {
+            return Err(format!(
+                "cw_exclusion_zone bounds must be finite, got ({min_hours}, {max_hours})"
+            ));
+        }
+        if min_hours >= max_hours {
+            return Err(format!(
+                "active cw_exclusion_zone needs min_hours < max_hours \
+                 (use null to disable), got ({min_hours}, {max_hours})"
+            ));
+        }
+        if min_hours < -12.0 || max_hours > 12.0 {
+            return Err(format!(
+                "active cw_exclusion_zone must satisfy -12 <= min_hours < max_hours <= 12 \
+                 (folded mech_HA), got ({min_hours}, {max_hours})"
+            ));
+        }
+        Ok(Self {
+            min_hours,
+            max_hours,
+        })
     }
     pub fn min_hours(self) -> f64 {
         self.min_hours
@@ -398,30 +442,7 @@ impl ActiveZone {
 impl TryFrom<ActiveZoneWire> for ActiveZone {
     type Error = String;
     fn try_from(w: ActiveZoneWire) -> std::result::Result<Self, String> {
-        if !w.min_hours.is_finite() || !w.max_hours.is_finite() {
-            return Err(format!(
-                "cw_exclusion_zone bounds must be finite, got ({}, {})",
-                w.min_hours, w.max_hours
-            ));
-        }
-        if w.min_hours >= w.max_hours {
-            return Err(format!(
-                "active cw_exclusion_zone needs min_hours < max_hours \
-                 (use null to disable), got ({}, {})",
-                w.min_hours, w.max_hours
-            ));
-        }
-        if w.min_hours < -12.0 || w.max_hours > 12.0 {
-            return Err(format!(
-                "active cw_exclusion_zone must satisfy -12 <= min_hours < max_hours <= 12 \
-                 (folded mech_HA), got ({}, {})",
-                w.min_hours, w.max_hours
-            ));
-        }
-        Ok(Self {
-            min_hours: w.min_hours,
-            max_hours: w.max_hours,
-        })
+        Self::try_new(w.min_hours, w.max_hours)
     }
 }
 
@@ -490,12 +511,30 @@ struct DecLimitsWire {
 }
 
 impl DecLimits {
-    /// Construct without validation — see [`FlipRangeHours::new`].
-    pub const fn new(min_degrees: f64, max_degrees: f64) -> Self {
+    /// Unchecked `const` constructor — see [`FlipRangeHours::new`].
+    pub(crate) const fn new(min_degrees: f64, max_degrees: f64) -> Self {
         Self {
             min_degrees,
             max_degrees,
         }
+    }
+    /// Validating constructor — see [`FlipRangeHours::try_new`]. `Err`
+    /// unless `-90 <= min_degrees < max_degrees <= 90`.
+    pub fn try_new(min_degrees: f64, max_degrees: f64) -> std::result::Result<Self, String> {
+        if !min_degrees.is_finite() || !max_degrees.is_finite() {
+            return Err(format!(
+                "dec_limits must be finite, got ({min_degrees}, {max_degrees})"
+            ));
+        }
+        if min_degrees < -90.0 || max_degrees > 90.0 || min_degrees >= max_degrees {
+            return Err(format!(
+                "dec_limits must satisfy -90 <= min_degrees < max_degrees <= 90, got ({min_degrees}, {max_degrees})"
+            ));
+        }
+        Ok(Self {
+            min_degrees,
+            max_degrees,
+        })
     }
     pub fn min_degrees(self) -> f64 {
         self.min_degrees
@@ -512,22 +551,7 @@ impl DecLimits {
 impl TryFrom<DecLimitsWire> for DecLimits {
     type Error = String;
     fn try_from(w: DecLimitsWire) -> std::result::Result<Self, String> {
-        if !w.min_degrees.is_finite() || !w.max_degrees.is_finite() {
-            return Err(format!(
-                "dec_limits must be finite, got ({}, {})",
-                w.min_degrees, w.max_degrees
-            ));
-        }
-        if w.min_degrees < -90.0 || w.max_degrees > 90.0 || w.min_degrees >= w.max_degrees {
-            return Err(format!(
-                "dec_limits must satisfy -90 <= min_degrees < max_degrees <= 90, got ({}, {})",
-                w.min_degrees, w.max_degrees
-            ));
-        }
-        Ok(Self {
-            min_degrees: w.min_degrees,
-            max_degrees: w.max_degrees,
-        })
+        Self::try_new(w.min_degrees, w.max_degrees)
     }
 }
 
@@ -546,14 +570,14 @@ impl From<DecLimits> for DecLimitsWire {
 impl Default for FlipRangeHours {
     /// `0.5` h — a half-hour meridian window.
     fn default() -> Self {
-        Self(0.5)
+        Self::new(0.5)
     }
 }
 
 impl Default for TrackingGuardMarginHours {
     /// `0.05` h (≈ 45 s of sidereal drift).
     fn default() -> Self {
-        Self(0.05)
+        Self::new(0.05)
     }
 }
 
@@ -1568,12 +1592,12 @@ mod tests {
             f64::NAN,
         ] {
             assert!(
-                FlipRangeHours::try_from(bad).is_err(),
+                FlipRangeHours::try_new(bad).is_err(),
                 "{bad} should be rejected"
             );
         }
-        assert!(FlipRangeHours::try_from(0.5).is_ok());
-        assert!(FlipRangeHours::try_from(MAX_FLIP_RANGE_HOURS).is_ok());
+        assert!(FlipRangeHours::try_new(0.5).is_ok());
+        assert!(FlipRangeHours::try_new(MAX_FLIP_RANGE_HOURS).is_ok());
         // The same rejection surfaces through serde with the field named.
         let err = serde_json::from_str::<FlipPolicy>(r#"{"flip_range_hours": 5.0}"#)
             .unwrap_err()
@@ -1585,12 +1609,14 @@ mod tests {
     fn tracking_guard_margin_validates_at_construction() {
         for bad in [MAX_TRACKING_GUARD_MARGIN_HOURS + 0.1, -0.01, f64::NAN] {
             assert!(
-                TrackingGuardMarginHours::try_from(bad).is_err(),
+                TrackingGuardMarginHours::try_new(bad).is_err(),
                 "{bad} should be rejected"
             );
         }
-        assert!(TrackingGuardMarginHours::try_from(0.0).is_ok());
-        assert!(TrackingGuardMarginHours::try_from(MAX_TRACKING_GUARD_MARGIN_HOURS).is_ok());
+        assert!(TrackingGuardMarginHours::try_new(0.0).is_ok());
+        assert!(TrackingGuardMarginHours::try_new(MAX_TRACKING_GUARD_MARGIN_HOURS).is_ok());
+        // The same rejection surfaces through serde (`try_from = "f64"`).
+        assert!(serde_json::from_str::<TrackingGuardMarginHours>("-0.01").is_err());
     }
 
     #[test]
@@ -1609,6 +1635,11 @@ mod tests {
         let ok: CwExclusionZone =
             serde_json::from_str(r#"{"min_hours": 0.95, "max_hours": 11.05}"#).expect("valid");
         assert!(matches!(ok, CwExclusionZone::Active(_)));
+        // The public checked constructor enforces the same invariant, so
+        // programmatic callers can't build an invalid zone either.
+        ActiveZone::try_new(0.95, 11.05).expect("in-range zone");
+        assert!(ActiveZone::try_new(11.05, 0.95).is_err(), "inverted");
+        assert!(ActiveZone::try_new(0.95, 20.0).is_err(), "max > 12");
     }
 
     #[test]
@@ -1624,6 +1655,10 @@ mod tests {
         }
         serde_json::from_str::<DecLimits>(r#"{"min_degrees": -90.0, "max_degrees": 90.0}"#)
             .expect("valid");
+        // The public checked constructor enforces the same invariant.
+        DecLimits::try_new(-90.0, 90.0).expect("full hemisphere");
+        assert!(DecLimits::try_new(10.0, -10.0).is_err(), "inverted");
+        assert!(DecLimits::try_new(-100.0, 90.0).is_err(), "< -90");
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/config.rs
+++ b/services/star-adventurer-gti/src/config.rs
@@ -144,10 +144,8 @@ pub struct MountConfig {
     /// this for tests or for mounts whose CW exclusion arc is known to
     /// be elsewhere. See the design doc's
     /// [§Per-pier safety envelopes](../../../docs/services/star-adventurer-gti.md#per-pier-safety-envelopes).
-    #[serde(default = "default_binding_zone_min_hours")]
-    pub binding_zone_min_hours: f64,
-    #[serde(default = "default_binding_zone_max_hours")]
-    pub binding_zone_max_hours: f64,
+    #[serde(default)]
+    pub cw_exclusion_zone: CwExclusionZone,
 
     /// Slack added on both edges of the CW exclusion zone for the
     /// **tracking-time safety guard** (see the design doc's
@@ -169,17 +167,15 @@ pub struct MountConfig {
     /// fails config loading. The guard additionally treats a non-finite or
     /// negative value as `0.0` as defense-in-depth for construction paths
     /// that bypass validation.
-    #[serde(default = "default_tracking_guard_margin_hours")]
-    pub tracking_guard_margin_hours: f64,
+    #[serde(default)]
+    pub tracking_guard_margin_hours: TrackingGuardMarginHours,
 
     /// Safe Dec mechanical-degree envelope. Same enforcement and
     /// rationale as the RA limits. Defaults `[-90.0, +90.0]` — the
     /// observable hemisphere, plus the convention that
     /// "encoder = 0" is OTA on the meridian.
-    #[serde(default = "default_dec_min_degrees")]
-    pub dec_min_degrees: f64,
-    #[serde(default = "default_dec_max_degrees")]
-    pub dec_max_degrees: f64,
+    #[serde(default)]
+    pub dec_limits: DecLimits,
 
     /// Persisted park-target encoder positions, written by `SetPark`
     /// and read on every connect. When `None` (default on first run),
@@ -263,15 +259,15 @@ pub struct FlipPolicy {
     /// returns the current side. Valid range `(0, 0.95]`; the upper
     /// bound matches the Phase 1.1 hardware-verified headroom past
     /// counterweight-horizontal on the pre-flip side.
-    #[serde(default = "default_flip_range_hours")]
-    pub flip_range_hours: f64,
+    #[serde(default)]
+    pub flip_range_hours: FlipRangeHours,
 }
 
 impl Default for FlipPolicy {
     fn default() -> Self {
         Self {
             enabled: default_flip_policy_enabled(),
-            flip_range_hours: default_flip_range_hours(),
+            flip_range_hours: FlipRangeHours::default(),
         }
     }
 }
@@ -282,27 +278,6 @@ impl Default for FlipPolicy {
 /// `docs/plans/star-adventurer-gti-meridian-flip.md` §2.6.
 pub const MAX_FLIP_RANGE_HOURS: f64 = 0.95;
 
-impl FlipPolicy {
-    /// Validate the policy against the constraints documented in the
-    /// design doc and §2.6 of the plan. Returns `Err(message)` on a
-    /// bad value; the caller surfaces it as a startup error.
-    pub fn validate(&self) -> std::result::Result<(), String> {
-        if !self.flip_range_hours.is_finite() {
-            return Err(format!(
-                "flip_policy.flip_range_hours must be finite, got {}",
-                self.flip_range_hours
-            ));
-        }
-        if self.flip_range_hours <= 0.0 || self.flip_range_hours > MAX_FLIP_RANGE_HOURS {
-            return Err(format!(
-                "flip_policy.flip_range_hours must be in (0, {MAX_FLIP_RANGE_HOURS}] hours, got {}",
-                self.flip_range_hours
-            ));
-        }
-        Ok(())
-    }
-}
-
 /// Outer bound on [`MountConfig::tracking_guard_margin_hours`]. The
 /// margin is operator-preference slack before the CW exclusion zone,
 /// not a mechanical limit; this cap only catches a misconfiguration
@@ -310,72 +285,290 @@ impl FlipPolicy {
 /// shipped default is `0.05` h.
 pub const MAX_TRACKING_GUARD_MARGIN_HOURS: f64 = 1.0;
 
-impl MountConfig {
-    /// Validate the mount configuration after load. Returns
-    /// `Err(message)` on a bad value; [`load_config`] surfaces it as a
-    /// startup error so an out-of-range config fails fast instead of
-    /// silently driving the mount with a bad parameter.
-    ///
-    /// These fields are bare `f64` with no newtype guarantees, so this
-    /// method is the single place their documented ranges are enforced.
-    pub fn validate(&self) -> std::result::Result<(), String> {
-        self.flip_policy.validate()?;
+// ===================== Validating config newtypes =====================
+//
+// Each field invariant lives in the type: an out-of-range value fails at
+// `serde_json::from_str` with the offending field named, so a bad config is
+// rejected at *load* rather than at slew/track time. This is what retired
+// the hand-rolled `MountConfig::validate` / `FlipPolicy::validate`.
 
-        // CW exclusion zone. `min >= max` is the documented "disabled"
-        // sentinel (used by tests and by operators whose geometry
-        // differs — see the field docs), accepted as "no zone". An
-        // *active* zone (`min < max`) must live in the folded
-        // mechanical-HA domain `[-12, +12)` that the guard and slew
-        // checks assume (neither does 24 h wrap handling).
-        if !self.binding_zone_min_hours.is_finite() || !self.binding_zone_max_hours.is_finite() {
-            return Err(format!(
-                "binding_zone_min_hours / binding_zone_max_hours must be finite, got ({}, {})",
-                self.binding_zone_min_hours, self.binding_zone_max_hours
-            ));
-        }
-        if self.binding_zone_min_hours < self.binding_zone_max_hours
-            && (self.binding_zone_min_hours < -12.0 || self.binding_zone_max_hours > 12.0)
-        {
-            return Err(format!(
-                "an active CW exclusion zone must satisfy \
-                 -12 <= binding_zone_min_hours < binding_zone_max_hours <= 12 (folded mech_HA), \
-                 got ({}, {})",
-                self.binding_zone_min_hours, self.binding_zone_max_hours
-            ));
-        }
+/// Half-width of the meridian-flip window, hours. Valid `(0, MAX_FLIP_RANGE_HOURS]`.
+/// JSON form is a bare number.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(into = "f64", try_from = "f64")]
+pub struct FlipRangeHours(f64);
 
-        // Tracking-guard margin: finite, non-negative, capped to catch a
-        // misconfiguration. The guard also sanitises bad values at
-        // runtime, but a startup error is clearer to the operator.
-        if !self.tracking_guard_margin_hours.is_finite()
-            || self.tracking_guard_margin_hours < 0.0
-            || self.tracking_guard_margin_hours > MAX_TRACKING_GUARD_MARGIN_HOURS
-        {
-            return Err(format!(
-                "tracking_guard_margin_hours must be in [0, {MAX_TRACKING_GUARD_MARGIN_HOURS}] hours, got {}",
-                self.tracking_guard_margin_hours
-            ));
-        }
+impl FlipRangeHours {
+    /// Construct without validation — for defaults and trusted internal
+    /// callers. The validating boundary is serde deserialize (`try_from`).
+    pub const fn new(hours: f64) -> Self {
+        Self(hours)
+    }
+    /// The underlying value in hours.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
 
-        // Dec clip range: a real celestial-Dec interval within the
-        // observable hemisphere.
-        if !self.dec_min_degrees.is_finite() || !self.dec_max_degrees.is_finite() {
+impl TryFrom<f64> for FlipRangeHours {
+    type Error = String;
+    fn try_from(v: f64) -> std::result::Result<Self, String> {
+        if !v.is_finite() || v <= 0.0 || v > MAX_FLIP_RANGE_HOURS {
             return Err(format!(
-                "dec_min_degrees / dec_max_degrees must be finite, got ({}, {})",
-                self.dec_min_degrees, self.dec_max_degrees
+                "flip_policy.flip_range_hours must be in (0, {MAX_FLIP_RANGE_HOURS}] hours, got {v}"
             ));
         }
-        if self.dec_min_degrees < -90.0
-            || self.dec_max_degrees > 90.0
-            || self.dec_min_degrees >= self.dec_max_degrees
-        {
-            return Err(format!(
-                "dec_min_degrees / dec_max_degrees must satisfy -90 <= min < max <= 90, got ({}, {})",
-                self.dec_min_degrees, self.dec_max_degrees
-            ));
-        }
+        Ok(Self(v))
+    }
+}
 
-        Ok(())
+impl From<FlipRangeHours> for f64 {
+    fn from(v: FlipRangeHours) -> Self {
+        v.0
+    }
+}
+
+/// Tracking-guard slack before the CW exclusion zone, hours. Valid
+/// `[0, MAX_TRACKING_GUARD_MARGIN_HOURS]`. JSON form is a bare number.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(into = "f64", try_from = "f64")]
+pub struct TrackingGuardMarginHours(f64);
+
+impl TrackingGuardMarginHours {
+    /// Construct without validation — see [`FlipRangeHours::new`].
+    pub const fn new(hours: f64) -> Self {
+        Self(hours)
+    }
+    /// The underlying value in hours.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for TrackingGuardMarginHours {
+    type Error = String;
+    fn try_from(v: f64) -> std::result::Result<Self, String> {
+        if !v.is_finite() || !(0.0..=MAX_TRACKING_GUARD_MARGIN_HOURS).contains(&v) {
+            return Err(format!(
+                "tracking_guard_margin_hours must be in [0, {MAX_TRACKING_GUARD_MARGIN_HOURS}] hours, got {v}"
+            ));
+        }
+        Ok(Self(v))
+    }
+}
+
+impl From<TrackingGuardMarginHours> for f64 {
+    fn from(v: TrackingGuardMarginHours) -> Self {
+        v.0
+    }
+}
+
+/// An active CW exclusion interval in encoder mech_HA (signed hours, folded
+/// `[-12, +12)`): `-12 <= min_hours < max_hours <= 12`. JSON form is
+/// `{ "min_hours": .., "max_hours": .. }`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(into = "ActiveZoneWire", try_from = "ActiveZoneWire")]
+pub struct ActiveZone {
+    min_hours: f64,
+    max_hours: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ActiveZoneWire {
+    min_hours: f64,
+    max_hours: f64,
+}
+
+impl ActiveZone {
+    /// Construct without validation — see [`FlipRangeHours::new`].
+    pub const fn new(min_hours: f64, max_hours: f64) -> Self {
+        Self {
+            min_hours,
+            max_hours,
+        }
+    }
+    pub fn min_hours(self) -> f64 {
+        self.min_hours
+    }
+    pub fn max_hours(self) -> f64 {
+        self.max_hours
+    }
+}
+
+impl TryFrom<ActiveZoneWire> for ActiveZone {
+    type Error = String;
+    fn try_from(w: ActiveZoneWire) -> std::result::Result<Self, String> {
+        if !w.min_hours.is_finite() || !w.max_hours.is_finite() {
+            return Err(format!(
+                "cw_exclusion_zone bounds must be finite, got ({}, {})",
+                w.min_hours, w.max_hours
+            ));
+        }
+        if w.min_hours >= w.max_hours {
+            return Err(format!(
+                "active cw_exclusion_zone needs min_hours < max_hours \
+                 (use null to disable), got ({}, {})",
+                w.min_hours, w.max_hours
+            ));
+        }
+        if w.min_hours < -12.0 || w.max_hours > 12.0 {
+            return Err(format!(
+                "active cw_exclusion_zone must satisfy -12 <= min_hours < max_hours <= 12 \
+                 (folded mech_HA), got ({}, {})",
+                w.min_hours, w.max_hours
+            ));
+        }
+        Ok(Self {
+            min_hours: w.min_hours,
+            max_hours: w.max_hours,
+        })
+    }
+}
+
+impl From<ActiveZone> for ActiveZoneWire {
+    fn from(z: ActiveZone) -> Self {
+        Self {
+            min_hours: z.min_hours,
+            max_hours: z.max_hours,
+        }
+    }
+}
+
+/// The counterweight exclusion zone: an [`ActiveZone`] interval, or
+/// explicitly [`Disabled`](CwExclusionZone::Disabled). Replaces the old
+/// `binding_zone_min/max_hours` pair and its `min >= max = disabled`
+/// convention. JSON form is the active object, or `null` for disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(from = "Option<ActiveZone>", into = "Option<ActiveZone>")]
+pub enum CwExclusionZone {
+    Active(ActiveZone),
+    Disabled,
+}
+
+impl CwExclusionZone {
+    /// `(min, max)` bounds for the path/guard/flip checks, which take a
+    /// bare `(f64, f64)`. `Disabled` yields the empty interval
+    /// `(+∞, −∞)` — `min > max` strictly, which every consumer
+    /// (`canonical_path_crosses_binding_zone`, `tracking_guard_breached`,
+    /// `select_pier_side_for_target`) treats as "no zone".
+    pub fn bounds(self) -> (f64, f64) {
+        match self {
+            Self::Active(z) => (z.min_hours(), z.max_hours()),
+            Self::Disabled => (f64::INFINITY, f64::NEG_INFINITY),
+        }
+    }
+}
+
+impl From<Option<ActiveZone>> for CwExclusionZone {
+    fn from(o: Option<ActiveZone>) -> Self {
+        o.map_or(Self::Disabled, Self::Active)
+    }
+}
+
+impl From<CwExclusionZone> for Option<ActiveZone> {
+    fn from(z: CwExclusionZone) -> Self {
+        match z {
+            CwExclusionZone::Active(a) => Some(a),
+            CwExclusionZone::Disabled => None,
+        }
+    }
+}
+
+/// Safe declination envelope, degrees: `-90 <= min_degrees < max_degrees <= 90`.
+/// JSON form is `{ "min_degrees": .., "max_degrees": .. }`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(into = "DecLimitsWire", try_from = "DecLimitsWire")]
+pub struct DecLimits {
+    min_degrees: f64,
+    max_degrees: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DecLimitsWire {
+    min_degrees: f64,
+    max_degrees: f64,
+}
+
+impl DecLimits {
+    /// Construct without validation — see [`FlipRangeHours::new`].
+    pub const fn new(min_degrees: f64, max_degrees: f64) -> Self {
+        Self {
+            min_degrees,
+            max_degrees,
+        }
+    }
+    pub fn min_degrees(self) -> f64 {
+        self.min_degrees
+    }
+    pub fn max_degrees(self) -> f64 {
+        self.max_degrees
+    }
+    /// Inclusive `[min, max]` range for membership tests.
+    pub fn range(self) -> std::ops::RangeInclusive<f64> {
+        self.min_degrees..=self.max_degrees
+    }
+}
+
+impl TryFrom<DecLimitsWire> for DecLimits {
+    type Error = String;
+    fn try_from(w: DecLimitsWire) -> std::result::Result<Self, String> {
+        if !w.min_degrees.is_finite() || !w.max_degrees.is_finite() {
+            return Err(format!(
+                "dec_limits must be finite, got ({}, {})",
+                w.min_degrees, w.max_degrees
+            ));
+        }
+        if w.min_degrees < -90.0 || w.max_degrees > 90.0 || w.min_degrees >= w.max_degrees {
+            return Err(format!(
+                "dec_limits must satisfy -90 <= min_degrees < max_degrees <= 90, got ({}, {})",
+                w.min_degrees, w.max_degrees
+            ));
+        }
+        Ok(Self {
+            min_degrees: w.min_degrees,
+            max_degrees: w.max_degrees,
+        })
+    }
+}
+
+impl From<DecLimits> for DecLimitsWire {
+    fn from(d: DecLimits) -> Self {
+        Self {
+            min_degrees: d.min_degrees,
+            max_degrees: d.max_degrees,
+        }
+    }
+}
+
+// Defaults live with the types, so the config fields can use bare
+// `#[serde(default)]` and no `default_*` free functions are needed.
+
+impl Default for FlipRangeHours {
+    /// `0.5` h — a half-hour meridian window.
+    fn default() -> Self {
+        Self(0.5)
+    }
+}
+
+impl Default for TrackingGuardMarginHours {
+    /// `0.05` h (≈ 45 s of sidereal drift).
+    fn default() -> Self {
+        Self(0.05)
+    }
+}
+
+impl Default for CwExclusionZone {
+    /// `(0.95, 11.05)` h — the wide-zone reading of the "0.95 h above
+    /// horizontal" rule, hardware-verified at lat 32.7°N.
+    fn default() -> Self {
+        Self::Active(ActiveZone::new(0.95, 11.05))
+    }
+}
+
+impl Default for DecLimits {
+    /// `[-90, +90]°` — the observable hemisphere.
+    fn default() -> Self {
+        Self::new(-90.0, 90.0)
     }
 }
 
@@ -704,26 +897,8 @@ fn default_discovery_port() -> Option<u16> {
 fn default_settle_after_slew() -> Duration {
     Duration::from_secs(2)
 }
-fn default_binding_zone_min_hours() -> f64 {
-    0.95
-}
-fn default_binding_zone_max_hours() -> f64 {
-    11.05
-}
-fn default_tracking_guard_margin_hours() -> f64 {
-    0.05
-}
-fn default_dec_min_degrees() -> f64 {
-    -90.0
-}
-fn default_dec_max_degrees() -> f64 {
-    90.0
-}
 fn default_flip_policy_enabled() -> bool {
     false
-}
-fn default_flip_range_hours() -> f64 {
-    0.5
 }
 fn default_true() -> bool {
     true
@@ -807,11 +982,9 @@ impl Default for MountConfig {
             site_elevation_m: 0.0,
             settle_after_slew: default_settle_after_slew(),
             tracking_rate: TrackingRateName::Sidereal,
-            binding_zone_min_hours: default_binding_zone_min_hours(),
-            binding_zone_max_hours: default_binding_zone_max_hours(),
-            tracking_guard_margin_hours: default_tracking_guard_margin_hours(),
-            dec_min_degrees: default_dec_min_degrees(),
-            dec_max_degrees: default_dec_max_degrees(),
+            cw_exclusion_zone: CwExclusionZone::default(),
+            tracking_guard_margin_hours: TrackingGuardMarginHours::default(),
+            dec_limits: DecLimits::default(),
             park_ra_ticks: None,
             park_dec_ticks: None,
             flip_policy: FlipPolicy::default(),
@@ -824,11 +997,12 @@ impl Default for MountConfig {
 /// Load a [`Config`] from a JSON file.
 pub fn load_config(path: &Path) -> std::result::Result<Config, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(path)?;
+    // Validation is construct-time: the config newtypes
+    // (`FlipRangeHours`, `CwExclusionZone`, `DecLimits`,
+    // `TrackingGuardMarginHours`) reject out-of-range values during
+    // deserialize, with the offending field named in the error — so a
+    // bad config fails here at load rather than at slew/track time.
     let config: Config = serde_json::from_str(&content)?;
-    config
-        .mount
-        .validate()
-        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidData, msg))?;
     Ok(config)
 }
 
@@ -1302,9 +1476,9 @@ mod tests {
         let p = FlipPolicy::default();
         assert!(!p.enabled);
         assert!(
-            (p.flip_range_hours - 0.5).abs() < f64::EPSILON,
+            (p.flip_range_hours.value() - 0.5).abs() < f64::EPSILON,
             "got {}",
-            p.flip_range_hours
+            p.flip_range_hours.value()
         );
     }
 
@@ -1328,7 +1502,7 @@ mod tests {
         }"#;
         let m: MountConfig = serde_json::from_str(json).expect("deserialise");
         assert!(!m.flip_policy.enabled);
-        assert!((m.flip_policy.flip_range_hours - 0.5).abs() < f64::EPSILON);
+        assert!((m.flip_policy.flip_range_hours.value() - 0.5).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1337,9 +1511,9 @@ mod tests {
         // design doc's §"Tracking-time safety guard" documents.
         let cfg = MountConfig::default();
         assert!(
-            (cfg.tracking_guard_margin_hours - 0.05).abs() < f64::EPSILON,
+            (cfg.tracking_guard_margin_hours.value() - 0.05).abs() < f64::EPSILON,
             "got {}",
-            cfg.tracking_guard_margin_hours
+            cfg.tracking_guard_margin_hours.value()
         );
     }
 
@@ -1356,114 +1530,100 @@ mod tests {
             "site_longitude_deg": 0.0
         }"#;
         let m: MountConfig = serde_json::from_str(json).expect("deserialise");
-        assert!((m.tracking_guard_margin_hours - 0.05).abs() < f64::EPSILON);
+        assert!((m.tracking_guard_margin_hours.value() - 0.05).abs() < f64::EPSILON);
+    }
+
+    // ---- Construct-time validation (replaces the retired validate()) ----
+
+    #[test]
+    fn default_config_round_trips_through_json() {
+        // Defaults are in-range, so the typed fields construct without
+        // error and survive a serialise → deserialise round trip.
+        let json = serde_json::to_string(&MountConfig::default()).expect("serialise");
+        serde_json::from_str::<MountConfig>(&json).expect("deserialise default");
     }
 
     #[test]
-    fn mount_config_validate_accepts_defaults() {
-        MountConfig::default().validate().unwrap();
+    fn cw_exclusion_zone_disabled_is_null_and_empty_interval() {
+        let m: MountConfig = serde_json::from_str(
+            r#"{"name":"t","unique_id":"t","description":"t",
+                "site_latitude_deg":0.0,"site_longitude_deg":0.0,
+                "cw_exclusion_zone":null}"#,
+        )
+        .expect("deserialise");
+        assert_eq!(m.cw_exclusion_zone, CwExclusionZone::Disabled);
+        // Disabled yields an empty interval (min > max) for the path checks.
+        let (lo, hi) = m.cw_exclusion_zone.bounds();
+        assert!(lo > hi, "disabled zone must be empty, got ({lo}, {hi})");
     }
 
     #[test]
-    fn mount_config_validate_accepts_disabled_binding_zone() {
-        // `min >= max` is the documented disable sentinel — must pass.
-        MountConfig {
-            binding_zone_min_hours: 24.0,
-            binding_zone_max_hours: 0.0,
-            ..Default::default()
+    fn flip_range_hours_validates_at_construction() {
+        for bad in [
+            5.0,
+            0.0,
+            -0.1,
+            MAX_FLIP_RANGE_HOURS + 1e-6,
+            f64::INFINITY,
+            f64::NAN,
+        ] {
+            assert!(
+                FlipRangeHours::try_from(bad).is_err(),
+                "{bad} should be rejected"
+            );
         }
-        .validate()
-        .unwrap();
-    }
-
-    #[test]
-    fn mount_config_validate_delegates_to_flip_policy() {
-        // Previously dead: an out-of-range flip_range_hours is now
-        // rejected because `load_config` calls `validate`.
-        let m = MountConfig {
-            flip_policy: FlipPolicy {
-                flip_range_hours: 5.0, // > MAX_FLIP_RANGE_HOURS
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let err = m.validate().unwrap_err();
+        assert!(FlipRangeHours::try_from(0.5).is_ok());
+        assert!(FlipRangeHours::try_from(MAX_FLIP_RANGE_HOURS).is_ok());
+        // The same rejection surfaces through serde with the field named.
+        let err = serde_json::from_str::<FlipPolicy>(r#"{"flip_range_hours": 5.0}"#)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("flip_range_hours"), "got {err}");
     }
 
     #[test]
-    fn mount_config_validate_rejects_margin_above_cap() {
-        let m = MountConfig {
-            tracking_guard_margin_hours: MAX_TRACKING_GUARD_MARGIN_HOURS + 0.1,
-            ..Default::default()
-        };
-        let err = m.validate().unwrap_err();
-        assert!(err.contains("tracking_guard_margin_hours"), "got {err}");
-    }
-
-    #[test]
-    fn mount_config_validate_rejects_negative_margin() {
-        MountConfig {
-            tracking_guard_margin_hours: -0.01,
-            ..Default::default()
+    fn tracking_guard_margin_validates_at_construction() {
+        for bad in [MAX_TRACKING_GUARD_MARGIN_HOURS + 0.1, -0.01, f64::NAN] {
+            assert!(
+                TrackingGuardMarginHours::try_from(bad).is_err(),
+                "{bad} should be rejected"
+            );
         }
-        .validate()
-        .unwrap_err();
+        assert!(TrackingGuardMarginHours::try_from(0.0).is_ok());
+        assert!(TrackingGuardMarginHours::try_from(MAX_TRACKING_GUARD_MARGIN_HOURS).is_ok());
     }
 
     #[test]
-    fn mount_config_validate_rejects_non_finite_margin() {
-        MountConfig {
-            tracking_guard_margin_hours: f64::NAN,
-            ..Default::default()
+    fn cw_exclusion_zone_validates_active_bounds_at_deserialize() {
+        // Out-of-folded-range and inverted active zones are rejected at
+        // deserialize (disable via null instead).
+        for bad in [
+            r#"{"min_hours": 0.95, "max_hours": 20.0}"#,  // max > 12
+            r#"{"min_hours": 11.05, "max_hours": 0.95}"#, // inverted
+        ] {
+            assert!(
+                serde_json::from_str::<CwExclusionZone>(bad).is_err(),
+                "{bad} should be rejected"
+            );
         }
-        .validate()
-        .unwrap_err();
+        let ok: CwExclusionZone =
+            serde_json::from_str(r#"{"min_hours": 0.95, "max_hours": 11.05}"#).expect("valid");
+        assert!(matches!(ok, CwExclusionZone::Active(_)));
     }
 
     #[test]
-    fn mount_config_validate_rejects_non_finite_binding_zone() {
-        MountConfig {
-            binding_zone_min_hours: f64::INFINITY,
-            ..Default::default()
+    fn dec_limits_validates_at_deserialize() {
+        for bad in [
+            r#"{"min_degrees": 10.0, "max_degrees": -10.0}"#, // inverted
+            r#"{"min_degrees": -100.0, "max_degrees": 90.0}"#, // < -90
+        ] {
+            assert!(
+                serde_json::from_str::<DecLimits>(bad).is_err(),
+                "{bad} should be rejected"
+            );
         }
-        .validate()
-        .unwrap_err();
-    }
-
-    #[test]
-    fn mount_config_validate_rejects_active_zone_outside_folded_range() {
-        // An active zone (min < max) must stay within folded mech_HA
-        // [-12, +12); a max beyond +12 is out of the domain the guard
-        // and slew checks assume.
-        let m = MountConfig {
-            binding_zone_min_hours: 0.95,
-            binding_zone_max_hours: 20.0,
-            ..Default::default()
-        };
-        let err = m.validate().unwrap_err();
-        assert!(err.contains("active CW exclusion zone"), "got {err}");
-    }
-
-    #[test]
-    fn mount_config_validate_rejects_inverted_dec_range() {
-        let m = MountConfig {
-            dec_min_degrees: 10.0,
-            dec_max_degrees: -10.0,
-            ..Default::default()
-        };
-        let err = m.validate().unwrap_err();
-        assert!(err.contains("dec_"), "got {err}");
-    }
-
-    #[test]
-    fn mount_config_validate_rejects_out_of_range_dec() {
-        MountConfig {
-            dec_min_degrees: -100.0,
-            ..Default::default()
-        }
-        .validate()
-        .unwrap_err();
+        serde_json::from_str::<DecLimits>(r#"{"min_degrees": -90.0, "max_degrees": 90.0}"#)
+            .expect("valid");
     }
 
     #[test]
@@ -1475,7 +1635,9 @@ mod tests {
         let cfg = Config {
             mount: MountConfig {
                 flip_policy: FlipPolicy {
-                    flip_range_hours: 5.0,
+                    // Unchecked ctor builds a bad value that serialises to
+                    // 5.0; load_config's deserialize is what rejects it.
+                    flip_range_hours: FlipRangeHours::new(5.0),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1497,14 +1659,14 @@ mod tests {
         let cfg = MountConfig {
             flip_policy: FlipPolicy {
                 enabled: true,
-                flip_range_hours: 0.7,
+                flip_range_hours: FlipRangeHours::new(0.7),
             },
             ..MountConfig::default()
         };
         let json = serde_json::to_string(&cfg).expect("serialise");
         let back: MountConfig = serde_json::from_str(&json).expect("deserialise");
         assert!(back.flip_policy.enabled);
-        assert!((back.flip_policy.flip_range_hours - 0.7).abs() < f64::EPSILON);
+        assert!((back.flip_policy.flip_range_hours.value() - 0.7).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1514,69 +1676,12 @@ mod tests {
         let json = r#"{"enabled": true}"#;
         let p: FlipPolicy = serde_json::from_str(json).expect("deserialise");
         assert!(p.enabled);
-        assert!((p.flip_range_hours - 0.5).abs() < f64::EPSILON);
+        assert!((p.flip_range_hours.value() - 0.5).abs() < f64::EPSILON);
 
         let json = r#"{"flip_range_hours": 0.25}"#;
         let p: FlipPolicy = serde_json::from_str(json).expect("deserialise");
         assert!(!p.enabled);
-        assert!((p.flip_range_hours - 0.25).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn flip_policy_validate_accepts_defaults() {
-        FlipPolicy::default().validate().unwrap();
-    }
-
-    #[test]
-    fn flip_policy_validate_accepts_upper_bound() {
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: MAX_FLIP_RANGE_HOURS,
-        };
-        p.validate().unwrap();
-    }
-
-    #[test]
-    fn flip_policy_validate_rejects_zero() {
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: 0.0,
-        };
-        let err = p.validate().unwrap_err();
-        assert!(err.contains("flip_range_hours"), "got: {err}");
-    }
-
-    #[test]
-    fn flip_policy_validate_rejects_negative() {
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: -0.1,
-        };
-        p.validate().unwrap_err();
-    }
-
-    #[test]
-    fn flip_policy_validate_rejects_above_upper_bound() {
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: MAX_FLIP_RANGE_HOURS + 1e-6,
-        };
-        let err = p.validate().unwrap_err();
-        assert!(err.contains("flip_range_hours"), "got: {err}");
-    }
-
-    #[test]
-    fn flip_policy_validate_rejects_non_finite() {
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: f64::INFINITY,
-        };
-        p.validate().unwrap_err();
-        let p = FlipPolicy {
-            enabled: true,
-            flip_range_hours: f64::NAN,
-        };
-        p.validate().unwrap_err();
+        assert!((p.flip_range_hours.value() - 0.25).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -311,7 +311,7 @@ pub fn select_pier_side_for_target(
         // Post-flip side: operational rule, stay on flipped only near
         // meridian. The binding zone for flipped-side mech_HA is
         // separately enforced by `check_within_safe_envelope`.
-        target_ha.abs() <= policy.flip_range_hours
+        target_ha.abs() <= policy.flip_range_hours.value()
     };
     if current_covers {
         current
@@ -861,13 +861,13 @@ mod tests {
     fn flip_disabled() -> FlipPolicy {
         FlipPolicy {
             enabled: false,
-            flip_range_hours: 0.5,
+            flip_range_hours: crate::config::FlipRangeHours::new(0.5),
         }
     }
     fn flip_enabled() -> FlipPolicy {
         FlipPolicy {
             enabled: true,
-            flip_range_hours: 0.5,
+            flip_range_hours: crate::config::FlipRangeHours::new(0.5),
         }
     }
     const BINDING_ZONE: (f64, f64) = (6.95, 11.05);

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -25,32 +25,7 @@ use erfars::timescales::{Dtf2d, Taitt, Utctai};
 
 use crate::config::FlipPolicy;
 use crate::error::{Result, StarAdvError};
-
-/// Convert RA-axis encoder ticks to a mechanical hour-angle in the range
-/// `[-12, +12)` hours.
-pub fn ra_ticks_to_mechanical_ha(ticks: i32, cpr: u32) -> f64 {
-    if cpr == 0 {
-        return 0.0;
-    }
-    let hours = (ticks as f64) * 24.0 / (cpr as f64);
-    fold_to_signed(hours, 24.0)
-}
-
-/// Convert Dec-axis encoder ticks to a declination angle in degrees.
-///
-/// Returns the linear mapping `ticks * 360 / cpr` then folded into
-/// `[-180, +180)`. **Does not** fold through the celestial pole — values
-/// outside `[-90, +90]` are returned as-is so the caller can detect a
-/// mount that ended up "through the pole" (Phase 4 sync logic decides
-/// what to do with that). For the BDD scenarios this is enough: every
-/// scenario stays inside the legal Dec range.
-pub fn dec_ticks_to_degrees(ticks: i32, cpr: u32) -> f64 {
-    if cpr == 0 {
-        return 0.0;
-    }
-    let deg = (ticks as f64) * 360.0 / (cpr as f64);
-    fold_to_signed(deg, 360.0)
-}
+use crate::units::{Cpr, Dec, DecTicks, Lst, Ra, RaTicks};
 
 /// Local apparent sidereal time in hours `[0, 24)` from the host's wall
 /// clock and the configured site longitude (east-positive, ASCOM
@@ -69,7 +44,7 @@ pub fn dec_ticks_to_degrees(ticks: i32, cpr: u32) -> f64 {
 /// silently accepted here. The coordinate-read hot path maps any Err
 /// to an ASCOM error rather than letting the tokio task abort and
 /// the Alpaca client see a connection reset.
-pub fn local_sidereal_time_hours(utc: SystemTime, site_longitude_deg: f64) -> Result<f64> {
+pub fn local_sidereal_time_hours(utc: SystemTime, site_longitude_deg: f64) -> Result<Lst> {
     lst_for_datetime(utc.into(), site_longitude_deg)
 }
 
@@ -79,9 +54,9 @@ pub fn local_sidereal_time_hours(utc: SystemTime, site_longitude_deg: f64) -> Re
 /// `SystemTime` (which on Windows is backed by FILETIME and cannot
 /// represent years below 1601, let alone below ERFA's `IYMIN = -4799`
 /// floor).
-pub(crate) fn lst_for_datetime(dt: DateTime<Utc>, site_longitude_deg: f64) -> Result<f64> {
+pub(crate) fn lst_for_datetime(dt: DateTime<Utc>, site_longitude_deg: f64) -> Result<Lst> {
     let gast_hours = greenwich_apparent_sidereal_hours(dt)?;
-    Ok((gast_hours + site_longitude_deg / 15.0).rem_euclid(24.0))
+    Ok(Lst::new(gast_hours + site_longitude_deg / 15.0))
 }
 
 fn greenwich_apparent_sidereal_hours(dt: DateTime<Utc>) -> Result<f64> {
@@ -114,22 +89,6 @@ fn greenwich_apparent_sidereal_hours(dt: DateTime<Utc>) -> Result<f64> {
     Ok(gast_radians * 12.0 / ERFA_DPI)
 }
 
-/// Mechanical hour angle (signed hours) → ASCOM right ascension (hours
-/// `[0, 24)`), given the LST.
-///
-/// `RA = LST - mechanical_HA`, folded into the standard `[0, 24)` range.
-pub fn mechanical_ha_to_ra(mech_ha: f64, lst_hours: f64) -> f64 {
-    (lst_hours - mech_ha).rem_euclid(24.0)
-}
-
-/// ASCOM right ascension (hours `[0, 24)`) → mechanical hour angle.
-///
-/// Inverse of [`mechanical_ha_to_ra`]. Folds the result into `[-12, +12)`
-/// because that matches what the encoder reports.
-pub fn ra_to_mechanical_ha(ra_hours: f64, lst_hours: f64) -> f64 {
-    fold_to_signed((lst_hours - ra_hours).rem_euclid(24.0), 24.0)
-}
-
 /// Side-of-pier classification derived from the Dec-axis encoder
 /// position, the Dec-axis CPR, and the site latitude.
 ///
@@ -158,18 +117,18 @@ pub fn ra_to_mechanical_ha(ra_hours: f64, lst_hours: f64) -> f64 {
 /// here; AP Park 5 N (saddle east, dec normal) reports `pierWest`.
 /// The encoder values for each park pose are still mechanically
 /// correct — only the operational-vs-geometric label disagrees.
-pub fn side_of_pier(dec_ticks: i32, cpr_dec: u32, site_latitude_deg: f64) -> PierSide {
-    if cpr_dec == 0 {
+pub fn side_of_pier(dec_ticks: DecTicks, cpr_dec: Cpr, site_latitude_deg: f64) -> PierSide {
+    if cpr_dec.get() == 0 {
         return PierSide::Unknown;
     }
-    let quarter = (cpr_dec / 4) as i64;
+    let quarter = (cpr_dec.get() / 4) as i64;
     // Fold the raw counter into the canonical band before classifying:
     // raw can sit outside `[-cpr/2, +cpr/2)` after through-wrap flip
     // slews, and the half-classification only makes sense on the folded
     // position. Without folding, a raw in `(3·cpr/4, 5·cpr/4)` whose
     // folded value lies in `(-cpr/4, +cpr/4)` would be misread as
     // post-flip and the East/West label would invert.
-    let folded = fold_to_canonical_band(dec_ticks, cpr_dec);
+    let folded = dec_ticks.fold_to_canonical_band(cpr_dec).value();
     // Past-the-pole detection: |Dec encoder| > 90° means the mount
     // has rotated the Dec axis beyond either celestial pole — the
     // post-meridian-flip / cross-axis-rotated-180° state. The
@@ -189,15 +148,6 @@ pub fn side_of_pier(dec_ticks: i32, cpr_dec: u32, site_latitude_deg: f64) -> Pie
     }
 }
 
-/// Convert a mechanical hour-angle (signed hours) to RA-axis encoder ticks.
-/// Inverse of [`ra_ticks_to_mechanical_ha`].
-pub fn mechanical_ha_to_ra_ticks(mech_ha_hours: f64, cpr: u32) -> i32 {
-    if cpr == 0 {
-        return 0;
-    }
-    (mech_ha_hours * (cpr as f64) / 24.0).round() as i32
-}
-
 /// Compute the target's RA/Dec encoder pair for the "normal"
 /// (pre-flip) pointing state.
 ///
@@ -207,15 +157,15 @@ pub fn mechanical_ha_to_ra_ticks(mech_ha_hours: f64, cpr: u32) -> i32 {
 /// behaviour for every slew before Phase 6, extracted into a helper
 /// so [`target_encoder_flipped`] can share the structure.
 pub fn target_encoder_normal(
-    ra_hours: f64,
-    dec_degrees: f64,
-    lst_hours: f64,
-    cpr_ra: u32,
-    cpr_dec: u32,
-) -> (i32, i32) {
-    let mech_ha = ra_to_mechanical_ha(ra_hours, lst_hours);
-    let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, cpr_ra);
-    let dec_ticks = dec_degrees_to_ticks(dec_degrees, cpr_dec);
+    ra: Ra,
+    dec: Dec,
+    lst: Lst,
+    cpr_ra: Cpr,
+    cpr_dec: Cpr,
+) -> (RaTicks, DecTicks) {
+    let mech_ha = lst.hour_angle_of(ra).to_mech();
+    let ra_ticks = mech_ha.to_ticks(cpr_ra);
+    let dec_ticks = dec.to_mech().to_ticks(cpr_dec);
     (ra_ticks, dec_ticks)
 }
 
@@ -238,17 +188,15 @@ pub fn target_encoder_normal(
 /// physical mechanical position at the encoder wrap; downstream
 /// callers don't distinguish between them.
 pub fn target_encoder_flipped(
-    ra_hours: f64,
-    dec_degrees: f64,
-    lst_hours: f64,
-    cpr_ra: u32,
-    cpr_dec: u32,
-) -> (i32, i32) {
-    let mech_ha_normal = ra_to_mechanical_ha(ra_hours, lst_hours);
-    let mech_ha_flipped = fold_to_signed(mech_ha_normal + 12.0, 24.0);
-    let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha_flipped, cpr_ra);
-    let dec_flipped = dec_degrees.signum() * (180.0 - dec_degrees.abs());
-    let dec_ticks = dec_degrees_to_ticks(dec_flipped, cpr_dec);
+    ra: Ra,
+    dec: Dec,
+    lst: Lst,
+    cpr_ra: Cpr,
+    cpr_dec: Cpr,
+) -> (RaTicks, DecTicks) {
+    let mech_ha_flipped = lst.hour_angle_of(ra).to_mech().flipped();
+    let ra_ticks = mech_ha_flipped.to_ticks(cpr_ra);
+    let dec_ticks = dec.to_mech_flipped().to_ticks(cpr_dec);
     (ra_ticks, dec_ticks)
 }
 
@@ -270,15 +218,15 @@ pub fn target_encoder_flipped(
 /// pointing, and the pickup loop would interpret a successful flip
 /// as a 12-hour RA residual and try to undo it.
 pub fn encoder_to_celestial(
-    ra_ticks: i32,
-    dec_ticks: i32,
-    lst_hours: f64,
-    cpr_ra: u32,
-    cpr_dec: u32,
+    ra_ticks: RaTicks,
+    dec_ticks: DecTicks,
+    lst: Lst,
+    cpr_ra: Cpr,
+    cpr_dec: Cpr,
     site_latitude_deg: f64,
-) -> (f64, f64) {
-    let mech_ha = ra_ticks_to_mechanical_ha(ra_ticks, cpr_ra);
-    let dec_enc = dec_ticks_to_degrees(dec_ticks, cpr_dec);
+) -> (Ra, Dec) {
+    let mech_ha = ra_ticks.to_mech_ha(cpr_ra);
+    let dec_enc = dec_ticks.to_mech_dec(cpr_dec);
     let pier = side_of_pier(dec_ticks, cpr_dec, site_latitude_deg);
     let pre_flip_side = if site_latitude_deg >= 0.0 {
         PierSide::West
@@ -287,16 +235,15 @@ pub fn encoder_to_celestial(
     };
     let is_flipped = pier != pre_flip_side && pier != PierSide::Unknown;
     if is_flipped {
-        let ra = (lst_hours - mech_ha + 12.0).rem_euclid(24.0);
-        // `dec_enc.signum()` returns ±1 for any non-zero value; the
-        // degenerate `dec_enc == 0` post-flip case (dec encoder at the
+        let ra = mech_ha.to_ra_flipped(lst);
+        // The degenerate `dec_enc == 0` post-flip case (dec encoder at the
         // wrap) is unreachable when `is_flipped == true` because
         // `side_of_pier`'s `|dec_ticks| > cpr/4` check is strict.
-        let dec = dec_enc.signum() * (180.0 - dec_enc.abs());
+        let dec = dec_enc.to_dec_flipped();
         (ra, dec)
     } else {
-        let ra = (lst_hours - mech_ha).rem_euclid(24.0);
-        (ra, dec_enc)
+        let ra = mech_ha.to_ra(lst);
+        (ra, dec_enc.to_dec())
     }
 }
 
@@ -335,8 +282,8 @@ pub fn opposite_pier_side(side: PierSide) -> PierSide {
 /// classification to anchor a flip decision on. This mirrors how
 /// [`side_of_pier`] degrades when `cpr_dec == 0`.
 pub fn select_pier_side_for_target(
-    target_ra_hours: f64,
-    lst_hours: f64,
+    target_ra: Ra,
+    lst: Lst,
     current: PierSide,
     policy: &FlipPolicy,
     binding_zone_hours: (f64, f64),
@@ -348,7 +295,7 @@ pub fn select_pier_side_for_target(
     if current == PierSide::Unknown {
         return PierSide::Unknown;
     }
-    let target_ha = ra_to_mechanical_ha(target_ra_hours, lst_hours);
+    let target_ha = lst.hour_angle_of(target_ra).value();
     let northern = site_latitude_deg >= 0.0;
     let pre_flip_side = if northern {
         PierSide::West
@@ -371,15 +318,6 @@ pub fn select_pier_side_for_target(
     } else {
         opposite_pier_side(current)
     }
-}
-
-/// Convert a declination (degrees, `[-90, +90]`) to Dec-axis encoder ticks.
-/// Inverse of [`dec_ticks_to_degrees`].
-pub fn dec_degrees_to_ticks(dec_degrees: f64, cpr: u32) -> i32 {
-    if cpr == 0 {
-        return 0;
-    }
-    (dec_degrees * (cpr as f64) / 360.0).round() as i32
 }
 
 /// Compute the RA-axis encoder target for a pickup-loop re-slew,
@@ -407,14 +345,16 @@ pub fn dec_degrees_to_ticks(dec_degrees: f64, cpr: u32) -> i32 {
 /// ~`polling_interval × 2` (one watcher sleep + one slew-settle
 /// + wire round-trips).
 pub fn pickup_target_ra_ticks(
-    target_ra_hours: f64,
-    current_lst_hours: f64,
+    target_ra: Ra,
+    current_lst: Lst,
     projection: std::time::Duration,
-    cpr_ra: u32,
-) -> i32 {
-    let lst_at_next_check = current_lst_hours + projection.as_secs_f64() / 3600.0;
-    let mech_ha = ra_to_mechanical_ha(target_ra_hours, lst_at_next_check);
-    mechanical_ha_to_ra_ticks(mech_ha, cpr_ra)
+    cpr_ra: Cpr,
+) -> RaTicks {
+    let lst_at_next_check = Lst::new(current_lst.value() + projection.as_secs_f64() / 3600.0);
+    lst_at_next_check
+        .hour_angle_of(target_ra)
+        .to_mech()
+        .to_ticks(cpr_ra)
 }
 
 /// Convert RA / Dec → topocentric (altitude, azimuth) given the site
@@ -424,14 +364,9 @@ pub fn pickup_target_ra_ticks(
 /// clockwise from north in the range `[0, 360)`. Refraction is **not**
 /// applied — the design doc keeps the driver refraction-free
 /// (`DoesRefraction = false`).
-pub fn ra_dec_to_alt_az(
-    ra_hours: f64,
-    dec_degrees: f64,
-    site_latitude_deg: f64,
-    lst_hours: f64,
-) -> (f64, f64) {
-    let ha_rad = ((lst_hours - ra_hours) * 15.0).to_radians();
-    let dec_rad = dec_degrees.to_radians();
+pub fn ra_dec_to_alt_az(ra: Ra, dec: Dec, site_latitude_deg: f64, lst: Lst) -> (f64, f64) {
+    let ha_rad = ((lst.value() - ra.value()) * 15.0).to_radians();
+    let dec_rad = dec.value().to_radians();
     let lat_rad = site_latitude_deg.to_radians();
     let sin_alt = dec_rad.sin() * lat_rad.sin() + dec_rad.cos() * lat_rad.cos() * ha_rad.cos();
     let alt_rad = sin_alt.clamp(-1.0, 1.0).asin();
@@ -460,12 +395,12 @@ pub fn ra_dec_to_alt_az(
 ///
 /// For the GTi defaults (`tmr_freq = 0xF42400 = 16_000_000`,
 /// `cpr = 0x375F00 = 3_628_800`), this gives roughly `379,887`.
-pub fn sidereal_step_period(tmr_freq: u32, cpr_ra: u32) -> u32 {
-    if cpr_ra == 0 {
+pub fn sidereal_step_period(tmr_freq: u32, cpr_ra: Cpr) -> u32 {
+    if cpr_ra.get() == 0 {
         return 0;
     }
     let sidereal_seconds = 86164.0905_f64;
-    ((tmr_freq as f64) * sidereal_seconds / (cpr_ra as f64)).round() as u32
+    ((tmr_freq as f64) * sidereal_seconds / (cpr_ra.get() as f64)).round() as u32
 }
 
 /// Sidereal rate in degrees per second.
@@ -500,53 +435,6 @@ pub fn pulse_guide_step_period(sidereal_period: u32, rate_factor: f64) -> u32 {
     ((sidereal_period as f64) / rate_factor).round() as u32
 }
 
-/// Fold an hour-angle value into `[-12, +12)`. Public helper so
-/// callers can compute "flipped" mech_HA = `fold_ha(mech_HA_normal + 12)`
-/// without re-deriving the modular-arithmetic convention.
-pub fn fold_ha(hours: f64) -> f64 {
-    fold_to_signed(hours, 24.0)
-}
-
-/// Fold a value into `[-period/2, +period/2)`. Used by both the RA and
-/// Dec encoder mappings.
-fn fold_to_signed(value: f64, period: f64) -> f64 {
-    let half = period / 2.0;
-    let folded = value.rem_euclid(period);
-    if folded >= half {
-        folded - period
-    } else {
-        folded
-    }
-}
-
-/// Fold an encoder-tick value (position or delta) into the shortest
-/// equivalent representation in `[-cpr/2, +cpr/2)`.
-///
-/// The Sky-Watcher firmware's encoder counter is wider than the physical
-/// axis's logical period (cpr): a single revolution is `cpr` ticks, but
-/// the counter can run from `−2²³` to `+2²³ − 1` before the codec's
-/// 24-bit field wraps. A through-wrap meridian-flip slew can therefore
-/// leave the encoder counter outside the canonical `[−cpr/2, +cpr/2)`
-/// band (e.g. `−1.89M` for a flip that landed physically at `+11.5 h`,
-/// modular `+1.74M`). Without folding, the next slew's
-/// `target_ticks − current_ticks` would order a full extra revolution,
-/// and the [`side_of_pier`] half-classification would misread the
-/// physical position. This helper collapses the raw value to its
-/// canonical-band equivalent.
-pub fn fold_to_canonical_band(value: i32, cpr: u32) -> i32 {
-    if cpr == 0 {
-        return value;
-    }
-    let cpr_i = cpr as i32;
-    let half_cpr = cpr_i / 2;
-    let modular = value.rem_euclid(cpr_i);
-    if modular >= half_cpr {
-        modular - cpr_i
-    } else {
-        modular
-    }
-}
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
@@ -555,45 +443,8 @@ mod tests {
 
     const GTI_CPR: u32 = 0x0037_5F00;
 
-    #[test]
-    fn ra_at_encoder_zero_is_meridian() {
-        assert_eq!(ra_ticks_to_mechanical_ha(0, GTI_CPR), 0.0);
-    }
-
-    #[test]
-    fn ra_at_quarter_revolution_is_six_hours_east() {
-        let ha = ra_ticks_to_mechanical_ha((GTI_CPR / 4) as i32, GTI_CPR);
-        assert!((ha - 6.0).abs() < 1e-9, "got {ha}");
-    }
-
-    #[test]
-    fn ra_at_negative_quarter_is_minus_six_hours() {
-        let ha = ra_ticks_to_mechanical_ha(-((GTI_CPR / 4) as i32), GTI_CPR);
-        assert!((ha + 6.0).abs() < 1e-9, "got {ha}");
-    }
-
-    #[test]
-    fn ra_at_half_revolution_folds_to_minus_twelve() {
-        let ha = ra_ticks_to_mechanical_ha((GTI_CPR / 2) as i32, GTI_CPR);
-        // Either -12 or just below 12, depending on fold direction.
-        assert!(ha.abs().abs_diff_eq(&12.0_f64, 1e-9), "got {ha}");
-    }
-
-    #[test]
-    fn dec_at_encoder_zero_is_celestial_equator() {
-        assert_eq!(dec_ticks_to_degrees(0, GTI_CPR), 0.0);
-    }
-
-    #[test]
-    fn dec_at_quarter_revolution_is_north_pole() {
-        let deg = dec_ticks_to_degrees((GTI_CPR / 4) as i32, GTI_CPR);
-        assert!((deg - 90.0).abs() < 1e-9, "got {deg}");
-    }
-
-    #[test]
-    fn dec_at_negative_quarter_is_south_pole() {
-        let deg = dec_ticks_to_degrees(-((GTI_CPR / 4) as i32), GTI_CPR);
-        assert!((deg + 90.0).abs() < 1e-9, "got {deg}");
+    fn cpr() -> Cpr {
+        Cpr::new(GTI_CPR)
     }
 
     #[test]
@@ -601,8 +452,8 @@ mod tests {
         // Two LSTs at the same UTC, 90° apart in longitude, must be 6
         // hours apart.
         let utc = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-        let lst_0 = local_sidereal_time_hours(utc, 0.0).unwrap();
-        let lst_e = local_sidereal_time_hours(utc, 90.0).unwrap();
+        let lst_0 = local_sidereal_time_hours(utc, 0.0).unwrap().value();
+        let lst_e = local_sidereal_time_hours(utc, 90.0).unwrap().value();
         let diff = (lst_e - lst_0).rem_euclid(24.0);
         assert!((diff - 6.0).abs() < 1e-6, "LST(90E) - LST(0) = {diff}h");
     }
@@ -644,22 +495,10 @@ mod tests {
     }
 
     #[test]
-    fn mechanical_ha_to_ra_round_trips() {
-        for &(mech_ha, lst) in &[(0.0, 0.0), (3.0, 6.0), (-4.5, 18.0), (5.999, 12.0)] {
-            let ra = mechanical_ha_to_ra(mech_ha, lst);
-            let back = ra_to_mechanical_ha(ra, lst);
-            assert!(
-                (back - mech_ha).abs() < 1e-9,
-                "mech_ha={mech_ha} lst={lst} ra={ra} back={back}"
-            );
-        }
-    }
-
-    #[test]
     fn side_of_pier_north_equator_is_west() {
         // Dec encoder at home (0 ticks ≈ celestial equator on the
         // meridian). Mount is in normal-pointing state → pierWest.
-        assert_eq!(side_of_pier(0, GTI_CPR, 47.6), PierSide::West);
+        assert_eq!(side_of_pier(DecTicks::new(0), cpr(), 47.6), PierSide::West);
     }
 
     #[test]
@@ -668,14 +507,26 @@ mod tests {
         // is reachable without a meridian flip. ConformU's SOPPierTest
         // exercises these cases; all four must read pierWest.
         let quarter = (GTI_CPR / 4) as i32;
-        assert_eq!(side_of_pier(quarter / 3, GTI_CPR, 47.6), PierSide::West);
-        assert_eq!(side_of_pier(-quarter / 3, GTI_CPR, 47.6), PierSide::West);
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter / 3), cpr(), 47.6),
+            PierSide::West
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(-quarter / 3), cpr(), 47.6),
+            PierSide::West
+        );
         // Boundary cases at exactly ±90°: the mount can reach either
         // celestial pole via normal pointing, so the boundary is
         // included in `West` (matches INDI eqmod's `> 90°` strict
         // check).
-        assert_eq!(side_of_pier(quarter, GTI_CPR, 47.6), PierSide::West);
-        assert_eq!(side_of_pier(-quarter, GTI_CPR, 47.6), PierSide::West);
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter), cpr(), 47.6),
+            PierSide::West
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(-quarter), cpr(), 47.6),
+            PierSide::West
+        );
     }
 
     #[test]
@@ -684,26 +535,47 @@ mod tests {
         // the Dec axis beyond the celestial pole — the post-flip /
         // counterweight-up state, which ASCOM names pierEast.
         let quarter = (GTI_CPR / 4) as i32;
-        assert_eq!(side_of_pier(quarter + 1, GTI_CPR, 47.6), PierSide::East);
-        assert_eq!(side_of_pier(-(quarter + 1), GTI_CPR, 47.6), PierSide::East);
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter + 1), cpr(), 47.6),
+            PierSide::East
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(-(quarter + 1)), cpr(), 47.6),
+            PierSide::East
+        );
         // Mid-flip and "full flip to equator on the opposite side".
         let half = (GTI_CPR / 2) as i32;
         assert_eq!(
-            side_of_pier(quarter + half / 4, GTI_CPR, 47.6),
+            side_of_pier(DecTicks::new(quarter + half / 4), cpr(), 47.6),
             PierSide::East
         );
-        assert_eq!(side_of_pier(half, GTI_CPR, 47.6), PierSide::East);
+        assert_eq!(
+            side_of_pier(DecTicks::new(half), cpr(), 47.6),
+            PierSide::East
+        );
     }
 
     #[test]
     fn side_of_pier_southern_hemisphere_inverts() {
         // Mirror of the northern split.
         let quarter = (GTI_CPR / 4) as i32;
-        assert_eq!(side_of_pier(0, GTI_CPR, -33.9), PierSide::East);
-        assert_eq!(side_of_pier(quarter / 3, GTI_CPR, -33.9), PierSide::East);
-        assert_eq!(side_of_pier(quarter, GTI_CPR, -33.9), PierSide::East);
-        assert_eq!(side_of_pier(quarter + 1, GTI_CPR, -33.9), PierSide::West);
-        assert_eq!(side_of_pier(-(quarter + 1), GTI_CPR, -33.9), PierSide::West);
+        assert_eq!(side_of_pier(DecTicks::new(0), cpr(), -33.9), PierSide::East);
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter / 3), cpr(), -33.9),
+            PierSide::East
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter), cpr(), -33.9),
+            PierSide::East
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(quarter + 1), cpr(), -33.9),
+            PierSide::West
+        );
+        assert_eq!(
+            side_of_pier(DecTicks::new(-(quarter + 1)), cpr(), -33.9),
+            PierSide::West
+        );
     }
 
     #[test]
@@ -713,7 +585,10 @@ mod tests {
         // `NOT_CONNECTED` before reaching the helper in practice, but
         // the helper still has to handle this defensively to stay a
         // total function.
-        assert_eq!(side_of_pier(0, 0, 47.6), PierSide::Unknown);
+        assert_eq!(
+            side_of_pier(DecTicks::new(0), Cpr::new(0), 47.6),
+            PierSide::Unknown
+        );
     }
 
     #[test]
@@ -728,114 +603,35 @@ mod tests {
         let cpr_i = GTI_CPR as i32;
         let raw_positive_zone = cpr_i * 7 / 8; // 7·cpr/8, folds to -cpr/8
         assert!(raw_positive_zone.abs() > cpr_i / 4);
-        let folded = fold_to_canonical_band(raw_positive_zone, GTI_CPR);
+        let folded = DecTicks::new(raw_positive_zone)
+            .fold_to_canonical_band(cpr())
+            .value();
         assert!(folded.abs() <= cpr_i / 4, "must fold into pre-flip half");
         assert_eq!(
-            side_of_pier(raw_positive_zone, GTI_CPR, 47.6),
+            side_of_pier(DecTicks::new(raw_positive_zone), cpr(), 47.6),
             PierSide::West,
             "raw in positive disagreement zone must classify by folded position"
         );
         // Mirror on the negative side.
         let raw_negative_zone = -cpr_i * 7 / 8;
         assert_eq!(
-            side_of_pier(raw_negative_zone, GTI_CPR, 47.6),
+            side_of_pier(DecTicks::new(raw_negative_zone), cpr(), 47.6),
             PierSide::West,
             "raw in negative disagreement zone must classify by folded position"
         );
         // And the southern hemisphere mirror.
         assert_eq!(
-            side_of_pier(raw_positive_zone, GTI_CPR, -33.9),
+            side_of_pier(DecTicks::new(raw_positive_zone), cpr(), -33.9),
             PierSide::East,
             "south: raw in disagreement zone must classify by folded position"
         );
     }
 
     #[test]
-    fn fold_to_canonical_band_passes_through_small_deltas() {
-        assert_eq!(fold_to_canonical_band(0, GTI_CPR), 0);
-        assert_eq!(fold_to_canonical_band(1, GTI_CPR), 1);
-        assert_eq!(fold_to_canonical_band(-1, GTI_CPR), -1);
-        assert_eq!(fold_to_canonical_band(100_000, GTI_CPR), 100_000);
-        assert_eq!(fold_to_canonical_band(-100_000, GTI_CPR), -100_000);
-    }
-
-    #[test]
-    fn fold_to_canonical_band_collapses_long_way_to_short_way() {
-        let half = GTI_CPR as i32 / 2;
-        // Delta of +cpr/2 + 100 folds to −cpr/2 + 100 (taking the
-        // shorter path on the modular axis).
-        let folded = fold_to_canonical_band(half + 100, GTI_CPR);
-        assert_eq!(folded, -half + 100);
-        // Symmetric for the negative direction.
-        let folded = fold_to_canonical_band(-half - 100, GTI_CPR);
-        assert_eq!(folded, half - 100);
-    }
-
-    #[test]
-    fn fold_to_canonical_band_recovers_from_through_wrap_encoder() {
-        // After a through-wrap flip slew, the encoder may have landed
-        // at e.g. raw −1,890,000 (= +1,738,800 modular). A subsequent
-        // pickup that computes `target_canonical (+1,738,800) −
-        // current_raw (−1,890,000) = +3,628,800` would order a full
-        // revolution; folding collapses it to the (near-)zero residual
-        // it should be.
-        let target_canonical = 1_738_800_i32;
-        let current_raw = -1_890_000_i32;
-        let raw_delta = target_canonical - current_raw;
-        // raw_delta ≈ cpr. Folded should be small.
-        let folded = fold_to_canonical_band(raw_delta, GTI_CPR);
-        assert!(folded.abs() < 1000, "expected near-zero, got {folded}");
-    }
-
-    #[test]
-    fn fold_to_canonical_band_handles_zero_cpr_defensively() {
-        // cpr = 0 is the degenerate "parameter cache not populated"
-        // case. Callers normally short-circuit on NOT_CONNECTED
-        // before reaching this helper; pass-through is the defensive
-        // fallback so a logic bug there can't divide by zero here.
-        assert_eq!(fold_to_canonical_band(12_345, 0), 12_345);
-    }
-
-    /// Tiny `f64` helper so the half-revolution fold test can be stated
-    /// concisely.
-    trait AbsDiffEq {
-        fn abs_diff_eq(&self, other: &f64, tol: f64) -> bool;
-    }
-    impl AbsDiffEq for f64 {
-        fn abs_diff_eq(&self, other: &f64, tol: f64) -> bool {
-            (self - other).abs() < tol
-        }
-    }
-
-    #[test]
-    fn ra_ticks_round_trip_through_mechanical_ha() {
-        for ticks in [
-            0,
-            100_000,
-            -200_000,
-            GTI_CPR as i32 / 8,
-            -(GTI_CPR as i32 / 4),
-        ] {
-            let ha = ra_ticks_to_mechanical_ha(ticks, GTI_CPR);
-            let back = mechanical_ha_to_ra_ticks(ha, GTI_CPR);
-            assert_eq!(back, ticks, "ticks={ticks}");
-        }
-    }
-
-    #[test]
-    fn dec_ticks_round_trip_through_degrees() {
-        for ticks in [0, 1_000, -1_000, GTI_CPR as i32 / 8, -(GTI_CPR as i32 / 4)] {
-            let deg = dec_ticks_to_degrees(ticks, GTI_CPR);
-            let back = dec_degrees_to_ticks(deg, GTI_CPR);
-            assert_eq!(back, ticks, "ticks={ticks}");
-        }
-    }
-
-    #[test]
     fn alt_az_for_zenith_at_equator() {
         // At the equator, the celestial equator passes through the zenith
         // when the LST equals the target's RA.
-        let (alt, _az) = ra_dec_to_alt_az(12.0, 0.0, 0.0, 12.0);
+        let (alt, _az) = ra_dec_to_alt_az(Ra::new(12.0), Dec::new(0.0), 0.0, Lst::new(12.0));
         assert!((alt - 90.0).abs() < 1e-6, "got alt={alt}");
     }
 
@@ -843,14 +639,14 @@ mod tests {
     fn alt_az_for_celestial_pole_at_north_observer() {
         // From a northern observer, the NCP sits at altitude = latitude.
         // (Matches the standard astronomy textbook result.)
-        let (alt, _az) = ra_dec_to_alt_az(0.0, 90.0, 47.6, 12.0);
+        let (alt, _az) = ra_dec_to_alt_az(Ra::new(0.0), Dec::new(90.0), 47.6, Lst::new(12.0));
         assert!((alt - 47.6).abs() < 1e-6, "got alt={alt}");
     }
 
     #[test]
     fn sidereal_step_period_for_gti_defaults() {
         // tmr_freq = 16M, cpr = 3,628,800 → period ≈ 379,887.
-        let p = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let p = sidereal_step_period(0x00F4_2400, cpr());
         assert!((379_000..=380_000).contains(&p), "expected ~380K, got {p}");
     }
 
@@ -860,12 +656,11 @@ mod tests {
         // mech_ha → ticks math the slew-issue path uses. This is the
         // backwards-compat case: pre-compensation off ⇒ identical
         // wire behaviour to before the change.
-        let target_ra = 6.0;
-        let lst = 12.0;
-        let mech_ha = ra_to_mechanical_ha(target_ra, lst);
-        let unprojected = mechanical_ha_to_ra_ticks(mech_ha, GTI_CPR);
+        let target_ra = Ra::new(6.0);
+        let lst = Lst::new(12.0);
+        let unprojected = lst.hour_angle_of(target_ra).to_mech().to_ticks(cpr());
         let projected_zero =
-            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, cpr());
         assert_eq!(projected_zero, unprojected);
     }
 
@@ -878,15 +673,13 @@ mod tests {
         // sidereal seconds → 0.4/3600 hours of mech_HA.
         // Ticks per hour of mech_HA = cpr/24 = 151,200. So 400 ms ≈
         // 0.4/3600 × 151,200 ≈ 16.8 ticks.
-        let target_ra = 6.0;
-        let lst = 12.0;
-        let no_proj = pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
-        let projected = pickup_target_ra_ticks(
-            target_ra,
-            lst,
-            std::time::Duration::from_millis(400),
-            GTI_CPR,
-        );
+        let target_ra = Ra::new(6.0);
+        let lst = Lst::new(12.0);
+        let no_proj =
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, cpr()).value();
+        let projected =
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::from_millis(400), cpr())
+                .value();
         let delta = projected - no_proj;
         // Expected: ~16-17 ticks. Tolerance +/-1 for round() boundary.
         assert!(
@@ -899,20 +692,17 @@ mod tests {
     fn pickup_target_projection_scales_linearly_with_duration() {
         // Doubling the projection should double the tick delta (within
         // round-to-int noise).
-        let target_ra = 6.0;
-        let lst = 12.0;
-        let d1 = pickup_target_ra_ticks(
-            target_ra,
-            lst,
-            std::time::Duration::from_millis(200),
-            GTI_CPR,
-        ) - pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
-        let d2 = pickup_target_ra_ticks(
-            target_ra,
-            lst,
-            std::time::Duration::from_millis(400),
-            GTI_CPR,
-        ) - pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, GTI_CPR);
+        let target_ra = Ra::new(6.0);
+        let lst = Lst::new(12.0);
+        let zero = pickup_target_ra_ticks(target_ra, lst, std::time::Duration::ZERO, cpr()).value();
+        let d1 =
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::from_millis(200), cpr())
+                .value()
+                - zero;
+        let d2 =
+            pickup_target_ra_ticks(target_ra, lst, std::time::Duration::from_millis(400), cpr())
+                .value()
+                - zero;
         assert!(
             (d2 - 2 * d1).abs() <= 1,
             "expected ~2× scaling: 200ms→{d1}, 400ms→{d2}"
@@ -923,7 +713,7 @@ mod tests {
     fn pulse_guide_step_period_identity_at_unit_rate_factor() {
         // Rate factor = 1.0 reproduces the sidereal period exactly
         // (modulo rounding to integer).
-        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let p_sid = sidereal_step_period(0x00F4_2400, cpr());
         assert_eq!(pulse_guide_step_period(p_sid, 1.0), p_sid);
     }
 
@@ -931,7 +721,7 @@ mod tests {
     fn pulse_guide_step_period_halves_rate_doubles_period() {
         // Rate factor = 0.5 (Dec North/South at fraction = 0.5, or East
         // at fraction = 0.5) doubles the step period.
-        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let p_sid = sidereal_step_period(0x00F4_2400, cpr());
         let shifted = pulse_guide_step_period(p_sid, 0.5);
         assert_eq!(shifted, 2 * p_sid);
     }
@@ -939,7 +729,7 @@ mod tests {
     #[test]
     fn pulse_guide_step_period_west_at_fraction_half_uses_one_and_a_half_rate() {
         // West at fraction = 0.5 → rate_factor = 1.5 → period = P_sid / 1.5.
-        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let p_sid = sidereal_step_period(0x00F4_2400, cpr());
         let shifted = pulse_guide_step_period(p_sid, 1.5);
         let expected = ((p_sid as f64) / 1.5).round() as u32;
         assert_eq!(shifted, expected);
@@ -951,7 +741,7 @@ mod tests {
     #[test]
     fn pulse_guide_step_period_small_fraction_grows_period_proportionally() {
         // fraction = 0.1 on Dec → rate_factor = 0.1 → period = 10 × sidereal.
-        let p_sid = sidereal_step_period(0x00F4_2400, GTI_CPR);
+        let p_sid = sidereal_step_period(0x00F4_2400, cpr());
         let shifted = pulse_guide_step_period(p_sid, 0.1);
         assert_eq!(shifted, 10 * p_sid);
     }
@@ -963,11 +753,12 @@ mod tests {
         // The "normal" helper is the existing slew-issue pipeline,
         // extracted. Targets at LST=12h, RA=12h → mech_HA=0 (meridian);
         // any dec → encoder reflects that dec.
-        let (ra_ticks, dec_ticks) = target_encoder_normal(12.0, 30.0, 12.0, GTI_CPR, GTI_CPR);
-        assert_eq!(ra_ticks, 0);
+        let (ra_ticks, dec_ticks) =
+            target_encoder_normal(Ra::new(12.0), Dec::new(30.0), Lst::new(12.0), cpr(), cpr());
+        assert_eq!(ra_ticks.value(), 0);
         // Dec encoder at 30° / 360° × CPR.
         let expected_dec = (30.0 * (GTI_CPR as f64) / 360.0).round() as i32;
-        assert_eq!(dec_ticks, expected_dec);
+        assert_eq!(dec_ticks.value(), expected_dec);
     }
 
     #[test]
@@ -978,10 +769,15 @@ mod tests {
         let lst = 5.0; // arbitrary
         let target_ra = lst + 0.5; // mech_HA = lst − ra = −0.5
         let target_dec = 45.0;
-        let (ra_ticks, dec_ticks) =
-            target_encoder_flipped(target_ra, target_dec, lst, GTI_CPR, GTI_CPR);
-        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
-        let dec_enc_flipped = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        let (ra_ticks, dec_ticks) = target_encoder_flipped(
+            Ra::new(target_ra),
+            Dec::new(target_dec),
+            Lst::new(lst),
+            cpr(),
+            cpr(),
+        );
+        let mech_ha_flipped = ra_ticks.to_mech_ha(cpr()).value();
+        let dec_enc_flipped = dec_ticks.to_mech_dec(cpr()).value();
         assert!(
             (mech_ha_flipped - 11.5).abs() < 1e-6,
             "expected mech_HA_flipped ≈ +11.5, got {mech_ha_flipped}"
@@ -998,8 +794,14 @@ mod tests {
         // +0.5; post-flip = +0.5 + 12 = +12.5 → folds to −11.5.
         let lst = 5.0;
         let target_ra = lst - 0.5; // mech_HA = +0.5
-        let (ra_ticks, _dec) = target_encoder_flipped(target_ra, 30.0, lst, GTI_CPR, GTI_CPR);
-        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
+        let (ra_ticks, _dec) = target_encoder_flipped(
+            Ra::new(target_ra),
+            Dec::new(30.0),
+            Lst::new(lst),
+            cpr(),
+            cpr(),
+        );
+        let mech_ha_flipped = ra_ticks.to_mech_ha(cpr()).value();
         assert!(
             (mech_ha_flipped + 11.5).abs() < 1e-6,
             "expected mech_HA_flipped ≈ −11.5, got {mech_ha_flipped}"
@@ -1013,8 +815,14 @@ mod tests {
         // branch).
         let lst = 5.0;
         let target_ra = lst; // mech_HA = 0
-        let (ra_ticks, _) = target_encoder_flipped(target_ra, 30.0, lst, GTI_CPR, GTI_CPR);
-        let mech_ha_flipped = ra_ticks_to_mechanical_ha(ra_ticks, GTI_CPR);
+        let (ra_ticks, _) = target_encoder_flipped(
+            Ra::new(target_ra),
+            Dec::new(30.0),
+            Lst::new(lst),
+            cpr(),
+            cpr(),
+        );
+        let mech_ha_flipped = ra_ticks.to_mech_ha(cpr()).value();
         assert!(
             (mech_ha_flipped + 12.0).abs() < 1e-6 || (mech_ha_flipped - 12.0).abs() < 1e-6,
             "expected mech_HA_flipped at the ±12 wrap, got {mech_ha_flipped}"
@@ -1024,8 +832,9 @@ mod tests {
     #[test]
     fn target_encoder_flipped_dec_negative_target_flips_through_south_pole() {
         // dec = −45° → flipped dec_enc = −(180 − 45) = −135°.
-        let (_, dec_ticks) = target_encoder_flipped(6.0, -45.0, 6.0, GTI_CPR, GTI_CPR);
-        let dec_enc = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        let (_, dec_ticks) =
+            target_encoder_flipped(Ra::new(6.0), Dec::new(-45.0), Lst::new(6.0), cpr(), cpr());
+        let dec_enc = dec_ticks.to_mech_dec(cpr()).value();
         assert!(
             (dec_enc + 135.0).abs() < 1e-6,
             "expected dec_enc ≈ −135°, got {dec_enc}"
@@ -1038,8 +847,9 @@ mod tests {
         // (180 − 90) = +90. The pole is the same physical position
         // whether you're flipped or not — only the OTA's rotation about
         // its optical axis differs.
-        let (_, dec_ticks) = target_encoder_flipped(6.0, 90.0, 6.0, GTI_CPR, GTI_CPR);
-        let dec_enc = dec_ticks_to_degrees(dec_ticks, GTI_CPR);
+        let (_, dec_ticks) =
+            target_encoder_flipped(Ra::new(6.0), Dec::new(90.0), Lst::new(6.0), cpr(), cpr());
+        let dec_enc = dec_ticks.to_mech_dec(cpr()).value();
         assert!(
             (dec_enc - 90.0).abs() < 1e-6,
             "expected dec_enc ≈ +90°, got {dec_enc}"
@@ -1071,8 +881,14 @@ mod tests {
         // Even with target way outside the pre-flip envelope, !enabled
         // means "leave the side alone".
         for current in [PierSide::West, PierSide::East, PierSide::Unknown] {
-            let chosen =
-                select_pier_side_for_target(0.0, lst, current, &policy, BINDING_ZONE, LAT_NORTH);
+            let chosen = select_pier_side_for_target(
+                Ra::new(0.0),
+                Lst::new(lst),
+                current,
+                &policy,
+                BINDING_ZONE,
+                LAT_NORTH,
+            );
             assert_eq!(chosen, current, "current={current:?}");
         }
     }
@@ -1083,8 +899,8 @@ mod tests {
         // enabled, return Unknown.
         let policy = flip_enabled();
         let chosen = select_pier_side_for_target(
-            0.0,
-            12.0,
+            Ra::new(0.0),
+            Lst::new(12.0),
             PierSide::Unknown,
             &policy,
             BINDING_ZONE,
@@ -1101,8 +917,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst + 3.0; // mech_HA = lst − ra = −3
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::West,
             &policy,
             BINDING_ZONE,
@@ -1119,8 +935,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst - 0.3; // mech_HA = +0.3 (within ±0.5)
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::East,
             &policy,
             BINDING_ZONE,
@@ -1138,8 +954,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst + 3.0; // mech_HA = −3, outside ±0.5
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::East,
             &policy,
             BINDING_ZONE,
@@ -1159,8 +975,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst - 7.5; // mech_HA = +7.5
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::West,
             &policy,
             BINDING_ZONE,
@@ -1179,8 +995,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst - 0.5; // mech_HA = +0.5 = flip_range_hours
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::East,
             &policy,
             BINDING_ZONE,
@@ -1200,8 +1016,8 @@ mod tests {
         let lst = 12.0;
         let target_ra = lst + 3.0; // mech_HA = −3
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::East,
             &policy,
             BINDING_ZONE,
@@ -1211,8 +1027,8 @@ mod tests {
         // And the post-flip side (pierWest in south): outside flip
         // window means flip back to East (normal in south).
         let chosen = select_pier_side_for_target(
-            target_ra,
-            lst,
+            Ra::new(target_ra),
+            Lst::new(lst),
             PierSide::West,
             &policy,
             BINDING_ZONE,
@@ -1229,9 +1045,11 @@ mod tests {
         // must invert target_encoder_normal exactly.
         let lst = 5.0;
         for (ra, dec) in [(12.0, 30.0), (3.5, -45.0), (0.0, 0.0), (23.9, 89.9)] {
-            let (ra_ticks, dec_ticks) = target_encoder_normal(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_ticks, dec_ticks) =
+                target_encoder_normal(Ra::new(ra), Dec::new(dec), Lst::new(lst), cpr(), cpr());
             let (ra_back, dec_back) =
-                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, 47.6);
+                encoder_to_celestial(ra_ticks, dec_ticks, Lst::new(lst), cpr(), cpr(), 47.6);
+            let (ra_back, dec_back) = (ra_back.value(), dec_back.value());
             assert!(
                 ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
                 "ra round-trip: {ra} → {ra_back}"
@@ -1251,9 +1069,11 @@ mod tests {
         // RA/Dec of the OTA pointing.
         let lst = 5.0;
         for (ra, dec) in [(lst + 0.5, 45.0), (lst - 0.3, 30.0), (lst, 0.0)] {
-            let (ra_ticks, dec_ticks) = target_encoder_flipped(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_ticks, dec_ticks) =
+                target_encoder_flipped(Ra::new(ra), Dec::new(dec), Lst::new(lst), cpr(), cpr());
             let (ra_back, dec_back) =
-                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, 47.6);
+                encoder_to_celestial(ra_ticks, dec_ticks, Lst::new(lst), cpr(), cpr(), 47.6);
+            let (ra_back, dec_back) = (ra_back.value(), dec_back.value());
             assert!(
                 ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
                 "post-flip ra round-trip: {ra} → {ra_back}"
@@ -1273,9 +1093,11 @@ mod tests {
         // internally and `encoder_to_celestial` consumes it.
         let lst = 5.0;
         for (ra, dec) in [(lst + 0.5, 45.0), (lst, -30.0), (lst, 0.0)] {
-            let (ra_ticks, dec_ticks) = target_encoder_flipped(ra, dec, lst, GTI_CPR, GTI_CPR);
+            let (ra_ticks, dec_ticks) =
+                target_encoder_flipped(Ra::new(ra), Dec::new(dec), Lst::new(lst), cpr(), cpr());
             let (ra_back, dec_back) =
-                encoder_to_celestial(ra_ticks, dec_ticks, lst, GTI_CPR, GTI_CPR, -33.0);
+                encoder_to_celestial(ra_ticks, dec_ticks, Lst::new(lst), cpr(), cpr(), -33.0);
+            let (ra_back, dec_back) = (ra_back.value(), dec_back.value());
             assert!(
                 ((ra - ra_back + 12.0).rem_euclid(24.0) - 12.0).abs() < 1e-4,
                 "south post-flip ra round-trip: {ra} → {ra_back}"
@@ -1292,7 +1114,15 @@ mod tests {
         // Encoder at (0, 0) means mech_HA = 0 and dec encoder = 0 →
         // pre-flip pierWest in north → celestial (LST, 0).
         let lst = 7.25;
-        let (ra, dec) = encoder_to_celestial(0, 0, lst, GTI_CPR, GTI_CPR, 47.6);
+        let (ra, dec) = encoder_to_celestial(
+            RaTicks::new(0),
+            DecTicks::new(0),
+            Lst::new(lst),
+            cpr(),
+            cpr(),
+            47.6,
+        );
+        let (ra, dec) = (ra.value(), dec.value());
         assert!((ra - lst).abs() < 1e-6, "ra = {ra}, expected {lst}");
         assert!(dec.abs() < 1e-6, "dec = {dec}");
     }
@@ -1305,7 +1135,15 @@ mod tests {
         // (180 - 180) = 0. RA mapping uses the post-flip +12h shift.
         let lst = 12.0;
         let half_cpr = (GTI_CPR / 2) as i32;
-        let (_ra, dec) = encoder_to_celestial(0, half_cpr, lst, GTI_CPR, GTI_CPR, 47.6);
+        let (_ra, dec) = encoder_to_celestial(
+            RaTicks::new(0),
+            DecTicks::new(half_cpr),
+            Lst::new(lst),
+            cpr(),
+            cpr(),
+            47.6,
+        );
+        let dec = dec.value();
         assert!(dec.abs() < 1e-6, "dec at wrap = {dec}");
     }
 

--- a/services/star-adventurer-gti/src/coordinates.rs
+++ b/services/star-adventurer-gti/src/coordinates.rs
@@ -304,9 +304,16 @@ pub fn select_pier_side_for_target(
     };
     let current_covers = if current == pre_flip_side {
         // Natural side: mech_HA = celestial HA. "Covers" means not in
-        // binding zone — including the safe wrap region near ±12.
+        // binding zone — including the safe wrap region near ±12. The
+        // zone is the **open** interval `(zone_min, zone_max)` with
+        // `zone_min >= zone_max` meaning disabled, matching
+        // `check_within_safe_envelope`, `canonical_path_crosses_binding_zone`,
+        // and `tracking_guard_breached`. A target landing exactly on a
+        // boundary is therefore *not* in the zone — the envelope check
+        // would permit it on this side, so the selector must not force a
+        // spurious flip.
         let (zone_min, zone_max) = binding_zone_hours;
-        !(zone_min <= zone_max && (zone_min..=zone_max).contains(&target_ha))
+        !(zone_min < zone_max && target_ha > zone_min && target_ha < zone_max)
     } else {
         // Post-flip side: operational rule, stay on flipped only near
         // meridian. The binding zone for flipped-side mech_HA is
@@ -1003,6 +1010,35 @@ mod tests {
             LAT_NORTH,
         );
         assert_eq!(chosen, PierSide::East);
+    }
+
+    #[test]
+    fn select_pier_side_north_target_on_zone_boundary_stays_natural_side() {
+        // Open-interval semantics, consistent with
+        // check_within_safe_envelope: a target landing exactly on a
+        // binding-zone boundary is *not* in the zone, so the selector
+        // keeps the natural (pre-flip) side instead of forcing a
+        // spurious flip the envelope check would not require. Uses an
+        // exactly-representable zone so the boundary equality is precise.
+        let policy = flip_enabled();
+        let lst = 12.0;
+        let zone = (6.0, 10.0);
+        for boundary in [zone.0, zone.1] {
+            let target_ra = lst - boundary; // mech_HA = lst − ra = boundary, exact
+            let chosen = select_pier_side_for_target(
+                Ra::new(target_ra),
+                Lst::new(lst),
+                PierSide::West,
+                &policy,
+                zone,
+                LAT_NORTH,
+            );
+            assert_eq!(
+                chosen,
+                PierSide::West,
+                "target on zone boundary {boundary} must stay the natural side"
+            );
+        }
     }
 
     #[test]

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod manager;
 pub mod mount_device;
 pub mod transport;
+pub mod units;
 
 pub use config::{
     load_config, ApPark, Config, FlipPolicy, MountConfig, ServerConfig, TrackingRateName,

--- a/services/star-adventurer-gti/src/lib.rs
+++ b/services/star-adventurer-gti/src/lib.rs
@@ -14,7 +14,8 @@ pub mod transport;
 pub mod units;
 
 pub use config::{
-    load_config, ApPark, Config, FlipPolicy, MountConfig, ServerConfig, TrackingRateName,
+    load_config, ActiveZone, ApPark, Config, CwExclusionZone, DecLimits, FlipPolicy,
+    FlipRangeHours, MountConfig, ServerConfig, TrackingGuardMarginHours, TrackingRateName,
     TransportConfig, UdpConfig, UsbConfig, MAX_FLIP_RANGE_HOURS,
 };
 pub use error::{Result, StarAdvError};

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -178,12 +178,13 @@ impl MountDevice {
     /// The check is in **encoder `mech_HA` space** (signed hours
     /// folded to `[−12, +12)`). For a target on the natural pier
     /// side, `target_mech_HA = celestial_HA`. For a flipped target,
-    /// `target_mech_HA = celestial_HA + 12 h` folded. The interval
-    /// `(binding_zone_min_hours, binding_zone_max_hours)` is **open**
-    /// — a target landing exactly on a zone boundary is permitted (and
-    /// matches the open-interval convention [`super::slew::check_non_flip_ra_path`]
-    /// uses for path checks). An empty zone (`min >= max`) disables
-    /// the check, matching the same path-check convention.
+    /// `target_mech_HA = celestial_HA + 12 h` folded. The zone comes from
+    /// [`crate::config::CwExclusionZone::bounds`] and is treated as an
+    /// **open** interval `(min, max)` — a target landing exactly on a
+    /// boundary is permitted (and matches the open-interval convention
+    /// [`super::slew::check_non_flip_ra_path`] uses for path checks). A
+    /// disabled zone (JSON `null`, where `bounds()` returns `min > max`)
+    /// disables the check, matching the same path-check convention.
     ///
     /// Note: this is the *destination-only* leg of the safety model.
     /// Path crossings are handled separately by

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -38,11 +38,11 @@ use tracing::{debug, info};
 use crate::codec::SkywatcherCodec;
 use crate::config::ApPark;
 use crate::coordinates::{
-    dec_degrees_to_ticks, fold_ha, fold_to_canonical_band, local_sidereal_time_hours,
-    mechanical_ha_to_ra_ticks, ra_to_mechanical_ha, side_of_pier as side_of_pier_calc,
-    target_encoder_flipped, target_encoder_normal, SIDEREAL_DEG_PER_SEC,
+    local_sidereal_time_hours, side_of_pier as side_of_pier_calc, target_encoder_flipped,
+    target_encoder_normal, SIDEREAL_DEG_PER_SEC,
 };
 use crate::error::StarAdvError;
+use crate::units::{Cpr, Dec, DecTicks, Lst, MechDec, MechHa, Ra, RaTicks};
 
 use super::park_persistence::{read_connect_fields, MountConnectFields};
 use super::slew::{
@@ -210,9 +210,12 @@ impl MountDevice {
         target_is_flipped: bool,
     ) -> ASCOMResult<()> {
         let target_mech_ha = {
-            let normal = ra_to_mechanical_ha(ra_hours, lst_hours);
+            let normal = Lst::new(lst_hours)
+                .hour_angle_of(Ra::new(ra_hours))
+                .to_mech()
+                .value();
             if target_is_flipped {
-                fold_ha(normal + 12.0)
+                MechHa::new(normal + 12.0).value()
             } else {
                 normal
             }
@@ -492,8 +495,12 @@ impl MountDevice {
         let dec_deg = park.codebase_dec_encoder_degrees(self.config.site_latitude_deg)?;
         let params = self.manager.parameters().await?;
         Some((
-            mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra),
-            dec_degrees_to_ticks(dec_deg, params.cpr_dec),
+            MechHa::new(mech_ha)
+                .to_ticks(Cpr::new(params.cpr_ra))
+                .value(),
+            MechDec::new(dec_deg)
+                .to_ticks(Cpr::new(params.cpr_dec))
+                .value(),
         ))
     }
 
@@ -563,8 +570,12 @@ impl MountDevice {
             );
             return Ok(());
         }
-        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
-        let dec_ticks = dec_degrees_to_ticks(dec_deg, params.cpr_dec);
+        let ra_ticks = MechHa::new(mech_ha)
+            .to_ticks(Cpr::new(params.cpr_ra))
+            .value();
+        let dec_ticks = MechDec::new(dec_deg)
+            .to_ticks(Cpr::new(params.cpr_dec))
+            .value();
         self.reset_mount_encoders(session, ra_ticks, dec_ticks)
             .await?;
         info!(
@@ -611,14 +622,26 @@ impl MountDevice {
         let pre_flip_side = pre_flip_side_for_latitude(self.config.site_latitude_deg);
         let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
         let (ra_ticks, dec_ticks) = if target_is_flipped {
-            target_encoder_flipped(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+            target_encoder_flipped(
+                Ra::new(ra),
+                Dec::new(dec),
+                lst,
+                Cpr::new(params.cpr_ra),
+                Cpr::new(params.cpr_dec),
+            )
         } else {
-            target_encoder_normal(ra, dec, lst, params.cpr_ra, params.cpr_dec)
+            target_encoder_normal(
+                Ra::new(ra),
+                Dec::new(dec),
+                lst,
+                Cpr::new(params.cpr_ra),
+                Cpr::new(params.cpr_dec),
+            )
         };
         // Refuse before any wire motion if the slew target falls
         // outside the configured mechanical envelope for the chosen
         // pier side.
-        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
+        self.check_within_safe_envelope(ra, dec, lst.value(), target_is_flipped)?;
 
         // Atomically reserve the in-progress slot **before** issuing
         // any motion. Latch the target + capture the tracking flag in
@@ -646,8 +669,8 @@ impl MountDevice {
         let result: ASCOMResult<()> = async {
             let snap = self.manager.snapshot().await;
             let current_side = side_of_pier_calc(
-                snap.dec.position_ticks,
-                params.cpr_dec,
+                DecTicks::new(snap.dec.position_ticks),
+                Cpr::new(params.cpr_dec),
                 self.config.site_latitude_deg,
             );
             let is_flip_slew = current_side != chosen_side;
@@ -655,8 +678,9 @@ impl MountDevice {
             // landed outside `[−cpr/2, +cpr/2)` after a prior
             // through-wrap flip doesn't trigger a full-revolution
             // correction here.
-            let ra_delta_canonical =
-                fold_to_canonical_band(ra_ticks - snap.ra.position_ticks, params.cpr_ra);
+            let ra_delta_canonical = RaTicks::new(ra_ticks.value() - snap.ra.position_ticks)
+                .fold_to_canonical_band(Cpr::new(params.cpr_ra))
+                .value();
             let binding_zone = (
                 self.config.binding_zone_min_hours,
                 self.config.binding_zone_max_hours,
@@ -688,8 +712,9 @@ impl MountDevice {
                 )?;
                 ra_delta_canonical
             };
-            let dec_delta_canonical =
-                fold_to_canonical_band(dec_ticks - snap.dec.position_ticks, params.cpr_dec);
+            let dec_delta_canonical = DecTicks::new(dec_ticks.value() - snap.dec.position_ticks)
+                .fold_to_canonical_band(Cpr::new(params.cpr_dec))
+                .value();
             let dec_delta = if is_flip_slew {
                 // Flip slews force the Dec axis to traverse the
                 // visible celestial pole (NCP for north, SCP for

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -220,8 +220,7 @@ impl MountDevice {
                 normal
             }
         };
-        let zone_min = self.config.binding_zone_min_hours;
-        let zone_max = self.config.binding_zone_max_hours;
+        let (zone_min, zone_max) = self.config.cw_exclusion_zone.bounds();
         // Open interval: target landing exactly on a boundary is OK.
         // Disable on `min >= max` (empty zone), matching the path
         // check's convention so destination and path checks agree on
@@ -235,12 +234,13 @@ impl MountDevice {
                 ),
             ));
         }
-        if !(self.config.dec_min_degrees..=self.config.dec_max_degrees).contains(&dec_degrees) {
+        if !self.config.dec_limits.range().contains(&dec_degrees) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_VALUE,
                 format!(
                     "Dec target {dec_degrees:.3}° outside safe envelope [{}, {}]°",
-                    self.config.dec_min_degrees, self.config.dec_max_degrees
+                    self.config.dec_limits.min_degrees(),
+                    self.config.dec_limits.max_degrees()
                 ),
             ));
         }
@@ -681,10 +681,7 @@ impl MountDevice {
             let ra_delta_canonical = RaTicks::new(ra_ticks.value() - snap.ra.position_ticks)
                 .fold_to_canonical_band(Cpr::new(params.cpr_ra))
                 .value();
-            let binding_zone = (
-                self.config.binding_zone_min_hours,
-                self.config.binding_zone_max_hours,
-            );
+            let binding_zone = self.config.cw_exclusion_zone.bounds();
             let ra_delta = if is_flip_slew {
                 // Flip slews steer the polar-axis sweep out of the
                 // CW exclusion zone — see

--- a/services/star-adventurer-gti/src/mount_device/slew.rs
+++ b/services/star-adventurer-gti/src/mount_device/slew.rs
@@ -22,9 +22,10 @@ use skywatcher_motor_protocol::command::{ModeKind, MotionMode, Speed};
 use skywatcher_motor_protocol::{Axis, Command, Response};
 
 use crate::codec::SkywatcherCodec;
-use crate::coordinates::{ra_ticks_to_mechanical_ha, sidereal_step_period};
+use crate::coordinates::sidereal_step_period;
 use crate::error::StarAdvError;
 use crate::manager::{MountManager, MountParameters};
+use crate::units::{Cpr, RaTicks};
 
 /// Upper bound on how long [`stop_axis_and_wait`] will poll `:f<axis>`
 /// after a `:K` (decelerate stop) before giving up. The firmware
@@ -146,7 +147,7 @@ pub(super) async fn enable_sidereal_tracking_ra(
     session: &Session<SkywatcherCodec>,
     params: &MountParameters,
 ) -> crate::error::Result<()> {
-    let period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
+    let period = sidereal_step_period(params.tmr_freq, Cpr::new(params.cpr_ra));
     manager
         .send(
             session,
@@ -238,7 +239,9 @@ pub(super) fn flip_slew_ra_delta(
         return Ok(canonical_delta);
     }
     let cpr_i = cpr as i32;
-    let cur_ha = ra_ticks_to_mechanical_ha(current_ticks, cpr);
+    let cur_ha = RaTicks::new(current_ticks)
+        .to_mech_ha(Cpr::new(cpr))
+        .value();
     let delta_ha = (canonical_delta as f64) * 24.0 / (cpr as f64);
     if !canonical_path_crosses_binding_zone(cur_ha, delta_ha, binding_zone_hours) {
         return Ok(canonical_delta);
@@ -279,7 +282,9 @@ pub(super) fn check_non_flip_ra_path(
     if cpr == 0 || canonical_delta == 0 {
         return Ok(());
     }
-    let cur_ha = ra_ticks_to_mechanical_ha(current_ticks, cpr);
+    let cur_ha = RaTicks::new(current_ticks)
+        .to_mech_ha(Cpr::new(cpr))
+        .value();
     let delta_ha = (canonical_delta as f64) * 24.0 / (cpr as f64);
     if !canonical_path_crosses_binding_zone(cur_ha, delta_ha, binding_zone_hours) {
         return Ok(());

--- a/services/star-adventurer-gti/src/mount_device/telescope.rs
+++ b/services/star-adventurer-gti/src/mount_device/telescope.rs
@@ -340,10 +340,7 @@ impl Telescope for MountDevice {
             lst,
             current_side,
             &self.config.flip_policy,
-            (
-                self.config.binding_zone_min_hours,
-                self.config.binding_zone_max_hours,
-            ),
+            self.config.cw_exclusion_zone.bounds(),
             self.config.site_latitude_deg,
         );
         let pre_flip_side = pre_flip_side_for_latitude(self.config.site_latitude_deg);
@@ -591,10 +588,7 @@ impl Telescope for MountDevice {
             lst,
             current_side,
             &self.config.flip_policy,
-            (
-                self.config.binding_zone_min_hours,
-                self.config.binding_zone_max_hours,
-            ),
+            self.config.cw_exclusion_zone.bounds(),
             self.config.site_latitude_deg,
         );
         self.execute_slew_with_explicit_side(ra, dec, chosen_side)

--- a/services/star-adventurer-gti/src/mount_device/telescope.rs
+++ b/services/star-adventurer-gti/src/mount_device/telescope.rs
@@ -21,11 +21,11 @@ use skywatcher_motor_protocol::{Axis, Command};
 use tracing::debug;
 
 use crate::coordinates::{
-    dec_degrees_to_ticks, encoder_to_celestial, local_sidereal_time_hours,
-    mechanical_ha_to_ra_ticks, pulse_guide_step_period, ra_dec_to_alt_az, ra_to_mechanical_ha,
+    encoder_to_celestial, local_sidereal_time_hours, pulse_guide_step_period, ra_dec_to_alt_az,
     select_pier_side_for_target, side_of_pier as side_of_pier_calc, sidereal_step_period,
     SIDEREAL_DEG_PER_SEC,
 };
+use crate::units::{Cpr, Dec, DecTicks, Ra, RaTicks};
 
 use super::inherent::validate_guide_rate;
 use super::park_persistence::write_park_to_config;
@@ -117,14 +117,14 @@ impl Telescope for MountDevice {
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(ASCOMError::from)?;
         let (ra, _dec) = encoder_to_celestial(
-            snap.ra.position_ticks,
-            snap.dec.position_ticks,
+            RaTicks::new(snap.ra.position_ticks),
+            DecTicks::new(snap.dec.position_ticks),
             lst,
-            params.cpr_ra,
-            params.cpr_dec,
+            Cpr::new(params.cpr_ra),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
-        Ok(ra)
+        Ok(ra.value())
     }
 
     async fn right_ascension_rate(&self) -> ASCOMResult<f64> {
@@ -142,14 +142,14 @@ impl Telescope for MountDevice {
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(ASCOMError::from)?;
         let (_ra, dec) = encoder_to_celestial(
-            snap.ra.position_ticks,
-            snap.dec.position_ticks,
+            RaTicks::new(snap.ra.position_ticks),
+            DecTicks::new(snap.dec.position_ticks),
             lst,
-            params.cpr_ra,
-            params.cpr_dec,
+            Cpr::new(params.cpr_ra),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
-        Ok(dec)
+        Ok(dec.value())
     }
 
     async fn declination_rate(&self) -> ASCOMResult<f64> {
@@ -161,7 +161,12 @@ impl Telescope for MountDevice {
         let dec = self.declination().await?;
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(ASCOMError::from)?;
-        let (_alt, az) = ra_dec_to_alt_az(ra, dec, self.config.site_latitude_deg, lst);
+        let (_alt, az) = ra_dec_to_alt_az(
+            Ra::new(ra),
+            Dec::new(dec),
+            self.config.site_latitude_deg,
+            lst,
+        );
         Ok(az)
     }
 
@@ -170,12 +175,18 @@ impl Telescope for MountDevice {
         let dec = self.declination().await?;
         let lst = local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
             .map_err(ASCOMError::from)?;
-        let (alt, _az) = ra_dec_to_alt_az(ra, dec, self.config.site_latitude_deg, lst);
+        let (alt, _az) = ra_dec_to_alt_az(
+            Ra::new(ra),
+            Dec::new(dec),
+            self.config.site_latitude_deg,
+            lst,
+        );
         Ok(alt)
     }
 
     async fn sidereal_time(&self) -> ASCOMResult<f64> {
         local_sidereal_time_hours(SystemTime::now(), self.config.site_longitude_deg)
+            .map(|lst| lst.value())
             .map_err(ASCOMError::from)
     }
 
@@ -290,8 +301,8 @@ impl Telescope for MountDevice {
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
         Ok(side_of_pier_calc(
-            snap.dec.position_ticks,
-            params.cpr_dec,
+            DecTicks::new(snap.dec.position_ticks),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         ))
     }
@@ -320,12 +331,12 @@ impl Telescope for MountDevice {
             .map_err(ASCOMError::from)?;
         let snap = self.manager.snapshot().await;
         let current_side = side_of_pier_calc(
-            snap.dec.position_ticks,
-            params.cpr_dec,
+            DecTicks::new(snap.dec.position_ticks),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
         let chosen_side = select_pier_side_for_target(
-            ra,
+            Ra::new(ra),
             lst,
             current_side,
             &self.config.flip_policy,
@@ -337,7 +348,7 @@ impl Telescope for MountDevice {
         );
         let pre_flip_side = pre_flip_side_for_latitude(self.config.site_latitude_deg);
         let target_is_flipped = chosen_side != pre_flip_side && chosen_side != PierSide::Unknown;
-        self.check_within_safe_envelope(ra, dec, lst, target_is_flipped)?;
+        self.check_within_safe_envelope(ra, dec, lst.value(), target_is_flipped)?;
         Ok(chosen_side)
     }
 
@@ -386,8 +397,8 @@ impl Telescope for MountDevice {
             .map_err(ASCOMError::from)?;
         let snap = self.manager.snapshot().await;
         let current_side = side_of_pier_calc(
-            snap.dec.position_ticks,
-            params.cpr_dec,
+            DecTicks::new(snap.dec.position_ticks),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
         if side_of_pier == current_side {
@@ -402,13 +413,14 @@ impl Telescope for MountDevice {
         // `execute_slew_with_explicit_side` will re-compute the target
         // encoder for the chosen side.
         let (cur_ra, cur_dec) = encoder_to_celestial(
-            snap.ra.position_ticks,
-            snap.dec.position_ticks,
+            RaTicks::new(snap.ra.position_ticks),
+            DecTicks::new(snap.dec.position_ticks),
             lst,
-            params.cpr_ra,
-            params.cpr_dec,
+            Cpr::new(params.cpr_ra),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
+        let (cur_ra, cur_dec) = (cur_ra.value(), cur_dec.value());
         // Drive the slew with the chosen-side encoder math directly,
         // bypassing the policy decision tree. The selector's
         // stay-on-current preference is correct for slew_to_coordinates
@@ -486,10 +498,13 @@ impl Telescope for MountDevice {
         // false`); operators must `AbortSlew` and re-sync the pre-
         // flip pointing first if a manual flip left the mount in a
         // post-flip state.
-        self.check_within_safe_envelope(ra, dec, lst, false)?;
-        let mech_ha = ra_to_mechanical_ha(ra, lst);
-        let ra_ticks = mechanical_ha_to_ra_ticks(mech_ha, params.cpr_ra);
-        let dec_ticks = dec_degrees_to_ticks(dec, params.cpr_dec);
+        self.check_within_safe_envelope(ra, dec, lst.value(), false)?;
+        let mech_ha = lst.hour_angle_of(Ra::new(ra)).to_mech();
+        let ra_ticks = mech_ha.to_ticks(Cpr::new(params.cpr_ra)).value();
+        let dec_ticks = Dec::new(dec)
+            .to_mech()
+            .to_ticks(Cpr::new(params.cpr_dec))
+            .value();
         self.send(Command::SetPosition {
             axis: Axis::Ra,
             ticks: ra_ticks,
@@ -567,12 +582,12 @@ impl Telescope for MountDevice {
         // [§"Meridian flip"](../../../../docs/services/star-adventurer-gti.md#meridian-flip).
         let snap = self.manager.snapshot().await;
         let current_side = side_of_pier_calc(
-            snap.dec.position_ticks,
-            params.cpr_dec,
+            DecTicks::new(snap.dec.position_ticks),
+            Cpr::new(params.cpr_dec),
             self.config.site_latitude_deg,
         );
         let chosen_side = select_pier_side_for_target(
-            ra,
+            Ra::new(ra),
             lst,
             current_side,
             &self.config.flip_policy,
@@ -946,7 +961,7 @@ impl Telescope for MountDevice {
             .parameters()
             .await
             .ok_or(ASCOMError::NOT_CONNECTED)?;
-        let sidereal_period = sidereal_step_period(params.tmr_freq, params.cpr_ra);
+        let sidereal_period = sidereal_step_period(params.tmr_freq, Cpr::new(params.cpr_ra));
         let shifted_period = pulse_guide_step_period(sidereal_period, rate_factor);
         const MAX_STEP_PERIOD: u32 = 0x00FF_FFFF;
         if shifted_period == 0 || shifted_period > MAX_STEP_PERIOD {

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -19,7 +19,7 @@ use ascom_alpaca::{ASCOMError, ASCOMErrorCode};
 use skywatcher_motor_protocol::Axis;
 use tokio::sync::RwLock;
 
-use crate::config::Config;
+use crate::config::{ActiveZone, Config, CwExclusionZone, DecLimits, TrackingGuardMarginHours};
 use crate::coordinates::SIDEREAL_DEG_PER_SEC;
 use crate::error::StarAdvError;
 use crate::manager::MountManager;
@@ -40,8 +40,7 @@ fn device() -> MountDevice {
     // Same rationale as `fast_settle_device`: open the
     // mechanical-envelope check for tests that don't exercise it.
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     MountDevice::new(cfg.mount, manager)
 }
@@ -147,9 +146,8 @@ async fn guard_device(margin_hours: f64) -> (MountDevice, Arc<tokio::sync::Mutex
     let factory = CapturingMockFactory::new();
     let mock = Arc::clone(&factory.state);
     let mut cfg = Config::default();
-    cfg.mount.binding_zone_min_hours = 0.95;
-    cfg.mount.binding_zone_max_hours = 11.05;
-    cfg.mount.tracking_guard_margin_hours = margin_hours;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Active(ActiveZone::new(0.95, 11.05));
+    cfg.mount.tracking_guard_margin_hours = TrackingGuardMarginHours::new(margin_hours);
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     let session = d.manager.transport().acquire().await.unwrap();
@@ -236,8 +234,7 @@ async fn tracking_guard_tick_is_noop_when_parameters_not_cached() {
     // never connect, so `parameters()` stays None.
     let cfg = Config {
         mount: MountConfig {
-            binding_zone_min_hours: 0.95,
-            binding_zone_max_hours: 11.05,
+            cw_exclusion_zone: CwExclusionZone::Active(ActiveZone::new(0.95, 11.05)),
             ..Default::default()
         },
         ..Config::default()
@@ -265,8 +262,7 @@ async fn tracking_guard_tick_is_noop_when_session_closed_mid_tick() {
     let mock = Arc::clone(&factory.state);
     let cfg = Config {
         mount: MountConfig {
-            binding_zone_min_hours: 0.95,
-            binding_zone_max_hours: 11.05,
+            cw_exclusion_zone: CwExclusionZone::Active(ActiveZone::new(0.95, 11.05)),
             ..Default::default()
         },
         ..Config::default()
@@ -516,8 +512,7 @@ fn fast_settle_device() -> MountDevice {
     // behaviour is covered separately by
     // [`fast_settle_connected_narrow_envelope`].
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     // Pin the park target to the mock's start position (0, 0) so
     // `park()` is a zero-distance, instant slew. The park-lifecycle
     // tests using this helper exercise the watcher / AtPark flip, not
@@ -554,10 +549,8 @@ async fn fast_settle_connected_narrow_envelope() -> MountDevice {
     // target 1 h past meridian on the natural side is inside it,
     // and tight Dec band `[-5°, +5°]` so off-equator targets are
     // rejected.
-    cfg.mount.binding_zone_min_hours = 0.5;
-    cfg.mount.binding_zone_max_hours = 1.5;
-    cfg.mount.dec_min_degrees = -5.0;
-    cfg.mount.dec_max_degrees = 5.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Active(ActiveZone::new(0.5, 1.5));
+    cfg.mount.dec_limits = DecLimits::new(-5.0, 5.0);
     // Pin the park target to (0, 0) — see `fast_settle_device` for why
     // (keeps `park()` instant despite the `preferred_ap_park` default).
     cfg.mount.park_ra_ticks = Some(0);
@@ -785,8 +778,7 @@ async fn slew_async_issues_indi_sequence_per_axis() {
     }
     cfg.mount.settle_after_slew = Duration::from_millis(0);
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
@@ -867,8 +859,7 @@ async fn slew_watcher_pickup_loop_reissues_when_residual_exceeds_tolerance() {
     }
     cfg.mount.settle_after_slew = Duration::from_millis(0);
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
@@ -937,8 +928,7 @@ async fn slew_watcher_aborts_via_instant_stop_when_axis_reports_blocked() {
     }
     cfg.mount.settle_after_slew = Duration::from_millis(0);
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
@@ -1380,8 +1370,7 @@ async fn pickup_reslew_axis_swallows_transport_errors() {
 fn device_with_path(path: PathBuf) -> MountDevice {
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     MountDevice::with_config_file_path(cfg.mount, manager, Some(path))
 }
@@ -1741,8 +1730,7 @@ async fn set_park_refuses_when_wire_snapshot_reports_axis_running() {
         usb.polling_interval = Duration::from_millis(20);
     }
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("config.json");
     seed_default_config(&path);
@@ -1844,8 +1832,7 @@ async fn unpark_seed_fires_when_firmware_reports_near_zero_encoder() {
     }
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
@@ -1875,8 +1862,7 @@ async fn unpark_seed_skips_when_firmware_encoder_beyond_tolerance() {
     }
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
@@ -1903,8 +1889,7 @@ async fn unpark_seed_skips_just_above_fresh_power_up_tolerance() {
         state.ra.position_ticks = 50;
     }
     let mut cfg = Config::default();
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
@@ -1924,8 +1909,7 @@ async fn park_target_uses_preferred_ap_park_distinct_from_unpark_seed() {
     // target resolves to the ap_park_2 encoder pair.
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.unpark_from_ap_position = crate::config::ApPark::ApPark3;
     cfg.mount.preferred_ap_park = crate::config::ApPark::ApPark2;
     cfg.mount.site_latitude_deg = 32.7157;
@@ -2143,8 +2127,7 @@ async fn unpark_from_ap_position_named_park_resets_encoder_and_clears_at_park() 
         state.dec.position_ticks = -50_000;
     }
     let mut cfg = Config::default();
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.site_latitude_deg = 32.7157;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
@@ -2250,8 +2233,7 @@ async fn park_target_prefers_config_values_over_handshake_capture() {
     // (zeroed) handshake fallback.
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.park_ra_ticks = Some(5000);
     cfg.mount.park_dec_ticks = Some(-7000);
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
@@ -2771,8 +2753,7 @@ async fn pulse_guide_rolls_back_flag_on_wire_failure() {
     // lack of actual motion.
     let mut cfg = Config::default();
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(StuckAxisFactory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();
@@ -3383,8 +3364,7 @@ async fn flip_enabled_device() -> MountDevice {
     }
     cfg.mount.settle_after_slew = Duration::from_millis(0);
     // Disable the CW-exclusion zone check for this test.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     cfg.mount.flip_policy.enabled = true;
     let manager = MountManager::new(cfg.clone(), Arc::new(MockTransportFactory));
     MountDevice::new(cfg.mount, manager)
@@ -3774,8 +3754,7 @@ async fn slew_watcher_re_enables_tracking_after_completion() {
     }
     cfg.mount.settle_after_slew = Duration::from_millis(0);
     // Open the envelope so the test target lands inside.
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
     let manager = MountManager::new(cfg.clone(), Arc::new(factory));
     let d = MountDevice::new(cfg.mount, manager);
     d.set_connected(true).await.unwrap();

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -20,10 +20,11 @@ use skywatcher_motor_protocol::Axis;
 use tokio::sync::RwLock;
 
 use crate::config::Config;
-use crate::coordinates::{fold_to_canonical_band, SIDEREAL_DEG_PER_SEC};
+use crate::coordinates::SIDEREAL_DEG_PER_SEC;
 use crate::error::StarAdvError;
 use crate::manager::MountManager;
 use crate::transport::mock::{CapturingMockFactory, MockMountState, MockTransportFactory};
+use crate::units::{Cpr, RaTicks};
 
 use super::park_persistence::{read_connect_fields, write_park_to_config};
 use super::slew::{
@@ -2713,7 +2714,8 @@ async fn pulse_guide_east_uses_rate_factor_one_minus_fraction() {
     let payload: &[u8; 6] = (&i1[3..9]).try_into().unwrap();
     let actual_period = decode_u24(payload).unwrap();
     let mock_state = mock.lock().await;
-    let p_sid = crate::coordinates::sidereal_step_period(mock_state.tmr_freq, mock_state.cpr_ra);
+    let p_sid =
+        crate::coordinates::sidereal_step_period(mock_state.tmr_freq, Cpr::new(mock_state.cpr_ra));
     let expected = 2 * p_sid;
     drop(mock_state);
     assert_eq!(
@@ -2956,7 +2958,9 @@ fn flip_slew_ra_delta_flip_back_from_plus_half_cpr_forces_cw_through_wrap() {
     let cpr = GTI_CPR;
     let current = cpr as i32 / 2;
     let canonical_raw = -(cpr as i32 / 4) - current; // -3cpr/4
-    let canonical = fold_to_canonical_band(canonical_raw, cpr); // +cpr/4
+    let canonical = RaTicks::new(canonical_raw)
+        .fold_to_canonical_band(Cpr::new(cpr))
+        .value(); // +cpr/4
     let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_CW_EXCLUSION_ZONE).unwrap();
     assert!(issued > 0, "post-flip wrap → safe arc must use CW");
     assert_eq!(issued, canonical, "canonical CW is already safe here");
@@ -3079,7 +3083,9 @@ fn flip_slew_ra_delta_wide_zone_picks_long_way_for_zone_boundary_traversal() {
     let target_h = 0.9_f64;
     let current = (cur_h * cpr as f64 / 24.0).round() as i32;
     let target = (target_h * cpr as f64 / 24.0).round() as i32;
-    let canonical = fold_to_canonical_band(target - current, cpr);
+    let canonical = RaTicks::new(target - current)
+        .fold_to_canonical_band(Cpr::new(cpr))
+        .value();
     let issued = flip_slew_ra_delta(canonical, current, cpr, GTI_CW_EXCLUSION_ZONE).unwrap();
     assert!(
         issued > 0,

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -35,8 +35,8 @@ use tracing::{debug, warn};
 
 use crate::codec::SkywatcherCodec;
 use crate::config::MountConfig;
-use crate::coordinates::ra_ticks_to_mechanical_ha;
 use crate::manager::MountManager;
+use crate::units::{Cpr, RaTicks};
 
 use super::DriverState;
 
@@ -106,7 +106,9 @@ pub(super) async fn tracking_guard_tick(
         return false;
     };
     let snap = manager.snapshot().await;
-    let mech_ha = ra_ticks_to_mechanical_ha(snap.ra.position_ticks, params.cpr_ra);
+    let mech_ha = RaTicks::new(snap.ra.position_ticks)
+        .to_mech_ha(Cpr::new(params.cpr_ra))
+        .value();
     if !tracking_guard_breached(mech_ha, zone, margin) {
         return false;
     }

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -59,8 +59,8 @@ type SessionSlot = Arc<RwLock<Option<Session<SkywatcherCodec>>>>;
 /// guard — the same convention the slew-path binding-zone check uses.
 /// A non-finite or negative `margin` is treated as `0.0` (stop exactly
 /// at zone entry) so a bad value fails safe rather than open. Config-file
-/// margins are already rejected at load by
-/// [`crate::config::MountConfig::validate`]; this sanitisation is
+/// margins are already rejected at load — [`crate::config::TrackingGuardMarginHours`]
+/// validates at deserialize time; this sanitisation is
 /// defense-in-depth for construction paths that bypass that check
 /// (programmatic configs, tests).
 pub(super) fn tracking_guard_breached(mech_ha: f64, zone: (f64, f64), margin: f64) -> bool {

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -168,8 +168,8 @@ pub(super) fn spawn_tracking_guard(
     config: MountConfig,
     polling_interval: Duration,
 ) {
-    let zone = (config.binding_zone_min_hours, config.binding_zone_max_hours);
-    let margin = config.tracking_guard_margin_hours;
+    let zone = config.cw_exclusion_zone.bounds();
+    let margin = config.tracking_guard_margin_hours.value();
     tokio::spawn(async move {
         let mut ticker = interval(polling_interval);
         // Skip the immediate first tick (matches the background poll

--- a/services/star-adventurer-gti/src/mount_device/watchers.rs
+++ b/services/star-adventurer-gti/src/mount_device/watchers.rs
@@ -32,11 +32,11 @@ use tracing::debug;
 use crate::codec::SkywatcherCodec;
 use crate::config::MountConfig;
 use crate::coordinates::{
-    dec_degrees_to_ticks, encoder_to_celestial, fold_to_canonical_band, local_sidereal_time_hours,
-    pickup_target_ra_ticks, target_encoder_flipped,
+    encoder_to_celestial, local_sidereal_time_hours, pickup_target_ra_ticks, target_encoder_flipped,
 };
 use crate::error::StarAdvError;
 use crate::manager::{MountManager, MountSnapshot};
+use crate::units::{Cpr, Dec, DecTicks, Lst, Ra, RaTicks};
 
 use super::slew::{
     enable_sidereal_tracking_ra, pickup_reslew_axis, stop_axis_and_wait, AXIS_STOP_TIMEOUT,
@@ -478,13 +478,14 @@ async fn slew_completion_step(
             // RA residual and the pickup loop would try to undo
             // the flip on its first iteration.
             let (cur_ra, cur_dec) = encoder_to_celestial(
-                snap.ra.position_ticks,
-                snap.dec.position_ticks,
+                RaTicks::new(snap.ra.position_ticks),
+                DecTicks::new(snap.dec.position_ticks),
                 lst,
-                params.cpr_ra,
-                params.cpr_dec,
+                Cpr::new(params.cpr_ra),
+                Cpr::new(params.cpr_dec),
                 config.site_latitude_deg,
             );
+            let (cur_ra, cur_dec) = (cur_ra.value(), cur_dec.value());
             // RA residual is on a 24-hour circle; take the
             // shorter arc. Convert hours → arc-seconds
             // (15°/hour × 3600″/°).
@@ -543,17 +544,24 @@ async fn slew_completion_step(
                     .filter(|s| *s != pre_flip_side && *s != PierSide::Unknown)
                     .is_some();
                 let (new_ra_ticks, new_dec_ticks) = if target_is_flipped {
-                    let lst_proj = lst + projection.as_secs_f64() / 3600.0;
+                    let lst_proj = Lst::new(lst.value() + projection.as_secs_f64() / 3600.0);
                     target_encoder_flipped(
-                        target_ra,
-                        target_dec,
+                        Ra::new(target_ra),
+                        Dec::new(target_dec),
                         lst_proj,
-                        params.cpr_ra,
-                        params.cpr_dec,
+                        Cpr::new(params.cpr_ra),
+                        Cpr::new(params.cpr_dec),
                     )
                 } else {
-                    let new_ra = pickup_target_ra_ticks(target_ra, lst, projection, params.cpr_ra);
-                    let new_dec = dec_degrees_to_ticks(target_dec, params.cpr_dec);
+                    let new_ra = pickup_target_ra_ticks(
+                        Ra::new(target_ra),
+                        lst,
+                        projection,
+                        Cpr::new(params.cpr_ra),
+                    );
+                    let new_dec = Dec::new(target_dec)
+                        .to_mech()
+                        .to_ticks(Cpr::new(params.cpr_dec));
                     (new_ra, new_dec)
                 };
                 // Fold the deltas to canonical so the pickup
@@ -561,10 +569,12 @@ async fn slew_completion_step(
                 // current encoder snapshot landed outside
                 // `[−cpr/2, +cpr/2)` after a through-wrap
                 // flip — see [`fold_to_canonical_band`].
-                let ra_delta =
-                    fold_to_canonical_band(new_ra_ticks - snap.ra.position_ticks, params.cpr_ra);
-                let dec_delta =
-                    fold_to_canonical_band(new_dec_ticks - snap.dec.position_ticks, params.cpr_dec);
+                let ra_delta = RaTicks::new(new_ra_ticks.value() - snap.ra.position_ticks)
+                    .fold_to_canonical_band(Cpr::new(params.cpr_ra))
+                    .value();
+                let dec_delta = DecTicks::new(new_dec_ticks.value() - snap.dec.position_ticks)
+                    .fold_to_canonical_band(Cpr::new(params.cpr_dec))
+                    .value();
                 *pickup_iterations += 1;
                 debug!(
                     iteration = *pickup_iterations,

--- a/services/star-adventurer-gti/src/units.rs
+++ b/services/star-adventurer-gti/src/units.rs
@@ -1,0 +1,569 @@
+//! Typed physical quantities for the mount's pointing math.
+//!
+//! Every angle in this driver is "hours" or "degrees", but the *frame* —
+//! what the number is measured against — matters as much as the unit, and on
+//! this mount a frame mix-up drives the counterweights into the tripod. These
+//! newtypes make the frame explicit at the type level so the pointing math
+//! can't be written wrong: you cannot pass a celestial hour angle where a
+//! mechanical one is expected, mix RA-axis and Dec-axis ticks, or cross
+//! between frames without naming the conversion, without a compile error.
+//!
+//! This mirrors the convention `pa-falcon-rotator` established in its own
+//! `units.rs` (mechanical vs sky angle bridged by a sync offset) — see
+//! [ADR-006](../../../docs/decisions/006-typed-physical-quantities-for-mount-pointing.md).
+//!
+//! ## Frames
+//!
+//! Two axes, each with a *mechanical* (encoder) frame and a *celestial*
+//! (sky) frame, plus the sidereal-time and RA reference quantities:
+//!
+//! ```text
+//! RA axis  (hours)    Lst, Ra            reference quantities
+//!                     HourAngle          celestial HA = LST - RA, [-12, +12)
+//!                     MechHa             mechanical (encoder) HA, [-12, +12)
+//!                     RaTicks            RA-axis encoder counts
+//! Dec axis (degrees)  Dec                celestial declination (~[-90, +90])
+//!                     MechDec            mechanical (encoder) dec, [-180, +180)
+//!                     DecTicks           Dec-axis encoder counts
+//! shared              Cpr                counts per revolution (per axis)
+//! ```
+//!
+//! ## Conversions (the named operations)
+//!
+//! ```text
+//! Lst.hour_angle_of(Ra)        -> HourAngle      LST - RA, folded
+//! HourAngle.to_mech()          -> MechHa         pre-flip: value preserved
+//! MechHa.flipped()             -> MechHa         post-flip mirror (+12 h fold)
+//! MechHa.to_ticks(Cpr)         -> RaTicks
+//! RaTicks.to_mech_ha(Cpr)      -> MechHa
+//! MechHa.to_ra(Lst)            -> Ra             pre-flip:  LST - mech_HA
+//! MechHa.to_ra_flipped(Lst)    -> Ra             post-flip: LST - mech_HA + 12
+//!
+//! Dec.to_mech()                -> MechDec        pre-flip: value preserved
+//! Dec.to_mech_flipped()        -> MechDec        through the pole: sign*(180-|d|)
+//! MechDec.to_dec()             -> Dec            pre-flip: value preserved
+//! MechDec.to_dec_flipped()     -> Dec            through the pole (self-inverse)
+//! MechDec.to_ticks(Cpr)        -> DecTicks
+//! DecTicks.to_mech_dec(Cpr)    -> MechDec
+//! ```
+//!
+//! Each constructor funnels through a fold/normalise helper, so every value
+//! is canonical by construction. The conversions are the only way to cross a
+//! frame boundary, and each is total. Constructors do **not** sanitise
+//! non-finite input — callers reject `NaN`/`inf` first (the ASCOM boundary,
+//! the wire parsers, and the config newtypes all do); a non-finite value
+//! would propagate.
+
+/// Fold a value into `[-period/2, +period/2)`. Shared by the hour-angle fold
+/// (`period = 24`) and the mechanical-declination fold (`period = 360`).
+fn fold_to_signed(value: f64, period: f64) -> f64 {
+    let half = period / 2.0;
+    let folded = value.rem_euclid(period);
+    if folded >= half {
+        folded - period
+    } else {
+        folded
+    }
+}
+
+/// The "through the celestial pole" reflection used by a meridian flip:
+/// `sign(d) * (180 - |d|)`. Maps a celestial declination to its post-flip
+/// mechanical-encoder degree and back — the operation is its own inverse.
+///
+/// `f64::signum(0.0)` is `+1.0`, so `d = 0` maps to `+180°` (which the
+/// [`MechDec`] fold then canonicalises to `-180°`); both are the same
+/// physical position at the encoder wrap.
+fn through_pole(deg: f64) -> f64 {
+    deg.signum() * (180.0 - deg.abs())
+}
+
+/// Fold a raw encoder-tick value into the canonical band `[-cpr/2, +cpr/2)`.
+/// The firmware's counter is wider than one axis revolution, so a
+/// through-wrap slew can leave it outside the band; this collapses it to the
+/// shortest equivalent. `cpr == 0` (parameter cache not populated) passes the
+/// value through unchanged.
+fn fold_ticks_canonical(value: i32, cpr: u32) -> i32 {
+    if cpr == 0 {
+        return value;
+    }
+    let cpr_i = cpr as i32;
+    let half = cpr_i / 2;
+    let modular = value.rem_euclid(cpr_i);
+    if modular >= half {
+        modular - cpr_i
+    } else {
+        modular
+    }
+}
+
+/// Counts per revolution for one axis, queried from the mount at handshake.
+///
+/// A `Cpr(0)` models the "parameters not yet populated" state; the
+/// tick↔angle conversions treat it defensively (returning a zero quantity)
+/// rather than dividing by zero, matching the pre-typed accessors that
+/// short-circuit before the math runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Cpr(u32);
+
+impl Cpr {
+    /// Construct from a raw counts-per-revolution value.
+    pub fn new(cpr: u32) -> Self {
+        Self(cpr)
+    }
+
+    /// The underlying counts-per-revolution.
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+// ===================== RA axis (hours) =====================
+
+/// Local apparent sidereal time, hours `[0, 24)`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Lst(f64);
+
+impl Lst {
+    /// Construct from hours, normalising into `[0, 24)`.
+    pub fn new(hours: f64) -> Self {
+        Self(hours.rem_euclid(24.0))
+    }
+
+    /// The underlying value in hours `[0, 24)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Celestial hour angle of a target: `HA = LST - RA`, folded to
+    /// `[-12, +12)`.
+    pub fn hour_angle_of(self, ra: Ra) -> HourAngle {
+        HourAngle::new(self.0 - ra.0)
+    }
+}
+
+/// Right ascension, hours `[0, 24)` — the ASCOM client's frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ra(f64);
+
+impl Ra {
+    /// Construct from hours, normalising into `[0, 24)`.
+    pub fn new(hours: f64) -> Self {
+        Self(hours.rem_euclid(24.0))
+    }
+
+    /// The underlying value in hours `[0, 24)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Celestial hour angle (`LST - RA`), signed hours `[-12, +12)`. The frame the
+/// flip-window decision reasons about; distinct from [`MechHa`] because the
+/// two coincide only on the pre-flip pointing side.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HourAngle(f64);
+
+impl HourAngle {
+    /// Construct from hours, folding into `[-12, +12)`.
+    pub fn new(hours: f64) -> Self {
+        Self(fold_to_signed(hours, 24.0))
+    }
+
+    /// The underlying value in signed hours `[-12, +12)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Mechanical hour angle for the **pre-flip** (normal) pointing side,
+    /// where mechanical HA equals celestial HA. Use [`MechHa::flipped`] for
+    /// the post-flip mirror.
+    pub fn to_mech(self) -> MechHa {
+        MechHa::new(self.0)
+    }
+}
+
+/// Mechanical hour angle: the encoder's view of where the polar axis points,
+/// signed hours `[-12, +12)`. The quantity the counterweight exclusion zone,
+/// the slew-path checks, and the tracking guard reason about.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MechHa(f64);
+
+impl MechHa {
+    /// Construct from hours, folding into `[-12, +12)`.
+    pub fn new(hours: f64) -> Self {
+        Self(fold_to_signed(hours, 24.0))
+    }
+
+    /// The underlying value in signed hours `[-12, +12)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// The post-meridian-flip mirror of this mechanical HA: `mech_HA + 12 h`,
+    /// folded back into `[-12, +12)`. Self-inverse.
+    pub fn flipped(self) -> MechHa {
+        MechHa::new(self.0 + 12.0)
+    }
+
+    /// Convert to RA-axis encoder ticks. `Cpr(0)` yields `RaTicks(0)`.
+    pub fn to_ticks(self, cpr: Cpr) -> RaTicks {
+        if cpr.0 == 0 {
+            return RaTicks(0);
+        }
+        RaTicks((self.0 * (cpr.0 as f64) / 24.0).round() as i32)
+    }
+
+    /// ASCOM right ascension for the **pre-flip** side: `RA = (LST - mech_HA)`,
+    /// folded to `[0, 24)`.
+    pub fn to_ra(self, lst: Lst) -> Ra {
+        Ra::new(lst.0 - self.0)
+    }
+
+    /// ASCOM right ascension for the **post-flip** side:
+    /// `RA = (LST - mech_HA + 12)`, folded to `[0, 24)`.
+    pub fn to_ra_flipped(self, lst: Lst) -> Ra {
+        Ra::new(lst.0 - self.0 + 12.0)
+    }
+}
+
+/// RA-axis encoder counts (signed; the firmware's raw counter, which can sit
+/// outside one revolution after a through-wrap slew).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RaTicks(i32);
+
+impl RaTicks {
+    /// Construct from a raw RA-axis encoder count.
+    pub fn new(ticks: i32) -> Self {
+        Self(ticks)
+    }
+
+    /// The underlying signed encoder count.
+    pub fn value(self) -> i32 {
+        self.0
+    }
+
+    /// Convert to a mechanical hour angle, folded to `[-12, +12)`. `Cpr(0)`
+    /// yields `MechHa(0)`.
+    pub fn to_mech_ha(self, cpr: Cpr) -> MechHa {
+        if cpr.0 == 0 {
+            return MechHa(0.0);
+        }
+        MechHa::new((self.0 as f64) * 24.0 / (cpr.0 as f64))
+    }
+
+    /// Collapse a raw counter (or tick delta) to its canonical-band
+    /// equivalent in `[-cpr/2, +cpr/2)`.
+    pub fn fold_to_canonical_band(self, cpr: Cpr) -> RaTicks {
+        RaTicks(fold_ticks_canonical(self.0, cpr.0))
+    }
+}
+
+// ===================== Dec axis (degrees) =====================
+
+/// Celestial declination, degrees. Normally `[-90, +90]`; the constructor
+/// does **not** clamp, so a "through the pole" encoder reading can surface as
+/// a magnitude past 90° for the caller to detect (matching the pre-typed
+/// `dec_ticks_to_degrees` contract).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Dec(f64);
+
+impl Dec {
+    /// Construct from a celestial declination in degrees.
+    pub fn new(degrees: f64) -> Self {
+        Self(degrees)
+    }
+
+    /// The underlying declination in degrees.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Mechanical (encoder) declination for the **pre-flip** side, where the
+    /// encoder degree equals the celestial declination.
+    pub fn to_mech(self) -> MechDec {
+        MechDec::new(self.0)
+    }
+
+    /// Mechanical (encoder) declination for the **post-flip** side: the OTA
+    /// has rotated through the celestial pole, `sign(dec) * (180 - |dec|)`.
+    pub fn to_mech_flipped(self) -> MechDec {
+        MechDec::new(through_pole(self.0))
+    }
+}
+
+/// Mechanical (encoder) declination, degrees folded to `[-180, +180)` — the
+/// raw Dec-axis encoder angle, which runs past `±90°` once the axis rotates
+/// through the celestial pole.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MechDec(f64);
+
+impl MechDec {
+    /// Construct from degrees, folding into `[-180, +180)`.
+    pub fn new(degrees: f64) -> Self {
+        Self(fold_to_signed(degrees, 360.0))
+    }
+
+    /// The underlying encoder declination in degrees `[-180, +180)`.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// Celestial declination for the **pre-flip** side (value preserved).
+    pub fn to_dec(self) -> Dec {
+        Dec::new(self.0)
+    }
+
+    /// Celestial declination for the **post-flip** side: undo the through-pole
+    /// rotation, `sign(d) * (180 - |d|)`. Inverse of [`Dec::to_mech_flipped`].
+    pub fn to_dec_flipped(self) -> Dec {
+        Dec::new(through_pole(self.0))
+    }
+
+    /// Convert to Dec-axis encoder ticks. `Cpr(0)` yields `DecTicks(0)`.
+    pub fn to_ticks(self, cpr: Cpr) -> DecTicks {
+        if cpr.0 == 0 {
+            return DecTicks(0);
+        }
+        DecTicks((self.0 * (cpr.0 as f64) / 360.0).round() as i32)
+    }
+}
+
+/// Dec-axis encoder counts (signed; the firmware's raw counter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DecTicks(i32);
+
+impl DecTicks {
+    /// Construct from a raw Dec-axis encoder count.
+    pub fn new(ticks: i32) -> Self {
+        Self(ticks)
+    }
+
+    /// The underlying signed encoder count.
+    pub fn value(self) -> i32 {
+        self.0
+    }
+
+    /// Convert to a mechanical declination, folded to `[-180, +180)`. `Cpr(0)`
+    /// yields `MechDec(0)`.
+    pub fn to_mech_dec(self, cpr: Cpr) -> MechDec {
+        if cpr.0 == 0 {
+            return MechDec(0.0);
+        }
+        MechDec::new((self.0 as f64) * 360.0 / (cpr.0 as f64))
+    }
+
+    /// Collapse a raw counter (or tick delta) to its canonical-band
+    /// equivalent in `[-cpr/2, +cpr/2)`.
+    pub fn fold_to_canonical_band(self, cpr: Cpr) -> DecTicks {
+        DecTicks(fold_ticks_canonical(self.0, cpr.0))
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    const EPS: f64 = 1e-9;
+    /// GTi counts-per-revolution (`0x0037_5F00`), both axes.
+    const GTI_CPR: u32 = 0x0037_5F00;
+
+    fn cpr() -> Cpr {
+        Cpr::new(GTI_CPR)
+    }
+
+    // ---- Construction / normalisation ------------------------------------
+
+    #[test]
+    fn lst_and_ra_wrap_into_24() {
+        assert!((Lst::new(25.0).value() - 1.0).abs() < EPS);
+        assert!((Ra::new(-1.0).value() - 23.0).abs() < EPS);
+    }
+
+    #[test]
+    fn hour_angle_and_mech_ha_fold_into_signed_twelve() {
+        // +13 h folds to -11 h; the wrap boundary +12 folds to -12.
+        assert!((HourAngle::new(13.0).value() + 11.0).abs() < EPS);
+        assert!((MechHa::new(12.0).value() + 12.0).abs() < EPS);
+    }
+
+    #[test]
+    fn mech_dec_folds_into_signed_one_eighty() {
+        assert!((MechDec::new(190.0).value() + 170.0).abs() < EPS);
+        // The wrap boundary +180 folds to -180.
+        assert!((MechDec::new(180.0).value() + 180.0).abs() < EPS);
+    }
+
+    #[test]
+    fn dec_is_not_clamped_so_through_pole_is_detectable() {
+        // A raw encoder reading past the pole is kept as-is.
+        assert!((Dec::new(135.0).value() - 135.0).abs() < EPS);
+    }
+
+    // ---- Frame algebra: RA axis ------------------------------------------
+
+    #[test]
+    fn hour_angle_of_is_lst_minus_ra() {
+        let ha = Lst::new(12.0).hour_angle_of(Ra::new(15.0));
+        assert!((ha.value() + 3.0).abs() < EPS, "got {}", ha.value());
+    }
+
+    #[test]
+    fn mech_ha_to_ra_round_trips_pre_flip() {
+        // On the natural side mech_HA == celestial HA, so RA -> HA -> mech ->
+        // RA is the identity (modulo the [0,24) fold).
+        for &(mech, lst) in &[(0.0, 0.0), (3.0, 6.0), (-4.5, 18.0), (5.999, 12.0)] {
+            let m = MechHa::new(mech);
+            let ra = m.to_ra(Lst::new(lst));
+            let back = Lst::new(lst).hour_angle_of(ra).to_mech();
+            assert!(
+                (back.value() - m.value()).abs() < EPS,
+                "mech={mech} lst={lst} back={}",
+                back.value()
+            );
+        }
+    }
+
+    #[test]
+    fn flipped_mech_ha_is_self_inverse() {
+        let m = MechHa::new(11.5);
+        assert!((m.flipped().value() + 0.5).abs() < EPS);
+        assert!((m.flipped().flipped().value() - m.value()).abs() < EPS);
+    }
+
+    #[test]
+    fn lat45_flip_worked_example_matches_plan() {
+        // Plan §2.0, lat 45°N: target HA = -0.5 -> post-flip mech_HA = +11.5;
+        // dec = +45° -> post-flip mech encoder = +135°.
+        let mech_flipped = HourAngle::new(-0.5).to_mech().flipped();
+        assert!(
+            (mech_flipped.value() - 11.5).abs() < EPS,
+            "got {}",
+            mech_flipped.value()
+        );
+        let dec_flipped = Dec::new(45.0).to_mech_flipped();
+        assert!(
+            (dec_flipped.value() - 135.0).abs() < EPS,
+            "got {}",
+            dec_flipped.value()
+        );
+    }
+
+    #[test]
+    fn meridian_flip_lands_at_encoder_wrap() {
+        // target HA = 0 -> post-flip mech_HA = +12 -> folds to -12 (the wrap).
+        let m = HourAngle::new(0.0).to_mech().flipped();
+        assert!((m.value().abs() - 12.0).abs() < EPS, "got {}", m.value());
+    }
+
+    #[test]
+    fn post_flip_ra_read_adds_twelve_hours() {
+        // (LST - mech + 12) mod 24, vs the pre-flip (LST - mech) mod 24.
+        let m = MechHa::new(2.0);
+        let lst = Lst::new(5.0);
+        let pre = m.to_ra(lst).value();
+        let post = m.to_ra_flipped(lst).value();
+        assert!(((post - pre).rem_euclid(24.0) - 12.0).abs() < EPS);
+    }
+
+    // ---- Frame algebra: Dec axis -----------------------------------------
+
+    #[test]
+    fn dec_through_pole_negative_target() {
+        // dec = -45° -> post-flip mech encoder = -(180 - 45) = -135°.
+        assert!((Dec::new(-45.0).to_mech_flipped().value() + 135.0).abs() < EPS);
+    }
+
+    #[test]
+    fn dec_at_pole_stays_at_pole_through_flip() {
+        // dec = +90° -> sign * (180 - 90) = +90°: the pole is the same
+        // physical position flipped or not.
+        assert!((Dec::new(90.0).to_mech_flipped().value() - 90.0).abs() < EPS);
+    }
+
+    #[test]
+    fn mech_dec_to_celestial_round_trips_through_flip() {
+        // The through-pole reflection is its own inverse on the Dec axis.
+        for d in [45.0, -45.0, 30.0, -89.9, 0.0] {
+            let back = Dec::new(d).to_mech_flipped().to_dec_flipped();
+            assert!(
+                (back.value() - d).abs() < EPS,
+                "d={d} back={}",
+                back.value()
+            );
+        }
+    }
+
+    // ---- Tick <-> angle conversions --------------------------------------
+
+    #[test]
+    fn ra_quarter_revolution_is_six_hours() {
+        let ha = RaTicks::new((GTI_CPR / 4) as i32).to_mech_ha(cpr());
+        assert!((ha.value() - 6.0).abs() < EPS, "got {}", ha.value());
+    }
+
+    #[test]
+    fn dec_quarter_revolution_is_ninety_degrees() {
+        let d = DecTicks::new((GTI_CPR / 4) as i32).to_mech_dec(cpr());
+        assert!((d.value() - 90.0).abs() < EPS, "got {}", d.value());
+    }
+
+    #[test]
+    fn cpr_zero_is_handled_defensively() {
+        let zero = Cpr::new(0);
+        assert_eq!(RaTicks::new(123).to_mech_ha(zero).value(), 0.0);
+        assert_eq!(DecTicks::new(123).to_mech_dec(zero).value(), 0.0);
+        assert_eq!(MechHa::new(6.0).to_ticks(zero).value(), 0);
+        assert_eq!(MechDec::new(90.0).to_ticks(zero).value(), 0);
+    }
+
+    #[test]
+    fn fold_to_canonical_band_recovers_through_wrap_counter() {
+        // A through-wrap flip can leave the counter ~one revolution off; the
+        // fold collapses a near-cpr delta to its near-zero equivalent.
+        let raw_delta = 1_738_800 - (-1_890_000);
+        let folded = RaTicks::new(raw_delta).fold_to_canonical_band(cpr());
+        assert!(folded.value().abs() < 1000, "got {}", folded.value());
+    }
+
+    // ---- Property tests --------------------------------------------------
+
+    proptest! {
+        /// RA ticks within one revolution survive a tick -> mech_HA -> tick
+        /// round trip exactly.
+        #[test]
+        fn ra_ticks_round_trip(t in -((GTI_CPR / 2) as i32)..((GTI_CPR / 2) as i32)) {
+            let back = RaTicks::new(t).to_mech_ha(cpr()).to_ticks(cpr());
+            prop_assert_eq!(back.value(), t);
+        }
+
+        /// Dec ticks within one revolution survive a tick -> mech_dec -> tick
+        /// round trip exactly.
+        #[test]
+        fn dec_ticks_round_trip(t in -((GTI_CPR / 2) as i32)..((GTI_CPR / 2) as i32)) {
+            let back = DecTicks::new(t).to_mech_dec(cpr()).to_ticks(cpr());
+            prop_assert_eq!(back.value(), t);
+        }
+
+        /// The hour-angle fold is idempotent: a constructed value is already
+        /// canonical, so re-folding it is a no-op.
+        #[test]
+        fn mech_ha_fold_is_idempotent(h in -1000.0f64..1000.0) {
+            let once = MechHa::new(h);
+            let twice = MechHa::new(once.value());
+            prop_assert!((twice.value() - once.value()).abs() < EPS);
+            prop_assert!(once.value() >= -12.0 && once.value() < 12.0);
+        }
+
+        /// The through-pole reflection is its own inverse for any celestial
+        /// declination in the observable hemisphere.
+        #[test]
+        fn dec_through_pole_is_self_inverse(d in -90.0f64..90.0) {
+            let back = Dec::new(d).to_mech_flipped().to_dec_flipped();
+            prop_assert!((back.value() - d).abs() < 1e-6, "d={} back={}", d, back.value());
+        }
+    }
+}

--- a/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::world::StarAdventurerWorld;
 use cucumber::{given, then};
+use star_adventurer_gti::{ActiveZone, CwExclusionZone, TrackingGuardMarginHours};
 
 /// GTi counts-per-revolution on both axes (`0x375F00`) — the value the
 /// mock seeds and the driver caches at handshake. Used to convert a
@@ -17,8 +18,7 @@ const GTI_CPR: f64 = 3_628_800.0;
 )]
 async fn configured_zone(world: &mut StarAdventurerWorld, min_hours: f64, max_hours: f64) {
     let cfg = world.config_mut();
-    cfg.mount.binding_zone_min_hours = min_hours;
-    cfg.mount.binding_zone_max_hours = max_hours;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Active(ActiveZone::new(min_hours, max_hours));
 }
 
 #[given("a star-adventurer service with the CW exclusion zone disabled")]
@@ -26,13 +26,13 @@ async fn configured_zone_disabled(world: &mut StarAdventurerWorld) {
     // An inverted interval (min > max) switches the binding-zone check
     // off — the convention the slew planner and the guard share.
     let cfg = world.config_mut();
-    cfg.mount.binding_zone_min_hours = 24.0;
-    cfg.mount.binding_zone_max_hours = 0.0;
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
 }
 
 #[given(expr = "a tracking-guard margin of {float} hours")]
 async fn configured_margin(world: &mut StarAdventurerWorld, margin_hours: f64) {
-    world.config_mut().mount.tracking_guard_margin_hours = margin_hours;
+    world.config_mut().mount.tracking_guard_margin_hours =
+        TrackingGuardMarginHours::new(margin_hours);
 }
 
 #[given(expr = "the RA encoder is at mechanical HA {float} hours")]

--- a/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
+++ b/services/star-adventurer-gti/tests/bdd/steps/tracking_safety_steps.rs
@@ -18,13 +18,16 @@ const GTI_CPR: f64 = 3_628_800.0;
 )]
 async fn configured_zone(world: &mut StarAdventurerWorld, min_hours: f64, max_hours: f64) {
     let cfg = world.config_mut();
-    cfg.mount.cw_exclusion_zone = CwExclusionZone::Active(ActiveZone::new(min_hours, max_hours));
+    let zone = ActiveZone::try_new(min_hours, max_hours)
+        .expect("feature files specify a valid CW exclusion zone");
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Active(zone);
 }
 
 #[given("a star-adventurer service with the CW exclusion zone disabled")]
 async fn configured_zone_disabled(world: &mut StarAdventurerWorld) {
-    // An inverted interval (min > max) switches the binding-zone check
-    // off — the convention the slew planner and the guard share.
+    // Disabling is explicit: `CwExclusionZone::Disabled` (JSON `null`),
+    // which `bounds()` maps to an empty interval so the slew planner and
+    // the guard both treat it as "no zone".
     let cfg = world.config_mut();
     cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
 }
@@ -32,7 +35,8 @@ async fn configured_zone_disabled(world: &mut StarAdventurerWorld) {
 #[given(expr = "a tracking-guard margin of {float} hours")]
 async fn configured_margin(world: &mut StarAdventurerWorld, margin_hours: f64) {
     world.config_mut().mount.tracking_guard_margin_hours =
-        TrackingGuardMarginHours::new(margin_hours);
+        TrackingGuardMarginHours::try_new(margin_hours)
+            .expect("feature files specify a valid tracking-guard margin");
 }
 
 #[given(expr = "the RA encoder is at mechanical HA {float} hours")]

--- a/services/star-adventurer-gti/tests/bdd/world.rs
+++ b/services/star-adventurer-gti/tests/bdd/world.rs
@@ -19,7 +19,9 @@ use ascom_alpaca::Client as AlpacaClient;
 use bdd_infra::ServiceHandle;
 use cucumber::World;
 use serde_json::Value;
-use star_adventurer_gti::{Config, MountConfig, ServerConfig, TransportConfig, UsbConfig};
+use star_adventurer_gti::{
+    Config, CwExclusionZone, MountConfig, ServerConfig, TransportConfig, UsbConfig,
+};
 use tempfile::TempDir;
 use tokio::time::sleep;
 
@@ -227,8 +229,7 @@ fn default_test_config() -> Config {
             // `(6.95, 11.05)` zone. The gate itself is exercised by
             // the unit tests in
             // `mount_device::tests::slew_async_refuses_ra_target_in_binding_zone`.
-            binding_zone_min_hours: 24.0,
-            binding_zone_max_hours: 0.0,
+            cw_exclusion_zone: CwExclusionZone::Disabled,
             ..MountConfig::default()
         },
     }

--- a/services/star-adventurer-gti/tests/bdd/world.rs
+++ b/services/star-adventurer-gti/tests/bdd/world.rs
@@ -222,11 +222,11 @@ fn default_test_config() -> Config {
             // BDD scenarios pass hardcoded RA / Dec targets (the
             // canonical example is `RA = 6.0 h, Dec = 30°`) whose
             // computed mech-HA depends on wallclock LST. Disable the
-            // binding-zone safety gate (empty range: min > max) so
-            // those scenarios don't intermittently trip
+            // binding-zone safety gate (`CwExclusionZone::Disabled`,
+            // JSON `null`) so those scenarios don't intermittently trip
             // `INVALID_VALUE` when the test happens to run at an
             // LST that puts the target inside the default
-            // `(6.95, 11.05)` zone. The gate itself is exercised by
+            // `(0.95, 11.05)` zone. The gate itself is exercised by
             // the unit tests in
             // `mount_device::tests::slew_async_refuses_ra_target_in_binding_zone`.
             cw_exclusion_zone: CwExclusionZone::Disabled,


### PR DESCRIPTION
Implements **ADR-006** — typed physical quantities for the Star Adventurer GTi pointing math. Makes unit and reference-frame mix-ups (mechanical vs celestial HA/Dec, RA-axis vs Dec-axis ticks) **compile errors**, and moves config validation to construct-time (parse-don't-validate) so a bad config fails at startup, not mid-session.

## What changed

- **`units` module** (`src/units.rs`): concrete, frame-distinct newtypes — `MechHa`/`HourAngle`/`Ra`/`Lst` (RA axis), `MechDec`/`Dec` (Dec axis), `RaTicks`/`DecTicks`/`Cpr`. Conversions are named, type-checked methods (the only way to cross a frame). Hand-rolled in the style `pa-falcon-rotator` established. 21 unit + property tests.
- **`coordinates.rs` + consumers**: the pointing math (`coordinates`, `slew`, `tracking_guard`, `inherent`, `telescope`, `watchers`) threads typed values; `f64` survives only at the three documented boundaries — the `ascom-alpaca` trait API, the Sky-Watcher wire codec, and serde. The thin 1:1 conversion wrappers are deleted in favour of the `units` methods.
- **Config Scope A** (parse-don't-validate): `FlipRangeHours`, `TrackingGuardMarginHours`, `CwExclusionZone` (`Active(ActiveZone) | Disabled`), `DecLimits` — validating newtypes that reject a bad config at deserialize, retiring the runtime `MountConfig::validate` / `FlipPolicy::validate`. **Config JSON schema changed** (no operators yet → no back-compat constraint): `binding_zone_min/max_hours` → `cw_exclusion_zone` (object, or `null` = disabled); `dec_min/max_degrees` → `dec_limits`.
- **Docs**: ADR-006 → Accepted; design-doc Configuration section + safety/guard prose updated to the new schema; the newtype + parse-don't-validate convention added to `docs/skills/development-workflow.md` (citing `pa-falcon-rotator` and `star-adventurer-gti` as the two precedents).

## Verification

Behavior-preserving — the existing tests are the oracle throughout:
- **422** unit/integration tests pass (the drop from 446 is only the redundant tests now covered by `units.rs` plus the retired `validate()` tests).
- **136** BDD scenarios (628 steps) pass.
- `cargo build`, `clippy -D warnings`, `fmt --check` clean. Each commit is independently green and reviewable.

Refs ADR-006, issue #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)