### PR TITLE
ci(bazel): stop the per-run analysis-cache discard (hoist --test_env to build:ci)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -111,6 +111,17 @@ build:ci --experimental_ui_max_stdouterr_bytes=10485760
 test:ci --test_output=errors
 test:ci --test_summary=terse
 
+# Forward OMNISIM_PATH (the install-omnisim action's pinned OmniSim binary path,
+# consumed by bdd_infra::rp_harness::OmniSimHandle::start) into test sandboxes.
+# Deliberately on build:ci — applied to EVERY ci invocation (build, fast test,
+# BDD), not just the BDD step — so the --test_env flag never CHANGES between the
+# Bazel invocations sharing one server. A changing --test_env discards the
+# analysis cache and forces a full re-analysis of all targets (expensive, worst
+# on Windows). Only the BDD step reads OMNISIM_PATH; the others carry the flag
+# harmlessly. Forwarding by name (not --test_env=PATH) keeps the action key
+# stable across push vs pull_request events.
+build:ci --test_env=OMNISIM_PATH
+
 # Remote cache is opt-in via a separate --config=remote-cache flag so local
 # developers don't accidentally point at the shared cache. CI jobs combine:
 # --config=ci --config=remote-cache.

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -157,17 +157,12 @@ jobs:
 
       - name: bazel test (BDD)
         # BDD cucumber tests spawn service binaries and take 30-150s each;
-        # run them explicitly in their own step. `--test_env=OMNISIM_PATH`
-        # forwards the install-omnisim composite action's pinned binary
-        # path into test sandboxes; `bdd_infra::rp_harness::OmniSimHandle::start`
-        # consumes it via the binary lookup in
-        # `crates/bdd-infra/src/rp_harness/omnisim.rs`. We deliberately do
-        # NOT use `--test_env=PATH` here:
-        # the runner's full PATH is large and on Windows differs between
-        # `push` and `pull_request` events, which would bake unstable
-        # values into every BDD test action's cache key and silently
-        # invalidate every cache entry across event types. Pinning
-        # `OMNISIM_PATH` keeps the action key stable.
+        # run them explicitly in their own step. They need OMNISIM_PATH (the
+        # install-omnisim action's pinned binary path, consumed by
+        # `bdd_infra::rp_harness::OmniSimHandle::start`), forwarded via
+        # `--test_env=OMNISIM_PATH` — which lives in `.bazelrc` `build:ci` so it
+        # applies to every step and the flag never changes mid-run (a changing
+        # --test_env discards Bazel's analysis cache; see .bazelrc for the why).
         # On macOS, darwin-sandbox blocks OmniSim from binding network
         # ports; --spawn_strategy=local bypasses the sandbox for tests.
         run: |
@@ -180,7 +175,7 @@ jobs:
           if [[ "$RUNNER_OS" != "Linux" ]]; then
             REMOTE_FLAGS+=(--spawn_strategy=local)
           fi
-          bazel test --config=ci "${REMOTE_FLAGS[@]}" --test_tag_filters=bdd --test_env=OMNISIM_PATH \
+          bazel test --config=ci "${REMOTE_FLAGS[@]}" --test_tag_filters=bdd \
             --execution_log_compact_file="${RUNNER_TEMP}/bdd-exec.log.zst" \
             --profile="${RUNNER_TEMP}/bdd-profile.json.gz" \
             --noslim_profile \


### PR DESCRIPTION
## Problem

Every Bazel CI run logged this at the **BDD step**, on all three OSes:

> `WARNING: Build option --test_env has changed, discarding analysis cache (this can be expensive…)`

`bazel.yml` runs three invocations on one Bazel server — `bazel build`, `bazel test (fast)`, `bazel test (BDD)` — and only the BDD step set `--test_env=OMNISIM_PATH`. The flag flipping on mid-run made Bazel **discard its analysis cache and re-analyze all ~25k targets** at the BDD step. On Windows that step ran **~7.5 min**, much of it the forced re-analysis (the run showed `2263 action cache hit` — i.e. almost no actual compiling).

## Fix

Hoist `--test_env=OMNISIM_PATH` into `.bazelrc` `build:ci` so **all** ci invocations carry it and the flag never changes between steps; drop the now-redundant copy from the BDD step (it still gets it via `--config=ci`; build/fast-test carry it harmlessly).

## Validated locally

- `bazel build` **accepts** `--test_env` (no "unrecognized option").
- Reproduced the discard (toggling `--test_env`) and confirmed it **disappears** when the flag is constant.
- Ran the real sequence on a fresh server — `build` → `test` → `test --test_tag_filters=bdd`, all `--config=ci` — **zero** discards. (The `--test_tag_filters` change is *not* a discard cause, confirming `--test_env` was the only one.)

Independent of everything else in flight; biggest win is Windows BDD-step wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)