### PR TITLE
refactor(star-adventurer-gti): RAII guard for slew_in_progress reservation

### DIFF
--- a/services/star-adventurer-gti/src/mount_device.rs
+++ b/services/star-adventurer-gti/src/mount_device.rs
@@ -30,6 +30,7 @@
 //!   and the boot-time writability probe.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,12 +75,6 @@ struct DriverState {
     target_ra_hours: Option<f64>,
     target_dec_degrees: Option<f64>,
     slew_settle_time: Option<Duration>,
-    /// `true` between the moment a slew is issued and the moment the
-    /// completion watcher has finished re-enabling tracking + the
-    /// settle delay. `slewing()` ORs this with the snapshot's running
-    /// flags so callers see "still slewing" until the watcher signals
-    /// otherwise.
-    slew_in_progress: bool,
     /// In-memory park-target encoder pair. Populated on the 0→1 connect
     /// transition from `MountConfig::park_*_ticks` if `Some`, otherwise
     /// from the handshake-captured positions. `None` here means "not
@@ -119,7 +114,6 @@ impl Default for DriverState {
             target_ra_hours: None,
             target_dec_degrees: None,
             slew_settle_time: None,
-            slew_in_progress: false,
             park_ra_ticks: None,
             park_dec_ticks: None,
             target_pier_side: None,
@@ -146,9 +140,12 @@ impl DriverState {
     ///     `SetTargetRA` / `SetTargetDec` call; not durable.
     ///   - `tracking_requested` — disconnect halted tracking on the
     ///     wire (`:K1`); the in-memory flag must follow.
-    ///   - `slew_in_progress` — the polling task is gone, the watcher
-    ///     has nothing left to observe; clearing the flag also tells
-    ///     any in-flight watcher iteration to bail out.
+    ///   - `slew_in_progress` is **not** cleared here — it now lives on
+    ///     [`MountDevice`] as an [`AtomicBool`], cleared synchronously by
+    ///     [`SlewReservation`] on rollback and by the disconnect path in
+    ///     `device.rs` (the `set_connected(false)` arm) alongside this
+    ///     call. Clearing it there still tells any in-flight watcher
+    ///     iteration to bail out.
     ///   - `park_ra_ticks` / `park_dec_ticks` — re-loaded on next
     ///     connect from config / handshake. Clearing here means a
     ///     mid-session edit to `MountConfig::park_*_ticks` would take
@@ -161,7 +158,6 @@ impl DriverState {
         self.target_ra_hours = None;
         self.target_dec_degrees = None;
         self.tracking_requested = false;
-        self.slew_in_progress = false;
         self.park_ra_ticks = None;
         self.park_dec_ticks = None;
         self.pulse_guiding_ra = false;
@@ -186,6 +182,13 @@ pub struct MountDevice {
     #[debug(skip)]
     session: Arc<RwLock<Option<Session<SkywatcherCodec>>>>,
     state: Arc<RwLock<DriverState>>,
+    /// Slew/park "in progress" flag. Lives here as an [`AtomicBool`]
+    /// rather than a [`DriverState`] field so [`SlewReservation`] can
+    /// roll it back **synchronously** from `Drop` — a `Drop` impl can't
+    /// `.await` the `state` `RwLock`. Set by the slew / park reservation,
+    /// ORed into `slewing()` and the concurrent-motion refusals, and
+    /// cleared by the completion watchers, `AbortSlew`, and disconnect.
+    slew_in_progress: Arc<AtomicBool>,
     #[debug(skip)]
     manager: Arc<MountManager>,
 }
@@ -208,6 +211,7 @@ impl MountDevice {
             config_file_path,
             session: Arc::new(RwLock::new(None)),
             state: Arc::new(RwLock::new(DriverState::default())),
+            slew_in_progress: Arc::new(AtomicBool::new(false)),
             manager,
         }
     }
@@ -224,6 +228,59 @@ impl MountDevice {
             .as_ref()
             .ok_or(crate::error::StarAdvError::NotConnected)?;
         self.manager.send(session, cmd).await
+    }
+}
+
+/// RAII reservation of the `slew_in_progress` slot on [`MountDevice`].
+///
+/// Acquired before a slew or park issues any motion. While held, the
+/// reservation **rolls back on drop** — clearing `slew_in_progress` — so
+/// every `?` early-return on the motion-issue path (a failed wire
+/// command, or a failed hand-off to the completion watcher) restores the
+/// flag without an explicit clear at the call site. On the success path
+/// the caller calls [`SlewReservation::dismiss`] once the completion
+/// watcher has been spawned; from that point the watcher owns clearing
+/// the flag.
+///
+/// The flag is an [`AtomicBool`] rather than a field behind the device's
+/// `RwLock<DriverState>` precisely so this rollback can be a synchronous
+/// store from `Drop` (a `Drop` impl cannot `.await` a `tokio::sync::RwLock`
+/// write). Mirrors the synchronous rollback-on-drop guard the
+/// `rusty-photon-shared-transport` `acquire()` path uses for its refcount.
+#[must_use = "a dropped reservation rolls back slew_in_progress; bind it for the operation's duration"]
+pub(super) struct SlewReservation {
+    flag: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl SlewReservation {
+    /// Reserve the slot, returning the guard, or [`None`] when a slew /
+    /// park is already in progress. The check-and-set is a single
+    /// `compare_exchange`, so two concurrent callers can't both win the
+    /// reservation (the TOCTOU-free guarantee the previous lock-guarded
+    /// check-and-set gave).
+    pub(super) fn try_acquire(flag: &Arc<AtomicBool>) -> Option<Self> {
+        flag.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .ok()
+            .map(|_| Self {
+                flag: Arc::clone(flag),
+                armed: true,
+            })
+    }
+
+    /// Hand the flag's lifecycle off to the completion watcher: disarm
+    /// the rollback so dropping this guard leaves `slew_in_progress` set.
+    /// Call only after the watcher has been successfully spawned.
+    pub(super) fn dismiss(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SlewReservation {
+    fn drop(&mut self) {
+        if self.armed {
+            self.flag.store(false, Ordering::SeqCst);
+        }
     }
 }
 

--- a/services/star-adventurer-gti/src/mount_device/actions.rs
+++ b/services/star-adventurer-gti/src/mount_device/actions.rs
@@ -17,6 +17,8 @@
 //!
 //! [§Unpark from AP position]: ../../../../docs/services/star-adventurer-gti.md#unpark-from-ap-position
 
+use std::sync::atomic::Ordering;
+
 use ascom_alpaca::{ASCOMError, ASCOMErrorCode, ASCOMResult};
 
 use crate::config::ApPark;
@@ -162,20 +164,17 @@ impl MountDevice {
     ) -> ASCOMResult<String> {
         let park = parse_ap_park(parameter)?;
         self.ensure_connected().await?;
-        {
-            let state = self.state.read().await;
-            if !state.at_park {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "UnparkFromApPosition refused: mount is not parked",
-                ));
-            }
-            if state.slew_in_progress {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "UnparkFromApPosition refused: slew in progress",
-                ));
-            }
+        if !self.state.read().await.at_park {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "UnparkFromApPosition refused: mount is not parked",
+            ));
+        }
+        if self.slew_in_progress.load(Ordering::SeqCst) {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "UnparkFromApPosition refused: slew in progress",
+            ));
         }
         if park == ApPark::ApPark0 {
             // "Current position": no encoder change — equivalent to a

--- a/services/star-adventurer-gti/src/mount_device/device.rs
+++ b/services/star-adventurer-gti/src/mount_device/device.rs
@@ -7,6 +7,7 @@
 //! `load_park_target_after_connect`) with structural rollback via
 //! `session.close().await` on any error.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use ascom_alpaca::api::Device;
@@ -91,6 +92,7 @@ impl Device for MountDevice {
                     Arc::clone(&self.state),
                     Arc::clone(&self.manager),
                     Arc::clone(&self.session),
+                    Arc::clone(&self.slew_in_progress),
                     self.config.clone(),
                     self.manager.polling_interval_for_watcher(),
                 );
@@ -103,8 +105,12 @@ impl Device for MountDevice {
                 // mechanical state (`at_park`) intact — the mount's encoder
                 // doesn't move just because we closed the socket. See
                 // [`super::DriverState::reset_for_disconnect`] for the field-
-                // by-field rationale.
+                // by-field rationale. `slew_in_progress` lives outside
+                // `DriverState` (an atomic, so [`super::SlewReservation`] can
+                // roll it back from `Drop`), so clear it here too — this also
+                // signals any in-flight completion watcher to bail.
                 self.state.write().await.reset_for_disconnect();
+                self.slew_in_progress.store(false, Ordering::SeqCst);
             }
             _ => {}
         }

--- a/services/star-adventurer-gti/src/mount_device/inherent.rs
+++ b/services/star-adventurer-gti/src/mount_device/inherent.rs
@@ -25,6 +25,7 @@
 //!   [`MountDevice::execute_slew_with_explicit_side`] — the shared
 //!   body for `SlewToCoordinatesAsync` and `SetSideOfPier`.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -50,7 +51,7 @@ use super::slew::{
     stop_axis_and_wait, AXIS_STOP_TIMEOUT,
 };
 use super::watchers::spawn_slew_completion_watcher;
-use super::{pre_flip_side_for_latitude, MountDevice};
+use super::{pre_flip_side_for_latitude, MountDevice, SlewReservation};
 
 /// Upper bound on how long the synchronous `SlewToCoordinates` /
 /// `SlewToTarget` will wait for the watcher to clear `slew_in_progress`.
@@ -478,8 +479,8 @@ impl MountDevice {
         self.manager.seed_dec_position(dec_target_ticks).await;
         // 3. Clear driver-internal motion / target / tracking state so
         //    the freshly written encoder is the source of truth.
+        self.slew_in_progress.store(false, Ordering::SeqCst);
         let mut state = self.state.write().await;
-        state.slew_in_progress = false;
         state.target_ra_hours = None;
         state.target_dec_degrees = None;
         state.tracking_requested = false;
@@ -644,29 +645,31 @@ impl MountDevice {
         // pier side.
         self.check_within_safe_envelope(ra, dec, lst.value(), target_is_flipped)?;
 
-        // Atomically reserve the in-progress slot **before** issuing
-        // any motion. Latch the target + capture the tracking flag in
-        // the same write.
+        // Reserve the in-progress slot **before** issuing any motion.
+        // The returned guard clears `slew_in_progress` on drop, so every
+        // `?` below — a failed wire command or a failed watcher hand-off
+        // — rolls the flag back without an explicit clear.
+        let Some(reservation) = SlewReservation::try_acquire(&self.slew_in_progress) else {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "slew refused: slew already in progress",
+            ));
+        };
+        // Latch the target + capture the tracking flag.
         let tracking_was_on;
         {
             let mut s = self.state.write().await;
-            if s.slew_in_progress {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "slew refused: slew already in progress",
-                ));
-            }
             s.target_ra_hours = Some(ra);
             s.target_dec_degrees = Some(dec);
             s.target_pier_side = Some(chosen_side);
             tracking_was_on = s.tracking_requested;
-            s.slew_in_progress = true;
             s.pulse_guiding_ra = false;
             s.pulse_guiding_dec = false;
         }
 
-        // From here on, any error path must clear `slew_in_progress`
-        // — otherwise the driver gets stuck reporting Slewing forever.
+        // Issue the motion sequence. Any `?` failure inside drops
+        // `reservation`, which clears `slew_in_progress` — the driver
+        // can't get stuck reporting Slewing after a failed slew.
         let result: ASCOMResult<()> = async {
             let snap = self.manager.snapshot().await;
             let current_side = side_of_pier_calc(
@@ -750,10 +753,7 @@ impl MountDevice {
             Ok(())
         }
         .await;
-        if let Err(e) = result {
-            self.state.write().await.slew_in_progress = false;
-            return Err(e);
-        }
+        result?;
 
         // Hand off to the completion watcher. The watcher acquires its
         // own session so the user's disconnect path doesn't have to
@@ -766,6 +766,7 @@ impl MountDevice {
             Arc::clone(&self.state),
             Arc::clone(&self.manager),
             Arc::clone(&self.session),
+            Arc::clone(&self.slew_in_progress),
             self.config.clone(),
             self.manager.polling_interval_for_watcher(),
             settle,
@@ -773,6 +774,11 @@ impl MountDevice {
         )
         .await
         .map_err(ASCOMError::from)?;
+        // Watcher spawned — hand off the flag. If the spawn above had
+        // failed, `?` would have dropped `reservation` and rolled the
+        // flag back, so a failed hand-off can no longer leave the driver
+        // stuck reporting Slewing with no watcher to clear it.
+        reservation.dismiss();
         Ok(())
     }
 }

--- a/services/star-adventurer-gti/src/mount_device/telescope.rs
+++ b/services/star-adventurer-gti/src/mount_device/telescope.rs
@@ -6,6 +6,7 @@
 //! sibling submodules; methods here orchestrate but rarely compute.
 
 use std::ops::RangeInclusive;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -31,7 +32,7 @@ use super::inherent::validate_guide_rate;
 use super::park_persistence::write_park_to_config;
 use super::slew::enable_sidereal_tracking_ra;
 use super::watchers::{clear_pulse_flag, spawn_park_completion_watcher, spawn_pulse_guide_watcher};
-use super::{pre_flip_side_for_latitude, MountDevice};
+use super::{pre_flip_side_for_latitude, MountDevice, SlewReservation};
 
 #[async_trait]
 impl Telescope for MountDevice {
@@ -198,7 +199,7 @@ impl Telescope for MountDevice {
         // task signalling completion (after settle + tracking re-issue),
         // so the flag covers both the active-motion period and the
         // post-motion settle window.
-        if self.state.read().await.slew_in_progress {
+        if self.slew_in_progress.load(Ordering::SeqCst) {
             return Ok(true);
         }
         let snap = self.manager.snapshot().await;
@@ -375,7 +376,7 @@ impl Telescope for MountDevice {
         // own `slew_in_progress` check, but rejecting here yields a
         // cleaner error before we read the snapshot and compute a
         // stale celestial target.
-        if self.state.read().await.slew_in_progress {
+        if self.slew_in_progress.load(Ordering::SeqCst) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_OPERATION,
                 "SetSideOfPier refused: slew already in progress",
@@ -628,28 +629,27 @@ impl Telescope for MountDevice {
         if self.state.read().await.at_park {
             return Ok(());
         }
-        // Atomically reserve the in-progress slot **before** issuing
-        // any motion. Doing the flag-set after `:J` (the old layout)
-        // left a TOCTOU window where a concurrent `SetPark` could
-        // read mid-slew encoder positions. Cancel any in-flight
-        // pulse-guide in the same write — park takes ownership of
+        // Reserve the in-progress slot **before** issuing any motion —
+        // a concurrent `SetPark` must not read mid-slew encoder
+        // positions. The guard clears `slew_in_progress` on drop, so any
+        // `?` failure below (or a failed watcher hand-off) rolls it back
+        // without an explicit clear.
+        let Some(reservation) = SlewReservation::try_acquire(&self.slew_in_progress) else {
+            return Err(ASCOMError::new(
+                ASCOMErrorCode::INVALID_OPERATION,
+                "park refused: slew already in progress",
+            ));
+        };
+        // Cancel any in-flight pulse-guide — park takes ownership of
         // both axes from this point.
         {
             let mut s = self.state.write().await;
-            if s.slew_in_progress {
-                return Err(ASCOMError::new(
-                    ASCOMErrorCode::INVALID_OPERATION,
-                    "park refused: slew already in progress",
-                ));
-            }
-            s.slew_in_progress = true;
             s.pulse_guiding_ra = false;
             s.pulse_guiding_dec = false;
         }
-        // From here on, any error path must clear `slew_in_progress`
-        // — otherwise the driver gets stuck reporting Slewing forever.
-        // Wrap motion-issue in an inner future so a single rollback
-        // covers every `?` failure.
+        // Issue the motion sequence in an inner future. Any `?` failure
+        // drops `reservation`, which clears `slew_in_progress` — no
+        // explicit rollback needed.
         let result: ASCOMResult<()> = async {
             // Stop tracking before slewing home (per ASCOM, tracking
             // remains off after Park). The wire `:K1` is issued first
@@ -716,14 +716,11 @@ impl Telescope for MountDevice {
             Ok(())
         }
         .await;
-        if let Err(e) = result {
-            self.state.write().await.slew_in_progress = false;
-            return Err(e);
-        }
-        // Hand off to the park watcher; it owns `slew_in_progress`
-        // from here and will clear it on completion. The watcher
-        // acquires its own session so a user disconnect during park
-        // doesn't have to wait for completion.
+        result?;
+        // Hand off to the park watcher; it owns `slew_in_progress` from
+        // here and will clear it on completion. The watcher acquires its
+        // own session so a user disconnect during park doesn't have to
+        // wait for completion.
         let settle = self
             .state
             .read()
@@ -734,11 +731,13 @@ impl Telescope for MountDevice {
             Arc::clone(&self.state),
             Arc::clone(&self.manager),
             Arc::clone(&self.session),
+            Arc::clone(&self.slew_in_progress),
             self.manager.polling_interval_for_watcher(),
             settle,
         )
         .await
         .map_err(ASCOMError::from)?;
+        reservation.dismiss();
         Ok(())
     }
 
@@ -775,7 +774,7 @@ impl Telescope for MountDevice {
         //      reason the in-memory flag wouldn't capture (a tracking
         //      pulse, an external `:J` from a future out-of-band path,
         //      a flag-set racing the wire send).
-        if self.state.read().await.slew_in_progress {
+        if self.slew_in_progress.load(Ordering::SeqCst) {
             return Err(ASCOMError::new(
                 ASCOMErrorCode::INVALID_OPERATION,
                 "SetPark refused while slew or park is in progress",
@@ -853,9 +852,9 @@ impl Telescope for MountDevice {
         // may have re-issued. After abort the user must explicitly
         // re-enable tracking. Matches ASCOM's "AbortSlew does not
         // auto-restore tracking" guarantee.
+        self.slew_in_progress.store(false, Ordering::SeqCst);
         {
             let mut s = self.state.write().await;
-            s.slew_in_progress = false;
             s.tracking_requested = false;
             // Cancel any in-flight pulse-guide on either axis. The
             // watcher's post-sleep restore step bails when it sees the
@@ -1053,6 +1052,7 @@ impl Telescope for MountDevice {
             Arc::clone(&self.state),
             Arc::clone(&self.manager),
             Arc::clone(&self.session),
+            Arc::clone(&self.slew_in_progress),
             axis,
             duration,
             tracking_was_on,

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -7,6 +7,7 @@
 //! and `super::<sub>::*` reaches sibling submodules.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -179,7 +180,15 @@ async fn tracking_guard_tick_stops_tracking_inside_the_zone() {
     seed_mech_ha(&d, &mock, 6.0).await; // mid-zone (mech_HA = +6 h)
     d.state.write().await.tracking_requested = true;
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(fired, "guard should fire mid-zone");
     assert!(
@@ -196,7 +205,15 @@ async fn tracking_guard_tick_is_noop_far_from_the_zone() {
     seed_mech_ha(&d, &mock, -3.0).await; // typical session start, well clear
     d.state.write().await.tracking_requested = true;
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(!fired, "guard must not fire far from the zone");
     assert!(
@@ -217,7 +234,15 @@ async fn tracking_guard_tick_is_noop_when_not_tracking() {
                                         // `tracking_requested` left false — the guard only acts while the
                                         // client has tracking engaged.
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(!fired, "guard only acts while tracking is engaged");
     let log = mock.lock().await.command_log.clone();
@@ -244,7 +269,15 @@ async fn tracking_guard_tick_is_noop_when_parameters_not_cached() {
     d.state.write().await.tracking_requested = true;
     assert!(d.manager.parameters().await.is_none());
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(!fired, "no cached CPR -> guard cannot act");
     assert!(
@@ -276,7 +309,15 @@ async fn tracking_guard_tick_is_noop_when_session_closed_mid_tick() {
     d.state.write().await.tracking_requested = true;
     assert!(d.session.read().await.is_none());
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(!fired, "no session -> nothing to stop");
     assert!(
@@ -297,7 +338,15 @@ async fn tracking_guard_tick_leaves_tracking_set_when_stop_fails() {
     mock.lock().await.fail_command = Some(b'K'); // make :K1 error
     d.state.write().await.tracking_requested = true;
 
-    let fired = tracking_guard_tick(&d.state, &d.manager, &d.session, (0.95, 11.05), 0.05).await;
+    let fired = tracking_guard_tick(
+        &d.state,
+        &d.manager,
+        &d.session,
+        &d.slew_in_progress,
+        (0.95, 11.05),
+        0.05,
+    )
+    .await;
 
     assert!(!fired, "a failed stop is not a successful fire");
     assert!(
@@ -1126,6 +1175,71 @@ async fn abort_slew_does_not_auto_restore_tracking() {
     let _ = d.tracking().await;
 }
 
+/// Connected device backed by a [`CapturingMockFactory`] with the CW
+/// exclusion zone disabled and instant settle, returning the shared mock
+/// state so a test can inject a wire failure (`fail_command`) mid-motion
+/// and observe the reservation rollback. Mirrors the capturing-mock setup
+/// `set_tracking_true_issues_g_i_j_on_ra_axis` uses.
+async fn capturing_connected_device() -> (MountDevice, Arc<tokio::sync::Mutex<MockMountState>>) {
+    let factory = CapturingMockFactory::new();
+    let mock = Arc::clone(&factory.state);
+    let mut cfg = Config::default();
+    // Open the envelope so the slew reaches the wire; settle instantly so
+    // a successful slew's watcher doesn't linger between scenarios.
+    cfg.mount.cw_exclusion_zone = CwExclusionZone::Disabled;
+    cfg.mount.settle_after_slew = Duration::from_millis(0);
+    let manager = MountManager::new(cfg.clone(), Arc::new(factory));
+    let d = MountDevice::new(cfg.mount, manager);
+    d.set_connected(true).await.unwrap();
+    (d, mock)
+}
+
+#[tokio::test]
+async fn slew_rolls_back_slew_in_progress_when_motion_fails() {
+    // A wire failure while issuing the slew must roll the reservation
+    // back, or the driver would report Slewing forever. The
+    // SlewReservation guard clears the flag on drop; because the flag is
+    // an atomic the rollback is synchronous — observable the instant the
+    // error returns, with no settle wait.
+    let (d, mock) = capturing_connected_device().await;
+    // Fail the slew's first wire op (`:K1` in stop_and_wait).
+    mock.lock().await.fail_command = Some(b'K');
+
+    d.slew_to_coordinates_async(6.0, 30.0).await.unwrap_err();
+
+    assert!(
+        !d.slew_in_progress.load(Ordering::SeqCst),
+        "slew_in_progress must be cleared after a failed slew"
+    );
+    assert!(!d.slewing().await.unwrap());
+}
+
+#[tokio::test]
+async fn park_rolls_back_slew_in_progress_when_motion_fails() {
+    let (d, mock) = capturing_connected_device().await;
+    // Fail park's first wire op (`:K1` in the per-axis stop_and_wait).
+    mock.lock().await.fail_command = Some(b'K');
+
+    d.park().await.unwrap_err();
+
+    assert!(
+        !d.slew_in_progress.load(Ordering::SeqCst),
+        "slew_in_progress must be cleared after a failed park"
+    );
+    assert!(!d.slewing().await.unwrap());
+}
+
+#[tokio::test]
+async fn disconnect_clears_slew_in_progress() {
+    // `slew_in_progress` lives outside `DriverState` now, so the
+    // disconnect arm of `set_connected` clears it directly — the coverage
+    // that used to live in the `reset_for_disconnect` field test.
+    let d = connected_device().await;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
+    d.set_connected(false).await.unwrap();
+    assert!(!d.slew_in_progress.load(Ordering::SeqCst));
+}
+
 #[tokio::test]
 async fn abort_slew_refuses_while_disconnected() {
     let d = fast_settle_device();
@@ -1319,22 +1433,22 @@ async fn watcher_should_abort_returns_true_when_slew_in_progress_cleared() {
     // `manager.is_available()` (the watcher's own session keeps
     // the transport open even after the user disconnects).
     use rusty_photon_shared_transport::Session;
-    let state = Arc::new(RwLock::new(DriverState::default()));
+    let slew_in_progress = AtomicBool::new(false);
     let manager = MountManager::new(Config::default(), Arc::new(MockTransportFactory));
     let device_session = manager.transport().acquire().await.unwrap();
     let session_slot: Arc<RwLock<Option<Session<crate::codec::SkywatcherCodec>>>> =
         Arc::new(RwLock::new(Some(device_session)));
 
-    // Default state has slew_in_progress=false → abort=true.
+    // slew_in_progress=false → abort=true.
     assert!(
-        watcher_should_abort(&state, &session_slot).await,
-        "default DriverState has slew_in_progress=false → should abort"
+        watcher_should_abort(&slew_in_progress, &session_slot).await,
+        "slew_in_progress=false → should abort"
     );
 
     // With slew_in_progress=true and the session slot populated → no abort.
-    state.write().await.slew_in_progress = true;
+    slew_in_progress.store(true, Ordering::SeqCst);
     assert!(
-        !watcher_should_abort(&state, &session_slot).await,
+        !watcher_should_abort(&slew_in_progress, &session_slot).await,
         "in-progress slew with live device session → should continue"
     );
 
@@ -1344,7 +1458,7 @@ async fn watcher_should_abort_returns_true_when_slew_in_progress_cleared() {
         s.close().await.unwrap();
     }
     assert!(
-        watcher_should_abort(&state, &session_slot).await,
+        watcher_should_abort(&slew_in_progress, &session_slot).await,
         "user disconnect mid-slew → should abort"
     );
 }
@@ -1720,7 +1834,7 @@ async fn set_park_refuses_while_slew_in_progress() {
     seed_default_config(&path);
     let d = device_with_path(path);
     d.set_connected(true).await.unwrap();
-    d.state.write().await.slew_in_progress = true;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
     let err = d.set_park().await.unwrap_err();
     assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
 }
@@ -1779,7 +1893,7 @@ async fn set_park_refuses_when_wire_snapshot_reports_axis_running() {
     // slew_in_progress flag is still false — only the wire
     // snapshot is reporting motion. The new defence layer must
     // still refuse.
-    assert!(!d.state.read().await.slew_in_progress);
+    assert!(!d.slew_in_progress.load(Ordering::SeqCst));
     let err = d.set_park().await.unwrap_err();
     assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
     assert!(
@@ -1955,9 +2069,9 @@ async fn park_target_uses_preferred_ap_park_distinct_from_unpark_seed() {
 async fn reset_mount_encoders_writes_encoder_and_clears_state() {
     let d = connected_device().await;
     // Dirty the in-memory motion/target/tracking state a reset clears.
+    d.slew_in_progress.store(true, Ordering::SeqCst);
     {
         let mut s = d.state.write().await;
-        s.slew_in_progress = true;
         s.target_ra_hours = Some(5.0);
         s.target_dec_degrees = Some(10.0);
         s.tracking_requested = true;
@@ -1974,8 +2088,8 @@ async fn reset_mount_encoders_writes_encoder_and_clears_state() {
     assert_eq!(snap.ra.position_ticks, 12_345);
     assert_eq!(snap.dec.position_ticks, -6_789);
     // Driver-internal motion/target/tracking state is cleared.
+    assert!(!d.slew_in_progress.load(Ordering::SeqCst));
     let s = d.state.read().await;
-    assert!(!s.slew_in_progress);
     assert_eq!(s.target_ra_hours, None);
     assert_eq!(s.target_dec_degrees, None);
     assert!(!s.tracking_requested);
@@ -2190,11 +2304,8 @@ async fn unpark_from_ap_position_refuses_when_disconnected() {
 #[tokio::test]
 async fn unpark_from_ap_position_refuses_while_slewing() {
     let d = connected_device().await;
-    {
-        let mut s = d.state.write().await;
-        s.at_park = true;
-        s.slew_in_progress = true;
-    }
+    d.state.write().await.at_park = true;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
     let err = d
         .action("UnparkFromApPosition".to_string(), "ap_park_3".to_string())
         .await
@@ -3450,7 +3561,7 @@ async fn set_side_of_pier_refuses_while_parked() {
 #[tokio::test]
 async fn set_side_of_pier_refuses_while_slew_in_progress() {
     let d = flip_enabled_connected_device().await;
-    d.state.write().await.slew_in_progress = true;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
     let err = d.set_side_of_pier(PierSide::East).await.unwrap_err();
     assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
 }
@@ -3463,7 +3574,7 @@ async fn set_side_of_pier_to_current_side_succeeds_as_noop() {
     // pierWest. SetSideOfPier(West) is a no-op.
     d.set_side_of_pier(PierSide::West).await.unwrap();
     // State unchanged.
-    assert!(!d.state.read().await.slew_in_progress);
+    assert!(!d.slew_in_progress.load(Ordering::SeqCst));
 }
 
 #[tokio::test]
@@ -3475,8 +3586,8 @@ async fn set_side_of_pier_to_opposite_side_starts_a_flip_slew() {
     // completed in the mock (instant-settle config), so accept
     // either: the slew was either still in progress at this read,
     // or already finished with the encoder mutated.
+    let slewing = d.slew_in_progress.load(Ordering::SeqCst);
     let s = d.state.read().await;
-    let slewing = s.slew_in_progress;
     let target_set = s.target_ra_hours.is_some() && s.target_dec_degrees.is_some();
     drop(s);
     assert!(
@@ -3496,7 +3607,7 @@ async fn set_side_of_pier_to_opposite_side_starts_a_flip_slew() {
 
 use async_trait::async_trait;
 use rusty_photon_shared_transport::{FrameTransport, TransportError, TransportFactory};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::AtomicU32;
 
 /// Inject N consecutive transport failures and count `:L<axis>`
 /// frames that crossed the wire. Shared between the test and the
@@ -3730,7 +3841,6 @@ async fn reset_for_disconnect_clears_session_state_but_keeps_mechanical() {
         target_ra_hours: Some(12.0),
         target_dec_degrees: Some(45.0),
         slew_settle_time: Some(Duration::from_secs(7)),
-        slew_in_progress: true,
         park_ra_ticks: Some(1_000),
         park_dec_ticks: Some(-1_000),
         target_pier_side: Some(PierSide::East),
@@ -3746,7 +3856,6 @@ async fn reset_for_disconnect_clears_session_state_but_keeps_mechanical() {
     assert!(!s.tracking_requested);
     assert_eq!(s.target_ra_hours, None);
     assert_eq!(s.target_dec_degrees, None);
-    assert!(!s.slew_in_progress);
     assert_eq!(s.park_ra_ticks, None);
     assert_eq!(s.park_dec_ticks, None);
     assert!(!s.pulse_guiding_ra);

--- a/services/star-adventurer-gti/src/mount_device/tests.rs
+++ b/services/star-adventurer-gti/src/mount_device/tests.rs
@@ -1241,6 +1241,43 @@ async fn disconnect_clears_slew_in_progress() {
 }
 
 #[tokio::test]
+async fn slew_refuses_while_slew_already_in_progress() {
+    // `slew_to_coordinates_async` has no early slew_in_progress guard
+    // (unlike `set_side_of_pier`), so a slew issued while one is already
+    // in flight reaches the `SlewReservation::try_acquire` refusal in
+    // `execute_slew_with_explicit_side` rather than being rejected sooner.
+    let d = fast_settle_connected().await;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
+    let err = d.slew_to_coordinates_async(6.0, 30.0).await.unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    assert!(
+        err.message.contains("slew already in progress"),
+        "expected the reservation refusal, got: {}",
+        err.message
+    );
+    // try_acquire failed, so no guard armed and the early return did not
+    // clear the in-flight reservation.
+    assert!(d.slew_in_progress.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn park_refuses_while_slew_already_in_progress() {
+    // `park` reaches its own `SlewReservation::try_acquire` refusal when a
+    // slew/park is already in flight (it has no early slew_in_progress
+    // guard before the reservation either).
+    let d = fast_settle_connected().await;
+    d.slew_in_progress.store(true, Ordering::SeqCst);
+    let err = d.park().await.unwrap_err();
+    assert_eq!(err.code, ASCOMErrorCode::INVALID_OPERATION);
+    assert!(
+        err.message.contains("slew already in progress"),
+        "expected the reservation refusal, got: {}",
+        err.message
+    );
+    assert!(d.slew_in_progress.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
 async fn abort_slew_refuses_while_disconnected() {
     let d = fast_settle_device();
     let err = d.abort_slew().await.unwrap_err();

--- a/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
+++ b/services/star-adventurer-gti/src/mount_device/tracking_guard.rs
@@ -24,6 +24,7 @@
 //! [`crate::config::FlipPolicy::enabled`] — it is the safety floor that
 //! keeps an unattended autoguided session from contacting hardware.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -86,6 +87,7 @@ pub(super) async fn tracking_guard_tick(
     state: &Arc<RwLock<DriverState>>,
     manager: &MountManager,
     session_slot: &SessionSlot,
+    slew_in_progress: &AtomicBool,
     zone: (f64, f64),
     margin: f64,
 ) -> bool {
@@ -95,11 +97,8 @@ pub(super) async fn tracking_guard_tick(
     // it already keeps the guard dormant during slews; the
     // `slew_in_progress` check is belt-and-suspenders for the brief
     // post-slew tracking-restart window.
-    {
-        let s = state.read().await;
-        if !s.tracking_requested || s.slew_in_progress {
-            return false;
-        }
+    if !state.read().await.tracking_requested || slew_in_progress.load(Ordering::SeqCst) {
+        return false;
     }
     // `mech_HA` needs the per-axis CPR captured at handshake.
     let Some(params) = manager.parameters().await else {
@@ -165,6 +164,7 @@ pub(super) fn spawn_tracking_guard(
     state: Arc<RwLock<DriverState>>,
     manager: Arc<MountManager>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     config: MountConfig,
     polling_interval: Duration,
 ) {
@@ -181,7 +181,15 @@ pub(super) fn spawn_tracking_guard(
                 debug!("tracking-guard: session closed, exiting");
                 return;
             }
-            tracking_guard_tick(&state, &manager, &session_slot, zone, margin).await;
+            tracking_guard_tick(
+                &state,
+                &manager,
+                &session_slot,
+                &slew_in_progress,
+                zone,
+                margin,
+            )
+            .await;
         }
     });
 }

--- a/services/star-adventurer-gti/src/mount_device/watchers.rs
+++ b/services/star-adventurer-gti/src/mount_device/watchers.rs
@@ -15,11 +15,13 @@
 //! shared scaffold lives in [`run_completion_watcher`]; each spawner
 //! supplies an `on_axes_stopped` closure returning a
 //! [`CompletionDecision`] plus a [`FnOnce(&mut DriverState)`]
-//! finalizer that lands the per-operation state mutation under the
-//! same write lock that clears `slew_in_progress`. The pulse-guide
+//! finalizer that lands the per-operation state mutation under a
+//! `DriverState` write lock, after which the watcher clears the
+//! `slew_in_progress` atomic. The pulse-guide
 //! watcher has a different shape (no polling loop, axis-targeted
 //! restore) and stays as a standalone spawner.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -111,10 +113,10 @@ const WATCHER_POLL_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 /// commands (the EQMOD pickup re-slew or the post-slew tracking
 /// restart).
 pub(super) async fn watcher_should_abort(
-    state: &Arc<RwLock<DriverState>>,
+    slew_in_progress: &AtomicBool,
     session_slot: &SessionSlot,
 ) -> bool {
-    !state.read().await.slew_in_progress || user_disconnected(session_slot).await
+    !slew_in_progress.load(Ordering::SeqCst) || user_disconnected(session_slot).await
 }
 
 /// Retrying wrapper around [`MountManager::poll_axes_now`] used by
@@ -211,8 +213,9 @@ enum CompletionDecision {
     /// clears `slew_in_progress` on the way out.
     Bail,
     /// Per-operation work is done. The helper drops the polling
-    /// guard, sleeps `settle`, then runs the finalizer under the
-    /// same write lock that clears `slew_in_progress`.
+    /// guard, sleeps `settle`, runs the finalizer under a
+    /// `DriverState` write lock, then clears the `slew_in_progress`
+    /// atomic.
     Complete,
 }
 
@@ -242,7 +245,8 @@ enum CompletionDecision {
 ///   watcher's last `poll_axes_now` from before the completion step;
 ///   without this the reported RA lags by `(tracking_engagement +
 ///   settle) × sidereal rate`). After the settle, the finalizer
-///   runs under one write lock that also clears `slew_in_progress`.
+///   runs under a `DriverState` write lock, then the watcher clears
+///   the `slew_in_progress` atomic.
 ///
 /// The polling-pause guard is owned by an in-scope binding so every
 /// exit path releases it: the `Complete` branch drops it explicitly
@@ -256,6 +260,7 @@ async fn run_completion_watcher<C, F>(
     manager: Arc<MountManager>,
     session: Session<SkywatcherCodec>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     polling_interval: Duration,
     settle: Duration,
     context: &'static str,
@@ -281,7 +286,7 @@ async fn run_completion_watcher<C, F>(
         // `slew_in_progress` before issuing :L; set_connected(false)
         // also clears it. Either way, bail before overwriting
         // user-visible state.
-        if !state.read().await.slew_in_progress {
+        if !slew_in_progress.load(Ordering::SeqCst) {
             break;
         }
         // Belt-and-braces: if the user disconnected, exit even if
@@ -290,7 +295,7 @@ async fn run_completion_watcher<C, F>(
         // so `manager.is_available()` would lie — we look at the
         // device's session slot instead.
         if user_disconnected(&session_slot).await {
-            state.write().await.slew_in_progress = false;
+            slew_in_progress.store(false, Ordering::SeqCst);
             break;
         }
 
@@ -305,7 +310,7 @@ async fn run_completion_watcher<C, F>(
         let snap = match watcher_poll_with_retry(&manager, &session, context).await {
             Ok(s) => s,
             Err(_) => {
-                state.write().await.slew_in_progress = false;
+                slew_in_progress.store(false, Ordering::SeqCst);
                 break;
             }
         };
@@ -330,7 +335,7 @@ async fn run_completion_watcher<C, F>(
             let _ = manager
                 .send(&session, Command::InstantStop(Axis::Dec))
                 .await;
-            state.write().await.slew_in_progress = false;
+            slew_in_progress.store(false, Ordering::SeqCst);
             break;
         }
         if snap.ra.running || snap.dec.running {
@@ -339,7 +344,7 @@ async fn run_completion_watcher<C, F>(
         match on_axes_stopped(snap, &session).await {
             CompletionDecision::Continue => continue,
             CompletionDecision::Bail => {
-                state.write().await.slew_in_progress = false;
+                slew_in_progress.store(false, Ordering::SeqCst);
                 break;
             }
             CompletionDecision::Complete => {
@@ -360,9 +365,11 @@ async fn run_completion_watcher<C, F>(
                 // (~5-10″).
                 drop(_poll_guard);
                 tokio::time::sleep(settle).await;
-                let mut s = state.write().await;
-                on_finalize(&mut s);
-                s.slew_in_progress = false;
+                {
+                    let mut s = state.write().await;
+                    on_finalize(&mut s);
+                }
+                slew_in_progress.store(false, Ordering::SeqCst);
                 break;
             }
         }
@@ -401,6 +408,7 @@ async fn slew_completion_step(
     state: Arc<RwLock<DriverState>>,
     manager: Arc<MountManager>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     session: &Session<SkywatcherCodec>,
     config: MountConfig,
     polling_interval: Duration,
@@ -506,7 +514,7 @@ async fn slew_completion_step(
                 // transport) may have raced ahead. Without
                 // this second guard the pickup loop would
                 // restart motion after the user aborted.
-                if watcher_should_abort(&state, &session_slot).await {
+                if watcher_should_abort(&slew_in_progress, &session_slot).await {
                     return CompletionDecision::Bail;
                 }
                 // Pre-compensate the RA target for the LST drift
@@ -611,7 +619,7 @@ async fn slew_completion_step(
     // between the top-of-loop check and now must skip the
     // tracking restart, or the user-visible state would say
     // "aborted" while the wire is back to tracking.
-    if watcher_should_abort(&state, &session_slot).await {
+    if watcher_should_abort(&slew_in_progress, &session_slot).await {
         return CompletionDecision::Bail;
     }
     if tracking_was_on {
@@ -647,10 +655,12 @@ async fn slew_completion_step(
 /// `tracking_requested` flag is cleared by `slew_to_coordinates_async`
 /// so `tracking()` reports the wire state during the slew, hence we
 /// can't read it from `state` here.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn spawn_slew_completion_watcher(
     state: Arc<RwLock<DriverState>>,
     manager: Arc<MountManager>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     config: MountConfig,
     polling_interval: Duration,
     settle: Duration,
@@ -686,11 +696,13 @@ pub(super) async fn spawn_slew_completion_watcher(
         let helper_state = Arc::clone(&state);
         let helper_manager = Arc::clone(&manager);
         let helper_slot = Arc::clone(&session_slot);
+        let helper_flag = Arc::clone(&slew_in_progress);
         run_completion_watcher(
             helper_state,
             helper_manager,
             session,
             helper_slot,
+            helper_flag,
             polling_interval,
             settle,
             "slew_watcher",
@@ -704,6 +716,7 @@ pub(super) async fn spawn_slew_completion_watcher(
                     Arc::clone(&state),
                     Arc::clone(&manager),
                     Arc::clone(&session_slot),
+                    Arc::clone(&slew_in_progress),
                     watcher_session,
                     config.clone(),
                     polling_interval,
@@ -731,7 +744,8 @@ pub(super) async fn spawn_slew_completion_watcher(
 /// Same outer loop as [`spawn_slew_completion_watcher`] (provided
 /// by [`run_completion_watcher`]), but the per-axes-stopped step
 /// has no extra work to do, and the finalizer sets `at_park = true`
-/// in the same write lock that clears `slew_in_progress`. Park
+/// under the `DriverState` write lock just before the watcher clears
+/// the `slew_in_progress` atomic. Park
 /// always leaves tracking off per the ASCOM spec.
 ///
 /// A blocked-axis abort (handled inside [`run_completion_watcher`])
@@ -743,6 +757,7 @@ pub(super) async fn spawn_park_completion_watcher(
     state: Arc<RwLock<DriverState>>,
     manager: Arc<MountManager>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     polling_interval: Duration,
     settle: Duration,
 ) -> crate::error::Result<()> {
@@ -757,6 +772,7 @@ pub(super) async fn spawn_park_completion_watcher(
             manager,
             session,
             session_slot,
+            slew_in_progress,
             polling_interval,
             settle,
             "park_watcher",
@@ -788,6 +804,7 @@ pub(super) async fn spawn_pulse_guide_watcher(
     state: Arc<RwLock<DriverState>>,
     manager: Arc<MountManager>,
     session_slot: SessionSlot,
+    slew_in_progress: Arc<AtomicBool>,
     axis: Axis,
     duration: Duration,
     tracking_was_on_for_restore: bool,
@@ -815,8 +832,8 @@ pub(super) async fn spawn_pulse_guide_watcher(
             } else {
                 s.pulse_guiding_dec
             };
-            active && !s.at_park && !s.slew_in_progress
-        };
+            active && !s.at_park
+        } && !slew_in_progress.load(Ordering::SeqCst);
         if !still_active || user_disconnected(&session_slot).await {
             clear_pulse_flag(&state, axis).await;
             if let Err(e) = session.close().await {


### PR DESCRIPTION
## What

Extracts the duplicated `slew_in_progress` reservation pattern from `MountDevice::execute_slew_with_explicit_side` and `Telescope::park` into a `SlewReservation` RAII guard that rolls back on drop, removing the hand-written `if let Err(e) = result { ... }` rollback blocks at both call sites. Implements #264.

## How

The rollback has to be **synchronous** — a `Drop` impl can't `.await` the `DriverState` `RwLock` — so `slew_in_progress` moves out of `DriverState` into `MountDevice.slew_in_progress: Arc<AtomicBool>`. `SlewReservation::try_acquire` reserves the slot via `compare_exchange` (the same TOCTOU-free guarantee the old lock-guarded check-and-set gave), and the guard clears the flag on drop unless `dismiss()`'d. This mirrors the synchronous rollback-on-drop guard the `rusty-photon-shared-transport` `acquire()` path already uses (`RollbackGuard`).

Both sites now: reserve → `?`-propagate the motion sequence (any failure drops the guard → rollback) → spawn the completion watcher → `dismiss()`.

## Bonus: closes a latent leak

Both sites spawn the watcher *after* the old rollback point, as `spawn_*_watcher(...).await?`, and that spawn calls `transport.acquire().await?` before spawning. If `acquire()` failed, the method returned `Err` with `slew_in_progress` still `true` and **no watcher to ever clear it** — the driver would report `Slewing` forever. The guard `dismiss()`es only after a successful spawn, so a failed hand-off now rolls back.

## Scope

The atomic is threaded through the slew/park/pulse-guide completion watchers and the tracking guard; the disconnect path clears it in `set_connected(false)`. Externally observable behaviour is unchanged (the rollback stays synchronous, matching the prior code).

## Testing

- `cargo rail run --profile commit -q`: **427 tests pass, 0 skipped**.
- Workspace `cargo clippy --all --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` clean (enforced by the pre-commit hook).
- New deterministic tests for the previously-uncovered rollback path: `slew_rolls_back_slew_in_progress_when_motion_fails`, `park_rolls_back_slew_in_progress_when_motion_fails`, and `disconnect_clears_slew_in_progress`.

Closes #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
