### PR TITLE
ci(bazel): shadow-mode Bazel coverage on every PR

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -133,6 +133,55 @@ build:ci --test_env=OMNISIM_PATH
 # gitignored user.bazelrc to point at a LAN bazel-remote instead.
 build:remote-cache --remote_cache=https://cache.rustyphoton.space
 
+# --- Coverage config -------------------------------------------------------
+
+# Activate with: bazel coverage --config=coverage //...
+# In CI also add --config=ci --config=remote-cache (see bazel-coverage.yml).
+#
+# Reproduces the Cargo coverage contract (.github/workflows/test.yml `coverage`)
+# under Bazel:
+#
+#  * channel=nightly -- the #[cfg_attr(coverage_nightly, coverage(off))] on every
+#    `#[cfg(test)] mod tests` block needs the nightly-only `coverage_attribute`
+#    feature. cargo-llvm-cov gets this by running on a nightly toolchain; under
+#    Bazel we select the pinned nightly registered in MODULE.bazel. Overrides
+#    the default `--@rules_rust//rust/toolchain/channel=stable` above.
+#  * --cfg=coverage_nightly -- cargo-llvm-cov sets this automatically on nightly;
+#    rules_rust does not, so we set it explicitly. This is what activates the
+#    coverage(off) attributes so test code stays out of the numbers. Passed as a
+#    single value (not comma-joined) so it composes with the base -Cdebuginfo=0
+#    regardless of how repeated list-flag occurrences resolve. Source-based
+#    coverage uses the __llvm_covmap section, not DWARF, so debuginfo is
+#    irrelevant to line/region coverage either way.
+#  * rules_rust adds -Cinstrument-coverage itself for instrumented targets under
+#    `bazel coverage`; we only choose WHICH targets via --instrumentation_filter.
+#  * --instrumentation_filter -- first-party only; @cr// crates.io deps are never
+#    instrumented (matches cargo llvm-cov, which reports workspace crates only).
+#  * --combined_report=lcov -- single merged lcov at
+#    $(bazel info output_path)/_coverage/_coverage_report.dat, split per package
+#    by tools/coverage/split_lcov.py before the per-flag Codecov upload.
+#
+# --test_tag_filters=-requires-cargo OVERRIDES the base
+# `test --test_tag_filters=-requires-cargo,-bdd`: coverage MUST include the BDD
+# suite, which exercises the service-binary integration paths (main.rs,
+# startup/shutdown, cross-service wiring) that unit tests never reach.
+# requires-cargo stays excluded (those tests shell out to cargo). BDD needs
+# OMNISIM_PATH (forwarded by build:ci --test_env) for rp's scenarios, so a local
+# `bazel coverage --config=coverage` needs OmniSim installed + OMNISIM_PATH set,
+# exactly like a local `bazel test --test_tag_filters=bdd` run.
+#
+# Child-process coverage caveat: under `bazel coverage //...` the spawned service
+# binaries ARE instrumented (first-party top-level targets matching the filter),
+# but whether their .profraw is COLLECTED depends on Bazel/rules_rust propagating
+# a unique LLVM_PROFILE_FILE to each spawned child and merging it back. Validate
+# in the first CI run by diffing bazel-<service> vs <service> coverage; see
+# docs/plans/bazel-migration.md for the contingency if child coverage is missing.
+coverage:coverage --@rules_rust//rust/toolchain/channel=nightly
+coverage:coverage --@rules_rust//rust/settings:extra_rustc_flags=--cfg=coverage_nightly
+coverage:coverage --instrumentation_filter=^//crates,^//services
+coverage:coverage --combined_report=lcov
+coverage:coverage --test_tag_filters=-requires-cargo
+
 # --- Local overrides -------------------------------------------------------
 
 # Developers may add personal overrides in user.bazelrc (gitignored).

--- a/.github/workflows/bazel-coverage.yml
+++ b/.github/workflows/bazel-coverage.yml
@@ -1,0 +1,154 @@
+# Bazel-based code coverage, shadow mode. Runs alongside the canonical Cargo
+# coverage job (.github/workflows/test.yml `coverage`) during the migration in
+# docs/plans/bazel-migration.md. NOT required for merge.
+#
+# Why a separate workflow (not a job in bazel.yml): coverage needs a different
+# toolchain (nightly) and a fully instrumented build graph -- a separate action
+# namespace from bazel.yml's stable build/test. Keeping it separate means its
+# (slower, nightly, instrumented) actions and its cache never perturb the
+# shadow build/test job.
+#
+# Parity with the Cargo job:
+#  * nightly toolchain + --cfg=coverage_nightly (see .bazelrc --config=coverage)
+#    so #[cfg_attr(coverage_nightly, coverage(off))] on every `#[cfg(test)] mod
+#    tests` block takes effect and test code stays out of the numbers.
+#  * LLVM source-based instrumentation, first-party crates only.
+#  * per-package lcov uploaded to Codecov so the per-service flags survive.
+#
+# Differences from the Cargo job (intentional):
+#  * Runs `bazel coverage //...` over the WHOLE repo every time. Untouched
+#    targets are cache hits (local disk + remote R2 cache), so their
+#    coverage.dat is fetched, not recomputed -- every PR still gets a COMPLETE
+#    report without cargo-rail narrowing or Codecov carryforward. This is the
+#    headline win of doing coverage under Bazel.
+#  * Uploads under distinct `bazel-<pkg>` flags so it does NOT alter the
+#    canonical per-service badges while Cargo coverage still runs (shadow mode).
+#  * Includes the BDD suite (--config=coverage flips the default tag filter to
+#    -requires-cargo, see .bazelrc) so the service-binary integration paths are
+#    covered. Whether coverage from the BDD-spawned service binaries is actually
+#    COLLECTED is the open risk: cargo-llvm-cov gets it via a shared
+#    LLVM_PROFILE_FILE + whole-target-dir merge; Bazel's per-test-action model
+#    may not. Validate in run #1 (bazel-<service> vs <service>); see
+#    bazel-migration.md for the contingency.
+permissions:
+  contents: read
+on:
+  pull_request:
+  # push to main primes the coverage action cache (write token) so PRs read
+  # warm coverage.dat for untouched targets; also gives main a coverage baseline.
+  push:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: bazel-coverage
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    # Cold-cache headroom: the instrumented nightly graph is a distinct cache
+    # namespace, so the first run (and post-eviction runs) rebuild it from
+    # scratch -- and the instrumented BDD suite (rp ~150s warm) runs here too.
+    # Warm runs are fast.
+    timeout-minutes: 60
+    name: bazel coverage (shadow)
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Same trust model as bazel.yml: only push-to-main holds the write token,
+      # so only trusted code populates the coverage cache; PRs (including forks,
+      # which get no secrets at all) read anonymously and never write.
+      CACHE_WRITE_TOKEN: ${{ github.event_name == 'push' && secrets.BAZEL_CACHE_WRITE_TOKEN || '' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      # .bazelrc build:linux uses the lld linker.
+      - name: Install lld
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq lld >/dev/null
+
+      - name: Setup bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+        with:
+          bazelisk-version: 1.28.1
+
+      - name: Verify bazel version
+        run: bazel --version
+
+      # rp's BDD scenarios spawn the ASCOM Alpaca simulator. OMNISIM_PATH is
+      # forwarded into test sandboxes by .bazelrc `build:ci --test_env=OMNISIM_PATH`.
+      - name: Install ASCOM OmniSim
+        uses: ./.github/actions/install-omnisim
+
+      - name: bazel coverage
+        run: |
+          REMOTE_FLAGS=(--config=remote-cache)
+          if [[ -n "$CACHE_WRITE_TOKEN" ]]; then
+            REMOTE_FLAGS+=(--remote_header="Authorization=Bearer $CACHE_WRITE_TOKEN")
+          else
+            REMOTE_FLAGS+=(--remote_upload_local_results=false)
+          fi
+          # --config=coverage selects the nightly channel + --cfg=coverage_nightly
+          # + --combined_report=lcov + first-party instrumentation filter (.bazelrc).
+          # --test_tag_filters=-requires-cargo INCLUDES the BDD suite; it is also
+          # set by --config=coverage but pinned here on the command line so CI is
+          # not sensitive to rc precedence (command line always wins).
+          # --remote_download_outputs=all overrides build:ci's `toplevel` so the
+          # combined lcov and its per-test .dat inputs are materialised locally.
+          bazel coverage --config=ci --config=coverage "${REMOTE_FLAGS[@]}" \
+            --test_tag_filters=-requires-cargo \
+            --remote_download_outputs=all \
+            //...
+
+      - name: Split combined lcov per package
+        run: |
+          REPORT="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          echo "Combined report: $REPORT"
+          if [[ ! -s "$REPORT" ]]; then
+            echo "::error::combined coverage report missing or empty at $REPORT"
+            exit 1
+          fi
+          ls -l "$REPORT"
+          mkdir -p coverage-lcov
+          python3 tools/coverage/split_lcov.py "$REPORT" --output-dir coverage-lcov
+          ls -l coverage-lcov
+
+      - name: Upload per-package lcov (artifact)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-coverage-lcov
+          path: coverage-lcov/*.info
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload to codecov.io
+        if: env.ACT != 'true'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          # Fork PRs receive no secrets; skip the upload rather than fail.
+          if [[ -z "$CODECOV_TOKEN" ]]; then
+            echo "No CODECOV_TOKEN (likely a fork PR); skipping Codecov upload."
+            exit 0
+          fi
+          curl -Os https://cli.codecov.io/latest/linux/codecov
+          chmod +x ./codecov
+          # On pull_request events GitHub checks out an ephemeral merge commit;
+          # override the SHA so Codecov maps the upload to the PR head.
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "Uploading Bazel coverage for commit $COMMIT_SHA"
+          # Distinct `bazel-<pkg>` flags keep the canonical per-service badges
+          # (flag=<pkg>) Cargo-only during shadow mode.
+          for f in coverage-lcov/*.info; do
+            [ -f "$f" ] || continue
+            pkg="$(basename "$f")"; pkg="${pkg#lcov-}"; pkg="${pkg%.info}"
+            echo "Uploading coverage for $pkg as flag bazel-$pkg"
+            ./codecov upload-process \
+              --file "$f" \
+              --flag "bazel-$pkg" \
+              --token "$CODECOV_TOKEN" \
+              --git-service github \
+              --commit-sha "$COMMIT_SHA" \
+              || echo "Warning: upload failed for $pkg"
+          done

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,23 @@ bazel_dep(name = "platforms", version = "1.0.0")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["1.94.1"],  # matches workspace.package.rust-version
+    # Stable (the default channel, selected in .bazelrc) matches
+    # workspace.package.rust-version. The pinned nightly is used ONLY by the
+    # coverage workflow (.github/workflows/bazel-coverage.yml, via
+    # `--config=coverage` which selects channel=nightly): the
+    # #[cfg_attr(coverage_nightly, coverage(off))] attributes on every
+    # `#[cfg(test)] mod tests` block require the nightly-only
+    # `coverage_attribute` feature -- exactly like the Cargo coverage job
+    # (.github/workflows/test.yml) which runs on nightly + cargo-llvm-cov.
+    # The date is PINNED for remote-cache stability: a rolling nightly would
+    # change every coverage action's cache key on each bump and bust the
+    # coverage cache. Bump it if this nightly lacks the llvm-tools / rust-std /
+    # rustc components for the host triple (`bazel coverage` needs llvm-cov +
+    # llvm-profdata from the toolchain).
+    versions = [
+        "1.94.1",
+        "nightly/2026-05-01",
+    ],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ Cross-platform [ASCOM Alpaca](https://ascom-standards.org/Developer/Alpaca.htm) 
 
 ## Services
 
-| Service | Type | Port | Coverage | Description |
-|---------|------|------|----------|-------------|
-| [rp](services/rp) | Equipment gateway | 11115 | [![coverage][cov-rp]][cov-rp-link] | Main application: MCP tools, event bus, safety enforcer |
-| [filemonitor](services/filemonitor) | ASCOM SafetyMonitor | 11111 | [![coverage][cov-filemonitor]][cov-filemonitor-link] | Monitors file content for observatory safety status |
-| [ppba-driver](services/ppba-driver) | ASCOM Switch + ObservingConditions | 11112 | [![coverage][cov-ppba-driver]][cov-ppba-driver-link] | Driver for Pegasus Astro Pocket Powerbox Advance Gen2 |
-| [qhy-focuser](services/qhy-focuser) | ASCOM Focuser | 11113 | [![coverage][cov-qhy-focuser]][cov-qhy-focuser-link] | Driver for QHY Q-Focuser (EAF) |
-| [phd2-guider](services/phd2-guider) | Client library | — | [![coverage][cov-phd2-guider]][cov-phd2-guider-link] | Rust client for PHD2 autoguiding via JSON RPC |
-| [sentinel](services/sentinel) | Monitoring service | 11114 | [![coverage][cov-sentinel]][cov-sentinel-link] | Polls devices, sends notifications, serves web dashboard |
-| [calibrator-flats](services/calibrator-flats) | Orchestrator plugin | 11170 | [![coverage][cov-calibrator-flats]][cov-calibrator-flats-link] | Flat field calibration with CoverCalibrator device |
-| [sky-survey-camera](services/sky-survey-camera) | ASCOM Camera (simulator) | 11116 | [![coverage][cov-sky-survey-camera]][cov-sky-survey-camera-link] | Camera simulator that returns NASA SkyView cutouts for the configured optics |
-| [star-adventurer-gti](services/star-adventurer-gti) | ASCOM Telescope | 11117 | [![coverage][cov-star-adventurer-gti]][cov-star-adventurer-gti-link] | Driver for Sky-Watcher Star Adventurer GTi (USB and WiFi/UDP) |
-| [pa-falcon-rotator](services/pa-falcon-rotator) | ASCOM Rotator + Switch (status) | 11118 | [![coverage][cov-pa-falcon-rotator]][cov-pa-falcon-rotator-link] | Driver for Pegasus Astro Falcon Rotator (firmware ≥ 1.3) |
-| [dsd-fp2](services/dsd-fp2) | ASCOM CoverCalibrator | 11119 | [![coverage][cov-dsd-fp2]][cov-dsd-fp2-link] | Driver for Deep Sky Dad Flat Panel 2 (motorised flat field panel) |
+Coverage has two columns: **Cargo** is the canonical, required coverage; **Bazel** is the shadow-mode `bazel coverage` job (`.github/workflows/bazel-coverage.yml`), uploaded under `bazel-<pkg>` Codecov flags. The Bazel badges read "unknown" until that workflow has run on `main`.
+
+| Service | Type | Port | Coverage (Cargo) | Coverage (Bazel) | Description |
+|---------|------|------|------------------|------------------|-------------|
+| [rp](services/rp) | Equipment gateway | 11115 | [![coverage][cov-rp]][cov-rp-link] | [![coverage][cov-bazel-rp]][cov-bazel-rp-link] | Main application: MCP tools, event bus, safety enforcer |
+| [filemonitor](services/filemonitor) | ASCOM SafetyMonitor | 11111 | [![coverage][cov-filemonitor]][cov-filemonitor-link] | [![coverage][cov-bazel-filemonitor]][cov-bazel-filemonitor-link] | Monitors file content for observatory safety status |
+| [ppba-driver](services/ppba-driver) | ASCOM Switch + ObservingConditions | 11112 | [![coverage][cov-ppba-driver]][cov-ppba-driver-link] | [![coverage][cov-bazel-ppba-driver]][cov-bazel-ppba-driver-link] | Driver for Pegasus Astro Pocket Powerbox Advance Gen2 |
+| [qhy-focuser](services/qhy-focuser) | ASCOM Focuser | 11113 | [![coverage][cov-qhy-focuser]][cov-qhy-focuser-link] | [![coverage][cov-bazel-qhy-focuser]][cov-bazel-qhy-focuser-link] | Driver for QHY Q-Focuser (EAF) |
+| [phd2-guider](services/phd2-guider) | Client library | — | [![coverage][cov-phd2-guider]][cov-phd2-guider-link] | [![coverage][cov-bazel-phd2-guider]][cov-bazel-phd2-guider-link] | Rust client for PHD2 autoguiding via JSON RPC |
+| [sentinel](services/sentinel) | Monitoring service | 11114 | [![coverage][cov-sentinel]][cov-sentinel-link] | [![coverage][cov-bazel-sentinel]][cov-bazel-sentinel-link] | Polls devices, sends notifications, serves web dashboard |
+| [calibrator-flats](services/calibrator-flats) | Orchestrator plugin | 11170 | [![coverage][cov-calibrator-flats]][cov-calibrator-flats-link] | [![coverage][cov-bazel-calibrator-flats]][cov-bazel-calibrator-flats-link] | Flat field calibration with CoverCalibrator device |
+| [sky-survey-camera](services/sky-survey-camera) | ASCOM Camera (simulator) | 11116 | [![coverage][cov-sky-survey-camera]][cov-sky-survey-camera-link] | [![coverage][cov-bazel-sky-survey-camera]][cov-bazel-sky-survey-camera-link] | Camera simulator that returns NASA SkyView cutouts for the configured optics |
+| [star-adventurer-gti](services/star-adventurer-gti) | ASCOM Telescope | 11117 | [![coverage][cov-star-adventurer-gti]][cov-star-adventurer-gti-link] | [![coverage][cov-bazel-star-adventurer-gti]][cov-bazel-star-adventurer-gti-link] | Driver for Sky-Watcher Star Adventurer GTi (USB and WiFi/UDP) |
+| [pa-falcon-rotator](services/pa-falcon-rotator) | ASCOM Rotator + Switch (status) | 11118 | [![coverage][cov-pa-falcon-rotator]][cov-pa-falcon-rotator-link] | [![coverage][cov-bazel-pa-falcon-rotator]][cov-bazel-pa-falcon-rotator-link] | Driver for Pegasus Astro Falcon Rotator (firmware ≥ 1.3) |
+| [dsd-fp2](services/dsd-fp2) | ASCOM CoverCalibrator | 11119 | [![coverage][cov-dsd-fp2]][cov-dsd-fp2-link] | [![coverage][cov-bazel-dsd-fp2]][cov-bazel-dsd-fp2-link] | Driver for Deep Sky Dad Flat Panel 2 (motorised flat field panel) |
 
 ### RP (Main Application)
 
@@ -217,7 +219,7 @@ rusty-photon/
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT License](LICENSE-MIT) at your option.
 
-<!-- per-service coverage badges -->
+<!-- per-service coverage badges (Cargo, flag=<pkg>) -->
 [cov-rp]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=rp
 [cov-rp-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=rp
 [cov-filemonitor]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=filemonitor
@@ -240,3 +242,27 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT L
 [cov-dsd-fp2-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=dsd-fp2
 [cov-pa-falcon-rotator]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=pa-falcon-rotator
 [cov-pa-falcon-rotator-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=pa-falcon-rotator
+
+<!-- per-service coverage badges (Bazel shadow build, flag=bazel-<pkg>; read "unknown" until .github/workflows/bazel-coverage.yml has run on main) -->
+[cov-bazel-rp]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-rp
+[cov-bazel-rp-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-rp
+[cov-bazel-filemonitor]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-filemonitor
+[cov-bazel-filemonitor-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-filemonitor
+[cov-bazel-ppba-driver]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-ppba-driver
+[cov-bazel-ppba-driver-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-ppba-driver
+[cov-bazel-qhy-focuser]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-qhy-focuser
+[cov-bazel-qhy-focuser-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-qhy-focuser
+[cov-bazel-phd2-guider]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-phd2-guider
+[cov-bazel-phd2-guider-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-phd2-guider
+[cov-bazel-sentinel]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-sentinel
+[cov-bazel-sentinel-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-sentinel
+[cov-bazel-calibrator-flats]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-calibrator-flats
+[cov-bazel-calibrator-flats-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-calibrator-flats
+[cov-bazel-sky-survey-camera]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-sky-survey-camera
+[cov-bazel-sky-survey-camera-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-sky-survey-camera
+[cov-bazel-star-adventurer-gti]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-star-adventurer-gti
+[cov-bazel-star-adventurer-gti-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-star-adventurer-gti
+[cov-bazel-dsd-fp2]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-dsd-fp2
+[cov-bazel-dsd-fp2-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-dsd-fp2
+[cov-bazel-pa-falcon-rotator]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-pa-falcon-rotator
+[cov-bazel-pa-falcon-rotator-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-pa-falcon-rotator

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -251,6 +251,72 @@ Each service's `tests/bdd.rs` is now a Bazel `rust_test` with:
 
 Env var names follow the `{UPPER_SNAKE_PACKAGE}_BINARY` convention (e.g. `RP_BINARY`, `PPBA_DRIVER_BINARY`, `QHY_FOCUSER_BINARY`). `bdd-infra` derives the name from the package string passed to `ServiceHandle::start` — there is no per-service override.
 
+## Coverage under Bazel (shadow, added 2026-05-26)
+
+A separate shadow-mode workflow, `.github/workflows/bazel-coverage.yml`, runs
+`bazel coverage` on every PR (and push to main) alongside the canonical Cargo
+coverage job (`test.yml`). It is **not required** for merge.
+
+**Why it's worth doing under Bazel.** Coverage actions are content-addressed and
+cacheable like any other action. `bazel coverage //...` builds/tests the whole
+repo, but targets untouched by a PR are cache hits (local disk + remote R2), so
+their `coverage.dat` is fetched rather than recomputed. Every PR therefore gets
+a *complete* full-repo report while paying only for the changed targets — no
+cargo-rail narrowing, and no dependence on Codecov flag carryforward to fill in
+the untouched packages (we upload every package's flag every run, mostly from
+cache). The coverage cache is a **separate action namespace** from `bazel.yml`'s
+stable build/test (different rustc flags + nightly toolchain), so the coverage
+workflow primes it on push-to-main with the write token.
+
+**Parity requirements (the non-obvious parts):**
+
+- **Pinned nightly toolchain + `--cfg=coverage_nightly`.** The `coverage(off)`
+  attributes on every `#[cfg(test)] mod tests` block are gated on the
+  nightly-only `coverage_attribute` feature. cargo-llvm-cov activates them by
+  running on nightly and auto-setting `--cfg=coverage_nightly`; rules_rust does
+  neither. So `MODULE.bazel` registers a pinned nightly alongside stable, and
+  `.bazelrc`'s `--config=coverage` selects `channel=nightly` and adds
+  `--cfg=coverage_nightly`. Without this, either the code fails to compile (the
+  feature gate) or test modules pollute the numbers. The date is pinned (not
+  rolling) so a nightly bump doesn't bust every coverage action's cache key.
+- **Per-package flags.** Bazel emits one combined lcov;
+  `tools/coverage/split_lcov.py` splits it per package (by `crates/<pkg>/` |
+  `services/<pkg>/` source path — directory basename is the package name
+  throughout this workspace) so the per-service Codecov flags survive.
+- **Distinct `bazel-<pkg>` flags (shadow mode).** Uploads go to `bazel-<pkg>`,
+  not `<pkg>`, so the canonical per-service badges stay Cargo-only until
+  cutover. Codecov's project-wide total becomes the union of Cargo+Bazel during
+  shadow mode (union can only raise coverage, never trip the 1 % drop gate);
+  scope the `project` status to the Cargo flags in `.github/codecov.yml` if you
+  want the total kept strictly Cargo-only.
+
+**BDD is included; child-process coverage is the open risk.** Coverage runs the
+BDD suite too — `--config=coverage` sets `--test_tag_filters=-requires-cargo`,
+so only requires-cargo (cargo-shelling) tests are dropped — and the CI job
+installs OmniSim for rp's scenarios. Under `bazel coverage //...` the spawned
+service binaries ARE instrumented (first-party top-level targets matching the
+instrumentation filter), so the ingredients for service-binary coverage are
+present. What is NOT guaranteed is **collection**: cargo-llvm-cov captures
+child-process coverage via a shared `LLVM_PROFILE_FILE` (with `%p`/`%m` patterns)
+and a whole-target-dir `llvm-profdata merge`; Bazel's per-test-action model
+reliably collects only the test process's own `.profraw`. Whether each
+BDD-spawned child's `.profraw` lands in `COVERAGE_DIR` and gets merged depends on
+the `LLVM_PROFILE_FILE` pattern rules_rust sets and whether its merge step globs
+the whole directory.
+
+**Validate in run #1** by diffing each `bazel-<service>` flag against `<service>`
+(Cargo). If a service's Bazel coverage is materially lower, child-process
+profraw is being dropped. **Contingency:** have `bdd-infra`'s spawn path set
+`LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw` on each child `Command`
+only when `COVERAGE_DIR` is set (Bazel-only — cargo-llvm-cov sets
+`LLVM_PROFILE_FILE`, not `COVERAGE_DIR`, so the Cargo path is untouched), so
+every child writes a distinct file into the directory Bazel's lcov merger
+consumes. Each service's BDD coverage still caches independently, same as the
+unit/integration actions.
+
+This supersedes the Phase 7 note that coverage stays a Cargo-only gate: coverage
+now has a Bazel shadow path, to be validated in CI before any cutover.
+
 ## Open questions
 
 1. **bzlmod vs WORKSPACE.** Starting with bzlmod. Fallback to WORKSPACE mode if `crate_universe` bzlmod issues block progress.

--- a/docs/skills/pre-push.md
+++ b/docs/skills/pre-push.md
@@ -316,6 +316,24 @@ bazel test --test_tag_filters=bdd //...
 bazel test //services/filemonitor:bdd
 ```
 
+Coverage runs as a separate shadow workflow
+(`.github/workflows/bazel-coverage.yml`) on every PR. Locally it needs the
+pinned nightly toolchain, which `--config=coverage` selects (see `.bazelrc`):
+
+```bash
+bazel coverage --config=coverage //...
+# Combined lcov: $(bazel info output_path)/_coverage/_coverage_report.dat
+```
+
+It mirrors the Cargo `coverage` job (nightly + `coverage_nightly`, so the
+`#[cfg(test)] mod tests` blocks stay out of the numbers) but uploads under
+distinct `bazel-<pkg>` Codecov flags. It **includes the BDD suite**
+(`--config=coverage` drops only the `requires-cargo` tag), so locally it needs
+OmniSim installed and `OMNISIM_PATH` set, the same as a
+`bazel test --test_tag_filters=bdd` run. Whether the BDD-spawned service
+binaries' coverage is collected is validated in CI — see
+[docs/plans/bazel-migration.md](../plans/bazel-migration.md).
+
 Known limitations during migration:
 - A few tests in `bdd-infra`, `phd2-guider`, and `filemonitor:test_cli`
   shell out to `cargo` or assume `target/debug` paths; they are tagged

--- a/tools/coverage/split_lcov.py
+++ b/tools/coverage/split_lcov.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Split a combined LCOV coverage report into one file per workspace package.
+
+`bazel coverage --combined_report=lcov` emits a single merged LCOV report
+covering every first-party crate. The Cargo coverage job, by contrast, emits
+one report per package (`cargo llvm-cov report --package <pkg>`) and uploads
+each to Codecov under its own flag so the per-service badges work. To keep that
+behaviour under Bazel we split the combined report here: every LCOV record is
+routed to a package by the `crates/<pkg>/` or `services/<pkg>/` segment of its
+`SF:` source path (the directory basename is the Cargo package name throughout
+this workspace), producing `lcov-<pkg>.info` files ready to upload with
+`--flag <pkg>` (or `--flag bazel-<pkg>` in shadow mode).
+
+Records whose source path is under neither `crates/` nor `services/` (generated
+files, or external crates that slipped past the instrumentation filter) are
+dropped -- they have no package flag. Test-file records (tests/, mock_*/test_*
+bins) are kept; Codecov's `ignore:` rules drop them uniformly, exactly as for
+the Cargo-produced reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+
+# Match .../crates/<pkg>/... or .../services/<pkg>/... anywhere in the path,
+# tolerating absolute, workspace-relative, or bazel-out-prefixed SF: paths.
+_PKG_RE = re.compile(r"(?:^|/)(?:crates|services)/([^/]+)/")
+
+
+def split(report_path: str, output_dir: str) -> "dict[str, int]":
+    """Split ``report_path`` into ``lcov-<pkg>.info`` files in ``output_dir``.
+
+    Returns a mapping of package name -> number of LCOV records written.
+    """
+    with open(report_path, "r", encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+
+    # LCOV records are delimited by `end_of_record`; each opens with an `SF:`
+    # source-file line. We route a whole record on its first SF: path.
+    buckets: "dict[str, list[str]]" = defaultdict(list)
+    record: "list[str]" = []
+    pkg_for_record: "str | None" = None
+
+    def flush() -> None:
+        nonlocal record, pkg_for_record
+        if record and pkg_for_record is not None:
+            buckets[pkg_for_record].append("".join(record))
+        record = []
+        pkg_for_record = None
+
+    for line in text.splitlines(keepends=True):
+        record.append(line)
+        if pkg_for_record is None and line.startswith("SF:"):
+            match = _PKG_RE.search(line[3:])
+            if match:
+                pkg_for_record = match.group(1)
+        if line.startswith("end_of_record"):
+            flush()
+    flush()  # tolerate a missing trailing end_of_record
+
+    os.makedirs(output_dir, exist_ok=True)
+    counts: "dict[str, int]" = {}
+    for pkg, records in sorted(buckets.items()):
+        out_path = os.path.join(output_dir, f"lcov-{pkg}.info")
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write("".join(records))
+        counts[pkg] = len(records)
+    return counts
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Split a combined LCOV report into per-package lcov-<pkg>.info files."
+    )
+    parser.add_argument("report", help="path to the combined LCOV report (.dat/.info)")
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="directory to write lcov-<pkg>.info files into (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    if not os.path.isfile(args.report):
+        print(f"error: report not found: {args.report}", file=sys.stderr)
+        return 1
+
+    counts = split(args.report, args.output_dir)
+    if not counts:
+        print("warning: no first-party (crates/|services/) records found", file=sys.stderr)
+        return 0
+
+    total = sum(counts.values())
+    print(f"wrote {len(counts)} package report(s), {total} record(s) total:")
+    for pkg, count in sorted(counts.items()):
+        print(f"  {pkg}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

A separate, **non-required** shadow-mode workflow (`.github/workflows/bazel-coverage.yml`) that runs `bazel coverage //...` on every PR (and push to main), reproducing the Cargo coverage contract under Bazel. Adds per-service `bazel-<pkg>` Codecov flags and a **Coverage (Bazel)** column to the README beside the existing **Coverage (Cargo)** column.

## Why under Bazel

Coverage actions are content-addressed and cacheable. `bazel coverage //...` runs the whole repo, but targets untouched by a PR are cache hits (local disk + remote R2), so their `coverage.dat` is fetched, not recomputed. Every PR therefore gets a **complete** full-repo report while only paying for the changed targets — no cargo-rail narrowing, no dependence on Codecov flag carryforward. The coverage cache is a separate action namespace (nightly + instrumented), primed on push-to-main with the write token.

## Parity details (the non-obvious parts)

- **Pinned nightly toolchain + `--cfg=coverage_nightly`** (`MODULE.bazel`, `.bazelrc`). The `#[cfg_attr(coverage_nightly, coverage(off))]` attributes on the `#[cfg(test)] mod tests` blocks need the nightly-only `coverage_attribute` feature; cargo-llvm-cov gets this on nightly automatically, rules_rust does not. Date is pinned so a nightly bump doesn't bust every coverage action's cache key.
- **Per-package flags** — `tools/coverage/split_lcov.py` splits the single combined lcov per package so the per-service Codecov flags survive.
- **Distinct `bazel-<pkg>` flags** so the canonical per-service badges stay Cargo-only during shadow mode.
- **BDD included** — `--config=coverage` sets `--test_tag_filters=-requires-cargo` (pinned on the CI command line too); the job installs OmniSim for rp's scenarios.

## Validation status

- ✅ `split_lcov.py` tested locally (absolute / workspace-relative / external / multi-file paths).
- ✅ Workflow YAML parses; no Rust changes (Cargo gates are no-ops).
- ⚠️ `bazel coverage` itself is **unrun locally** (it pulls a full nightly toolchain + instrumented graph). **This PR triggers the workflow on itself — that's run #1.** Watch for:
  1. Nightly `2026-05-01` resolving with `llvm-tools` (bump the date in `MODULE.bazel` if the toolchain fetch fails).
  2. Whether **BDD-spawned service-binary coverage is collected** — diff each `bazel-<service>` against `<service>`. If much lower, child `.profraw` is being dropped; contingency (a `bdd-infra` `LLVM_PROFILE_FILE`-per-child change, Bazel-only) is documented in `docs/plans/bazel-migration.md`.
  3. Cold-cache wall-clock (no coverage actions are cached yet) vs the 60-min timeout.

## Follow-ups

- [ ] Regenerate `MODULE.bazel.lock` for the nightly toolchain (`bazel mod deps`, then commit) — CI auto-updates it under the default lockfile mode in the meantime.
- [ ] Implement the `bdd-infra` child-process `LLVM_PROFILE_FILE` fix **iff** run #1 shows service coverage is dropped.
- [ ] Optionally scope the Codecov `project` status to the Cargo flags if the shadow `bazel-` uploads should not affect the project-wide total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
