### PR TITLE
fix(rp): bound Alpaca requests + ride out transient poll stalls

### DIFF
--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1643,6 +1643,27 @@ a mount that does not expose the property), the validation is
 skipped with a `debug!()` log. See
 [Site Validation Against the ASCOM Mount](#site-validation-against-the-ascom-mount).
 
+**Request timeouts and stall tolerance.** Every Alpaca request is
+bounded by a connect timeout and a per-read timeout
+(`equipment::alpaca::ALPACA_CONNECT_TIMEOUT` / `ALPACA_READ_TIMEOUT`).
+This is a hard requirement, not a tuning knob: reqwest applies no
+timeout by default and `ascom_alpaca::Client::new` adds none either, so
+without these a device that accepts the TCP connection but then stalls
+the response (a wedged keep-alive connection, a peer mid-restart, a
+starved simulator under load) would block the awaiting MCP tool
+*forever*. The blocking compound-tool helpers in `mcp::internals`
+(capture readout, slew-until-idle) poll the device and only re-check
+their own deadline *between* `await`s, so a single unbounded request
+defeats them entirely — this is what once hung `center_on_target` to
+the MCP client's 360 s backstop. With the request bounded, a stall
+surfaces as an `Err`; the poll loops then ride out up to
+`MAX_CONSECUTIVE_POLL_ERRORS` consecutive transient failures (resetting
+on any successful read) rather than aborting an operation still within
+its deadline, so a momentary stall is absorbed while a genuinely wedged
+device still fails promptly. A `read_timeout` (which resets as bytes
+arrive) rather than a whole-request timeout keeps legitimately large
+image downloads working.
+
 ### Guider Service
 
 The guider service is an **rp-managed service** that wraps PHD2 and

--- a/services/rp/src/equipment/alpaca.rs
+++ b/services/rp/src/equipment/alpaca.rs
@@ -25,6 +25,34 @@ pub(super) const CONNECT_ATTEMPTS: u32 = 3;
 /// rp startup.
 pub(super) const GET_DEVICES_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Connection-establishment timeout applied to every Alpaca request.
+/// Localhost and LAN devices connect near-instantly; a connect that
+/// takes longer means the host is unreachable, which the per-device
+/// retry/backoff ([`CONNECT_ATTEMPTS`]) already handles at startup.
+pub(super) const ALPACA_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Per-read timeout applied to every Alpaca request — the maximum gap
+/// reqwest will tolerate between received response bytes before failing
+/// the request. **This is the load-bearing robustness knob.** reqwest
+/// applies no timeout by default, and `ascom_alpaca::Client::new` does
+/// not add one either, so a device that accepts the TCP connection but
+/// then stalls the response (a wedged keep-alive connection, a peer mid
+/// restart, a starved sky-survey-camera under CI load) would block the
+/// awaiting call *forever*. The blocking MCP helpers in
+/// [`crate::mcp::internals`] (capture-readout and slew-until-idle polls)
+/// only re-check their own deadlines *between* `await`s, so a single
+/// stalled request defeats them entirely — which is exactly what hung
+/// the `center_on_target` BDD to the MCP client's 360 s backstop.
+///
+/// `read_timeout` (resets as bytes arrive) rather than a whole-request
+/// `timeout` so a legitimately large image download from a real camera
+/// keeps working as long as bytes keep flowing. Comfortably larger than
+/// any healthy Alpaca call (property reads are sub-100 ms; `StartExposure`
+/// and async slews return immediately) yet well under the capture
+/// (`duration + 120 s`) and slew (300 s) poll deadlines, so those still
+/// govern the overall operation.
+pub(super) const ALPACA_READ_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Result of a single attempt inside [`retry_connect_attempt`]. The
 /// `Permanent` / `Transient` split is what makes this a retry helper
 /// rather than a sleep-and-hope wrapper: the connect closures map each
@@ -98,23 +126,42 @@ where
     ))
 }
 
+/// Build the reqwest client that backs every Alpaca request, with the
+/// given connection/read timeouts and optional HTTP Basic Auth header.
+///
+/// Split out from [`build_alpaca_client`] so the timeout behaviour can be
+/// exercised with short durations in tests. We build our own client even
+/// in the no-auth case (rather than falling back to
+/// `ascom_alpaca::Client::new`'s built-in client) precisely so the
+/// timeouts below apply on every code path — see [`ALPACA_READ_TIMEOUT`].
+fn alpaca_reqwest_client(
+    auth: Option<&ClientAuthConfig>,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> Result<reqwest::Client, Box<dyn std::error::Error + Send + Sync>> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout);
+    if let Some(a) = auth {
+        let encoded = BASE64.encode(format!("{}:{}", a.username, a.password));
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("authorization", format!("Basic {encoded}").parse()?);
+        builder = builder.default_headers(headers);
+    }
+    Ok(builder.build()?)
+}
+
 /// Build an Alpaca client with optional HTTP Basic Auth credentials.
+///
+/// Every request the client makes is bounded by [`ALPACA_CONNECT_TIMEOUT`]
+/// and [`ALPACA_READ_TIMEOUT`] so a stalled device can never hang an
+/// awaiting MCP tool indefinitely.
 pub(super) fn build_alpaca_client(
     url: &str,
     auth: Option<&ClientAuthConfig>,
 ) -> Result<Client, Box<dyn std::error::Error + Send + Sync>> {
-    match auth {
-        Some(a) => {
-            let encoded = BASE64.encode(format!("{}:{}", a.username, a.password));
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert("authorization", format!("Basic {encoded}").parse()?);
-            let http = reqwest::Client::builder()
-                .default_headers(headers)
-                .build()?;
-            Ok(Client::new_with_client(url, http)?)
-        }
-        None => Ok(Client::new(url)?),
-    }
+    let http = alpaca_reqwest_client(auth, ALPACA_CONNECT_TIMEOUT, ALPACA_READ_TIMEOUT)?;
+    Ok(Client::new_with_client(url, http)?)
 }
 
 #[cfg(test)]
@@ -141,6 +188,52 @@ mod tests {
     fn build_alpaca_client_with_invalid_url_fails() {
         let result = build_alpaca_client("not-a-url", None);
         assert!(result.is_err());
+    }
+
+    /// The load-bearing regression guard: a device that accepts the TCP
+    /// connection but never writes a response must surface a bounded
+    /// timeout error, not hang the caller forever. Without
+    /// [`ALPACA_READ_TIMEOUT`] on the client the `send().await` blocks
+    /// indefinitely and the outer guard fires instead — which is the
+    /// exact failure that ran `center_on_target`'s capture poll to the
+    /// MCP client's 360 s backstop. Uses a short read timeout so the
+    /// test is fast; the production constant is larger.
+    #[tokio::test]
+    async fn alpaca_request_read_timeout_bounds_a_stalled_server() {
+        // Accept connections and hold them open without ever replying.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _acceptor = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock); // keep alive, send nothing
+            }
+        });
+
+        let http = alpaca_reqwest_client(None, Duration::from_secs(5), Duration::from_millis(300))
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        // Outer guard: a regression that drops `read_timeout` makes
+        // `send()` hang, so this `timeout` elapses and the `expect` fails
+        // loudly instead of stalling the whole suite.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            http.get(format!("http://{addr}/")).send(),
+        )
+        .await
+        .expect("Alpaca request hung past 5 s — read_timeout is not applied to the client");
+
+        let err = outcome.expect_err("a stalled server must produce an error, not a response");
+        assert!(
+            err.is_timeout(),
+            "expected a read-timeout error, got: {err}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "request should fail near the 300 ms read_timeout, took {:?}",
+            started.elapsed()
+        );
     }
 
     // ----- retry_connect_attempt direct unit tests --------------------

--- a/services/rp/src/imaging/tools/center_on_target.rs
+++ b/services/rp/src/imaging/tools/center_on_target.rs
@@ -13,24 +13,33 @@
 //! Behavioral contract: `docs/services/rp.md` → Compound Tools →
 //! `center_on_target` Contract.
 //!
-//! **BDD-author note.** `do_slew_blocking`'s 300 s deadline races
-//! rmcp's 300 s MCP-transport keep-alive — both fire at the same
-//! moment, so a single inner-iteration slew that approaches 5 minutes
-//! breaks the test client before the loop can return its
-//! `tolerance_not_reached` / `equipment` error. Keep BDD canned WCS
-//! values within ~2′ of any prior synced position so iter-1's sync +
-//! slew traverse a small distance even under heavy CI load. See
-//! `services/rp/tests/features/center_on_target.feature` for the
-//! worked numbers.
+//! **BDD-author note.** A wedged iteration is *capped* by two
+//! independent backstops — the BDD client's `MCP_CALL_TIMEOUT` (360 s)
+//! and rmcp's 300 s MCP-transport idle keep-alive — so a hang fails the
+//! scenario instead of running to the job's `timeout-minutes`. Neither
+//! is the *cause* of a hang, only its ceiling: a 300 s/360 s failure
+//! means "something upstream stalled," so look there, not at the
+//! backstops. No inner-iteration slew should ever approach those
+//! ceilings — keep BDD canned WCS values within ~2′ of any prior synced
+//! position so iter-1's sync + slew stay quick even under heavy CI
+//! load. See `services/rp/tests/features/center_on_target.feature`.
 //!
-//! Note: the 6 h CI hangs in the closed-loop centering BDD (May 2026)
-//! were *not* this slew/keep-alive race. They traced to `do_capture`
-//! looping forever on a **failed** `sky-survey-camera` exposure — its
-//! follow-mode mount read timed out under load, so `ImageReady` never
-//! went true and the capture poll spun indefinitely. Fixed at the
-//! source in `mcp/internals.rs::do_capture` (treat `CameraState::Error`
-//! as terminal + a readout deadline). CI job `timeout-minutes` and the
-//! BDD client's `MCP_CALL_TIMEOUT` are independent backstops.
+//! Both closed-loop-centering CI hangs to date were fixed at the source,
+//! not by tuning the backstops:
+//!   1. `do_capture` looped forever on a **failed** `sky-survey-camera`
+//!      exposure — its follow-mode mount read stalled under load, so
+//!      `ImageReady` never went true and the readiness poll spun. Fixed
+//!      by treating `CameraState::Error` as terminal + a readout
+//!      deadline (`mcp/internals.rs::do_capture`).
+//!   2. Every Alpaca request was unbounded, so a device that accepted
+//!      the connection but stalled the response hung the awaiting
+//!      `await` *forever* — defeating the capture/slew poll deadlines,
+//!      which only re-check time *between* awaits. Fixed by bounding
+//!      every Alpaca request (`equipment::alpaca::ALPACA_READ_TIMEOUT`)
+//!      so a stall becomes an `Err`, and by letting the readiness/idle
+//!      poll loops ride out a transient stall
+//!      (`MAX_CONSECUTIVE_POLL_ERRORS`) rather than aborting an
+//!      operation still within its deadline.
 
 use async_trait::async_trait;
 use serde::Serialize;

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -32,6 +32,18 @@ use super::handler::McpHandler;
 /// readout/download latency on top of the exposure itself.
 const CAPTURE_READOUT_GRACE: Duration = Duration::from_secs(120);
 
+/// How many *consecutive* failed device reads a polling loop tolerates
+/// before surfacing the error. Every Alpaca request is bounded by
+/// `equipment::alpaca::ALPACA_READ_TIMEOUT`, so a stalled response
+/// arrives here as an `Err` rather than an unbounded hang. A polling
+/// loop (capture-readout, slew-until-idle) issues many reads, so a
+/// single transient stall should not abort an operation still within
+/// its overall deadline — ride out a brief blip and keep polling,
+/// resetting the count on any successful read, but still fail promptly
+/// (rather than waiting out the full deadline) when a device is wedged
+/// and every read fails.
+const MAX_CONSECUTIVE_POLL_ERRORS: u32 = 3;
+
 // ---------------------------------------------------------------------------
 // Private helper types shared across imaging tool bodies. All
 // `pub(crate)` so individual category files can construct them.
@@ -470,11 +482,13 @@ impl McpHandler {
         // stored reason via `image_array`), and cap the total wait with a
         // deadline as a backstop for a camera wedged in `Exposing`.
         let deadline = tokio::time::Instant::now() + duration + CAPTURE_READOUT_GRACE;
+        let mut consecutive_errors = 0u32;
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
             match cam.image_ready().await {
                 Ok(true) => break,
                 Ok(false) => {
+                    consecutive_errors = 0;
                     // A transient `camera_state` read error is non-fatal —
                     // `ImageReady` stays the primary signal and the deadline
                     // below still bounds the wait.
@@ -494,7 +508,22 @@ impl McpHandler {
                         ));
                     }
                 }
-                Err(e) => return Err(format!("error checking image ready: {}", e)),
+                // A failed `image_ready()` read is a transient stall (the
+                // bounded `ALPACA_READ_TIMEOUT` turns a hung response into
+                // this error), not proof the exposure failed — that is what
+                // the `CameraState::Error` check above signals. Ride out up
+                // to `MAX_CONSECUTIVE_POLL_ERRORS` in a row so a momentary
+                // stall doesn't abort a capture still within its readout
+                // deadline; a wedged camera (every read failing) still
+                // surfaces the error promptly.
+                Err(e) => {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= MAX_CONSECUTIVE_POLL_ERRORS
+                        || tokio::time::Instant::now() >= deadline
+                    {
+                        return Err(format!("error checking image ready: {}", e));
+                    }
+                }
             }
         }
 
@@ -1145,13 +1174,31 @@ pub(crate) async fn poll_slewing_until_idle(
     mount: &(dyn ascom_alpaca::api::Telescope + Send + Sync),
 ) -> std::result::Result<(), PollIdleError> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+    let mut consecutive_errors = 0u32;
     loop {
         tokio::time::sleep(Duration::from_millis(100)).await;
         match mount.slewing().await {
             Ok(false) => return Ok(()),
-            Ok(true) if tokio::time::Instant::now() < deadline => continue,
+            Ok(true) if tokio::time::Instant::now() < deadline => {
+                consecutive_errors = 0;
+                continue;
+            }
             Ok(true) => return Err(PollIdleError::Timeout),
-            Err(e) => return Err(PollIdleError::Read(e)),
+            // A failed `slewing()` read is a transient stall (the bounded
+            // `ALPACA_READ_TIMEOUT` turns a hung response into this error),
+            // not a reason to abort a slew that is otherwise progressing.
+            // Ride out up to `MAX_CONSECUTIVE_POLL_ERRORS` in a row,
+            // resetting on any successful read; a wedged mount (every read
+            // failing) still surfaces the error promptly rather than
+            // waiting out the full deadline.
+            Err(e) => {
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_CONSECUTIVE_POLL_ERRORS
+                    || tokio::time::Instant::now() >= deadline
+                {
+                    return Err(PollIdleError::Read(e));
+                }
+            }
         }
     }
 }

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -86,6 +86,10 @@ struct MockCamera {
     /// that failed an exposure (e.g. sky-survey-camera's mount read
     /// timing out). Drives the `do_capture` failed-exposure path.
     report_error_state: bool,
+    /// Number of leading `image_ready()` reads that return a transient
+    /// `Err` before reporting readiness. Exercises `do_capture`'s
+    /// consecutive-error tolerance.
+    image_ready_transient_errors: std::sync::atomic::AtomicU32,
 }
 
 impl_mock_device!(MockCamera);
@@ -106,6 +110,15 @@ impl ascom_alpaca::api::Camera for MockCamera {
     async fn image_ready(&self) -> ascom_alpaca::ASCOMResult<bool> {
         if self.fail_image_ready {
             return Err(ASCOMError::invalid_operation("readout failed"));
+        }
+        if self
+            .image_ready_transient_errors
+            .load(std::sync::atomic::Ordering::SeqCst)
+            > 0
+        {
+            self.image_ready_transient_errors
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            return Err(ASCOMError::invalid_operation("transient readout stall"));
         }
         Ok(!self.never_ready)
     }
@@ -446,6 +459,10 @@ struct MockTelescope {
     fail_abort_slew: bool,
     /// `slewing()` returns `true` forever — drives the timeout path.
     stuck_slewing: bool,
+    /// Number of leading `slewing()` reads that return a transient `Err`
+    /// before falling through to `Ok(stuck_slewing)`. Exercises
+    /// `poll_slewing_until_idle`'s consecutive-error tolerance.
+    slewing_transient_errors: std::sync::atomic::AtomicU32,
     tracking_value: bool,
     can_set_tracking_value: bool,
     at_park_value: bool,
@@ -473,6 +490,7 @@ impl Default for MockTelescope {
             fail_can_unpark: false,
             fail_abort_slew: false,
             stuck_slewing: false,
+            slewing_transient_errors: std::sync::atomic::AtomicU32::new(0),
             tracking_value: true,
             can_set_tracking_value: true,
             at_park_value: false,
@@ -600,6 +618,17 @@ impl ascom_alpaca::api::Telescope for MockTelescope {
     async fn slewing(&self) -> ascom_alpaca::ASCOMResult<bool> {
         if self.fail_slewing_poll {
             return Err(ASCOMError::invalid_operation("slewing poll failed"));
+        }
+        if self
+            .slewing_transient_errors
+            .load(std::sync::atomic::Ordering::SeqCst)
+            > 0
+        {
+            self.slewing_transient_errors
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            return Err(ASCOMError::invalid_operation(
+                "transient slewing read stall",
+            ));
         }
         Ok(self.stuck_slewing)
     }
@@ -865,6 +894,47 @@ async fn test_capture_image_ready_error() {
         }))
         .await;
     assert_tool_error(result, "error checking image ready");
+}
+
+/// A *transient* `image_ready()` read failure — the shape the bounded
+/// `ALPACA_READ_TIMEOUT` produces when a device momentarily stalls a
+/// response — must NOT abort a capture still within its readout
+/// deadline. `do_capture` rides out up to `MAX_CONSECUTIVE_POLL_ERRORS`
+/// consecutive failures and keeps polling. This is the unit-level
+/// analogue of the `center_on_target` BDD hang, where a single stalled
+/// poll used to wedge the whole tool until the MCP client's 360 s
+/// backstop. `start_paused` auto-advances the 100 ms inter-poll sleeps.
+#[tokio::test(start_paused = true)]
+async fn test_capture_rides_out_transient_image_ready_errors() {
+    let cam = MockCamera {
+        image_ready_transient_errors: std::sync::atomic::AtomicU32::new(2),
+        ..Default::default()
+    };
+    let temp = tempfile::tempdir().unwrap();
+    let cache = ImageCache::new(64, 4, std::path::PathBuf::from("/nonexistent"));
+    let handler = McpHandler::new(
+        Arc::new(camera_registry(Arc::new(cam))),
+        Arc::new(crate::events::EventBus::from_config(&[])),
+        SessionConfig {
+            data_directory: temp.path().to_string_lossy().to_string(),
+        },
+        cache,
+        None,
+    );
+    let result = handler
+        .capture(Parameters(CaptureParams {
+            camera_id: "cam".into(),
+            duration: Duration::from_millis(100),
+        }))
+        .await
+        .unwrap();
+    // Two transient read errors were tolerated; the capture produced a
+    // document rather than failing with "error checking image ready".
+    let json = ok_text(result);
+    assert!(
+        json["document_id"].as_str().is_some(),
+        "capture should succeed after riding out transient image_ready errors, got: {json}"
+    );
 }
 
 #[tokio::test]
@@ -2611,6 +2681,36 @@ async fn test_slew_polling_error_propagates() {
         }))
         .await;
     assert_tool_error(result, "error polling mount slewing");
+}
+
+/// A *transient* `slewing()` read failure must not abort a slew that is
+/// otherwise progressing: `poll_slewing_until_idle` rides out up to
+/// `MAX_CONSECUTIVE_POLL_ERRORS` consecutive failures, resets on the
+/// next successful read, sees the mount idle, and returns the post-slew
+/// pointing. Mirrors the capture readiness-poll tolerance.
+/// `start_paused` auto-advances the 100 ms inter-poll sleeps.
+#[tokio::test(start_paused = true)]
+async fn test_slew_rides_out_transient_slewing_errors() {
+    let mount = MockTelescope {
+        slewing_transient_errors: std::sync::atomic::AtomicU32::new(2),
+        ra_value: 10.6847,
+        dec_value: 41.2689,
+        ..Default::default()
+    };
+    let handler = test_handler(mount_registry(Arc::new(mount), None));
+    let result = handler
+        .slew(Parameters(SlewParams {
+            ra: Some(10.6847),
+            dec: Some(41.2689),
+            settle_after: None,
+        }))
+        .await
+        .unwrap();
+    let json = ok_text(result);
+    assert_eq!(
+        json["actual_ra"], 10.6847,
+        "slew should succeed after riding out transient slewing() errors, got: {json}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

`rp`'s Alpaca client set **no HTTP request timeout**, so a device that accepted the TCP connection but stalled its response blocked the awaiting MCP tool *forever*. This is the root cause of the intermittent `center_on_target` closed-loop-centering BDD hang (the failure that's been red on recent CI, e.g. dependabot PR #318) — and a real production robustness hole.

## Why it hung

`equipment::alpaca::build_alpaca_client` set no timeout on the auth path, and the no-auth path delegated to `ascom_alpaca::Client::new`'s built-in client, which also sets none. reqwest applies no default timeout. The blocking poll loops in `mcp::internals` (capture readout, slew-until-idle) only re-check their 120 s / 300 s deadlines *between* `await`s, so a single unbounded request walked straight past them and the call ran to the BDD client's 360 s `MCP_CALL_TIMEOUT` (the 300 s rmcp session keep-alive having torn the transport down first).

It was **not** a slow slew. Evidence from the failing run's OmniSim logs: telescope requests were perfectly balanced (3449 start / 3449 finish — no hung mount call), and `slewing` was polled far too few times for a 300 s slew-wait. `rp` was stuck *before* the slew, inside one stalled `image_ready()` call to sky-survey-camera during `do_capture`. Every other rp HTTP client (e.g. `rp-plate-solver`) already sets a timeout; the Alpaca client was the outlier.

## The fix

1. **Bound every Alpaca request** with `connect_timeout` + `read_timeout` (`ALPACA_CONNECT_TIMEOUT` / `ALPACA_READ_TIMEOUT`), always building our own reqwest client via `Client::new_with_client` so the no-auth path is covered too. A `read_timeout` (resets as bytes arrive) rather than a whole-request timeout keeps large real-camera image downloads working. A stall now surfaces as a bounded `Err` instead of an infinite hang.
2. **Let the poll loops ride out a transient stall** — `do_capture`'s readiness poll and `poll_slewing_until_idle` tolerate up to `MAX_CONSECUTIVE_POLL_ERRORS` consecutive read failures (resetting on any success) rather than aborting an operation still within its deadline. A genuinely wedged device still fails promptly.

## Validation

- `cargo fmt`, `cargo rail run --profile commit` (check + 415 rp tests), and `clippy -D warnings` all pass.
- New tests: a stalled-server stub proves the client times out (~300 ms) instead of hanging; sequenced-error mocks prove capture/slew ride out transient stalls; existing all-error tests still surface the same errors (after a few tolerated retries).
- BDD smoke against real OmniSim: all 4 `@e2e-centering` scenarios pass, including the exact `179.99167 / -29.99444` example that hung in CI.
- Docs updated: `rp.md` "Request timeouts and stall tolerance" and the `center_on_target` module note (corrected — the hang was unbounded I/O, not a slow slew).

## Notes

- **Residual**: one-shot Alpaca calls (`start_exposure`, `image_array`, `sync`, slew kickoff) now *fail fast* at the read timeout rather than being retried — a strict improvement over an infinite hang. The high-frequency *poll* calls (the likely stall point) are fully resilient. Wrapping one-shots in retries would be a larger, separate change.
- This is independent of the reqwest bump in #318; that PR just had the bad luck of hitting this pre-existing flake and should go green on re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)