### PR TITLE
fix(bazel-coverage): make shadow badges reliable, bound the rp:bdd hang, collect child coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -205,16 +205,33 @@ test:conformu --test_env=CONFORMU_PATH
 # `bazel coverage --config=coverage` needs OmniSim installed + OMNISIM_PATH set,
 # exactly like a local `bazel test --test_tag_filters=bdd` run.
 #
-# Child-process coverage caveat: under `bazel coverage //...` the spawned service
-# binaries ARE instrumented (first-party top-level targets matching the filter),
-# but whether their .profraw is COLLECTED depends on Bazel/rules_rust propagating
-# a unique LLVM_PROFILE_FILE to each spawned child and merging it back. Validate
-# in the first CI run by diffing bazel-<service> vs <service> coverage; see
-# docs/plans/bazel-migration.md for the contingency if child coverage is missing.
+# Child-process coverage: under `bazel coverage //...` the spawned service
+# binaries ARE instrumented (first-party top-level targets matching the filter).
+# To COLLECT their .profraw, bdd-infra's spawn path sets a per-child
+# LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw when COVERAGE_DIR is set
+# (child_coverage_profile_var in crates/bdd-infra/src/lib.rs), so each child
+# writes into the directory Bazel's lcov merger consumes. Validate it works by
+# diffing bazel-<service> vs <service> coverage; see docs/plans/bazel-migration.md.
 coverage:coverage --@rules_rust//rust/toolchain/channel=nightly
 coverage:coverage --@rules_rust//rust/settings:extra_rustc_flags=--cfg=coverage_nightly
 coverage:coverage --instrumentation_filter=^//crates,^//services
 coverage:coverage --combined_report=lcov
+# Cap any single coverage test. An instrumented BDD suite (observed:
+# //services/rp:bdd stalling under instrumentation while it spawns OmniSim) can
+# hang indefinitely; the size=large (900s) timeout was observed NOT to fire
+# under `bazel coverage`, so the action ran to the CI job's 60-min wall and
+# uploaded nothing. An explicit --test_timeout kills the hang and marks it
+# FAILED; with --keep_going (set above) the rest of the report still builds, and
+# bazel-coverage.yml tolerates the resulting "tests failed" exit so the coverage
+# of every target that DID pass still uploads. 900s preserves rp:bdd's intended
+# budget (~400s warm) while bounding a hang at minutes, not the full hour.
+# NB: the single-value form is a fleet-wide override — it caps EVERY coverage
+# test at 900s, so a future coverage target needing more must switch this to the
+# 4-value form (short,moderate,long,eternal). Both OmniSim BDD targets are 900s
+# (size=large) today. If this still doesn't kill a hang under coverage (the
+# size-derived timeout didn't), exclude the two OmniSim spawners instead — see
+# docs/plans/bazel-migration.md.
+coverage:coverage --test_timeout=900
 # conformu is excluded from coverage too: it drives the external ConformU tool
 # (not instrumented) and only runs when CONFORMU_PATH is set.
 coverage:coverage --test_tag_filters=-requires-cargo,-conformu

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -21,3 +21,25 @@ ignore:
 comment:
   layout: "files"
   require_changes: true
+
+# Flag carryforward (ref: https://docs.codecov.com/docs/carryforward-flags).
+# When a commit does not re-upload a given flag, Codecov backfills that flag's
+# last-known coverage so the per-service badges stay populated instead of
+# flipping to "unknown". Two jobs depend on this:
+#   * Cargo (test.yml): narrows uploads to the changed packages via cargo-rail,
+#     so most commits upload only a subset of flags.
+#   * Bazel shadow (bazel-coverage.yml): uploads every bazel-<pkg> flag each run,
+#     but the run is sometimes cancelled (an instrumented-BDD hang hitting the
+#     60-min wall), uploading nothing for that commit.
+# Declaring carryforward here makes it explicit and version-controlled for every
+# flag, and — critically — applies it to the bazel-<pkg> shadow flags, which had
+# no carried baseline and rendered "unknown" on every commit whose bazel-coverage
+# run was cancelled. Carryforward is applied when an upload is processed, so the
+# badges fill in on the next main commit that uploads, not retroactively.
+# Note: the project status (above) has no `flags:` filter, so carried-forward
+# bazel-<pkg> data now enters its merged report; this cannot regress the gate
+# (Codecov merges flags by union, and bazel-* covers a subset of the Cargo lines,
+# so the merged % only stays equal or rises). See docs/plans/bazel-migration.md.
+flag_management:
+  default_rules:
+    carryforward: true

--- a/.github/workflows/bazel-coverage.yml
+++ b/.github/workflows/bazel-coverage.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: bazel coverage
         run: |
+          set -uo pipefail
           REMOTE_FLAGS=(--config=remote-cache)
           if [[ -n "$CACHE_WRITE_TOKEN" ]]; then
             REMOTE_FLAGS+=(--remote_header="Authorization=Bearer $CACHE_WRITE_TOKEN")
@@ -89,16 +90,38 @@ jobs:
             REMOTE_FLAGS+=(--remote_upload_local_results=false)
           fi
           # --config=coverage selects the nightly channel + --cfg=coverage_nightly
-          # + --combined_report=lcov + first-party instrumentation filter (.bazelrc).
-          # --test_tag_filters=-requires-cargo INCLUDES the BDD suite; it is also
-          # set by --config=coverage but pinned here on the command line so CI is
-          # not sensitive to rc precedence (command line always wins).
-          # --remote_download_outputs=all overrides build:ci's `toplevel` so the
-          # combined lcov and its per-test .dat inputs are materialised locally.
+          # + --combined_report=lcov + first-party instrumentation filter +
+          # --test_timeout=900 (.bazelrc). --test_tag_filters=-requires-cargo
+          # INCLUDES the BDD suite; it is also set by --config=coverage but pinned
+          # here on the command line so CI is not sensitive to rc precedence
+          # (command line always wins). --remote_download_outputs=all overrides
+          # build:ci's `toplevel` so the combined lcov and its per-test .dat inputs
+          # are materialised locally.
+          # Capture bazel's exit code. `|| status=$?` is robust whether or not
+          # `set -e` is active (GitHub's default step shell adds `-eo pipefail`):
+          # the `||` keeps a non-zero exit from aborting the step and records the
+          # code, so the classification below can tell exit 3 (tests failed/timed
+          # out — tolerated) from a real build failure.
+          status=0
           bazel coverage --config=ci --config=coverage "${REMOTE_FLAGS[@]}" \
             --test_tag_filters=-requires-cargo \
             --remote_download_outputs=all \
-            //...
+            //... || status=$?
+          # Bazel exit codes: 0 = everything passed; 3 = build OK but one or more
+          # tests FAILED or TIMED OUT. In shadow coverage we tolerate 3: with
+          # --keep_going every other target still ran, the --combined_report still
+          # builds from their coverage.dat, and the split/upload steps below then
+          # publish the coverage of everything that DID pass. This converts a
+          # single instrumented-BDD hang (killed by --test_timeout) from a 60-min
+          # job-cancel-with-no-output into an uploaded partial report. Any other
+          # non-zero (1 build error, 2 bad flags, 4 no tests, 8 interrupted, ...)
+          # is a real failure and aborts the job.
+          if [[ $status -eq 3 ]]; then
+            echo "::warning::Some coverage tests failed or timed out (bazel exit 3); uploading partial coverage for the targets that passed."
+          elif [[ $status -ne 0 ]]; then
+            echo "::error::bazel coverage failed (exit $status)"
+            exit "$status"
+          fi
 
       - name: Split combined lcov per package
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cross-platform [ASCOM Alpaca](https://ascom-standards.org/Developer/Alpaca.htm) 
 
 ## Services
 
-Coverage has two columns: **Cargo** is the canonical, required coverage; **Bazel** is the shadow-mode `bazel coverage` job (`.github/workflows/bazel-coverage.yml`), uploaded under `bazel-<pkg>` Codecov flags. The Bazel badges read "unknown" until that workflow has run on `main`.
+Coverage has two columns: **Cargo** is the canonical, required coverage; **Bazel** is the shadow-mode `bazel coverage` job (`.github/workflows/bazel-coverage.yml`), uploaded under `bazel-<pkg>` Codecov flags. During shadow mode the Bazel badges reflect the most recent `main` commit whose `bazel-coverage` run completed (Codecov carries the last value forward when a run is cancelled), so they may lag the Cargo badges — and may read lower where BDD child-process coverage is still being validated. They are not gating; the goal is Cargo↔Bazel parity before cutover.
 
 | Service | Type | Port | Coverage (Cargo) | Coverage (Bazel) | Description |
 |---------|------|------|------------------|------------------|-------------|

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -105,8 +105,16 @@ pub fn __bdd_bazel_chdir() {
         return;
     };
     let cwd = std::env::current_dir().expect("bdd_main: current_dir");
+    // Absolutize relative paths that must survive the chdir below: the
+    // `*_BINARY` discovery vars, and (under `bazel coverage`) `COVERAGE_DIR`,
+    // from which spawned children derive their `LLVM_PROFILE_FILE` at spawn time
+    // — by then the cwd is `BDD_PACKAGE_DIR`, so a relative `COVERAGE_DIR` would
+    // resolve wrong. Bazel sets it absolute today; this keeps us correct if it
+    // ever doesn't. See [`child_coverage_profile_var`].
     let to_absolutize: Vec<(String, String)> = std::env::vars()
-        .filter(|(k, v)| k.ends_with("_BINARY") && std::path::Path::new(v).is_relative())
+        .filter(|(k, v)| {
+            (k.ends_with("_BINARY") || k == "COVERAGE_DIR") && std::path::Path::new(v).is_relative()
+        })
         .collect();
     for (k, v) in to_absolutize {
         std::env::set_var(&k, cwd.join(v));
@@ -137,6 +145,41 @@ use tracing::debug;
 /// `ppba-driver` → `PPBA_DRIVER_BINARY`, `rp` → `RP_BINARY`, and so on.
 fn binary_env_var(package_name: &str) -> String {
     format!("{}_BINARY", package_name.to_uppercase().replace('-', "_"))
+}
+
+/// Per-child `LLVM_PROFILE_FILE` for coverage collection under `bazel coverage`.
+///
+/// Under `bazel coverage` rules_rust instruments the first-party service
+/// binaries and sets `COVERAGE_DIR` for the test action, but only the test
+/// process's own `.profraw` is collected by default — a spawned child inherits
+/// the parent test's `LLVM_PROFILE_FILE` and would clobber it. Point each child
+/// at a distinct file inside `COVERAGE_DIR` (`<pkg>-<pid>-<sig>.profraw`, via the
+/// LLVM `%p`/`%m` patterns) so Bazel's lcov merger — which globs that directory —
+/// folds the child's coverage into the combined report. This is the
+/// child-process-coverage contingency from `docs/plans/bazel-migration.md`.
+///
+/// Returns `None` when `COVERAGE_DIR` is unset: under plain `bazel test`, and
+/// under `cargo`/`cargo-llvm-cov` (which sets `LLVM_PROFILE_FILE`, not
+/// `COVERAGE_DIR`), leaving those paths untouched.
+fn child_coverage_profile_var(package_name: &str) -> Option<(&'static str, std::ffi::OsString)> {
+    let coverage_dir = std::env::var_os("COVERAGE_DIR")?;
+    Some((
+        "LLVM_PROFILE_FILE",
+        child_coverage_profile_path(&coverage_dir, package_name),
+    ))
+}
+
+/// Build the `<COVERAGE_DIR>/<pkg>-%p-%m.profraw` path. Split out from
+/// [`child_coverage_profile_var`] so the path construction is unit-testable
+/// without mutating process env. `%p` (pid) and `%m` (binary signature) keep
+/// each spawned child's file distinct from the parent's and from each other.
+fn child_coverage_profile_path(
+    coverage_dir: &std::ffi::OsStr,
+    package_name: &str,
+) -> std::ffi::OsString {
+    let mut path = std::path::PathBuf::from(coverage_dir);
+    path.push(format!("{package_name}-%p-%m.profraw"));
+    path.into_os_string()
 }
 
 /// Handle to a running service process.
@@ -316,6 +359,9 @@ pub fn run_once(
 
     let mut cmd = std::process::Command::new(&binary);
     cmd.args(args);
+    if let Some((key, value)) = child_coverage_profile_var(package_name) {
+        cmd.env(key, value);
+    }
 
     if let Some(data) = stdin_data {
         cmd.stdin(std::process::Stdio::piped());
@@ -428,6 +474,10 @@ fn spawn_process(binary: &str, package_name: &str, args: &[&str]) -> tokio::proc
     debug!(binary = %binary, ?args, "starting {} from pre-built binary", package_name);
     let mut cmd = tokio::process::Command::new(binary);
     cmd.args(args).stdout(Stdio::piped()).kill_on_drop(true);
+    if let Some((key, value)) = child_coverage_profile_var(package_name) {
+        debug!(profile = ?value, "routing {} child coverage into COVERAGE_DIR", package_name);
+        cmd.env(key, value);
+    }
     #[cfg(windows)]
     {
         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
@@ -726,6 +776,36 @@ mod tests {
         assert_eq!(value, "relative/path");
     }
 
+    #[test]
+    fn test_bdd_bazel_chdir_absolutizes_coverage_dir() {
+        let _lock = CWD_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("pkg");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let previous = std::env::current_dir().unwrap();
+        let saved_cov = std::env::var_os("COVERAGE_DIR");
+        std::env::set_var("COVERAGE_DIR", "relative/cov/dir");
+        std::env::set_var("BDD_PACKAGE_DIR", &target);
+
+        __bdd_bazel_chdir();
+
+        let absolutized = std::env::var("COVERAGE_DIR").unwrap();
+        std::env::set_current_dir(&previous).unwrap();
+        std::env::remove_var("BDD_PACKAGE_DIR");
+        match saved_cov {
+            Some(v) => std::env::set_var("COVERAGE_DIR", v),
+            None => std::env::remove_var("COVERAGE_DIR"),
+        }
+
+        // COVERAGE_DIR is absolutized like the *_BINARY vars so a spawned
+        // child's LLVM_PROFILE_FILE still resolves after the chdir.
+        assert_eq!(
+            std::path::PathBuf::from(&absolutized),
+            previous.join("relative/cov/dir")
+        );
+    }
+
     // -----------------------------------------------------------------------
     // binary_env_var tests
     // -----------------------------------------------------------------------
@@ -735,6 +815,66 @@ mod tests {
         assert_eq!(binary_env_var("rp"), "RP_BINARY");
         assert_eq!(binary_env_var("ppba-driver"), "PPBA_DRIVER_BINARY");
         assert_eq!(binary_env_var("qhy-focuser"), "QHY_FOCUSER_BINARY");
+    }
+
+    // -----------------------------------------------------------------------
+    // child_coverage_profile_path tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_child_coverage_profile_path_joins_dir_and_llvm_pattern() {
+        let path = child_coverage_profile_path(std::ffi::OsStr::new("/cov/dir"), "rp");
+        let path = std::path::PathBuf::from(path);
+        // Distinct per-child file inside COVERAGE_DIR; %p/%m keep it unique.
+        assert_eq!(
+            path.file_name().unwrap(),
+            std::ffi::OsStr::new("rp-%p-%m.profraw")
+        );
+        assert_eq!(path.parent().unwrap(), std::path::Path::new("/cov/dir"));
+    }
+
+    #[test]
+    fn test_child_coverage_profile_path_preserves_dashed_package_name() {
+        let path = child_coverage_profile_path(std::ffi::OsStr::new("/c"), "ppba-driver");
+        let path = std::path::PathBuf::from(path);
+        assert_eq!(
+            path.file_name().unwrap(),
+            std::ffi::OsStr::new("ppba-driver-%p-%m.profraw")
+        );
+    }
+
+    #[test]
+    fn test_child_coverage_profile_var_gates_on_coverage_dir() {
+        // The COVERAGE_DIR gate is the invariant that keeps the cargo /
+        // cargo-llvm-cov and plain `bazel test` paths untouched: no
+        // COVERAGE_DIR => no child env override. CWD_LOCK serialises the
+        // env mutation against the other COVERAGE_DIR-touching test.
+        let _lock = CWD_LOCK.lock().unwrap();
+        let saved = std::env::var_os("COVERAGE_DIR");
+
+        std::env::remove_var("COVERAGE_DIR");
+        let unset = child_coverage_profile_var("rp");
+
+        std::env::set_var("COVERAGE_DIR", "/cov/dir");
+        let set = child_coverage_profile_var("rp");
+
+        match saved {
+            Some(v) => std::env::set_var("COVERAGE_DIR", v),
+            None => std::env::remove_var("COVERAGE_DIR"),
+        }
+
+        assert!(
+            unset.is_none(),
+            "without COVERAGE_DIR the child env must be left untouched"
+        );
+        let (key, value) = set.expect("COVERAGE_DIR set => LLVM_PROFILE_FILE override");
+        assert_eq!(key, "LLVM_PROFILE_FILE");
+        let value = std::path::PathBuf::from(value);
+        assert_eq!(value.parent().unwrap(), std::path::Path::new("/cov/dir"));
+        assert_eq!(
+            value.file_name().unwrap(),
+            std::ffi::OsStr::new("rp-%p-%m.profraw")
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -362,13 +362,77 @@ the whole directory.
 
 **Validate in run #1** by diffing each `bazel-<service>` flag against `<service>`
 (Cargo). If a service's Bazel coverage is materially lower, child-process
-profraw is being dropped. **Contingency:** have `bdd-infra`'s spawn path set
-`LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw` on each child `Command`
-only when `COVERAGE_DIR` is set (Bazel-only — cargo-llvm-cov sets
-`LLVM_PROFILE_FILE`, not `COVERAGE_DIR`, so the Cargo path is untouched), so
-every child writes a distinct file into the directory Bazel's lcov merger
-consumes. Each service's BDD coverage still caches independently, same as the
-unit/integration actions.
+profraw is being dropped. The first runs confirmed exactly that — e.g.
+`bazel-filemonitor` ≈ 61 % vs Cargo `filemonitor` ≈ 97 %, `bazel-rp` ≈ 73 % vs
+`rp` ≈ 95 % — so the **contingency is now implemented**: `bdd-infra`'s spawn path
+([`child_coverage_profile_var`] in `crates/bdd-infra/src/lib.rs`, applied in
+`spawn_process` and `run_once`) sets
+`LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw` on each child `Command`,
+but only when `COVERAGE_DIR` is set. That gate makes it Bazel-coverage-only:
+plain `bazel test` and `cargo`/`cargo-llvm-cov` (which sets `LLVM_PROFILE_FILE`,
+not `COVERAGE_DIR`) are untouched. `bdd_main!` absolutizes `COVERAGE_DIR` before
+its chdir, alongside the `*_BINARY` vars, so the child's path resolves correctly.
+
+**This is necessary but may not be sufficient — know what run #1 can and cannot
+show.** Reading `rules_rust` 0.70.0's `util/collect_coverage/collect_coverage.rs`:
+it globs *every* `*.profraw` in `COVERAGE_DIR` into the `llvm-profdata merge`
+(so each child's counters ARE folded into the `.profdata`), but the subsequent
+`llvm-cov export` is passed exactly one object — the test binary — and no
+`-object` for the spawned service binaries. `llvm-cov` only emits coverage for
+functions whose coverage-mapping lives in the objects on its command line.
+Consequence: a spawned child's counters land in the profdata, but are exported
+only for code whose mapping is *also* in the `rust_test` binary — i.e. library
+crates the BDD target links (`rp:bdd` deps `:rp_lib`), not binary-only code
+(`main.rs`, startup/shutdown). So this change can lift the library-level numbers
+but will not, on its own, capture binary-only paths. **Run-#1 rubric:** re-diff
+`bazel-<service>` vs `<service>`. If the gap closes, done. If `bazel-<service>`
+stays near its pre-change value despite child `*.profraw` appearing in
+`COVERAGE_DIR`, the cause is the single-`-object` export above (not a wiring
+bug) — the fix is export-side: add the spawned binaries as `-object`s (a custom
+post-merge `llvm-cov export`, or a `rules_rust` change), or fall back to
+collecting those suites' coverage Cargo-style. Do **not** revert this wiring;
+it is the prerequisite that puts the child profraw where any export-side fix
+needs it.
+
+**Badge reliability (carryforward).** The `bazel-<pkg>` badges read "unknown"
+not from a wiring fault but because a Codecov *branch* badge resolves to the
+branch HEAD, and the shadow job uploads nothing whenever its run is cancelled.
+`.github/codecov.yml` now sets `flag_management.default_rules.carryforward:
+true`, so a commit that doesn't re-upload a flag inherits its last-known value
+instead of rendering "unknown". This makes carryforward explicit and
+version-controlled for every flag (the Cargo badges already behaved this way —
+the Cargo job narrows uploads to changed packages via cargo-rail yet all its
+badges stay populated — but in-repo there was no declaration of it). It
+decouples badge health from per-commit upload success.
+
+Two caveats. (1) **Not retroactive.** Codecov applies carryforward while
+*processing an upload*, so the currently-"unknown" badges do not populate the
+instant this config lands — they fill in on the next `main` commit whose
+`bazel-coverage` run uploads at least one report (HEAD's parent already carries
+real bazel data to inherit from). For an immediate fix, re-run the cancelled
+HEAD job or push a no-op `main` commit. (2) **Gating status.** The
+`coverage.status.project` gate has no `flags:` filter, so it runs on the merged
+report across all flags; with carryforward on, the partial `bazel-<pkg>` data is
+now carried into that merge. This cannot regress the 1 % drop gate — Codecov
+merges flags by union (a line is covered if *any* flag covers it) and `bazel-*`
+covers a strict subset of the first-party lines Cargo already covers, so the
+merged % is non-decreasing. If you want the gate kept strictly Cargo-only during
+shadow mode, scope `status.project.default.flags` to the Cargo flags.
+
+**The instrumented `rp:bdd` hang.** ~half of push-to-main coverage runs were
+cancelled at the 60-min job wall: `//services/rp:bdd` intermittently hangs under
+instrumentation while spawning OmniSim, and its `size = "large"` (900s) timeout
+was observed *not* to fire under `bazel coverage`, so nothing killed it and the
+run uploaded zero coverage. Two guards now bound the blast radius:
+`.bazelrc` `coverage:coverage --test_timeout=900` caps any single coverage test
+explicitly, and `bazel-coverage.yml` tolerates a "tests failed/timed out" exit
+(Bazel exit 3) so the combined report — built by `--keep_going` from every
+target that *did* pass — still splits and uploads. The underlying hang (an
+unbounded Alpaca poll under instrumentation, per the OmniSim flake family in the
+service docs) is the remaining reliability item; if the explicit `--test_timeout`
+also proves not to fire under coverage, the fallback is to exclude
+`//services/rp:bdd` + `//services/calibrator-flats:bdd` (the two OmniSim
+spawners) from the coverage graph and collect their BDD coverage separately.
 
 This supersedes the Phase 7 note that coverage stays a Cargo-only gate: coverage
 now has a Bazel shadow path, to be validated in CI before any cutover.


### PR DESCRIPTION
## Problem

The shadow-mode `bazel-<pkg>` coverage badges on the README all read **"unknown"**. This is **not** a wiring fault and Bazel coverage **does** collect real data (verified via the Codecov per-commit API: `bazel-filemonitor` ≈ 61 %, `bazel-rp` ≈ 73 % on commit `f1f442a`). The "unknown" is a chain of three things:

1. A Codecov **branch badge resolves to main's HEAD** commit.
2. **~half of push-to-main `bazel-coverage` runs are cancelled at the 60-min wall** — the instrumented `//services/rp:bdd` hangs under instrumentation and its `size=large` (900 s) timeout was observed *not* to fire under `bazel coverage` — so HEAD frequently has **no `bazel-*` upload**.
3. With **no carryforward** configured, a flag absent on HEAD renders "unknown" instead of the last-known value. (The Cargo badges already survive their own narrowed, cargo-rail uploads precisely because carryforward backfills them.)

## Fixes

### 1 — Badge reliability (`.github/codecov.yml`, `README.md`)
`flag_management.default_rules.carryforward: true` so a commit that doesn't re-upload a flag inherits its last-known value, decoupling badge health from per-commit upload success. Corrected the stale README note (it claimed badges read "unknown until that workflow has run on `main`" — it has, many times).

> ⚠️ Carryforward is applied at **upload-processing time**, so the currently-"unknown" badges fill in on the **next main commit whose run uploads**, not retroactively to the already-cancelled HEAD. For an immediate green badge, re-run the cancelled HEAD job or land a no-op commit on main.

### 2 — Operational hang (`.bazelrc`, `.github/workflows/bazel-coverage.yml`)
- Explicit, enforced `coverage:coverage --test_timeout=900` so a hung suite is killed and marked FAILED rather than running to the job wall.
- The `bazel coverage` step now tolerates Bazel **exit 3** (tests failed/timed out): with `--keep_going` the combined report still builds from every target that passed, so a single hung suite no longer zeroes the whole upload — partial coverage publishes.
- Documented fallback (exclude the two OmniSim-spawning BDD targets) if the explicit timeout also proves inert under coverage.

### 3 — Child-process parity (`crates/bdd-infra/src/lib.rs`)
Each spawned service binary's coverage is routed into `COVERAGE_DIR` via a per-child `LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw`, set in `spawn_process`/`run_once` **only when `COVERAGE_DIR` is present** (Bazel-coverage-only; `cargo`/`cargo-llvm-cov` and plain `bazel test` untouched). `COVERAGE_DIR` is absolutized in `bdd_main!` before the chdir. +4 unit tests.

> ⚠️ **Necessary but possibly insufficient.** Verified against `rules_rust` 0.70.0 `collect_coverage.rs`: it merges *every* `COVERAGE_DIR` profraw into the profdata ✓, but `llvm-cov export` is passed only the **test binary** as `-object`. So a child's coverage is exported only where its mapping is *also* linked into the `rust_test` target (`rp_lib`), not binary-only code (`main.rs`). Run #1 validates per service; if the gap stays wide the follow-up is export-side (add spawned binaries as `-object`s). `docs/plans/bazel-migration.md` carries the diagnosis + run-#1 rubric.

## Verification

- `cargo fmt` clean; `cargo rail` commit profile = **1915 tests pass across 13 affected crates**; pre-commit hook ran `clippy --all --all-targets --all-features -D warnings` + `fmt --check` clean.
- `codecov.yml` validated against the Codecov API (`Valid!`).
- Diagnosis and the diff were each put through a multi-agent **adversarial review** (the review refuted one false "second defect" and confirmed the rules_rust export limitation); final verdict **ship**, no blockers.

## Notes for review

- The `bazel-coverage` job is **non-gating** (shadow mode), so this is low-risk to merge.
- `default_rules.carryforward: true` also makes the Cargo flags' existing carryforward explicit. The gating `project` status now includes carried-forward `bazel-*` data, but Codecov merges flags by **union** (a line is covered if any flag covers it) and `bazel-*` covers a subset of the Cargo lines, so the merged % is non-decreasing — it cannot trip the 1 % drop gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)