### PR TITLE
chore(deps): pin time>=0.3.47 (RUSTSEC-2026-0009) and hoist tower to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ parking_lot = "0.12.5"
 tokio-serial = "5.4.5"
 ascom-alpaca = { git = "https://github.com/ivonnyssen/ascom-alpaca-rs.git", branch = "integration", default-features = false }
 axum = "0.8"
+tower = "0.5"
 reqwest = { version = "0.13.4", features = ["form", "json"] }
 rp-auth = { path = "crates/rp-auth" }
 rp-catalog = { path = "crates/rp-catalog" }

--- a/crates/rp-auth/Cargo.toml
+++ b/crates/rp-auth/Cargo.toml
@@ -26,4 +26,4 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 reqwest = { workspace = true }
-tower = "0.5"
+tower = { workspace = true }

--- a/crates/rp-tls/Cargo.toml
+++ b/crates/rp-tls/Cargo.toml
@@ -30,7 +30,9 @@ derive_more = { workspace = true }
 hostname = "0.4"
 instant-acme = { workspace = true }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
-time = "0.3"
+# Floor pinned to 0.3.47 — fixes RUSTSEC-2026-0009 (DoS via stack exhaustion in
+# RFC 2822 parsing). Affected: >=0.3.6, <0.3.47.
+time = "0.3.47"
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/services/sentinel/Cargo.toml
+++ b/services/sentinel/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { workspace = true }
 reqwest = { workspace = true }
 tokio-util = { workspace = true }
 axum = { workspace = true }
-tower = "0.5"
+tower = { workspace = true }
 tower-http = { version = "0.6", features = ["cors"] }
 rp-auth = { workspace = true }
 rp-tls = { workspace = true }


### PR DESCRIPTION
## Summary

Two manifest-only dependency fixes flagged by [deps.rs](https://deps.rs/repo/github/ivonnyssen/rusty-photon):

- **Security pin**: raise the `time` floor in `rp-tls` from `"0.3"` to `"0.3.47"` so a vulnerable version can never resolve. [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009.html) is a DoS via stack exhaustion in RFC 2822 parsing, affecting `>=0.3.6, <0.3.47` (fixed in `0.3.47`). `Cargo.lock` was already at `0.3.47`, so resolution is unchanged.
- **Workspace hygiene**: hoist `tower = "0.5"` to `[workspace.dependencies]` per CLAUDE.md rule 10 (used by 2+ crates — `sentinel` dep + `rp-auth` dev-dep). Both crates now use `{ workspace = true }`; neither requested non-default features, so no feature reconciliation was needed.

## Changes

| File | Change |
|------|--------|
| `crates/rp-tls/Cargo.toml` | `time` floor `"0.3"` → `"0.3.47"` |
| `Cargo.toml` | added `tower = "0.5"` to `[workspace.dependencies]` |
| `services/sentinel/Cargo.toml` | `tower = "0.5"` → `{ workspace = true }` |
| `crates/rp-auth/Cargo.toml` | `tower = "0.5"` → `{ workspace = true }` (dev-dep) |

`Cargo.lock` is unchanged — both were no-op resolutions (time already at 0.3.47, tower already at 0.5.3).

## Bazel

No changes required. BUILD files derive deps via `all_crate_deps()`/`aliases()` from the Cargo manifests (nothing hardcoded), `crate_universe` reads the unchanged `Cargo.lock`, and no new crates.io dep was added — so `MODULE.bazel.lock` needs no repin.

## Testing

`cargo rail run --profile commit -q` → **1855 tests passed, 0 failures**. Pre-commit hook (clippy `-D warnings` + `cargo fmt --check`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)