### PR TITLE
feat(bazel-coverage): export spawned-binary coverage (close BDD parity gap)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -205,13 +205,16 @@ test:conformu --test_env=CONFORMU_PATH
 # `bazel coverage --config=coverage` needs OmniSim installed + OMNISIM_PATH set,
 # exactly like a local `bazel test --test_tag_filters=bdd` run.
 #
-# Child-process coverage: under `bazel coverage //...` the spawned service
-# binaries ARE instrumented (first-party top-level targets matching the filter).
-# To COLLECT their .profraw, bdd-infra's spawn path sets a per-child
+# Child-process coverage (two halves): under `bazel coverage //...` the spawned
+# service binaries ARE instrumented (first-party targets matching the filter).
+# (1) COLLECT: bdd-infra's spawn path sets a per-child
 # LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%p-%m.profraw when COVERAGE_DIR is set
-# (child_coverage_profile_var in crates/bdd-infra/src/lib.rs), so each child
-# writes into the directory Bazel's lcov merger consumes. Validate it works by
-# diffing bazel-<service> vs <service> coverage; see docs/plans/bazel-migration.md.
+# (child_coverage_profile_var in crates/bdd-infra/src/lib.rs), so each child's
+# counters land in the merged profdata. (2) EXPORT: a pinned rules_rust patch
+# (MODULE.bazel single_version_override) adds each spawned binary as an
+# `llvm-cov export -object` via the RUST_COVERAGE_EXTRA_OBJECTS env var set on the
+# BDD/integration targets — without it the merged child counters have no covmap
+# to bind to and are dropped. See docs/plans/bazel-migration.md.
 coverage:coverage --@rules_rust//rust/toolchain/channel=nightly
 coverage:coverage --@rules_rust//rust/settings:extra_rustc_flags=--cfg=coverage_nightly
 coverage:coverage --instrumentation_filter=^//crates,^//services

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -36,3 +36,24 @@ jobs:
       # on ubuntu-latest.
       - name: Check Bazel/Cargo target parity
         run: ./scripts/check-bazel-cargo-parity.sh
+
+      # Guard the pinned rules_rust coverage patch (MODULE.bazel
+      # single_version_override -> third_party/patches/collect_coverage_extra_objects.patch).
+      # It teaches collect_coverage to export spawned-binary coverage via
+      # RUST_COVERAGE_EXTRA_OBJECTS; a rules_rust bump that drops or relocates it
+      # would silently regress BDD child-process coverage. A non-applying patch
+      # already fails every bazel command (fetch-time error); this asserts an
+      # applied-but-ineffective patch is caught too, by requiring both the env-var
+      # marker AND the structural anchor (the find_extra_object helper) to survive.
+      # --nobuild forces the fetch+patch without compiling the collector; the
+      # behavioural backstop is the bazel-coverage shadow job, which compiles and
+      # runs the patched collector on every PR.
+      - name: Guard - rules_rust coverage patch applied & effective
+        run: |
+          bazel build --nobuild @rules_rust//util/collect_coverage:collect_coverage
+          src="$(bazel info output_base)/external/rules_rust+/util/collect_coverage/collect_coverage.rs"
+          if ! grep -q 'RUST_COVERAGE_EXTRA_OBJECTS' "$src" || ! grep -q 'fn find_extra_object' "$src"; then
+            echo "::error::collect_coverage patch not effective: $src is missing RUST_COVERAGE_EXTRA_OBJECTS / find_extra_object. A rules_rust upgrade likely needs the patch re-rebased (third_party/patches/collect_coverage_extra_objects.patch)."
+            exit 1
+          fi
+          echo "rules_rust collect_coverage patch is applied and effective."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,22 @@ module(
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
+# Pinned single-file patch to rules_rust's coverage collector. BDD rust_tests
+# spawn the service binary as a child process; the collector merges the child's
+# profraw but `llvm-cov export` only emits coverage for functions in an -object
+# on its command line, and stock rules_rust passes ONLY the test binary. The
+# patch appends each spawned binary (RUST_COVERAGE_EXTRA_OBJECTS, set on the BDD
+# targets) as an extra -object so spawned-binary src/ coverage is exported.
+# Inert when the var is unset. Upstream has no equivalent hook (PRs #3490/#3808
+# unmerged; HEAD identical), so this is carried until upstreamed. The
+# `bazel/cargo target parity` CI job guards that the patch still applies and is
+# effective. See docs/plans/bazel-migration.md "Coverage under Bazel".
+single_version_override(
+    module_name = "rules_rust",
+    patch_strip = 1,
+    patches = ["//third_party/patches:collect_coverage_extra_objects.patch"],
+)
+
 # --- Rust toolchain --------------------------------------------------------
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -437,23 +437,44 @@ vs Cargo ~95.8%. The multi-object lcov is a strict superset (0 SF lost); the
 child's counters bind because `filemonitor/src` is compiled into both binaries
 with matching covmap hashes.
 
-**Recommended fix (low effort).** Pin a minimal single-file patch of
-`collect_coverage.rs` via `single_version_override(module_name="rules_rust",
-patches=[…], patch_strip=1)` that appends `-object <p>` for each `:`-separated
-entry of a new `RUST_COVERAGE_EXTRA_OBJECTS` env var (resolved with the file's
-existing runfiles/execroot fallback). Set that var on each BDD `rust_test` to the
-`$(rootpath …)` of the binaries it spawns — the same values already in the
-`*_BINARY` vars (mock variants where applicable, e.g. `star-adventurer-gti_mock`).
-Inert when unset → cargo/`cargo-llvm-cov` and plain `bazel test` untouched;
-`split_lcov.py` needs no change. Cost: carrying a vendored ~15-line rules_rust
-patch (re-rebased on upgrades; add a CI guard that the patch still applies).
-**Fallback** if the pinned patch is unwanted: a repo-owned CI post-step that
-re-merges the retained profraw and re-exports with all instrumented binaries as
-`-object`s (extra CI minutes, no cache hit) — same proven export, outside the
-action graph.
+**Fix (implemented).** A minimal single-file patch of `collect_coverage.rs`,
+pinned via `single_version_override(module_name="rules_rust", patch_strip=1,
+patches=["//third_party/patches:collect_coverage_extra_objects.patch"])` in
+`MODULE.bazel`, appends `-object <p>` to the `llvm-cov export` for each
+`:`-separated entry of a new `RUST_COVERAGE_EXTRA_OBJECTS` env var (resolved with
+the collector's own runfiles/`config_bin_dir` logic). Each `rust_test` that
+spawns a binary sets that var to the `$(rootpath …)` of the binaries it spawns —
+the same values already in its `*_BINARY` vars (mock variants included, e.g.
+`star-adventurer-gti_mock`). The var is read only by `collect_coverage` under
+`bazel coverage`, so it is inert for cargo/`cargo-llvm-cov` and plain
+`bazel test`; `split_lcov.py` and the upload are unchanged.
 
-Badge reliability and run reliability (PR #340) are delivered; this export-side
-change is the remaining parity prerequisite before cutover.
+Validated locally on three services (per-service `src`):
+
+| service `src` | before | after |
+|---|---|---|
+| filemonitor | 0% | 92.8% |
+| sentinel | (missing) | 79.6% |
+| star-adventurer-gti | 33% | 78.2% |
+
+Cost / guards: the vendored ~15-line patch must be re-rebased on rules_rust
+upgrades (upstream has no hook — PRs #3490/#3808 unmerged, HEAD identical). A
+non-applying patch already fails every `bazel` command at fetch time; the
+`parity` CI job additionally asserts the patch is *effective* (the
+`RUST_COVERAGE_EXTRA_OBJECTS` marker survives in the extracted collector), so a
+silently-dropped patch is caught. **Known gap to confirm in CI:** a cross-package
+spawn (e.g. `sentinel` → `filemonitor`) did not surface the cross-spawned
+binary's `src` locally. This is NOT a resolver bug — the cross-spawned binary is
+in the test's `data`, so `find_extra_object` resolves its runfiles path and the
+`-object` is placed; the residual is a downstream covmap/profraw-binding detail,
+not the BUILD wiring. It is supplementary anyway — each service's own `bdd`
+covers its own `src`, so the per-service flags are unaffected. The residual
+`bazel < cargo` deltas (e.g. star-adventurer 78% vs 95%) are the next item to
+characterize against the full shadow run.
+
+Badge reliability and run reliability (PR #340) are delivered; with this
+export-side change the per-service Bazel coverage now approaches Cargo, the last
+parity prerequisite before cutover.
 
 **Badge reliability (carryforward).** The `bazel-<pkg>` badges read "unknown"
 not from a wiring fault but because a Codecov *branch* badge resolves to the

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -394,6 +394,67 @@ collecting those suites' coverage Cargo-style. Do **not** revert this wiring;
 it is the prerequisite that puts the child profraw where any export-side fix
 needs it.
 
+**Run #1 result (commit `9e6deb9`, PR #340, coverage run 26675105103).** The run
+completed cleanly — `//services/rp:bdd` finished in 368 s (66/66 pass, no hang;
+the new `--test_timeout=900` and exit-3 tolerance stayed dormant) and split 27
+package reports. The parity diff confirmed the prediction above: the
+`bazel-<svc>` numbers were **unchanged** from before the child-coverage wiring.
+
+| service | Bazel | Cargo | gap |
+|---|---|---|---|
+| rp | 72.64 | 94.77 | −22 |
+| filemonitor | 61.18 | 95.78 | −35 |
+| ppba-driver | 78.29 | 94.69 | −16 |
+| sentinel | 72.02 | 93.86 | −22 |
+| star-adventurer-gti | 33.23 | 95.29 | −62 |
+
+`bazel-rp` (72.64) and `bazel-filemonitor` (61.18) are bit-identical to their
+pre-wiring values, so the child `.profraw` is being collected but not exported —
+exactly the single-`-object` limitation. `star-adventurer-gti` (−62) is the
+starkest, its coverage being almost entirely BDD-child-driven. The wiring is
+correct and regression-free; closing the gap is now an **export-side** task.
+
+**Export-side root cause + proven fix (spike, locally validated).** The gap is
+*not* a collection failure — under `VERBOSE_COVERAGE` the sandboxed
+`collect_coverage` provably feeds all ~36 spawned-`filemonitor` child `.profraw`
+into `llvm-profdata merge`, so the child counters ARE in the `.profdata`. The
+loss is that `rules_rust` 0.70.0's `util/collect_coverage/collect_coverage.rs`
+runs `llvm-cov export … -object <TEST_BINARY>` with **exactly one, hardcoded
+object** and no env/attr/provider to add more (confirmed; upstream HEAD is
+identical and the two relevant PRs — #3490 `COVERAGE_BINARY`, #3808 — only swap
+the single object and are unmerged). The test binary has no covmap for
+`filemonitor/src`, so the merged child counters have nothing to bind to.
+
+Proven locally on `filemonitor:bdd` (instrumented `bdd` + `filemonitor`
+binaries, one merged profdata):
+
+| `llvm-cov export` objects | `services/filemonitor/src` |
+|---|---|
+| `-object <test>` (rules_rust today) | **0 / 0 — none** |
+| `-object <test> -object <filemonitor>` | **155 / 166 = 93.4%** (`lib.rs` 92.8%, `main.rs` 100%) |
+
+vs Cargo ~95.8%. The multi-object lcov is a strict superset (0 SF lost); the
+child's counters bind because `filemonitor/src` is compiled into both binaries
+with matching covmap hashes.
+
+**Recommended fix (low effort).** Pin a minimal single-file patch of
+`collect_coverage.rs` via `single_version_override(module_name="rules_rust",
+patches=[…], patch_strip=1)` that appends `-object <p>` for each `:`-separated
+entry of a new `RUST_COVERAGE_EXTRA_OBJECTS` env var (resolved with the file's
+existing runfiles/execroot fallback). Set that var on each BDD `rust_test` to the
+`$(rootpath …)` of the binaries it spawns — the same values already in the
+`*_BINARY` vars (mock variants where applicable, e.g. `star-adventurer-gti_mock`).
+Inert when unset → cargo/`cargo-llvm-cov` and plain `bazel test` untouched;
+`split_lcov.py` needs no change. Cost: carrying a vendored ~15-line rules_rust
+patch (re-rebased on upgrades; add a CI guard that the patch still applies).
+**Fallback** if the pinned patch is unwanted: a repo-owned CI post-step that
+re-merges the retained profraw and re-exports with all instrumented binaries as
+`-object`s (extra CI minutes, no cache hit) — same proven export, outside the
+action graph.
+
+Badge reliability and run reliability (PR #340) are delivered; this export-side
+change is the remaining parity prerequisite before cutover.
+
 **Badge reliability (carryforward).** The `bazel-<pkg>` badges read "unknown"
 not from a wiring fault but because a Codecov *branch* badge resolves to the
 branch HEAD, and the shadow job uploads nothing whenever its run is cancelled.

--- a/services/calibrator-flats/BUILD.bazel
+++ b/services/calibrator-flats/BUILD.bazel
@@ -73,6 +73,7 @@ rust_test(
         "BDD_PACKAGE_DIR": "services/calibrator-flats",
         "CALIBRATOR_FLATS_BINARY": "$(rootpath :calibrator-flats)",
         "RP_BINARY": "$(rootpath //services/rp:rp)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :calibrator-flats):$(rootpath //services/rp:rp)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/dsd-fp2/BUILD.bazel
+++ b/services/dsd-fp2/BUILD.bazel
@@ -69,6 +69,7 @@ rust_test(
     edition = "2021",
     env = {
         "DSD_FP2_BINARY": "$(rootpath :dsd-fp2_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :dsd-fp2_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
@@ -131,6 +132,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/dsd-fp2",
         "DSD_FP2_BINARY": "$(rootpath :dsd-fp2_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :dsd-fp2_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/filemonitor/BUILD.bazel
+++ b/services/filemonitor/BUILD.bazel
@@ -71,7 +71,7 @@ rust_test(
     ),
     data = [":filemonitor"],
     edition = "2021",
-    env = {"FILEMONITOR_BINARY": "$(rootpath :filemonitor)"},
+    env = {"FILEMONITOR_BINARY": "$(rootpath :filemonitor)", "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :filemonitor)"},
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,
@@ -93,7 +93,7 @@ rust_test(
     crate_features = ["conformu"],
     data = [":filemonitor"],
     edition = "2021",
-    env = {"FILEMONITOR_BINARY": "$(rootpath :filemonitor)"},
+    env = {"FILEMONITOR_BINARY": "$(rootpath :filemonitor)", "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :filemonitor)"},
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,
@@ -132,6 +132,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/filemonitor",
         "FILEMONITOR_BINARY": "$(rootpath :filemonitor)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :filemonitor)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/pa-falcon-rotator/BUILD.bazel
+++ b/services/pa-falcon-rotator/BUILD.bazel
@@ -113,6 +113,7 @@ rust_test(
     edition = "2021",
     env = {
         "PA_FALCON_ROTATOR_BINARY": "$(rootpath :pa-falcon-rotator_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :pa-falcon-rotator_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/phd2-guider/BUILD.bazel
+++ b/services/phd2-guider/BUILD.bazel
@@ -105,6 +105,7 @@ rust_test(
     env = {
         "MOCK_PHD2_BINARY": "$(rootpath :mock_phd2)",
         "PHD2_GUIDER_BINARY": "$(rootpath :phd2-guider)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :mock_phd2):$(rootpath :phd2-guider)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/plate-solver/BUILD.bazel
+++ b/services/plate-solver/BUILD.bazel
@@ -73,6 +73,7 @@ rust_test(
     # discovers the binary. See tests/supervision_integration.rs.
     env = {
         "MOCK_ASTAP_BINARY": "$(rootpath :mock_astap)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :mock_astap)",
     },
     data = [":mock_astap"],
     edition = "2021",
@@ -99,6 +100,7 @@ rust_test(
     size = "small",
     env = {
         "MOCK_ASTAP_BINARY": "$(rootpath :mock_astap)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :mock_astap)",
     },
     data = [":mock_astap"],
     edition = "2021",
@@ -139,6 +141,7 @@ rust_test(
         "BDD_PACKAGE_DIR": "services/plate-solver",
         "MOCK_ASTAP_BINARY": "$(rootpath :mock_astap)",
         "PLATE_SOLVER_BINARY": "$(rootpath :plate-solver)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :mock_astap):$(rootpath :plate-solver)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/ppba-driver/BUILD.bazel
+++ b/services/ppba-driver/BUILD.bazel
@@ -109,7 +109,7 @@ rust_test(
     ),
     data = [":ppba-driver"],
     edition = "2021",
-    env = {"PPBA_DRIVER_BINARY": "$(rootpath :ppba-driver)"},
+    env = {"PPBA_DRIVER_BINARY": "$(rootpath :ppba-driver)", "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :ppba-driver)"},
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,
@@ -134,7 +134,7 @@ rust_test(
     ],
     data = [":ppba-driver_mock"],
     edition = "2021",
-    env = {"PPBA_DRIVER_BINARY": "$(rootpath :ppba-driver_mock)"},
+    env = {"PPBA_DRIVER_BINARY": "$(rootpath :ppba-driver_mock)", "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :ppba-driver_mock)"},
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
         proc_macro_dev = True,
@@ -197,6 +197,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/ppba-driver",
         "PPBA_DRIVER_BINARY": "$(rootpath :ppba-driver_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :ppba-driver_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/qhy-focuser/BUILD.bazel
+++ b/services/qhy-focuser/BUILD.bazel
@@ -85,6 +85,7 @@ rust_test(
     edition = "2021",
     env = {
         "QHY_FOCUSER_BINARY": "$(rootpath :qhy-focuser_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :qhy-focuser_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
@@ -141,6 +142,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/qhy-focuser",
         "QHY_FOCUSER_BINARY": "$(rootpath :qhy-focuser_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :qhy-focuser_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/rp/BUILD.bazel
+++ b/services/rp/BUILD.bazel
@@ -131,6 +131,7 @@ rust_test(
         "CALIBRATOR_FLATS_BINARY": "$(rootpath //services/calibrator-flats:calibrator-flats)",
         "RP_BINARY": "$(rootpath :rp)",
         "SKY_SURVEY_CAMERA_BINARY": "$(rootpath //services/sky-survey-camera:sky-survey-camera)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath //services/calibrator-flats:calibrator-flats):$(rootpath :rp):$(rootpath //services/sky-survey-camera:sky-survey-camera)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/sentinel/BUILD.bazel
+++ b/services/sentinel/BUILD.bazel
@@ -68,6 +68,7 @@ rust_test(
         "BDD_PACKAGE_DIR": "services/sentinel",
         "FILEMONITOR_BINARY": "$(rootpath //services/filemonitor:filemonitor)",
         "SENTINEL_BINARY": "$(rootpath :sentinel)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath //services/filemonitor:filemonitor):$(rootpath :sentinel)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/sky-survey-camera/BUILD.bazel
+++ b/services/sky-survey-camera/BUILD.bazel
@@ -94,6 +94,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/sky-survey-camera",
         "SKY_SURVEY_CAMERA_BINARY": "$(rootpath :sky-survey-camera)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :sky-survey-camera)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
@@ -128,6 +129,7 @@ rust_test(
     edition = "2021",
     env = {
         "SKY_SURVEY_CAMERA_BINARY": "$(rootpath :sky-survey-camera_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :sky-survey-camera_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/star-adventurer-gti/BUILD.bazel
+++ b/services/star-adventurer-gti/BUILD.bazel
@@ -92,6 +92,7 @@ rust_test(
     edition = "2021",
     env = {
         "STAR_ADVENTURER_GTI_BINARY": "$(rootpath :star-adventurer-gti_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :star-adventurer-gti_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
@@ -150,6 +151,7 @@ rust_test(
     env = {
         "BDD_PACKAGE_DIR": "services/star-adventurer-gti",
         "STAR_ADVENTURER_GTI_BINARY": "$(rootpath :star-adventurer-gti_mock)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath :star-adventurer-gti_mock)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/services/ui-htmx/BUILD.bazel
+++ b/services/ui-htmx/BUILD.bazel
@@ -82,6 +82,7 @@ rust_test(
         "BDD_PACKAGE_DIR": "services/ui-htmx",
         "DSD_FP2_BINARY": "$(rootpath //services/dsd-fp2:dsd-fp2_mock)",
         "UI_HTMX_BINARY": "$(rootpath :ui-htmx)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath //services/dsd-fp2:dsd-fp2_mock):$(rootpath :ui-htmx)",
     },
     proc_macro_deps = all_crate_deps(
         proc_macro = True,

--- a/third_party/patches/BUILD.bazel
+++ b/third_party/patches/BUILD.bazel
@@ -1,0 +1,2 @@
+# Patch sources for bzlmod single_version_override (see MODULE.bazel).
+exports_files(glob(["*.patch"]))

--- a/third_party/patches/collect_coverage_extra_objects.patch
+++ b/third_party/patches/collect_coverage_extra_objects.patch
@@ -1,0 +1,73 @@
+--- a/util/collect_coverage/collect_coverage.rs
++++ b/util/collect_coverage/collect_coverage.rs
+@@ -106,6 +106,31 @@
+         .join("bin")
+ }
+ 
++/// rusty-photon patch (collect_coverage_extra_objects): resolve a workspace-
++/// relative `$(rootpath ...)` path for a spawned binary listed in
++/// RUST_COVERAGE_EXTRA_OBJECTS, mirroring how `test_binary` is resolved above
++/// (runfiles when present, else the config bin dir). Returns None when neither
++/// candidate exists on disk, so a stale/missing entry is skipped rather than
++/// passed to `llvm-cov` (which hard-fails on a non-existent -object).
++fn find_extra_object(
++    execroot: &Path,
++    runfiles_dir: &Option<PathBuf>,
++    coverage_dir: &Path,
++    rel: &str,
++) -> Option<PathBuf> {
++    if let Some(rd) = runfiles_dir {
++        let in_runfiles = rd.join(env::var("TEST_WORKSPACE").unwrap()).join(rel);
++        if in_runfiles.exists() {
++            return Some(in_runfiles);
++        }
++    }
++    let in_bin = execroot.join(config_bin_dir(execroot, coverage_dir)).join(rel);
++    if in_bin.exists() {
++        return Some(in_bin);
++    }
++    None
++}
++
+ fn main() {
+     let coverage_dir = PathBuf::from(env::var("COVERAGE_DIR").unwrap());
+     let execroot = PathBuf::from(env::var("ROOT").unwrap());
+@@ -152,7 +177,7 @@
+             test_binary
+         }
+     };
+-    let profraw_files: Vec<PathBuf> = fs::read_dir(coverage_dir)
++    let profraw_files: Vec<PathBuf> = fs::read_dir(&coverage_dir)
+         .unwrap()
+         .flatten()
+         .filter_map(|entry| {
+@@ -192,7 +217,28 @@
+         .arg("-ignore-filename-regex=.*external/.+")
+         .arg("-ignore-filename-regex=/tmp/.+")
+         .arg(format!("-path-equivalence=.,{}", execroot.display()))
+-        .arg(test_binary)
++        .arg(test_binary);
++
++    // rusty-photon patch (collect_coverage_extra_objects): BDD rust_tests SPAWN
++    // the service binary as a child process. bdd-infra routes each child's
++    // LLVM_PROFILE_FILE into COVERAGE_DIR so its counters ARE merged above, but
++    // `llvm-cov export` only emits coverage for functions whose covmap lives in
++    // an -object on the command line. Append each spawned binary (a ':'-separated
++    // list of runfiles paths in RUST_COVERAGE_EXTRA_OBJECTS, set on the BDD
++    // targets) as an extra -object so its src/ coverage is emitted. Inert when the
++    // var is unset: cargo/cargo-llvm-cov, plain `bazel test`, and non-BDD coverage.
++    if let Ok(extra_objects) = env::var("RUST_COVERAGE_EXTRA_OBJECTS") {
++        for rel in extra_objects.split(':').filter(|s| !s.is_empty()) {
++            match find_extra_object(&execroot, &runfiles_dir, &coverage_dir, rel) {
++                Some(object) => {
++                    llvm_cov_cmd.arg("-object").arg(object);
++                }
++                None => debug_log!("RUST_COVERAGE_EXTRA_OBJECTS entry not found, skipping: {}", rel),
++            }
++        }
++    }
++
++    llvm_cov_cmd
+         .stdout(process::Stdio::piped())
+         .stderr(process::Stdio::piped());
+ 


### PR DESCRIPTION
## Problem

Follow-up to #340. Under `bazel coverage` the BDD/integration `rust_test`s **spawn the service binary as a child process**, so the service code under test runs in that child, not in the test binary. `bdd-infra` (merged in #340) routes each child's `LLVM_PROFILE_FILE` into `COVERAGE_DIR`, so the child's counters **are** merged into the `.profdata`. But `rules_rust`'s `util/collect_coverage/collect_coverage.rs` runs `llvm-cov export` with a **single hardcoded `-object <test_binary>`**, which has no coverage-mapping for the spawned service's `src` — so the merged child counters are dropped on export.

Run #1 of #340 confirmed this: `bazel-filemonitor` 61% vs Cargo 96%, `bazel-rp` 73% vs 95%, `bazel-star-adventurer-gti` **33% vs 95%**.

I proved the cause and fix locally: collection works (the child profraws are in the merge); adding the spawned binary as a second `-object` recovers the coverage. `llvm-cov export` supports repeated `-object`, but `rules_rust` doesn't wire it up, and there is **no env/attr/provider hook** (confirmed; the two relevant upstream PRs #3490/#3808 are unmerged and HEAD is identical).

## Fix (export-side)

A **pinned single-file patch** to `rules_rust`'s `collect_coverage.rs`, applied via `MODULE.bazel` `single_version_override`:
- adds a `find_extra_object` helper (mirrors the collector's own `test_binary` resolution — runfiles, else `config_bin_dir`; returns `Option` and **skips** a missing path rather than hard-failing `llvm-cov`);
- appends `-object <p>` for each `:`-separated entry of a new `RUST_COVERAGE_EXTRA_OBJECTS` env var.

Each `rust_test` that spawns a binary sets `RUST_COVERAGE_EXTRA_OBJECTS` to the same `$(rootpath …)` values already in its `*_BINARY` vars. The var is read only by `collect_coverage` under `bazel coverage`, so **cargo/`cargo-llvm-cov` and plain `bazel test` are untouched**; `split_lcov.py` and the Codecov upload are unchanged.

## Validated locally (real `bazel coverage` runs)

| service `src` | before | after |
|---|---|---|
| filemonitor | 0% | **92.8%** |
| sentinel | (missing) | **79.6%** |
| star-adventurer-gti | 33% | **78.2%** |

Patch applies + compiles + runs through Bazel; all BUILD files parse; all 88 service targets analyze (every `$(rootpath)` resolves).

## Guard

A non-applying patch already fails every `bazel` command at fetch time. The `parity` job additionally asserts the patch is **effective** — both the `RUST_COVERAGE_EXTRA_OBJECTS` marker and the `find_extra_object` anchor survive in the extracted collector — so a silently-dropped/mis-anchored patch after a `rules_rust` bump is caught. The behavioural backstop is the (non-required) `bazel-coverage` shadow job, which compiles and runs the patched collector every PR.

## Notes for review

- **Maintenance:** the vendored ~70-line patch must be re-rebased on `rules_rust` upgrades (Bazel uses strict, non-fuzz patch application, so context drift = clean non-apply, caught by the guard). Carried until upstreamed.
- **No lockfile change:** the override applies its patch at fetch time and needs no `MODULE.bazel.lock` delta (verified).
- **Known gap (supplementary, to confirm in CI):** a cross-package spawn (`sentinel` → `filemonitor`) didn't surface the cross-spawned binary's `src` locally. This is **not** a resolver bug — the binary is in `data`, so `find_extra_object` resolves it; the residual is a downstream covmap-binding detail. Each service's own `bdd` covers its own `src`, so the per-service flags are unaffected.
- This was developed with multi-agent investigation + adversarial review (verdict: ship; the robustness hardening + guard/doc clarifications here are from that review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)