### PR TITLE
ci(bazel): add bdd + integration test targets for plate-solver & calibrator-flats

### DIFF
--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -245,11 +245,32 @@ Each service's `tests/bdd.rs` is now a Bazel `rust_test` with:
 
 - `use_libtest_harness = False` (cucumber has its own main).
 - `BDD_PACKAGE_DIR = "services/<name>"` set in `env`; `bdd_main!` chdirs there at startup and absolutizes any `*_BINARY` env vars first so binary discovery still resolves relative to the runfiles root.
-- `<SERVICE>_BINARY = "$(rootpath :<binary>)"` for self-spawn. Cross-spawn services set additional binaries: sentinel sets `FILEMONITOR_BINARY`, rp sets `CALIBRATOR_FLATS_BINARY`.
+- `<SERVICE>_BINARY = "$(rootpath :<binary>)"` for self-spawn. Cross-spawn services set additional binaries: sentinel sets `FILEMONITOR_BINARY`, rp sets `CALIBRATOR_FLATS_BINARY`, and calibrator-flats sets `RP_BINARY` (the inverse of `rp:bdd`).
 - `data` includes the service binary, `Cargo.toml`, `tests/features/**`, and any fixture JSON (`tests/config.json` etc.).
 - ppba-driver and qhy-focuser have a second mock-feature binary target (`_mock` suffix) because Bazel treats `crate_features` as compile-time; the BDD test points at the mock binary.
 
 Env var names follow the `{UPPER_SNAKE_PACKAGE}_BINARY` convention (e.g. `RP_BINARY`, `PPBA_DRIVER_BINARY`, `QHY_FOCUSER_BINARY`). `bdd-infra` derives the name from the package string passed to `ServiceHandle::start` — there is no per-service override.
+
+All twelve service BDD suites now have Bazel `bdd` targets. The last two —
+`plate-solver` and `calibrator-flats` — were wired after the initial Phase-3
+batch; each adds a wrinkle worth noting:
+
+- **plate-solver** spawns its service binary, which in turn shells out to the
+  `mock_astap` stub (`src/bin/mock_astap.rs`), so its `bdd` target deps both
+  `:plate-solver` and `:mock_astap` and sets `PLATE_SOLVER_BINARY` +
+  `MOCK_ASTAP_BINARY`. It needs no OmniSim, so it runs under a plain
+  `bazel test //services/plate-solver:bdd`. The `@requires-astap` scenarios
+  self-gate on the `ASTAP_BINARY` env var (unset in PR jobs); `@unix` scenarios
+  self-gate on `cfg(unix)`. Adding the target also meant splitting `src/main.rs`
+  out of `plate-solver_lib` into a `plate-solver` `rust_binary` — the
+  hand-written BUILD previously had only the lib + `mock_astap` (Cargo
+  auto-discovers `src/main.rs` as the default binary, so there was no Cargo-side
+  gap to notice).
+- **calibrator-flats** is the inverse of `rp:bdd`: it cross-spawns rp
+  (`RP_BINARY`) and OmniSim through the `bdd-infra_rp_harness` variant, plus its
+  own binary (`CALIBRATOR_FLATS_BINARY`). Like every rp_harness target it needs
+  OmniSim (`OMNISIM_PATH`, forwarded by `build:ci --test_env`) at runtime, so a
+  local run requires OmniSim installed.
 
 ## Coverage under Bazel (shadow, added 2026-05-26)
 

--- a/services/calibrator-flats/BUILD.bazel
+++ b/services/calibrator-flats/BUILD.bazel
@@ -45,3 +45,49 @@ rust_test(
         normal_dev = True,
     ),
 )
+
+# BDD cucumber suite. Drives the flat-calibration workflow end-to-end through
+# three spawned processes: OmniSim (via OMNISIM_PATH, forwarded by the CI
+# `build:ci --test_env`), rp (RP_BINARY), and calibrator-flats itself
+# (CALIBRATOR_FLATS_BINARY). Uses bdd-infra's rp-harness variant — the same
+# shared harness rp's own BDD suite uses (rp:bdd cross-spawns calibrator-flats;
+# this is the inverse). A local `bazel test //services/calibrator-flats:bdd`
+# needs OmniSim installed and OMNISIM_PATH set, like any rp_harness BDD target.
+rust_test(
+    name = "bdd",
+    srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
+    # Spawns three processes per scenario; generous timeout.
+    size = "large",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_root = "tests/bdd.rs",
+    data = [
+        ":calibrator-flats",
+        "//services/rp:rp",
+        "Cargo.toml",
+    ] + glob(["tests/features/**"]),
+    edition = "2021",
+    env = {
+        "BDD_PACKAGE_DIR": "services/calibrator-flats",
+        "CALIBRATOR_FLATS_BINARY": "$(rootpath :calibrator-flats)",
+        "RP_BINARY": "$(rootpath //services/rp:rp)",
+    },
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
+    # be the service name (rules_rust would otherwise use the crate name "bdd").
+    rustc_env = {"CARGO_PKG_NAME": "calibrator-flats"},
+    tags = ["bdd"],
+    use_libtest_harness = False,
+    deps = [
+        ":calibrator-flats_lib",
+        "//crates/bdd-infra:bdd-infra_rp_harness",
+    ] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/services/plate-solver/BUILD.bazel
+++ b/services/plate-solver/BUILD.bazel
@@ -9,13 +9,28 @@ _INTRA_WORKSPACE_DEPS = [
 
 rust_library(
     name = "plate-solver_lib",
-    srcs = glob(["src/**/*.rs"], exclude = ["src/bin/**"]),
+    # Exclude src/main.rs (the service binary's crate root, built by the
+    # `plate-solver` rust_binary below) and src/bin/** (mock_astap).
+    srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs", "src/bin/**"]),
     aliases = aliases(),
     crate_name = "plate_solver",
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],
     deps = _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
+)
+
+# The plate-solver service binary (HTTP wrapper around the ASTAP CLI).
+# Cargo auto-discovers src/main.rs as the package's default binary; this
+# is the Bazel equivalent. The BDD suite spawns it via PLATE_SOLVER_BINARY.
+rust_binary(
+    name = "plate-solver",
+    srcs = ["src/main.rs"],
+    aliases = aliases(),
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+    deps = [":plate-solver_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(normal = True),
 )
 
 rust_binary(
@@ -66,6 +81,52 @@ rust_test(
         proc_macro_dev = True,
     ),
     deps = [":plate-solver_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
+# BDD cucumber suite. Self-contained: spawns the plate-solver service binary,
+# which in turn shells out to the mock_astap stub (no real ASTAP install, no
+# OmniSim). The @requires-astap scenarios self-gate on the ASTAP_BINARY env
+# var (unset here, so they're skipped); @unix scenarios self-gate on cfg(unix).
+rust_test(
+    name = "bdd",
+    srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
+    # Spawns a service process per scenario (26 scenarios); generous timeout.
+    size = "large",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    crate_root = "tests/bdd.rs",
+    data = [
+        ":mock_astap",
+        ":plate-solver",
+        "Cargo.toml",
+    ] + glob([
+        "tests/features/**",
+        "tests/fixtures/**",
+    ]),
+    edition = "2021",
+    env = {
+        "BDD_PACKAGE_DIR": "services/plate-solver",
+        "MOCK_ASTAP_BINARY": "$(rootpath :mock_astap)",
+        "PLATE_SOLVER_BINARY": "$(rootpath :plate-solver)",
+    },
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
+    # be the service name (rules_rust would otherwise use the crate name "bdd").
+    rustc_env = {"CARGO_PKG_NAME": "plate-solver"},
+    tags = ["bdd"],
+    use_libtest_harness = False,
+    deps = [
+        ":plate-solver_lib",
+        "//crates/bdd-infra:bdd-infra",
+    ] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),

--- a/services/plate-solver/BUILD.bazel
+++ b/services/plate-solver/BUILD.bazel
@@ -86,6 +86,32 @@ rust_test(
     ),
 )
 
+# Drives AstapCliRunner::solve() end-to-end against mock_astap in each of its
+# failure modes (success / ExitStatus / NoWcs / MalformedWcs). Same mock_astap
+# discovery as supervision_integration: MOCK_ASTAP_BINARY points at the binary.
+rust_test(
+    name = "runner_integration",
+    srcs = ["tests/runner_integration.rs"],
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    size = "small",
+    env = {
+        "MOCK_ASTAP_BINARY": "$(rootpath :mock_astap)",
+    },
+    data = [":mock_astap"],
+    edition = "2021",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = [":plate-solver_lib"] + _INTRA_WORKSPACE_DEPS + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
 # BDD cucumber suite. Self-contained: spawns the plate-solver service binary,
 # which in turn shells out to the mock_astap stub (no real ASTAP install, no
 # OmniSim). The @requires-astap scenarios self-gate on the ASTAP_BINARY env


### PR DESCRIPTION
## Why

Shadow-mode Bazel was missing test targets that these two services already run
under Cargo — `plate-solver` and `calibrator-flats` had cucumber feature files
(and `plate-solver` an extra integration test) with **no Bazel `rust_test`**, so
their scenarios never ran in the Bazel graph. They were the last two services
without a `bdd` target (calibrator-flats was only exercised indirectly via
`rp:bdd`; plate-solver not at all). This closes that test-coverage parity gap.
The `bdd` tag set goes **10 → 12 targets**.

## What

- **`//services/plate-solver:bdd`** — self-contained: spawns the service binary,
  which shells out to the `mock_astap` stub (no OmniSim). Sets
  `PLATE_SOLVER_BINARY` + `MOCK_ASTAP_BINARY`; `@requires-astap`/`@unix`
  scenarios self-gate. Adding it surfaced a second gap — the package had **no
  `plate-solver` binary target** (only the lib + `mock_astap`), so this also adds
  a `plate-solver` `rust_binary` and splits `src/main.rs` out of
  `plate-solver_lib` (Cargo auto-discovers `main.rs`, so there was no Cargo-side
  gap to notice).
- **`//services/calibrator-flats:bdd`** — the inverse of `rp:bdd`: cross-spawns
  rp + OmniSim via the `bdd-infra_rp_harness` variant plus its own binary
  (`RP_BINARY` + `CALIBRATOR_FLATS_BINARY`).
- **`//services/plate-solver:runner_integration`** — the 4-test
  `tests/runner_integration.rs` integration suite (mirrors the existing
  `supervision_integration` target; spawns `mock_astap`).
- Doc: updates the BDD-conventions section of `docs/plans/bazel-migration.md`.

## Validation

- `bazel test //services/plate-solver:bdd` → **PASS** (full harness wiring:
  binary discovery, fixtures, `BDD_PACKAGE_DIR` chdir).
- `bazel test //services/plate-solver:runner_integration` → **4 passed**.
- Non-BDD targets in both packages still build/pass; the `main.rs` lib-split
  broke nothing. cargo-rail commit profile **70/70**; clippy (`-D warnings`) +
  rustfmt clean via the pre-commit hook.
- **`calibrator-flats:bdd` is not runnable locally without OmniSim** — it builds,
  loads the feature file, and reaches the first step, failing only on the missing
  OmniSim binary (identical to every `rp_harness` target). It passes in CI via
  the `install-omnisim` action. This PR relies on the shadow-mode `bazel`
  workflow to exercise it on all three OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
