### PR TITLE
feat(rp): predictive park & move_focuser deadlines (Phase 2 §2.2+§2.3)

### DIFF
--- a/docs/plans/predictive-deadlines-phase2-park-focuser.md
+++ b/docs/plans/predictive-deadlines-phase2-park-focuser.md
@@ -1,0 +1,140 @@
+# Phase 2 §2.2 + §2.3 — Predictive park & move_focuser deadlines (implementation plan)
+
+Execution plan for **§2.2 (park)** and **§2.3 (move_focuser)** of
+[`predictive-deadlines-and-watchdog.md`](predictive-deadlines-and-watchdog.md):
+replace the two remaining hardcoded blocking-poll ceilings — `park`'s 300 s
+and `move_focuser`'s 120 s — with deadlines sized per call, and populate the
+`predicted_duration_ms` / `max_duration_ms` envelope fields that Phase 1
+reserved. Follows the slew template established by §2.1
+([`predictive-deadlines-phase2-slew.md`](predictive-deadlines-phase2-slew.md),
+PR #348).
+
+## Status
+
+| Step | What | State |
+|---|---|---|
+| 0 | Design-doc updates (rp.md park/move_focuser rows, Event Envelope, config, Sentinel monitored-ops, keep-alive note) | this PR |
+| 1 | `FocuserStepsPerSec` config newtype + `FocuserConfig` field | this PR |
+| 2 | `compute_park_deadline` + `compute_focuser_deadline`; `deadline` params on the two inner poll helpers | this PR |
+| 3 | Stamp `park_started` / `move_focuser_started` envelopes with deadlines | this PR |
+| 4 | Unit tests (deadline math, parameterised §2.6 timeout tests) + BDD (`operation_events.feature`) | this PR |
+
+**Scope: the park and move_focuser families only.** Exposure (§2.4) and
+centering (§2.5) are **out of scope** and untouched — see the parent plan and
+the §"Why exposure & centering are deferred" note below.
+
+## Goal
+
+```text
+# park (§2.2)
+predicted = PARK_WORST_CASE_TRAVERSE / mount.slew_rate_arcsec_per_sec + settle
+max       = max(predicted × 2, MIN_PARK_DEADLINE)          # 60 s floor
+
+# move_focuser (§2.3)
+predicted = |target_position − current_position| / focuser.steps_per_sec
+max       = max(predicted × 2, MIN_FOCUSER_DEADLINE)       # 5 s floor
+```
+
+`max` becomes the poll deadline (replacing the fixed 300 s / 120 s);
+`predicted` and `max` are emitted (rounded to ms) on the `*_started` envelope.
+
+## Decisions
+
+- **D1 — Park has no distance to scale from; size it off a worst-case
+  traverse.** The generic Alpaca `Telescope` trait exposes no park-position
+  getter, so rp cannot compute a great-circle distance to the park position
+  the way `slew` does. The deadline is therefore the worst-case full-axis
+  traverse — `PARK_WORST_CASE_TRAVERSE_DEG = 180°`, the maximum angular
+  separation between any two points on the sphere — at the configured slew
+  rate. This still tightens the deadline relative to the old flat 300 s for
+  any rig that sets a realistic `slew_rate_arcsec_per_sec`, and it is the
+  honest upper bound rp can know without reading the park coordinates.
+- **D2 — Park reuses `mount.slew_rate_arcsec_per_sec`; no new config field.**
+  Park and slew share the mount's one slew rate. `settle_after_slew` is the
+  settle term. So §2.2 adds *zero* config surface.
+- **D3 — Park keeps its no-auto-abort contract.** rp.md line 749 / the
+  `do_park_blocking` doc-comment: "a partially-completed park is closer to
+  safe than an aborted one." The new deadline only changes *when* `park`
+  surfaces the timeout error; it still does **not** call `abort_slew`. The
+  corrective-action ladder (Phase 5) owns that decision.
+- **D4 — Park headroom is ×2, not slew's ×3.** Slew's ×3 sits over a
+  *measured* small distance (absorbing accel ramps + rate optimism). Park's
+  `predicted` is already a worst-case 180° traverse, so a smaller ×2 headroom
+  is right — ×3 over worst-case would re-approach the old 300 s and defeat the
+  point. `MIN_PARK_DEADLINE = 60 s` (more generous than slew's 30 s floor —
+  park traverses to a fixed mechanical position that can be a long way off,
+  and OmniSim's BDD park is a from-rest physical traverse).
+- **D5 — `focuser.steps_per_sec` as a validating newtype.** Same
+  parse-don't-validate pattern as `SlewRateArcsecPerSec` (D6 of §2.1):
+  `serde(try_from = "f64")`, rejects non-finite / ≤ 0, named in the error,
+  fails at config load. The Alpaca `Focuser` trait has no step-*rate* property
+  (`MaxIncrement`/`MaxStep` are step *counts*, not rates), so config is the
+  only source.
+- **D6 — `DEFAULT_FOCUSER_STEPS_PER_SEC = 500`.** Deliberately conservative
+  (slow) — about half a typical EAF/Q-Focuser rate — so `predicted`
+  over-estimates the move duration and the deadline won't false-abort a
+  healthy move (mirrors §2.1's deliberately-slow 2°/s slew default). At
+  500 steps/s a typical autofocus move (a few thousand steps) gets a
+  single-digit-second deadline vs. the old flat 120 s, while a rare near-full
+  travel gets *more* headroom than 120 s (which the old flat ceiling would
+  have false-aborted). Tune up per-rig for a tighter bound.
+- **D7 — Self-compute from a pre-move position read.** `do_move_focuser_blocking`
+  reads the focuser's current `position()` before issuing the move (the same
+  accessor used post-move), so `|target − current|` is exact. Mirrors §2.1's
+  D2 pre-slew pointing read.
+- **D8 — Read-failure ⇒ fall back to the legacy ceiling.** A flaky pre-move
+  position read (or an unresolvable focuser) must not fail an otherwise-valid
+  move: the focuser deadline degrades to `FOCUSER_DEADLINE_FALLBACK = 120 s`
+  and the envelope deadline fields are omitted; the move proceeds (the inner
+  helper still produces the authoritative result/error). Park's analogous
+  fallback is `PARK_DEADLINE_FALLBACK = 300 s` when no mount is configured.
+- **D9 — Builders, not signature changes.** Reuse §2.1's chainable
+  `EventEnvelope::with_deadlines`; the tool-layer `park_inner` /
+  `move_focuser_inner` signatures are unchanged (the deadline is self-computed
+  inside the `do_*_blocking` wrapper).
+
+## Code anchors (verified)
+
+- `services/rp/src/config/focuser.rs` — add `FocuserStepsPerSec` + field.
+- `services/rp/src/mcp/internals.rs`
+  - new consts: `MIN_PARK_DEADLINE` (60 s), `PARK_DEADLINE_FALLBACK` (300 s),
+    `PARK_WORST_CASE_TRAVERSE_DEG` (180), `PARK_DEADLINE_HEADROOM` (2);
+    `MIN_FOCUSER_DEADLINE` (5 s), `FOCUSER_DEADLINE_FALLBACK` (120 s),
+    `FOCUSER_DEADLINE_HEADROOM` (2).
+  - `compute_park_deadline` (sync; no pointing read) +
+    `compute_focuser_deadline` (reads current position).
+  - `do_park_blocking` / `do_park_blocking_inner` — compute + thread deadline,
+    stamp `park_started`; inner's `total_budget` becomes the `deadline` param.
+  - `do_move_focuser_blocking` / `do_move_focuser_blocking_inner` — same shape.
+- `services/rp/src/mcp/tests.rs` — `focuser_registry` literal gains
+  `steps_per_sec: Default::default()`; relax `assert_end_mirrors_start` to
+  exempt park/move_focuser starts; assert deadlines on the two triple tests;
+  add §2.6 `elapsed <` assertions to the two timeout tests.
+- `services/rp/tests/features/operation_events.feature` + steps — flip the
+  park scenario to "carries the deadline fields"; add a move_focuser scenario.
+
+## Why exposure & centering are deferred
+
+- **§2.4 exposure** is envelope-stamping, not enforcement: rp.md §2.4 says rp
+  itself does not enforce the exposure deadline (the camera driver does), so it
+  is a different shape (a `camera.readout_time_estimate` config + envelope
+  stamp on `exposure_started`, leaving `do_capture`'s grace as the rp backstop).
+- **§2.5 centering** inherits §2.1's per-slew deadline through `do_slew_blocking`
+  already (slew §2.1 Decision D1). Whether to add an *outer* `centering_*`
+  deadline is the parent plan's open question; it is its own decision and PR.
+
+Both belong in a separate PR so this one stays "replace the two hardcoded
+blocking-poll ceilings."
+
+## Acceptance
+
+- `do_park_blocking`'s `Duration::from_secs(300)` and
+  `do_move_focuser_blocking`'s `Duration::from_secs(120)` are gone (replaced by
+  the computed `deadline` param; the fallbacks are explicit named constants).
+- `park_started` / `move_focuser_started` carry
+  `predicted_duration_ms`/`max_duration_ms`; a stuck mount/focuser fails in its
+  computed window, not at 300 s / 120 s (§2.6 timeout tests assert `elapsed`
+  lands below the old ceiling under `start_paused` virtual time).
+- rp.md documents both formulas, the floors, and the
+  `focuser.steps_per_sec` config (CLAUDE.md rule 2).
+- All gates green; existing webhook/BDD delivery unaffected.

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -408,7 +408,7 @@ and absent optional fields are omitted from the JSON.
 | `timestamp` | ISO-8601 emission time. Unchanged historical format. |
 | `started_at` / `ended_at` | RFC-3339 (millisecond) operation start / end. `started_at` is on the `*_started`/`*_complete`/`*_failed` triple; `ended_at` only on `*_complete`/`*_failed`. |
 | `elapsed_ms` | Wall-clock operation duration, on `*_complete`/`*_failed`. |
-| `predicted_duration_ms` / `max_duration_ms` | The operation's expected duration and hard-ceiling deadline, in integer milliseconds (a boundary serialization of an internal `Duration`). Populated on `slew_started` (Phase 2.1): `predicted = great-circle distance / mount.slew_rate_arcsec_per_sec + settle`, `max = max(predicted × 3, MIN_SLEW_DEADLINE = 30 s)`. Omitted for operations not yet converted to predictive deadlines. |
+| `predicted_duration_ms` / `max_duration_ms` | The operation's expected duration and hard-ceiling deadline, in integer milliseconds (a boundary serialization of an internal `Duration`). Populated (Phase 2) on: `slew_started` — `predicted = great-circle distance / mount.slew_rate_arcsec_per_sec + settle`, `max = max(predicted × 3, MIN_SLEW_DEADLINE = 30 s)`; `park_started` — `predicted = 180° / mount.slew_rate_arcsec_per_sec + settle` (worst-case traverse; rp can't read the park position via Alpaca), `max = max(predicted × 2, MIN_PARK_DEADLINE = 60 s)`; `move_focuser_started` — `predicted = \|target − current\| / focuser.steps_per_sec`, `max = max(predicted × 2, MIN_FOCUSER_DEADLINE = 5 s)`. Omitted for operations not yet converted to predictive deadlines. |
 | `payload` | Operation detail. For `*_started`, the inputs; for `*_complete`/`*_failed`, the outcome (or `{"error": "..."}` on failure). |
 
 A blocking operation emits a **triple** — a `*_started` envelope at the
@@ -738,7 +738,7 @@ the exact parameter types and return structure.
 |--------|-----------|---------|-------------|
 | `capture` | camera_id, duration, binning | image_path, document_id | Take an exposure, download `image_array`, save FITS file, create exposure document |
 | `get_camera_info` | camera_id | max_adu, exposure_min, exposure_max, sensor_x, sensor_y, bin_x, bin_y | Read camera capabilities and current settings |
-| `move_focuser` | focuser_id, position | actual_position | Move focuser to absolute position |
+| `move_focuser` | focuser_id, position | actual_position | Move focuser to absolute position (blocks polling `is_moving` until idle). Bounded by a **predicted deadline**: `predicted = \|target − current\| / focuser.steps_per_sec` (current position read before the move); `max = max(predicted × 2, MIN_FOCUSER_DEADLINE = 5 s)`. If the pre-move read fails it falls back to a 120 s ceiling; `predicted`/`max` ride the `move_focuser_started` envelope as `predicted_duration_ms`/`max_duration_ms` |
 | `get_focuser_position` | focuser_id | position | Read current focuser position |
 | `get_focuser_temperature` | focuser_id | temperature_c | Read focuser temperature sensor |
 | `slew` | ra, dec, settle_after (optional) | actual_ra, actual_dec | Slew the singular mount to coordinates (blocks until `Slewing == false` plus configured / per-call settle). Tracking must be on; ASCOM error propagates otherwise. Bounded by a **predicted deadline**: `predicted = great-circle(current, target) / mount.slew_rate_arcsec_per_sec + settle`; `max = max(predicted × 3, MIN_SLEW_DEADLINE = 30 s)`. The current pointing is read before the slew to size the deadline; if that read fails it falls back to a 300 s ceiling. On timeout `slew` best-effort aborts (unlike `park`); `predicted`/`max` ride the `slew_started` envelope as `predicted_duration_ms`/`max_duration_ms` |
@@ -746,7 +746,7 @@ the exact parameter types and return structure.
 | `get_mount_position` | — | ra, dec | Read the mount's current pointing |
 | `get_tracking` | — | tracking, can_set_tracking | Read tracking state and `CanSetTracking` capability; fails loud on read error |
 | `set_tracking` | enabled | — | Enable or disable sidereal tracking |
-| `park` | — | — | Park the mount (blocks polling `AtPark` every 100 ms until it returns `true`, 300 s deadline). `AtPark` is the ASCOM-canonical completion signal — `Slewing` is sticky on `MoveAxis` rate state and unrelated `SlewState` activity, so polling it would be over-conservative. Per ASCOM, a successful park clears `Tracking`. Unlike `slew`, does NOT auto-abort on timeout — call `abort_slew` to interrupt a stuck park |
+| `park` | — | — | Park the mount (blocks polling `AtPark` every 100 ms until it returns `true`). Bounded by a **predicted deadline**: rp can't read the park position via Alpaca, so it sizes a worst-case full-axis traverse — `predicted = 180° / mount.slew_rate_arcsec_per_sec + settle`; `max = max(predicted × 2, MIN_PARK_DEADLINE = 60 s)` (falls back to a 300 s ceiling with no mount configured); `predicted`/`max` ride the `park_started` envelope. `AtPark` is the ASCOM-canonical completion signal — `Slewing` is sticky on `MoveAxis` rate state and unrelated `SlewState` activity, so polling it would be over-conservative. Per ASCOM, a successful park clears `Tracking`. Unlike `slew`, does NOT auto-abort on timeout — call `abort_slew` to interrupt a stuck park |
 | `unpark` | — | — | Clear the mount's `AtPark` flag. Returns immediately. Does NOT auto-enable `Tracking`; call `set_tracking` before slewing |
 | `get_park_state` | — | at_park, can_park, can_unpark | Read park state and capabilities; fails loud on `AtPark` read error |
 | `abort_slew` | — | — | Abort an in-progress mount slew or park. Per ASCOM, only valid while `Slewing == true`; the natural Alpaca error propagates otherwise |
@@ -2384,9 +2384,13 @@ exactly one mount.
 - MCP session keep-alive vs. per-tool deadlines → companion fix on
   the same PR (#319). rmcp's `LocalSessionManager` defaults to a
   300 s `keep_alive` that fires if the session sees no activity. The
-  per-iteration `do_slew_blocking` (300 s slew deadline),
-  `do_park_blocking` (300 s), and `do_capture` (`duration + 120 s`
-  readout grace) all approach or match that 300 s. Without
+  per-iteration `do_slew_blocking`, `do_park_blocking`, and
+  `do_move_focuser_blocking` now carry **predicted deadlines** that
+  usually fall well under 300 s (a slew/park/focuser-move's
+  `max_duration_ms`), but a long legitimate slew or park can still
+  exceed the keep-alive; `do_capture` (`duration + 120 s` readout
+  grace) likewise approaches or matches 300 s for long exposures.
+  Without
   emission they race the keep-alive: when both fire near the same
   moment the SSE response stream EOFs and the client's `call_tool`
   future never resolves (BDD's 360 s `MCP_CALL_TIMEOUT` is the only
@@ -2850,6 +2854,8 @@ the disconnection is an immediate trigger for Sentinel to attempt recovery.
 |-----------|----------------|--------------------|----|
 | Exposure | `exposure_started` | `exposure_complete` | duration + configurable buffer |
 | Slew | `slew_started` | `slew_complete` | `max_duration_ms` from the `slew_started` envelope (rp-computed: `(distance / rate + settle) × 3`, floored at `MIN_SLEW_DEADLINE`) |
+| Park | `park_started` | `park_complete` | `max_duration_ms` from the `park_started` envelope (rp-computed worst-case traverse: `(180° / rate + settle) × 2`, floored at `MIN_PARK_DEADLINE`) |
+| Move focuser | `move_focuser_started` | `move_focuser_complete` | `max_duration_ms` from the `move_focuser_started` envelope (rp-computed: `(\|target − current\| / steps_per_sec) × 2`, floored at `MIN_FOCUSER_DEADLINE`) |
 | Focus | `focus_started` | `focus_complete` | configurable max focus time |
 | Guide settle | `guide_started` | `guide_settled` | configurable settle timeout |
 | Centering | `centering_started` | `centering_complete` | configurable max attempts * solve time |
@@ -2979,6 +2985,9 @@ when the config sets a non-zero default). `mount.slew_rate_arcsec_per_sec`
 (default `7200` = 2°/s, a conservative slow-stepper rate) feeds the
 predictive slew deadline; set it per-rig for a tighter bound. It must be a
 finite positive number — a bad value is rejected at config load.
+`focuser.steps_per_sec` (default `500`, a conservative slow rate) feeds the
+predictive `move_focuser` deadline the same way — likewise a finite
+positive number rejected at load otherwise.
 
 The `site` block is required for the ephemeris and planner tools
 (`compute_alt_az`, `get_twilight`, `get_next_target`, …); when present
@@ -3040,7 +3049,8 @@ return a structured "site not configured" error.
         "alpaca_url": "http://localhost:11113",
         "device_number": 0,
         "min_position": 0,
-        "max_position": 100000
+        "max_position": 100000,
+        "steps_per_sec": 1200
       },
       {
         "id": "guide-focuser",

--- a/services/rp/src/config/focuser.rs
+++ b/services/rp/src/config/focuser.rs
@@ -1,5 +1,55 @@
 use serde::Deserialize;
 
+/// Conservative default focuser step rate: 500 steps/sec. Deliberately
+/// slower than a typical EAF/Q-Focuser so the predicted move duration
+/// over-estimates and the deadline won't false-abort a healthy move.
+const DEFAULT_FOCUSER_STEPS_PER_SEC: f64 = 500.0;
+
+/// Assumed focuser step rate in steps/sec, feeding the predictive
+/// `move_focuser` deadline (`predicted = |target − current| / rate`). The
+/// Alpaca `Focuser` trait exposes no step-*rate* property (`MaxIncrement` /
+/// `MaxStep` are step *counts*, not rates), so this config value is the rate
+/// source; set it per-rig for a tighter deadline.
+///
+/// Validated at load (parse-don't-validate): a non-finite or non-positive
+/// rate is rejected during deserialization, so a bad config fails at
+/// startup rather than at move time.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(try_from = "f64")]
+pub struct FocuserStepsPerSec(f64);
+
+impl FocuserStepsPerSec {
+    /// The single validating constructor. Rejects non-finite or
+    /// non-positive rates, naming the field in the error.
+    pub fn try_new(value: f64) -> Result<Self, String> {
+        if !value.is_finite() || value <= 0.0 {
+            return Err(format!(
+                "steps_per_sec must be a finite positive number, got {value}"
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// The rate in steps/sec.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl Default for FocuserStepsPerSec {
+    fn default() -> Self {
+        Self(DEFAULT_FOCUSER_STEPS_PER_SEC)
+    }
+}
+
+impl TryFrom<f64> for FocuserStepsPerSec {
+    type Error = String;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct FocuserConfig {
     pub id: String,
@@ -16,6 +66,11 @@ pub struct FocuserConfig {
     /// Operator-supplied upper bound for `move_focuser` validation.
     #[serde(default)]
     pub max_position: Option<i32>,
+    /// Assumed focuser step rate (steps/sec) used to size the predictive
+    /// `move_focuser` deadline. Defaults to 500 (a conservative slow rate);
+    /// set per-rig for a tighter bound.
+    #[serde(default)]
+    pub steps_per_sec: FocuserStepsPerSec,
     /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
     #[serde(default)]
     pub auth: Option<rp_auth::config::ClientAuthConfig>,
@@ -94,5 +149,97 @@ mod tests {
         let auth = f.auth.as_ref().unwrap();
         assert_eq!(auth.username, "u");
         assert_eq!(auth.password, "p");
+    }
+
+    #[test]
+    fn focuser_config_steps_per_sec_defaults_to_500() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "focusers": [
+                        {"id": "main-focuser", "alpaca_url": "http://localhost:11113"}
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.equipment.focusers[0].steps_per_sec.value(), 500.0);
+    }
+
+    #[test]
+    fn focuser_config_steps_per_sec_explicit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "focusers": [
+                        {
+                            "id": "main-focuser",
+                            "alpaca_url": "http://localhost:11113",
+                            "steps_per_sec": 1200
+                        }
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.equipment.focusers[0].steps_per_sec.value(), 1200.0);
+    }
+
+    #[test]
+    fn focuser_config_steps_per_sec_rejects_non_positive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "focusers": [
+                        {
+                            "id": "main-focuser",
+                            "alpaca_url": "http://localhost:11113",
+                            "steps_per_sec": 0
+                        }
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let err = load_config(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("steps_per_sec must be a finite positive number"),
+            "expected the validation message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn focuser_steps_per_sec_newtype_validation_boundaries() {
+        use super::FocuserStepsPerSec;
+        assert_eq!(FocuserStepsPerSec::default().value(), 500.0);
+        assert_eq!(FocuserStepsPerSec::try_new(1200.0).unwrap().value(), 1200.0);
+        // The `<= 0.0` edge and the non-finite branch (unreachable from
+        // JSON, defensive-only) are rejected and name the field.
+        assert!(FocuserStepsPerSec::try_new(0.0)
+            .unwrap_err()
+            .contains("steps_per_sec"));
+        assert!(FocuserStepsPerSec::try_new(-1.0).is_err());
+        assert!(FocuserStepsPerSec::try_new(f64::NAN).is_err());
+        assert!(FocuserStepsPerSec::try_new(f64::INFINITY).is_err());
     }
 }

--- a/services/rp/src/equipment/focuser.rs
+++ b/services/rp/src/equipment/focuser.rs
@@ -117,6 +117,7 @@ mod tests {
             device_number: 0,
             min_position: None,
             max_position: None,
+            steps_per_sec: Default::default(),
             auth: None,
         }
     }
@@ -136,6 +137,7 @@ mod tests {
             device_number: 0,
             min_position: None,
             max_position: None,
+            steps_per_sec: Default::default(),
             auth: None,
         };
         let entry = connect_focuser(&cfg).await;
@@ -156,6 +158,7 @@ mod tests {
             device_number: 0,
             min_position: None,
             max_position: None,
+            steps_per_sec: Default::default(),
             auth: None,
         };
         let entry = connect_focuser(&cfg).await;

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -61,6 +61,47 @@ const MIN_SLEW_DEADLINE: Duration = Duration::from_secs(30);
 /// the slew.
 const SLEW_DEADLINE_FALLBACK: Duration = Duration::from_secs(300);
 
+/// Worst-case axis traverse used to size the park deadline (§2.2). The
+/// generic Alpaca `Telescope` trait exposes no park-position getter, so rp
+/// cannot compute a great-circle distance to the park position the way
+/// `slew` does. 180° is the maximum angular separation between any two
+/// points on the sphere — the honest upper bound on how far park can
+/// traverse without reading the park coordinates.
+const PARK_WORST_CASE_TRAVERSE_DEG: f64 = 180.0;
+
+/// Headroom multiplier over the worst-case park `predicted`. Smaller than
+/// slew's ×3 (which sits over a *measured* small distance): park's
+/// `predicted` is already a worst-case 180° traverse, so ×3 would re-approach
+/// the old 300 s ceiling and defeat the point.
+const PARK_DEADLINE_HEADROOM: f64 = 2.0;
+
+/// Floor on the predictive park deadline. More generous than
+/// [`MIN_SLEW_DEADLINE`] — park traverses to a fixed mechanical position
+/// that can be a long way off, and OmniSim's BDD park is a from-rest
+/// physical traverse.
+const MIN_PARK_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Park deadline used when no mount is configured (the only case in which
+/// the park deadline can't be sized). Park would fail immediately without a
+/// mount anyway; the fallback keeps the poll loop bounded for symmetry with
+/// the slew path.
+const PARK_DEADLINE_FALLBACK: Duration = Duration::from_secs(300);
+
+/// Headroom multiplier over the focuser `predicted` (§2.3): `max =
+/// max(predicted × 2, MIN_FOCUSER_DEADLINE)`.
+const FOCUSER_DEADLINE_HEADROOM: f64 = 2.0;
+
+/// Floor on the predictive `move_focuser` deadline — a tiny move still gets
+/// at least this long, covering fixed controller/`IsMoving` latency.
+const MIN_FOCUSER_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Move-focuser deadline used when the predicted deadline can't be computed
+/// — the focuser isn't resolvable, or the pre-move position read failed. A
+/// prediction is an optimization, not a precondition for moving, so the
+/// deadline degrades to the historical 120 s ceiling rather than failing
+/// the move.
+const FOCUSER_DEADLINE_FALLBACK: Duration = Duration::from_secs(120);
+
 // ---------------------------------------------------------------------------
 // Private helper types shared across imaging tool bodies. All
 // `pub(crate)` so individual category files can construct them.
@@ -742,10 +783,57 @@ impl McpHandler {
         capture_result.map(|()| (image_path, document_id))
     }
 
+    /// Size the predictive `move_focuser` deadline from the focuser's
+    /// current position, the requested target, and the configured step rate
+    /// (§2.3): `predicted = |target − current| / steps_per_sec`,
+    /// `max = max(predicted × 2, MIN_FOCUSER_DEADLINE)`. Returns the poll
+    /// deadline plus the `(predicted_ms, max_ms)` pair for the
+    /// `move_focuser_started` envelope.
+    ///
+    /// `Err` if the focuser can't be resolved or the pre-move position read
+    /// fails; the caller then falls back to [`FOCUSER_DEADLINE_FALLBACK`]
+    /// and omits the envelope deadline fields.
+    async fn compute_focuser_deadline(
+        &self,
+        focuser_id: &str,
+        target: i32,
+    ) -> std::result::Result<(Duration, u64, u64), String> {
+        let foc_entry = self
+            .equipment
+            .find_focuser(focuser_id)
+            .ok_or_else(|| format!("focuser not found: {focuser_id}"))?;
+        let foc = foc_entry
+            .device
+            .as_ref()
+            .ok_or_else(|| format!("focuser not connected: {focuser_id}"))?;
+        let rate = foc_entry.config.steps_per_sec.value();
+        let current = foc
+            .position()
+            .await
+            .map_err(|e| format!("failed to read focuser position: {e}"))?;
+        // i64 difference can't overflow two i32s; abs gives the step travel.
+        let distance = (i64::from(target) - i64::from(current)).unsigned_abs() as f64;
+        let predicted_secs = distance / rate;
+        let max_secs =
+            (predicted_secs * FOCUSER_DEADLINE_HEADROOM).max(MIN_FOCUSER_DEADLINE.as_secs_f64());
+        let deadline = Duration::try_from_secs_f64(max_secs).map_err(|e| {
+            format!(
+                "predicted focuser deadline out of range \
+                 (steps_per_sec {rate}, distance {distance} steps): {e}"
+            )
+        })?;
+        Ok((
+            deadline,
+            (predicted_secs * 1000.0).round() as u64,
+            (max_secs * 1000.0).round() as u64,
+        ))
+    }
+
     /// Resolve a focuser, validate the requested `position` against the
     /// operator-supplied `min_position`/`max_position` bounds, issue the
-    /// Alpaca move, poll `is_moving` until idle (with a 120 s deadline),
-    /// and return the focuser's reported `position` after settling.
+    /// Alpaca move, poll `is_moving` until idle (bounded by a predicted
+    /// deadline; see [`Self::compute_focuser_deadline`]), and return the
+    /// focuser's reported `position` after settling.
     ///
     /// This is the shared body of the `move_focuser` MCP tool and the
     /// `auto_focus` compound tool's per-step focuser drive — both want
@@ -754,7 +842,7 @@ impl McpHandler {
     /// When `progress` is `Some`, the `is_moving` poll loop emits
     /// `notifications/progress` every [`PROGRESS_INTERVAL`] so rmcp's
     /// 300 s session keep-alive sees session activity from a focuser
-    /// run that approaches its own 120 s deadline. `None` (unit tests,
+    /// run that approaches its own deadline. `None` (unit tests,
     /// clients without `progressToken`) makes the emission a no-op.
     pub(crate) async fn do_move_focuser_blocking(
         &self,
@@ -764,14 +852,38 @@ impl McpHandler {
     ) -> std::result::Result<i32, String> {
         let operation_id = Uuid::new_v4().to_string();
         let started_at = chrono::Utc::now();
-        self.event_bus.emit_operation(EventEnvelope::started(
-            "move_focuser",
-            &operation_id,
-            started_at,
-            serde_json::json!({ "focuser_id": focuser_id, "position": position }),
-        ));
+
+        // Size the deadline from the move's actual workload. If the focuser
+        // can't be resolved or the pre-move position read fails, fall back to
+        // the historical 120 s ceiling and omit the deadline fields — a
+        // prediction is an optimization, not a precondition for moving.
+        let started_payload = serde_json::json!({ "focuser_id": focuser_id, "position": position });
+        let (deadline, started_event) = match self
+            .compute_focuser_deadline(focuser_id, position)
+            .await
+        {
+            Ok((deadline, predicted_ms, max_ms)) => (
+                deadline,
+                EventEnvelope::started("move_focuser", &operation_id, started_at, started_payload)
+                    .with_deadlines(predicted_ms, max_ms),
+            ),
+            Err(e) => {
+                debug!(error = %e, "move_focuser deadline prediction unavailable; using fallback ceiling");
+                (
+                    FOCUSER_DEADLINE_FALLBACK,
+                    EventEnvelope::started(
+                        "move_focuser",
+                        &operation_id,
+                        started_at,
+                        started_payload,
+                    ),
+                )
+            }
+        };
+        self.event_bus.emit_operation(started_event);
+
         let result = self
-            .do_move_focuser_blocking_inner(focuser_id, position, progress)
+            .do_move_focuser_blocking_inner(focuser_id, position, deadline, progress)
             .await;
         match &result {
             Ok(final_position) => self.event_bus.emit_operation(EventEnvelope::complete(
@@ -793,11 +905,14 @@ impl McpHandler {
     /// Inner body of [`do_move_focuser_blocking`] — resolve + bounds-check
     /// then move, poll until idle, and read back. Split out so the public
     /// method wraps it in the `move_focuser_started` /
-    /// `move_focuser_complete` / `move_focuser_failed` triple.
+    /// `move_focuser_complete` / `move_focuser_failed` triple. `deadline` is
+    /// the predicted poll ceiling sized by the wrapper (see
+    /// [`Self::compute_focuser_deadline`]).
     async fn do_move_focuser_blocking_inner(
         &self,
         focuser_id: &str,
         position: i32,
+        deadline: Duration,
         progress: Option<&dyn ProgressEmitter>,
     ) -> std::result::Result<i32, String> {
         let foc_entry = self
@@ -832,7 +947,7 @@ impl McpHandler {
             .await
             .map_err(|e| format!("failed to move focuser: {}", e))?;
 
-        let total_budget = Duration::from_secs(120);
+        let total_budget = deadline;
         let total_budget_secs = total_budget.as_secs_f64();
         let started_at = Instant::now();
         let deadline = started_at + total_budget;
@@ -1089,8 +1204,43 @@ impl McpHandler {
         Ok((actual_ra, actual_dec))
     }
 
+    /// Size the park deadline (§2.2). rp can't read the mount's park
+    /// coordinates — the generic Alpaca `Telescope` trait exposes no
+    /// park-position getter — so the deadline is the worst-case full-axis
+    /// traverse ([`PARK_WORST_CASE_TRAVERSE_DEG`]) at the configured slew
+    /// rate, not a distance-scaled prediction like slew:
+    /// `predicted = 180° / slew_rate + settle`,
+    /// `max = max(predicted × 2, MIN_PARK_DEADLINE)`. Returns the poll
+    /// deadline plus the `(predicted_ms, max_ms)` pair for the
+    /// `park_started` envelope.
+    ///
+    /// `Err` only when no mount is configured (the caller then falls back
+    /// to [`PARK_DEADLINE_FALLBACK`] and omits the envelope deadline
+    /// fields — though park fails immediately without a mount anyway).
+    fn compute_park_deadline(&self) -> std::result::Result<(Duration, u64, u64), String> {
+        let entry = self
+            .equipment
+            .find_mount()
+            .ok_or_else(|| "no mount configured".to_string())?;
+        let rate = entry.config.slew_rate_arcsec_per_sec.value();
+        let settle = entry.config.settle_after_slew.unwrap_or(Duration::ZERO);
+        let worst_case_arcsec = PARK_WORST_CASE_TRAVERSE_DEG * 3600.0;
+        let predicted_secs = worst_case_arcsec / rate + settle.as_secs_f64();
+        let max_secs =
+            (predicted_secs * PARK_DEADLINE_HEADROOM).max(MIN_PARK_DEADLINE.as_secs_f64());
+        let deadline = Duration::try_from_secs_f64(max_secs).map_err(|e| {
+            format!("predicted park deadline out of range (slew_rate_arcsec_per_sec {rate}): {e}")
+        })?;
+        Ok((
+            deadline,
+            (predicted_secs * 1000.0).round() as u64,
+            (max_secs * 1000.0).round() as u64,
+        ))
+    }
+
     /// Resolve the mount, issue `park()`, then poll `at_park()` every
-    /// 100 ms until it returns `true` (300 s deadline).
+    /// 100 ms until it returns `true`, bounded by a predicted deadline
+    /// (see [`Self::compute_park_deadline`]).
     ///
     /// `AtPark` is the ASCOM-canonical "park is complete" signal — set
     /// in exactly one code path (the slew-to-park completion handler).
@@ -1112,20 +1262,39 @@ impl McpHandler {
     /// When `progress` is `Some`, the `at_park` poll loop emits
     /// `notifications/progress` every [`PROGRESS_INTERVAL`] so rmcp's
     /// 300 s session keep-alive cannot fire during a legitimate
-    /// long park (which has the same 300 s deadline).
+    /// long park (whose deadline can exceed the keep-alive).
     pub(crate) async fn do_park_blocking(
         &self,
         progress: Option<&dyn ProgressEmitter>,
     ) -> std::result::Result<(), String> {
         let operation_id = Uuid::new_v4().to_string();
         let started_at = chrono::Utc::now();
-        self.event_bus.emit_operation(EventEnvelope::started(
-            "park",
-            &operation_id,
-            started_at,
-            serde_json::json!({}),
-        ));
-        let result = self.do_park_blocking_inner(progress).await;
+
+        // Size the deadline from the worst-case traverse at the configured
+        // slew rate. With no mount configured, fall back to the historical
+        // 300 s ceiling and omit the deadline fields.
+        let (deadline, started_event) = match self.compute_park_deadline() {
+            Ok((deadline, predicted_ms, max_ms)) => (
+                deadline,
+                EventEnvelope::started("park", &operation_id, started_at, serde_json::json!({}))
+                    .with_deadlines(predicted_ms, max_ms),
+            ),
+            Err(e) => {
+                debug!(error = %e, "park deadline prediction unavailable; using fallback ceiling");
+                (
+                    PARK_DEADLINE_FALLBACK,
+                    EventEnvelope::started(
+                        "park",
+                        &operation_id,
+                        started_at,
+                        serde_json::json!({}),
+                    ),
+                )
+            }
+        };
+        self.event_bus.emit_operation(started_event);
+
+        let result = self.do_park_blocking_inner(deadline, progress).await;
         match &result {
             Ok(()) => self.event_bus.emit_operation(EventEnvelope::complete(
                 "park",
@@ -1148,9 +1317,11 @@ impl McpHandler {
     /// the `park_started` / `park_complete` / `park_failed` triple. The
     /// timeout path still returns `Err` (so `park_failed` fires) and
     /// still does NOT auto-abort — the watchdog ladder owns that decision
-    /// in Phase 5.
+    /// in Phase 5. `deadline` is the predicted poll ceiling sized by the
+    /// wrapper (see [`Self::compute_park_deadline`]).
     async fn do_park_blocking_inner(
         &self,
+        deadline: Duration,
         progress: Option<&dyn ProgressEmitter>,
     ) -> std::result::Result<(), String> {
         let (_entry, mount) = self.resolve_mount()?;
@@ -1161,7 +1332,7 @@ impl McpHandler {
             .await
             .map_err(|e| format!("failed to park: {}", e))?;
 
-        let total_budget = Duration::from_secs(300);
+        let total_budget = deadline;
         let total_budget_secs = total_budget.as_secs_f64();
         let started_at = Instant::now();
         let deadline = started_at + total_budget;

--- a/services/rp/src/mcp/internals.rs
+++ b/services/rp/src/mcp/internals.rs
@@ -790,9 +790,11 @@ impl McpHandler {
     /// deadline plus the `(predicted_ms, max_ms)` pair for the
     /// `move_focuser_started` envelope.
     ///
-    /// `Err` if the focuser can't be resolved or the pre-move position read
-    /// fails; the caller then falls back to [`FOCUSER_DEADLINE_FALLBACK`]
-    /// and omits the envelope deadline fields.
+    /// `Err` if the focuser can't be resolved, the pre-move position read
+    /// fails, or an absurdly small (but config-valid) step rate makes the
+    /// deadline overflow `Duration` (`try_from_secs_f64`); the caller then
+    /// falls back to [`FOCUSER_DEADLINE_FALLBACK`] and omits the envelope
+    /// deadline fields.
     async fn compute_focuser_deadline(
         &self,
         focuser_id: &str,
@@ -1214,9 +1216,11 @@ impl McpHandler {
     /// deadline plus the `(predicted_ms, max_ms)` pair for the
     /// `park_started` envelope.
     ///
-    /// `Err` only when no mount is configured (the caller then falls back
-    /// to [`PARK_DEADLINE_FALLBACK`] and omits the envelope deadline
-    /// fields — though park fails immediately without a mount anyway).
+    /// `Err` when no mount is configured, or when an absurdly small (but
+    /// config-valid) slew rate makes the worst-case deadline overflow
+    /// `Duration` (`try_from_secs_f64`). The caller then falls back to
+    /// [`PARK_DEADLINE_FALLBACK`] and omits the envelope deadline fields
+    /// (and park fails immediately anyway when no mount is configured).
     fn compute_park_deadline(&self) -> std::result::Result<(Duration, u64, u64), String> {
         let entry = self
             .equipment

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -978,6 +978,7 @@ fn focuser_registry(
                 device_number: 0,
                 min_position,
                 max_position,
+                steps_per_sec: Default::default(),
                 auth: None,
             },
             device: Some(foc),
@@ -2286,6 +2287,11 @@ async fn test_move_focuser_position_read_fails() {
     assert_tool_error(result, "failed to read focuser position");
 }
 
+/// §2.6: `is_moving()` stays `true`, the predicted deadline expires, and the
+/// move returns the timeout error. With current 0 → target 1000 at the
+/// default 500 steps/s the deadline is `max(2 s × 2, 5 s floor) = 5 s`, so
+/// the failure lands far under the old 120 s ceiling — proof the deadline
+/// now scales with the move. `start_paused` auto-advances virtual time.
 #[tokio::test(start_paused = true)]
 async fn test_move_focuser_timeout() {
     let foc = MockFocuser {
@@ -2293,6 +2299,7 @@ async fn test_move_focuser_timeout() {
         ..Default::default()
     };
     let handler = test_handler(focuser_registry(Arc::new(foc), None, None));
+    let started_at = tokio::time::Instant::now();
     let result = handler
         .move_focuser_inner(
             MoveFocuserParams {
@@ -2302,7 +2309,13 @@ async fn test_move_focuser_timeout() {
             None,
         )
         .await;
+    let elapsed = started_at.elapsed();
     assert_tool_error(result, "timeout waiting for focuser to settle");
+    assert!(
+        elapsed < Duration::from_secs(60),
+        "a short move should hit its computed ~5 s deadline, not the old \
+         120 s ceiling; elapsed {elapsed:?}"
+    );
 }
 
 #[tokio::test]
@@ -2321,6 +2334,7 @@ async fn test_move_focuser_not_connected() {
                 device_number: 0,
                 min_position: None,
                 max_position: None,
+                steps_per_sec: Default::default(),
                 auth: None,
             },
             device: None,
@@ -2373,6 +2387,7 @@ async fn test_get_focuser_position_not_connected() {
                 device_number: 0,
                 min_position: None,
                 max_position: None,
+                steps_per_sec: Default::default(),
                 auth: None,
             },
             device: None,
@@ -2885,11 +2900,12 @@ async fn test_park_alpaca_error_propagates() {
     assert_tool_error(result, "failed to park");
 }
 
-/// 300 s deadline expires while `at_park()` keeps returning `false`.
-/// Unlike `slew`, `park` does NOT auto-abort — it surfaces the
-/// timeout and lets the caller decide. `start_paused` lets tokio
-/// auto-advance virtual time so the test runs in real-time
-/// milliseconds.
+/// The predicted deadline expires while `at_park()` keeps returning
+/// `false`. Unlike `slew`, `park` does NOT auto-abort — it surfaces the
+/// timeout and lets the caller decide. §2.2: the deadline is the worst-case
+/// 180° traverse at the default 7200″/s rate (`90 s × 2 = 180 s`), so the
+/// failure lands below the old 300 s ceiling. `start_paused` auto-advances
+/// virtual time so the test runs in real-time milliseconds.
 #[tokio::test(start_paused = true)]
 async fn test_park_timeout_does_not_auto_abort() {
     let mount = MockTelescope {
@@ -2897,8 +2913,15 @@ async fn test_park_timeout_does_not_auto_abort() {
         ..Default::default()
     };
     let handler = test_handler(mount_registry(Arc::new(mount), None));
+    let started_at = tokio::time::Instant::now();
     let result = handler.park_inner(ParkParams {}, None).await;
+    let elapsed = started_at.elapsed();
     assert_tool_error(result, "timeout waiting for mount to park");
+    assert!(
+        elapsed < Duration::from_secs(250),
+        "park should hit its computed worst-case deadline (~180 s at the \
+         default rate), not the old 300 s ceiling; elapsed {elapsed:?}"
+    );
 }
 
 #[tokio::test]
@@ -4329,6 +4352,7 @@ fn auto_focus_registry(starting_position: i32) -> crate::equipment::EquipmentReg
                 device_number: 0,
                 min_position: None,
                 max_position: None,
+                steps_per_sec: Default::default(),
                 auth: None,
             },
             device: Some(Arc::new(focuser)),
@@ -4634,7 +4658,10 @@ async fn do_capture_emits_exposing_phase_before_readout() {
 /// `is_moving == true` for ~12 s and then `false` must fire at least two
 /// progress notifications (5 s + 10 s marks) tagged `"focuser_moving"`
 /// during the settle poll — the focuser counterpart to the slew/park/
-/// capture progress tests.
+/// capture progress tests. The target (10000) sits far enough from the
+/// current position (4321) that the predicted deadline
+/// (`5679 / 500 × 2 ≈ 22.7 s`) comfortably covers the 12 s move; the mock's
+/// fixed readback still returns 4321.
 #[tokio::test(start_paused = true)]
 async fn do_move_focuser_blocking_emits_progress_during_move() {
     let foc = MockFocuser {
@@ -4645,7 +4672,7 @@ async fn do_move_focuser_blocking_emits_progress_during_move() {
     let handler = test_handler(focuser_registry(Arc::new(foc), None, None));
     let emitter = super::progress::test_support::CountingProgressEmitter::default();
     let position = handler
-        .do_move_focuser_blocking("foc", 4321, Some(&emitter))
+        .do_move_focuser_blocking("foc", 10000, Some(&emitter))
         .await
         .expect("move completes when the focuser reports idle");
     assert_eq!(position, 4321);
@@ -4822,10 +4849,13 @@ fn assert_end_mirrors_start(
         "no ended_at on the start envelope"
     );
     // The matching `*_started` envelope carries deadline fields only for
-    // operations with a predictive deadline (slew, §2.1); every other
-    // operation's start must still omit them. (slew's start is asserted
-    // present by its own test.)
-    if !start.event.starts_with("slew") {
+    // operations with a predictive deadline (slew §2.1, park + move_focuser
+    // §2.2/§2.3); every other operation's start must still omit them. (Each
+    // converted operation's start is asserted present by its own test.)
+    let has_predictive_deadline = start.event.starts_with("slew")
+        || start.event.starts_with("park")
+        || start.event.starts_with("move_focuser");
+    if !has_predictive_deadline {
         assert!(
             start.predicted_duration_ms.is_none(),
             "{} start envelope must omit predicted_duration_ms",
@@ -5044,6 +5074,12 @@ async fn park_emits_started_complete_triple() {
     assert_eq!(started.event, "park_started");
     assert_eq!(complete.event, "park_complete");
     assert_end_mirrors_start(&started, &complete);
+
+    // §2.2: no park coordinates are knowable via Alpaca, so the deadline is
+    // the worst-case 180° traverse at the default 7200″/s rate: predicted =
+    // 648000″ / 7200 = 90 s, max = 90 × 2 = 180 s (above the 60 s floor).
+    assert_eq!(started.predicted_duration_ms, Some(90000));
+    assert_eq!(started.max_duration_ms, Some(180000));
 }
 
 #[tokio::test]
@@ -5071,6 +5107,72 @@ async fn move_focuser_emits_started_complete_triple() {
     assert_eq!(started.payload["position"], 4321);
     assert_eq!(complete.payload["position"], 4321);
     assert_end_mirrors_start(&started, &complete);
+
+    // §2.3: current == target (4321) ⇒ distance 0, so predicted floors at
+    // 0 ms and max at the 5 s MIN_FOCUSER_DEADLINE floor.
+    assert_eq!(started.predicted_duration_ms, Some(0));
+    assert_eq!(started.max_duration_ms, Some(5000));
+}
+
+/// §2.3: the `move_focuser_started` envelope carries a deadline sized from
+/// the step travel. Current 0 → target 10000 at the default 500 steps/s is
+/// predicted = 20 s and max = max(20 × 2, 5 s floor) = 40 s (target chosen
+/// large enough that `predicted × 2` clears the floor, so the distance
+/// scaling — not the floor — is what's asserted).
+#[tokio::test]
+async fn move_focuser_started_carries_distance_scaled_deadline() {
+    let foc = MockFocuser {
+        position_value: 0,
+        ..Default::default()
+    };
+    let handler = test_handler(focuser_registry(Arc::new(foc), None, None));
+    let mut rx = handler.event_bus.subscribe();
+
+    handler
+        .do_move_focuser_blocking("foc", 10000, None)
+        .await
+        .unwrap();
+
+    let started = next_event(&mut rx).await;
+    assert_eq!(started.event, "move_focuser_started");
+    assert_eq!(
+        started.predicted_duration_ms,
+        Some(20000),
+        "10000 steps / 500 steps·s⁻¹ = 20 s predicted"
+    );
+    assert_eq!(
+        started.max_duration_ms,
+        Some(40000),
+        "max = predicted × 2 = 40 s (above the 5 s floor)"
+    );
+}
+
+/// §2.3 fallback: when the pre-move position read fails the deadline can't
+/// be predicted, so `move_focuser_started` omits the deadline fields and the
+/// move proceeds on the fallback ceiling. (Here the same failing read also
+/// fails the post-move read, so the operation ends in error — the point
+/// under test is that the started envelope carries no deadline fields.)
+#[tokio::test]
+async fn move_focuser_started_omits_deadline_when_position_read_fails() {
+    let foc = MockFocuser {
+        fail_position: true,
+        ..Default::default()
+    };
+    let handler = test_handler(focuser_registry(Arc::new(foc), None, None));
+    let mut rx = handler.event_bus.subscribe();
+
+    let _ = handler.do_move_focuser_blocking("foc", 1000, None).await;
+
+    let started = next_event(&mut rx).await;
+    assert_eq!(started.event, "move_focuser_started");
+    assert!(
+        started.predicted_duration_ms.is_none(),
+        "fallback path must omit predicted_duration_ms"
+    );
+    assert!(
+        started.max_duration_ms.is_none(),
+        "fallback path must omit max_duration_ms"
+    );
 }
 
 #[tokio::test]

--- a/services/rp/tests/bdd/steps/operation_event_steps.rs
+++ b/services/rp/tests/bdd/steps/operation_event_steps.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use cucumber::{given, then, when};
 
-use bdd_infra::rp_harness::{ReceivedEvent, WebhookReceiver};
+use bdd_infra::rp_harness::{FocuserConfig, ReceivedEvent, WebhookReceiver};
 
 use crate::world::RpWorld;
 
@@ -56,6 +56,20 @@ async fn rp_with_camera_and_plugin(world: &mut RpWorld) {
     crate::steps::tool_steps::start_rp(world).await;
 }
 
+#[given("rp is running with a focuser and the operation-event plugin")]
+async fn rp_with_focuser_and_plugin(world: &mut RpWorld) {
+    crate::steps::tool_steps::ensure_omnisim(world).await;
+    let url = world.omnisim_url();
+    world.focusers.push(FocuserConfig {
+        id: "main-focuser".to_string(),
+        alpaca_url: url,
+        device_number: 0,
+        min_position: None,
+        max_position: None,
+    });
+    crate::steps::tool_steps::start_rp(world).await;
+}
+
 // --- When steps --------------------------------------------------------
 
 #[when(expr = "the operator slews to ra {float} dec {float}")]
@@ -74,6 +88,17 @@ async fn operator_parks(world: &mut RpWorld) {
 #[when("the operator unparks the mount")]
 async fn operator_unparks(world: &mut RpWorld) {
     let _ = world.mcp().call_tool("unpark", serde_json::json!({})).await;
+}
+
+#[when(expr = "the operator moves the focuser to position {int}")]
+async fn operator_moves_focuser(world: &mut RpWorld, position: i32) {
+    let _ = world
+        .mcp()
+        .call_tool(
+            "move_focuser",
+            serde_json::json!({ "focuser_id": "main-focuser", "position": position }),
+        )
+        .await;
 }
 
 #[when(expr = "the operator syncs the mount to ra {float} dec {float}")]

--- a/services/rp/tests/features/operation_events.feature
+++ b/services/rp/tests/features/operation_events.feature
@@ -5,9 +5,10 @@ Feature: Operation event envelopes
   event at exit, all sharing one `operation_id` so a consumer can
   correlate the triple. Each emission carries its own `event_id` and a
   monotonic `event_seq`; the start carries `started_at` and the end adds
-  `ended_at` plus `elapsed_ms`. The `slew_started` event also carries the
-  `predicted_duration_ms` / `max_duration_ms` deadline fields (Phase 2.1);
-  operations not yet converted to predictive deadlines omit them.
+  `ended_at` plus `elapsed_ms`. The `slew_started`, `park_started`, and
+  `move_focuser_started` events also carry the `predicted_duration_ms` /
+  `max_duration_ms` deadline fields (Phase 2); operations not yet converted
+  to predictive deadlines omit them.
 
   The envelope is additive over the historical webhook body: the
   `event_id`, `event`, `timestamp`, and `payload` keys keep their exact
@@ -60,7 +61,7 @@ Feature: Operation event envelopes
     And the webhook delivers the "park_complete" event
     And the "park_started" and "park_complete" events share one operation_id
     And the "park_complete" event has a higher event_seq than the "park_started" event
-    And the "park_started" event reserves the deadline fields as absent
+    And the "park_started" event carries the deadline fields
 
   Scenario: Sync emits a complete event with no started event
     Given a running Alpaca simulator
@@ -96,3 +97,16 @@ Feature: Operation event envelopes
     And the "exposure_started" event payload includes "camera_id"
     And the "exposure_complete" event payload includes "document_id"
     And the "exposure_complete" event payload includes "file_path"
+
+  Scenario: Move-focuser emits a started and complete event under one operation_id
+    Given a running Alpaca simulator
+    And a webhook subscriber for the "move_focuser" operation
+    And rp is running with a focuser and the operation-event plugin
+    And an MCP client connected to rp
+    When the operator moves the focuser to position 25500
+    Then the webhook delivers the "move_focuser_started" event
+    And the webhook delivers the "move_focuser_complete" event
+    And the "move_focuser_started" and "move_focuser_complete" events share one operation_id
+    And the "move_focuser_started" event carries the deadline fields
+    And the "move_focuser_started" event payload includes "focuser_id"
+    And the "move_focuser_complete" event payload includes "position"

--- a/services/rp/tests/features/operation_events.feature
+++ b/services/rp/tests/features/operation_events.feature
@@ -6,9 +6,11 @@ Feature: Operation event envelopes
   correlate the triple. Each emission carries its own `event_id` and a
   monotonic `event_seq`; the start carries `started_at` and the end adds
   `ended_at` plus `elapsed_ms`. The `slew_started`, `park_started`, and
-  `move_focuser_started` events also carry the `predicted_duration_ms` /
-  `max_duration_ms` deadline fields (Phase 2); operations not yet converted
-  to predictive deadlines omit them.
+  `move_focuser_started` events carry the `predicted_duration_ms` /
+  `max_duration_ms` deadline fields (Phase 2) when the deadline can be
+  predicted, and omit them on the fallback path (e.g. a pre-read failure, or
+  no mount configured for park); operations not yet converted to predictive
+  deadlines always omit them.
 
   The envelope is additive over the historical webhook body: the
   `event_id`, `event`, `timestamp`, and `payload` keys keep their exact


### PR DESCRIPTION
## Summary

Advances **Phase 2 of the predictive-deadlines plan** from one-fifth to three-fifths landed: replaces the last two hardcoded blocking-poll ceilings — `park`'s 300 s and `move_focuser`'s 120 s — with deadlines sized per call, and populates the `predicted_duration_ms` / `max_duration_ms` envelope fields that Phase 1 reserved. Follows the slew §2.1 template (#348).

Plan: [`docs/plans/predictive-deadlines-and-watchdog.md`](docs/plans/predictive-deadlines-and-watchdog.md) §2.2 + §2.3 · implementation plan: [`docs/plans/predictive-deadlines-phase2-park-focuser.md`](docs/plans/predictive-deadlines-phase2-park-focuser.md).

## park (§2.2)

rp can't read the mount's park coordinates via the generic Alpaca `Telescope` trait (no park-position getter), so the deadline is a **worst-case 180° axis traverse** at the configured slew rate rather than a distance-scaled prediction:

```
predicted = 180° / mount.slew_rate_arcsec_per_sec + settle
max       = max(predicted × 2, MIN_PARK_DEADLINE = 60 s)
```

- Reuses the existing `mount.slew_rate_arcsec_per_sec` — **no new config**.
- Park keeps its **no-auto-abort** contract; the deadline only changes *when* the timeout surfaces (300 s → ~180 s at the default rate). Falls back to 300 s with no mount configured.

## move_focuser (§2.3)

```
predicted = |target − current| / focuser.steps_per_sec   (current read before the move)
max       = max(predicted × 2, MIN_FOCUSER_DEADLINE = 5 s)
```

- Adds a validating `FocuserStepsPerSec` config newtype (`serde(try_from = "f64")`, rejects non-finite/≤0), default **500 steps/s** — deliberately slow so `predicted` over-estimates and the deadline won't false-abort a healthy move.
- A failed pre-move position read falls back to the legacy 120 s ceiling and omits the envelope deadline fields.

Both stamp `park_started` / `move_focuser_started` via `EventEnvelope::with_deadlines`.

## Out of scope

Exposure (§2.4, envelope-stamping only — rp doesn't enforce) and centering (§2.5, already inherits the per-slew deadline) are a separate PR — see the implementation plan's "Why exposure & centering are deferred".

## Changes

- `compute_park_deadline` / `compute_focuser_deadline` in `mcp/internals.rs`; `deadline` threaded into `do_park_blocking_inner` / `do_move_focuser_blocking_inner` (replacing `Duration::from_secs(300)`/`(120)`).
- `FocuserStepsPerSec` newtype + `FocuserConfig.steps_per_sec` field.
- Unit tests: deadline math, distance-scaled, read-failure fallback, and the §2.6 timeout tests assert elapsed lands below the old 300 s/120 s ceilings.
- BDD `operation_events.feature`: park scenario flipped to assert the deadline fields **present**; new move_focuser scenario.
- `rp.md`: park/move_focuser catalog rows, Event Envelope field doc, `focuser.steps_per_sec` config, Sentinel monitored-ops rows, keep-alive note.

## Testing

- `cargo fmt` clean; `cargo rail run --profile commit -q` green (462 unit tests).
- Full `rp` BDD suite: **272/272 scenarios (1910 steps)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
