### PR TITLE
ci(bazel): surface rp:bdd BDD-TRACE breadcrumbs in coverage runs

### DIFF
--- a/.github/workflows/bazel-coverage.yml
+++ b/.github/workflows/bazel-coverage.yml
@@ -95,9 +95,16 @@ jobs:
           # not sensitive to rc precedence (command line always wins).
           # --remote_download_outputs=all overrides build:ci's `toplevel` so the
           # combined lcov and its per-test .dat inputs are materialised locally.
+          # --test_output=all surfaces rp:bdd's unbuffered BDD-TRACE breadcrumbs
+          # (ENTER / reset-ok / EXIT, tagged +Ns) even on a *passing* run — parity
+          # with the BDD leg in bazel.yml. The default --test_output=errors hides
+          # the per-scenario timing on the slow-but-passing rp:bdd runs, which are
+          # exactly the runs that occasionally cross this job's 60-min cancel.
+          # (A run that actually times out still won't flush them — see PR.)
           bazel coverage --config=ci --config=coverage "${REMOTE_FLAGS[@]}" \
             --test_tag_filters=-requires-cargo \
             --remote_download_outputs=all \
+            --test_output=all \
             //...
 
       - name: Split combined lcov per package


### PR DESCRIPTION
## What
Add `--test_output=all` to the `bazel coverage` invocation in `bazel-coverage.yml`.

## Why
The bazel-coverage shadow job is where `//services/rp:bdd`'s coverage-instrumentation slowness actually bites — under `-Cinstrument-coverage` rp:bdd runs ~36 min (vs ~370 s un-instrumented) and *occasionally crosses this job's 60-min cancel*. But the job runs with the default `--test_output=errors`, so a slow-but-**passing** rp:bdd prints nothing. The per-scenario `BDD-TRACE` breadcrumbs added in #336 (`ENTER → reset-ok → EXIT`, tagged `+Ns`) only surface on the **`bazel.yml`** BDD leg, which already uses `--test_output=all`.

This brings the coverage job to parity, so a completing coverage run reveals where the ~36 min goes:
- `ENTER → reset-ok` = per-scenario OmniSim device reset
- `reset-ok → EXIT` = the scenario steps

## Limitation
`--test_output=all` only prints on test **completion**, so a coverage run that actually hits the 60-min timeout still won't flush rp:bdd's breadcrumbs. Capturing a timed-out run is a follow-up: either `--test_output=streamed` (serializes all targets — too slow for `//...`) or upload `bazel-testlogs/services/rp/bdd/test.log` as an `if: always()` artifact.

Non-required shadow workflow; CI-config only, no production code.