### PR TITLE
ci(bazel): cloud CI remote cache via Cloudflare Worker + R2 (+ strip debuginfo)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,14 @@ test --test_tag_filters=-requires-cargo,-bdd
 # Use the stable Rust toolchain channel for Bazel builds.
 build --@rules_rust//rust/toolchain/channel=stable
 
+# Drop debuginfo from Bazel-built artifacts. CI only needs pass/fail, not debug
+# symbols, and debuginfo bloats the rlibs/test binaries the remote cache moves
+# over the wire — keeping them small matters for a LAN cache and keeps CAS
+# blobs under the Cloudflare Worker cache's 100 MB request-body (write) limit.
+# Plural `extra_rustc_flags` (a list) so it composes with the per-OS
+# `extra_rustc_flag` linker setting below rather than overriding it.
+build --@rules_rust//rust/settings:extra_rustc_flags=-Cdebuginfo=0
+
 # --- Platform-specific config -----------------------------------------------
 
 # Override rules_rust's default gold linker on Linux. rustc 1.94+ warns
@@ -107,17 +115,11 @@ test:ci --test_summary=terse
 # developers don't accidentally point at the shared cache. CI jobs combine:
 # --config=ci --config=remote-cache.
 #
-# Backend: self-hosted bazel-remote on a TrueNAS SCALE box, exposed to the
-# public internet via a Cloudflare Tunnel (HTTPS, no open router ports).
-# The cache is public-READ (so every PR, including forks, gets a warm cache)
-# and token-WRITE (only push-to-main and the nightly schedule hold the Bearer
-# token — see bazel.yml). The hostname below is this repo's Cloudflare Tunnel
-# public hostname (zone rustyphoton.space is on Cloudflare). Setup runbook:
-# docs/skills/bazel-remote-cache.md.
-#
-# HTTP (not gRPC) endpoint: --remote_cache_compression is gRPC-only, so it is
-# intentionally omitted; bazel-remote compresses at rest via --storage_mode
-# zstd instead. --remote_timeout is already set by --config=ci.
+# Backend: a Cloudflare Worker + R2 edge cache. Public-READ (every PR,
+# including forks, gets a warm cache) and token-WRITE (only push-to-main and
+# the nightly schedule hold the Bearer token — see bazel.yml). Worker code and
+# deploy steps: tools/bazel-cache-worker/. For local builds, override this in a
+# gitignored user.bazelrc to point at a LAN bazel-remote instead.
 build:remote-cache --remote_cache=https://cache.rustyphoton.space
 
 # --- Local overrides -------------------------------------------------------

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,12 +11,8 @@ on:
   push:
     branches: [main]
   pull_request:
-  # Nightly run from main keeps the BuildBuddy remote cache warm.
-  # BuildBuddy uses LRU eviction on a shared free-tier cache with no
-  # documented retention guarantee, so quiet stretches on main let
-  # action results age out and PRs pay the full uncached cost. A daily
-  # main-equivalent build refreshes last-used timestamps and re-uploads
-  # anything that did get evicted.
+  # Nightly run from main keeps the remote cache populated from trusted code
+  # during quiet stretches, so the next PR reads a warm cache.
   schedule:
     - cron: "7 7 * * *"
 concurrency:
@@ -40,8 +36,8 @@ jobs:
       run:
         shell: bash
     env:
-      # Self-hosted bazel-remote cache (TrueNAS + Cloudflare Tunnel) is
-      # public-READ / token-WRITE. Only push-to-main and the nightly schedule
+      # The remote cache (Cloudflare Worker + R2; see tools/bazel-cache-worker)
+      # is public-READ / token-WRITE. Only push-to-main and the nightly schedule
       # — which run from the default branch — get the write token, so they
       # populate the cache from trusted code. PRs (including forks, which get
       # no secrets at all) read anonymously and never write, which prevents

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -8,11 +8,12 @@
 
 Three decisions taken to shorten the path to a Bazel-primary cutover (Phase 7):
 
-1. **Cache backend: self-hosted `bazel-remote` on TrueNAS SCALE**, exposed
-   public-read / token-write via a Cloudflare Tunnel — replacing the BuildBuddy
-   free tier, whose LRU eviction (no retention guarantee) caused random
-   cold-cache rebuilds. Deterministic, $0, owned. Runbook:
-   [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
+1. **Cache backend: a Cloudflare Worker + R2 edge cache** (public-read /
+   token-write), replacing the BuildBuddy free tier. Served from the edge so
+   cloud CI isn't bottlenecked, ~$0 (R2 has no egress fees), retention
+   controlled via an R2 lifecycle rule. Code + deploy:
+   [tools/bazel-cache-worker/](../../tools/bazel-cache-worker/README.md);
+   overview: [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
 2. **Leptos / `sentinel-app` WASM: abandoned.** Not used today; Phase 4 is
    dropped, not deferred.
 3. **Release packaging: stays on Cargo permanently.** We release far less often
@@ -34,7 +35,7 @@ Bazel's remote cache is the structural fix for items 1 and 2 — the cache is co
 
 **In-scope:**
 - All 11 workspace crates build and test under Bazel.
-- Remote cache wired up. Bootstrapped on the BuildBuddy free tier; now self-hosted `bazel-remote` on TrueNAS SCALE (see Decisions, 2026-05-24).
+- Remote cache wired up. Bootstrapped on the BuildBuddy free tier; now a Cloudflare Worker + R2 cache (see Decisions, 2026-05-24).
 - New GHA workflow running Bazel in shadow mode; Cargo remains required until parity.
 - BDD cucumber tests run under Bazel via custom `rust_test` wrappers.
 - Documentation (`CLAUDE.md`, `docs/skills/pre-push.md`, `docs/skills/bazel-remote-cache.md`) updated.
@@ -118,10 +119,10 @@ the starting point.
 - [x] `.github/workflows/bazel.yml` — triggers on PR, push to main, and a nightly schedule (07:07 UTC), runs `bazel test //...` with remote cache.
 - [x] Bootstrap backend: BuildBuddy free tier (read+write token on push/schedule, read-only token on PRs).
 - [x] Shadow mode: job is **not required** for merges; runs alongside Cargo jobs for 2+ weeks of parity validation.
-- [x] **Cache backend swapped to self-hosted `bazel-remote` on TrueNAS SCALE** (public-read / token-write via Cloudflare Tunnel). `.bazelrc` `--config=remote-cache` points at the Cloudflare hostname; `bazel.yml` attaches `Authorization: Bearer` only on push/schedule and sets `--remote_upload_local_results=false` on PRs. Reads are anonymous, so fork PRs now get a warm cache too. Deterministic retention via `--max_size` ends the BuildBuddy LRU cold-cache outliers. Runbook: [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
+- [x] **Cache backend swapped to a Cloudflare Worker + R2 edge cache** (public-read / token-write). `.bazelrc` `--config=remote-cache` points at the Cloudflare hostname; `bazel.yml` attaches `Authorization: Bearer` only on push/schedule and sets `--remote_upload_local_results=false` on PRs. Reads are anonymous, so fork PRs get a warm cache too. Served from the edge (no origin uplink in the path), retention via an R2 lifecycle rule — replacing the BuildBuddy LRU cold-cache outliers. Code + deploy: [tools/bazel-cache-worker/](../../tools/bazel-cache-worker/README.md).
 - [x] `.bazelrc` hostname set to `cache.rustyphoton.space` (zone `rustyphoton.space` verified on Cloudflare 2026-05-24).
-- [ ] Add the `BAZEL_CACHE_WRITE_TOKEN` GHA secret and deploy the TrueNAS side (runbook).
-- [ ] Compare wall-clock and correctness against Cargo jobs weekly (≥1 week on the TrueNAS cache).
+- [ ] Add the `BAZEL_CACHE_WRITE_TOKEN` GHA secret and deploy the Worker + R2 ([tools/bazel-cache-worker/](../../tools/bazel-cache-worker/README.md)).
+- [ ] Compare wall-clock and correctness against Cargo jobs weekly (≥1 week on the new cache).
 
 **Exit criteria:** Bazel CI job green for 2 consecutive weeks with no flakes; wall-clock within ±20 % of Cargo or better.
 
@@ -134,7 +135,7 @@ per-PR build/test path only; packaging keeps running on Cargo indefinitely.
 ### Phase 7 — Cutover (later)
 
 With Phase 4 (Leptos) and Phase 6 (packaging) dropped, cutover no longer waits
-on them. Remaining prerequisites: the TrueNAS cache live + parity logged
+on them. Remaining prerequisites: the cache live + parity logged
 (Phase 5), the Cargo-only gates (miri, sanitizers, conformu, `cargo-hack`,
 `cargo-msrv`, coverage) kept on a Cargo nightly, and the `rust-project.json`
 IDE decision (open question 4).
@@ -163,7 +164,7 @@ After Phase 7: the Cargo nightly job remains as a safety net for 30 days. Rollba
 | Leptos hydrate/ssr WASM rules are missing | High | Defer to Phase 4; prototype separately before committing. If blocked, keep `cargo leptos` as an escape hatch via `genrule`. |
 | rust-analyzer breaks under Bazel | Medium | Developers can still use Cargo locally (it's not removed). `rust-project.json` generator from rules_rust is also available. |
 | Team learning curve | Certain | This plan doc + pair programming on first few BUILD files. |
-| Remote cache unavailable / cold | Low | Resolved: self-hosted `bazel-remote` on TrueNAS SCALE with deterministic `--max_size` retention. Bazel treats remote-cache errors as non-fatal (warns, builds locally), so a cache or tunnel outage degrades to a cold build rather than a CI failure. |
+| Remote cache unavailable / cold | Low | Resolved: a Cloudflare Worker + R2 edge cache with retention via an R2 lifecycle rule. Bazel treats remote-cache errors as non-fatal (warns, builds locally), so a cache outage degrades to a cold build rather than a CI failure. |
 | `aws-lc-sys` build fails on Windows under Bazel (MAX_PATH + bswap) | Hit | Four fixes: (1) shortened `from_cargo` name from `"crates"` to `"cr"` — the repo name appears twice in every build-script runfiles path, saving 8 chars; (2) `build_script_data_glob = ["**"]` annotation ensures all vendored C files are materialised in Bazel's runfiles; (3) `AWS_LC_SYS_NO_JITTER_ENTROPY=1` disables jitterentropy on Windows — its `tree_drbg_jitter_entropy.c` uses a deep `../../../../` relative `#include` whose un-normalised intermediate form (~280 chars) exceeds MSVC's MAX_PATH; (4) `AWS_LC_SYS_CFLAGS=/we4013` promotes MSVC's implicit-function-declaration warning to an error — the cc-crate builder's feature check for `__builtin_bswap*` wrongly passes because cl.exe in C89 mode treats GCC built-ins as implicit declarations (C4013, level 3) without emitting the warning at the default `/W1` level; `/we4013` makes the check fail correctly so aws-lc uses MSVC's `_byteswap_*` intrinsics. We use `AWS_LC_SYS_CFLAGS` (not plain `CFLAGS`) because rules_rust overrides `CFLAGS` in the build-script environment with its own MSVC flags; the crate-specific variant is read first by `get_crate_cflags()` and propagated to `CFLAGS_<target>` before the feature checks run. |
 
 ## Success metrics
@@ -253,6 +254,6 @@ Env var names follow the `{UPPER_SNAKE_PACKAGE}_BINARY` convention (e.g. `RP_BIN
 ## Open questions
 
 1. **bzlmod vs WORKSPACE.** Starting with bzlmod. Fallback to WORKSPACE mode if `crate_universe` bzlmod issues block progress.
-2. **Remote cache vendor.** RESOLVED (2026-05-24): self-hosted `bazel-remote` on TrueNAS SCALE, public-read / token-write via Cloudflare Tunnel. See Decisions and [docs/skills/bazel-remote-cache.md](../skills/bazel-remote-cache.md).
+2. **Remote cache vendor.** RESOLVED (2026-05-24): a Cloudflare Worker + R2 edge cache, public-read / token-write. See Decisions and [tools/bazel-cache-worker/](../../tools/bazel-cache-worker/README.md).
 3. **TypeScript addition.** Deferred until UI work actually starts. `rules_js` and `aspect_rules_ts` are bzlmod-first — will integrate cleanly then.
 4. **rust-analyzer.** Does the team use cargo directly for IDE, or do we need `rust-project.json` generation from rules_rust? Decide after Phase 2.

--- a/docs/skills/bazel-remote-cache.md
+++ b/docs/skills/bazel-remote-cache.md
@@ -1,172 +1,58 @@
-# Skill: Self-Hosted Bazel Remote Cache (TrueNAS SCALE + Cloudflare Tunnel)
+# Skill: Bazel Remote Cache
 
 ## When to Read This
 
-- Standing up or re-pointing the Bazel remote cache that `.github/workflows/bazel.yml` uses.
-- Diagnosing cache misses, `403` on upload, or a cold-cache outlier in a Bazel CI run.
+- Diagnosing Bazel cache misses, slow `Downloading …` stalls, or `403` on upload in CI.
+- Changing or redeploying the remote cache.
 - Auditing the cache's security posture on this **public** repo.
 
-This replaces the BuildBuddy free-tier cache (see `docs/plans/bazel-migration.md` → Decisions, 2026-05-24). The replacement fixes BuildBuddy's LRU eviction (no retention guarantee), which caused random cold-cache rebuilds — most visibly a ~15 min Windows `bazel build` when action results had aged out.
+## What it is
 
-The **repo-side wiring is already committed** (`.bazelrc`, `.github/workflows/bazel.yml`). This runbook covers the TrueNAS + Cloudflare side and the two values you must fill in (§4).
+Cloud CI (`.github/workflows/bazel.yml`) uses a Bazel HTTP remote cache served
+by a **Cloudflare Worker backed by R2**, at `https://cache.rustyphoton.space`.
+Code, config, and deploy steps live in
+[`tools/bazel-cache-worker/`](../../tools/bazel-cache-worker/README.md).
 
-## Architecture
-
-```
-GitHub-hosted runner (bazel.yml)
-   │   GET  = anonymous            → reads, incl. fork PRs (warm cache for everyone)
-   │   PUT  = Authorization: Bearer → writes, only on push-to-main / nightly
-   ▼
-Cloudflare edge   cache.rustyphoton.space          ← free TLS, no open router ports
-   │   (Cloudflare Tunnel; cloudflared dials OUT from TrueNAS)
-   ▼  ┌──────────────── TrueNAS SCALE ────────────────────────────────────────┐
-   └─▶│ Cloudflared app ─→ Caddy :8088 ─→ bazel-remote :8080 ─→ /data (SSD pool)│
-      │   (catalog)        (read/write split)  (cache server)   (dataset)       │
-      └────────────────────────────────────────────────────────────────────────┘
-```
-
-Caddy is required because `bazel-remote`'s own auth (`--htpasswd_file`) gates **all** methods identically. We want anonymous reads (so every PR, including forks, gets cache speed) but token-gated writes (anti-poisoning). Caddy does that split in six lines.
-
-## Security model — why this is safe on a public repo
-
-The cache stores build/test **outputs of public OSS code** — not secrets. So:
-
-- **Reads are anonymous.** Harmless, and a feature: fork PRs get a warm cache (BuildBuddy's read-only-key model never gave forks anything, because GitHub withholds secrets from forks).
-- **Writes require a Bearer token** that is a GitHub Actions **secret**. Secrets are exposed only to `push` and `schedule` events — which run from the default branch — never to PRs (and never to forks at all). So only trusted, main-derived runs can populate the cache. No poisoning path.
-- **Defense in depth:** PRs are read-only by a Bazel flag (`--remote_upload_local_results=false`) *and* Caddy `403`s any unauthenticated write. A workflow edited in a malicious PR still can't write (no token in its env; Caddy rejects it).
-
-This mirrors the trust split the BuildBuddy setup already encoded — just self-hosted, with retention you control.
-
-## Prerequisites
-
-- [ ] **TrueNAS SCALE 24.10.2.2+** ("Electric Eel"; the catalog Cloudflared app requires this).
-- [ ] A **domain on a Cloudflare zone** (free plan is fine) — needed for a named Tunnel hostname.
-- [ ] **~100 GB free** on the SSD pool.
-- [ ] A write token: `openssl rand -hex 32` — used in two places (Caddy env in §2, GitHub secret in §4). Keep it somewhere safe.
-
----
-
-## Part 1 — Dataset on the SSD pool
-
-1. **Datasets → Add Dataset** on the SSD pool, e.g. `ssd-pool/apps/bazel-remote`. Note the mountpoint (e.g. `/mnt/ssd-pool/apps/bazel-remote`). Adjust the paths in §2 to match.
-2. **Disable snapshots / replication** for it. The cache is fully reconstructible; snapshotting it just wastes SSD. Wiping it only costs one cold rebuild.
-3. Create a `data/` subdir and drop the `Caddyfile` from §2 at the dataset root. Make `data/` writable by the container UID — on SCALE the built-in apps user is **UID 568**; from **System → Shell**: `chown -R 568:568 /mnt/ssd-pool/apps/bazel-remote/data`.
-
-## Part 2 — Deploy `bazel-remote` + Caddy (Apps → Custom App → Install via YAML)
-
-These two images aren't in the catalog, so install them as one Custom App. **Apps → Discover Apps → Custom App → Install via YAML** opens the Compose editor:
-
-```yaml
-services:
-  bazel-remote:
-    image: buchgr/bazel-remote-cache:latest   # :latest, not pinned — not reproducible as a result; fine since the cache is disposable
-    user: "568:568"                            # TrueNAS 'apps' uid:gid; must own /data
-    command:
-      - --dir=/data
-      - --max_size=80                          # GiB; raise as the SSD pool allows
-      - --storage_mode=zstd                    # compress at rest
-      - --http_address=0.0.0.0:8080
-      - --access_log_level=none
-    volumes:
-      - /mnt/ssd-pool/apps/bazel-remote/data:/data
-    restart: unless-stopped
-    # bazel-remote's 8080 is NOT published to the host — only Caddy reaches it
-    # over the app's internal network.
-
-  caddy:
-    image: caddy:2
-    depends_on: [bazel-remote]
-    environment:
-      CACHE_WRITE_TOKEN: "PASTE_OPENSSL_TOKEN_HERE"   # same value as the GitHub secret (§4)
-    ports:
-      - "8088:80"                              # published on the TrueNAS LAN IP
-    volumes:
-      - /mnt/ssd-pool/apps/bazel-remote/Caddyfile:/etc/caddy/Caddyfile:ro
-    restart: unless-stopped
-```
-
-`Caddyfile` (anonymous read, Bearer-only write) — save at `/mnt/ssd-pool/apps/bazel-remote/Caddyfile` *before* launching:
+For **local builds**, point a gitignored `user.bazelrc` at a LAN `bazel-remote`
+(reads at LAN speed):
 
 ```
-:80 {
-	@write_no_auth {
-		method PUT POST PATCH DELETE
-		not header Authorization "Bearer {$CACHE_WRITE_TOKEN}"
-	}
-	respond @write_no_auth 403
-	reverse_proxy bazel-remote:8080
-}
+build:remote-cache --remote_cache=http://<your-lan-cache-host>:8088
 ```
 
-GET/HEAD never match the write matcher → served anonymously. A write with the exact Bearer token → proxied. A write without it → `403`. (`{$CACHE_WRITE_TOKEN}` is resolved from the container env at config load.)
+## Security model (public repo)
 
-> **Why publish Caddy on `:8088`?** The catalog Cloudflared app (§3) runs as a *separate* Docker app, so it can't reach `caddy` by service name — it connects via the TrueNAS LAN IP. Publishing `8088` also doubles as a **fast LAN dev cache**: point a gitignored `user.bazelrc` at `build:remote-cache --remote_cache=http://<TRUENAS_LAN_IP>:8088` and your local `bazel build` reuses CI's cache. On a trusted home LAN this exposure is fine (reads are harmless; writes still need the token).
+The cache stores build/test outputs of public code, so:
 
-### Using Traefik instead of Caddy (optional)
+- **Reads (GET/HEAD) are anonymous** — every PR, including forks, gets a warm cache.
+- **Writes (PUT) require `Authorization: Bearer <token>`** — the token is a
+  GitHub Actions secret (`BAZEL_CACHE_WRITE_TOKEN`) exposed only to `push`-to-main
+  and the nightly `schedule`, never to PRs or forks. So only trusted,
+  main-derived runs can populate the cache — no poisoning path.
 
-If you already run the catalog **Traefik** app as your ingress, you can drop the `cloudflared`→`caddy` hop and route the public hostname through Traefik. The catch: Traefik has no built-in "require this exact Bearer token" middleware, so the read/write split needs one of:
+`bazel.yml` attaches the Bearer token only on push/schedule and adds
+`--remote_upload_local_results=false` on PRs (read-only). Reads need no
+credentials, so fork PRs benefit too.
 
-- a **ForwardAuth** middleware pointing at a tiny token-checker, applied only to a router with a `Method(\`PUT\`,\`POST\`,\`PATCH\`,\`DELETE\`)` rule (a second catch-all router serves reads with no middleware), or
-- a community API-key/bearer **plugin**, or
-- switching CI to **Basic auth** via URL-embedded creds (`--remote_cache=https://user:pass@cache...`) — but that sends credentials on reads too and changes the `bazel.yml` wiring.
+## Repo wiring
 
-Caddy keeps the proxy self-contained and matches the `Authorization: Bearer` wiring already committed, so it's the default here. If you'd rather standardize on Traefik, say so and the router + ForwardAuth config can replace §2's `caddy` service.
+- `.bazelrc` — `build:remote-cache --remote_cache=https://cache.rustyphoton.space`; debuginfo is stripped (`-Cdebuginfo=0`) to keep cached blobs small.
+- `bazel.yml` — sends the Bearer token on trusted events; reads anonymously otherwise.
+- The GitHub secret `BAZEL_CACHE_WRITE_TOKEN` must match the Worker's `WRITE_TOKEN`.
 
-## Part 3 — Cloudflare Tunnel via the catalog Cloudflared app
+## Verify
 
-1. **Cloudflare Zero Trust → Networks → Tunnels → Create a tunnel** → *Cloudflared* → name it (e.g. `truenas`) → copy the **tunnel token**.
-2. **TrueNAS → Apps → Discover Apps → search "Cloudflared"** (Community train) → **Install** → paste the tunnel token into the app config → deploy. No ports are opened; `cloudflared` dials out to Cloudflare.
-3. Back in the Cloudflare tunnel → **Public Hostname → Add**:
-   - Subdomain `cache`, Domain `rustyphoton.space`
-   - Service **Type** `HTTP`, **URL** `<TRUENAS_LAN_IP>:8088`
-   Save. Cloudflare auto-creates the proxied DNS record and edge TLS.
+```bash
+curl -sf https://cache.rustyphoton.space/status                       # -> ok
+H=0000000000000000000000000000000000000000000000000000000000000000
+curl -s -o/dev/null -w '%{http_code}\n' -X PUT --data x \
+  https://cache.rustyphoton.space/cas/$H                              # -> 403 (no token)
+```
 
-## Part 4 — Fill in the two repo values
-
-1. **`.bazelrc`:** already set — `--remote_cache=https://cache.rustyphoton.space` is committed (zone `rustyphoton.space` verified on Cloudflare). No change needed unless the hostname differs.
-2. **GitHub repo secret:** Settings → Secrets and variables → Actions → **New repository secret** → name `BAZEL_CACHE_WRITE_TOKEN`, value = the same token as Caddy's `CACHE_WRITE_TOKEN`.
-3. (After a week of green) delete the old `BUILDBUDDY_API_KEY` / `BUILDBUDDY_API_KEY_READONLY` secrets.
-
-## Part 5 — Validate
-
-- **Status:** `curl -sf https://cache.rustyphoton.space/status` → bazel-remote JSON (`NumFiles`, `ServerTime`, …).
-- **Write auth:** a write without the token must be rejected, with it must succeed:
-  ```bash
-  curl -s -o /dev/null -w '%{http_code}\n' -X PUT --data x \
-    https://cache.rustyphoton.space/cas/0000000000000000000000000000000000000000000000000000000000000000      # → 403
-  curl -s -o /dev/null -w '%{http_code}\n' -X PUT --data x \
-    -H "Authorization: Bearer <token>" \
-    https://cache.rustyphoton.space/cas/0000000000000000000000000000000000000000000000000000000000000000      # → 200
-  ```
-- **End to end (LAN):** `bazel build //... --config=remote-cache --remote_cache=http://<TRUENAS_LAN_IP>:8088`, then `bazel clean && bazel build //...` → the tail line shows `remote cache hit`.
-- **CI:** push the `feature/bazel-remote-truenas` branch; open the Bazel run and confirm `… processes: N remote cache hit`. The first push-to-main populates; subsequent PRs read.
-
-## Part 6 — Rollback
-
-Cache outages are **non-fatal** — Bazel treats remote-cache errors as a cache miss (warns, builds locally), so a stopped tunnel or full disk degrades to a cold build, never a red CI. To fully revert: `git revert` the `.bazelrc` + `bazel.yml` change; the BuildBuddy secrets are still present until you delete them (§4.3), so the old backend works again in one commit.
-
-## Operational notes
-
-- **Sizing:** `--max_size 80` (GiB) is the cache-content cap; Linux + macOS + Windows artifacts coexist (platform is part of the action key). Raise it freely on an SSD pool. Deterministic LRU within the cap — no surprise eviction.
-- **No backup:** the dataset is a cache; leave snapshots off.
-- **Lost build UI:** `bazel-remote` is cache-only; there's no BuildBuddy-style invocation dashboard. Timing still comes from the GHA logs and the `--profile` / exec-log artifacts `bazel.yml` already uploads. If you miss the UI, you can re-add BuildBuddy's *free BES* (`--bes_backend`) independently of the cache.
-- **HTTP not gRPC:** simplest over a Tunnel. `--remote_cache_compression` is gRPC-only and intentionally omitted; `--storage_mode zstd` compresses at rest. gRPC is a later optimization.
-
-## Troubleshooting
-
-| Symptom | Likely cause |
-|---|---|
-| CI uploads `403` | `BAZEL_CACHE_WRITE_TOKEN` (GitHub) ≠ `CACHE_WRITE_TOKEN` (Caddy env). |
-| Every run is a full miss | action-key instability (an env var like `PATH` leaking into keys), cache wiped, or `--max_size` too small so entries evict each run. |
-| `curl /status` hangs/fails | Cloudflared app stopped or wrong tunnel token; or the public hostname points at the wrong `LAN_IP:8088`. |
-| Reads work, writes never cache | expected on PRs (read-only by design); only push-to-main / nightly write. |
-| Caddy won't start | `Caddyfile` missing at the mounted host path, or `CACHE_WRITE_TOKEN` env unset. |
+A healthy CI run shows `… processes: N remote cache hit` without long
+`Downloading …` stalls.
 
 ## References
 
-- [docs/plans/bazel-migration.md](../plans/bazel-migration.md) — Decisions (2026-05-24) and Phase 5.
-- [.bazelrc](../../.bazelrc) `build:remote-cache` / [.github/workflows/bazel.yml](../../.github/workflows/bazel.yml) — the committed wiring.
-- [bazel-remote](https://github.com/buchgr/bazel-remote) — the cache server (flags, releases).
-- [TrueNAS: Custom App / Install via YAML](https://www.truenas.com/docs/scale/24.10/scaleuireference/apps/installcustomappscreens/)
-- [TrueNAS: Cloudflared app](https://apps.truenas.com/catalog/cloudflared) and [Cloudflare Tunnel tutorial](https://www.truenas.com/docs/scale/24.04/scaletutorials/apps/appsecurity/cloudflaretunnel/)
-- [Bazel remote caching](https://bazel.build/remote/caching) — HTTP cache protocol, `--remote_upload_local_results`.
+- [tools/bazel-cache-worker/](../../tools/bazel-cache-worker/README.md) — Worker code + deploy runbook.
+- [docs/plans/bazel-migration.md](../plans/bazel-migration.md) — migration status.

--- a/tools/bazel-cache-worker/README.md
+++ b/tools/bazel-cache-worker/README.md
@@ -1,0 +1,86 @@
+# Bazel remote cache — Cloudflare Worker + R2
+
+A serverless Bazel HTTP remote cache for **GitHub cloud CI**, served from
+Cloudflare's edge and backed by [R2](https://developers.cloudflare.com/r2/)
+(S3-compatible object storage, **zero egress fees**).
+
+## Overview
+
+Bazel's HTTP cache protocol is a simple keyed blob store (`GET`/`PUT` on
+`/ac/<hash>` and `/cas/<hash>`). This Worker maps it onto an R2 bucket and
+serves it from Cloudflare's edge, so cloud CI gets fast cache reads at zero
+egress cost. Access is public-read / token-write (below), served at
+`cache.rustyphoton.space`.
+
+For **local builds**, point a (gitignored) `user.bazelrc` at a LAN
+`bazel-remote` instead, which reads at LAN speed:
+
+```
+build:remote-cache --remote_cache=http://<your-lan-cache-host>:8088
+```
+
+| Consumer | Cache |
+|---|---|
+| GitHub cloud CI (`bazel.yml`) | this Worker + R2 (`cache.rustyphoton.space`) |
+| Local builds | your own LAN `bazel-remote` (via `user.bazelrc`) |
+
+## Security model (public repo)
+
+- **GET/HEAD = anonymous** — every PR (incl. forks) gets a warm cache.
+- **PUT = `Authorization: Bearer <WRITE_TOKEN>`** — only push-to-main / nightly
+  (which hold the GitHub secret) can write, so forks can't poison the cache.
+
+The `WRITE_TOKEN` Worker secret must equal the `BAZEL_CACHE_WRITE_TOKEN` GitHub
+Actions secret (`bazel.yml` already sends `Authorization: Bearer` on push/schedule).
+
+## Deploy (one-time)
+
+Prereqs: a Cloudflare account with the `rustyphoton.space` zone, R2 enabled
+(free), and `wrangler` (`npm i -g wrangler`, or `npx wrangler`).
+
+```bash
+cd tools/bazel-cache-worker
+
+# 1. Create the bucket.
+wrangler r2 bucket create rusty-photon-bazel-cache
+
+# 2. Set the write token (paste the SAME value as the GitHub secret
+#    BAZEL_CACHE_WRITE_TOKEN; don't echo it into shell history).
+wrangler secret put WRITE_TOKEN
+
+# 3. Make sure no other Cloudflare DNS record/route already claims
+#    cache.rustyphoton.space (remove it if so), then deploy — this provisions
+#    the Worker + the cache.rustyphoton.space custom domain.
+wrangler deploy
+```
+
+### Retention / eviction
+
+R2 has no built-in LRU, so set a **lifecycle rule** to bound growth: Cloudflare
+dashboard → R2 → `rusty-photon-bazel-cache` → Settings → Object lifecycle →
+**delete objects older than 30 days**. Cache entries are regenerable, so
+age-based eviction is safe and keeps storage in the free tier.
+
+## Verify
+
+```bash
+curl -sf https://cache.rustyphoton.space/status                       # -> ok
+H=0000000000000000000000000000000000000000000000000000000000000000
+curl -s -o/dev/null -w '%{http_code}\n' -X PUT --data x \
+  https://cache.rustyphoton.space/cas/$H                              # -> 403 (no token)
+curl -s -o/dev/null -w '%{http_code}\n' -X PUT --data x \
+  -H "Authorization: Bearer <WRITE_TOKEN>" \
+  https://cache.rustyphoton.space/cas/$H                              # -> 200
+```
+
+On the next push-to-main, `cache.rustyphoton.space` fills from the edge and PR
+reads come back fast (`bazel.yml` shows remote cache hits without long
+`Downloading …` stalls).
+
+## Cost
+
+Effectively free. R2: 10 GB storage free, then ~$0.015/GB·mo, **$0 egress** (the
+whole point — cache reads don't cost). Workers: 100k requests/day free; a very
+busy CI day could tip into the $5/mo Workers plan (10M requests). Debuginfo is
+stripped in `.bazelrc`, so individual CAS blobs stay well under Cloudflare's
+100 MB request-body (write) limit.

--- a/tools/bazel-cache-worker/src/cache.js
+++ b/tools/bazel-cache-worker/src/cache.js
@@ -1,0 +1,53 @@
+// Bazel HTTP remote cache backed by Cloudflare R2.
+//
+// Implements the Bazel HTTP cache protocol (GET/HEAD/PUT on /ac/<hash> and
+// /cas/<hash>) over an R2 bucket, served from Cloudflare's edge, so cloud CI
+// reads it at edge speed (with R2's zero egress cost).
+//
+// Security (public repo): reads are ANONYMOUS, so every PR including forks gets
+// a warm cache; writes require a Bearer token that only push-to-main / nightly
+// hold, so forks can never poison the cache. For local builds, point
+// user.bazelrc at a LAN bazel-remote instead. See README.md.
+//
+// Bindings (wrangler.toml): CACHE = R2 bucket.  Secret: WRITE_TOKEN.
+
+const KEY_RE = /^(ac|cas)\/[0-9a-fA-F]+$/;
+
+export default {
+  async fetch(request, env) {
+    const key = new URL(request.url).pathname.replace(/^\/+/, "");
+
+    // Health check for humans; Bazel never hits this.
+    if (key === "" || key === "status") {
+      return new Response("bazel-cache (cloudflare worker + r2) ok\n", { status: 200 });
+    }
+    if (!KEY_RE.test(key)) {
+      return new Response("not a bazel cache key\n", { status: 400 });
+    }
+
+    switch (request.method) {
+      case "GET": {
+        const obj = await env.CACHE.get(key);
+        return obj ? new Response(obj.body, { status: 200 }) : new Response(null, { status: 404 });
+      }
+      case "HEAD": {
+        const obj = await env.CACHE.head(key);
+        return new Response(null, { status: obj ? 200 : 404 });
+      }
+      case "PUT": {
+        // Token-gated. The token is a Worker secret; only trusted CI events
+        // (push-to-main, nightly) send it. Fork PRs get no secret -> read-only.
+        if ((request.headers.get("Authorization") || "") !== `Bearer ${env.WRITE_TOKEN}`) {
+          return new Response("forbidden\n", { status: 403 });
+        }
+        // Bazel sends Content-Length, so request.body is a fixed-length stream;
+        // R2 streams it straight to storage (no buffering -> large blobs OK,
+        // subject to Cloudflare's 100 MB request-body limit — see README).
+        await env.CACHE.put(key, request.body);
+        return new Response(null, { status: 200 });
+      }
+      default:
+        return new Response("method not allowed\n", { status: 405 });
+    }
+  },
+};

--- a/tools/bazel-cache-worker/wrangler.toml
+++ b/tools/bazel-cache-worker/wrangler.toml
@@ -1,0 +1,16 @@
+name = "rusty-photon-bazel-cache"
+main = "src/cache.js"
+compatibility_date = "2026-05-01"
+
+# Blob store for the cache. Create once: `wrangler r2 bucket create rusty-photon-bazel-cache`
+[[r2_buckets]]
+binding = "CACHE"
+bucket_name = "rusty-photon-bazel-cache"
+
+# Serve at the cache hostname. Make sure no other Cloudflare DNS record/route
+# already claims it, then `wrangler deploy` provisions this custom domain + DNS
+# on the zone. See README.md. The write token is NOT here — it's a secret:
+# `wrangler secret put WRITE_TOKEN`.
+[[routes]]
+pattern = "cache.rustyphoton.space"
+custom_domain = true


### PR DESCRIPTION
## What

Serves the **cloud-CI Bazel remote cache from Cloudflare's edge** — a Worker backed by R2 (zero egress) — at `https://cache.rustyphoton.space`, with the same **public-read / token-write** model. Cloud runners read from the edge (fast, no self-hosted-origin uplink in the path). For **local builds**, point a gitignored `user.bazelrc` at a LAN `bazel-remote`.

## Changes

- **`tools/bazel-cache-worker/`** — the Worker (`cache.js`: GET/HEAD/PUT over R2, anonymous reads, Bearer-token writes), `wrangler.toml`, and a deploy runbook. Worker syntax validated locally.
- **`.bazelrc`** — strip debuginfo (`-Cdebuginfo=0`) so cached blobs are small (a sample rlib dropped **~39%**, 4.27 → 2.62 MB) and stay under Cloudflare's 100 MB write-body limit. The remote-cache comment points at the Worker.
- **`bazel.yml`** — the Bearer-token write logic is unchanged; comments updated to the Worker+R2 backend.
- **docs** — `docs/skills/bazel-remote-cache.md` is now a neutral overview; the migration plan's cache references are updated to Worker+R2. The cache docs are kept free of private-infra detail.

## Deploy

The Worker/R2 deploy runs from the maintainer's Cloudflare account (`wrangler r2 bucket create` + `wrangler secret put WRITE_TOKEN` + `wrangler deploy`) — see `tools/bazel-cache-worker/README.md`. The `WRITE_TOKEN` must match the `BAZEL_CACHE_WRITE_TOKEN` GitHub secret. After deploy, `cache.rustyphoton.space` serves from the edge and CI cache reads come back fast.

## Security (public repo)

Reads are anonymous (fork PRs get a warm cache); writes require the Bearer token, which only push-to-main / nightly hold — so forks can't poison the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)