### PR TITLE
chore(deps): bump reqwest from 0.13.3 to 0.13.4 (+ Bazel repin)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ parking_lot = "0.12.5"
 tokio-serial = "5.4.5"
 ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", branch = "integration", default-features = false }
 axum = "0.8"
-reqwest = { version = "0.13.3", features = ["form", "json"] }
+reqwest = { version = "0.13.4", features = ["form", "json"] }
 rp-auth = { path = "crates/rp-auth" }
 rp-catalog = { path = "crates/rp-catalog" }
 rp-ephemeris = { path = "crates/rp-ephemeris" }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2831,7 +2831,7 @@
         "usagesDigest": "6qni3jvstpF/aGbXbYi3ZaJKVny4hFi1ss0PrSsuerU=",
         "recordedFileInputs": {
           "@@//Cargo.lock": "d677b106521a70c0c13f42beeab8db62e5162b88fe0d14e9c855705b20918310",
-          "@@//Cargo.toml": "341ebc1ed0a19b40ca13d553c707a9b79eef6c7d904d4a280167a42761b28e63",
+          "@@//Cargo.toml": "c8407dc708a36929208f10d085ac4dc1bf454cfd072f2ccb99ed8a36399853d8",
           "@@//crates/bdd-infra/Cargo.toml": "84cc9e00bd9501ef3db346f297cc98c97fae5ebbc33d58968a112753e993a462",
           "@@//crates/rp-auth/Cargo.toml": "5689e64d63137e20f3be8432e098b88e7395bbd337005175cda1d2a0289a161d",
           "@@//crates/rp-catalog/Cargo.toml": "d23dde986b9bf93e9b39ca21dcfe79c9098b078030daab5db112da9fe2558000",


### PR DESCRIPTION
Supersedes #318 — dependabot's `reqwest` 0.13.3 → 0.13.4 bump, rebased onto current `main` to clear its merge conflict, plus the Bazel crate-index repin that dependabot can't perform itself.

### Changes
- **`Cargo.toml`** — `reqwest` `0.13.3` → `0.13.4` (workspace dependency). Cherry-picked from #318 with dependabot authorship preserved.
- **`MODULE.bazel.lock`** — `CARGO_BAZEL_REPIN=1 bazel mod tidy`; refreshes the recorded `//Cargo.toml` hash only. No crate entries changed.

### Why `Cargo.lock` is unchanged
`main` already locked `reqwest` at `0.13.4` (via #329) because the prior `"0.13.3"` requirement is really `^0.13.3`. This PR just aligns the **declared** version with what was already resolved, so there is no lockfile churn.

### Verification
- `cargo rail run --profile commit` (full workspace — root-manifest change flips rail to `infra` mode): **2591 passed, 10 skipped**.
- Pre-commit hook: clippy `-D warnings` + `cargo fmt --check` clean.

Once merged, #318 is obsolete (closed as superseded).
