### PR TITLE
docs(qhy-camera): design doc for QHYCCD ASCOM Camera + FilterWheel service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Coverage has two columns: **Cargo** is the canonical, required coverage; **Bazel
 | [star-adventurer-gti](services/star-adventurer-gti) | ASCOM Telescope | 11117 | [![coverage][cov-star-adventurer-gti]][cov-star-adventurer-gti-link] | [![coverage][cov-bazel-star-adventurer-gti]][cov-bazel-star-adventurer-gti-link] | Driver for Sky-Watcher Star Adventurer GTi (USB and WiFi/UDP) |
 | [pa-falcon-rotator](services/pa-falcon-rotator) | ASCOM Rotator + Switch (status) | 11118 | [![coverage][cov-pa-falcon-rotator]][cov-pa-falcon-rotator-link] | [![coverage][cov-bazel-pa-falcon-rotator]][cov-bazel-pa-falcon-rotator-link] | Driver for Pegasus Astro Falcon Rotator (firmware ≥ 1.3) |
 | [dsd-fp2](services/dsd-fp2) | ASCOM CoverCalibrator | 11119 | [![coverage][cov-dsd-fp2]][cov-dsd-fp2-link] | [![coverage][cov-bazel-dsd-fp2]][cov-bazel-dsd-fp2-link] | Driver for Deep Sky Dad Flat Panel 2 (motorised flat field panel) |
+| [ui-htmx](services/ui-htmx) | Web config UI (BFF) | 11120 | [![coverage][cov-ui-htmx]][cov-ui-htmx-link] | [![coverage][cov-bazel-ui-htmx]][cov-bazel-ui-htmx-link] | Server-rendered configuration UI (axum + Maud + HTMX); edits any driver's config via its `config.get`/`config.apply` actions |
+| [plate-solver](services/plate-solver) | rp-managed HTTP service | 11131 | [![coverage][cov-plate-solver]][cov-plate-solver-link] | [![coverage][cov-bazel-plate-solver]][cov-bazel-plate-solver-link] | Wraps the ASTAP CLI for plate solving in a supervised, crash-isolated process |
+
+> 🚧 **In development:** [qhy-camera](services/qhy-camera) — ASCOM Camera (+ FilterWheel) driver for QHYCCD hardware (port 11121; design + BDD scaffold landed). Links a proprietary vendor SDK, so it is gated out of the default build. See [docs/services/qhy-camera.md](docs/services/qhy-camera.md).
+
+`sentinel-app` is a Leptos web frontend crate (a `cargo leptos` build target for the sentinel dashboard), not a standalone service, so it is not listed above.
 
 ### RP (Main Application)
 
@@ -87,6 +93,22 @@ See [docs/services/falcon-rotator.md](docs/services/falcon-rotator.md) for desig
 ASCOM Alpaca CoverCalibrator driver for the Deep Sky Dad Flat Panel 2 (FP2), a motorised flat-field panel combining a 4096-step EL light source with a servo-driven cover. Built on the workspace's `rusty-photon-shared-transport` crate (PR #269): the FP2's bracketed-ASCII protocol (`[GFRM]`, `[STRG270]`, `[SLBR1234]`, …) is plugged in as an `Fp2Codec`, `Fp2SerialTransportFactory` opens the USB-CDC port (115200 baud, `/dev/ttyACM*`), and a thin `FlatPanelManager` over `SharedTransport<Fp2Codec>` handles refcounting, request arbitration, and the polling task via `Hooks`. Pairs with `calibrator-flats` for automated flat-field calibration without any orchestrator changes.
 
 See [docs/services/dsd-fp2.md](docs/services/dsd-fp2.md) for design documentation.
+
+### UI-HTMX
+
+Browser-facing, server-rendered configuration UI — a standalone backend-for-frontend (BFF) that holds no UI logic inside `rp`. Renders HTML with axum + Maud and adds interactivity with HTMX. It is a **client** of the drivers, reading and writing each one's configuration through the cross-driver `config.get` / `config.apply` / `config.schema` ASCOM actions, so a single UI can configure any driver without driver-specific knowledge.
+
+See [docs/services/ui-htmx.md](docs/services/ui-htmx.md) for design documentation.
+
+### Plate Solver
+
+An **rp-managed** HTTP service that wraps an operator-supplied [ASTAP](https://www.hnsky.org/astap.htm) CLI install and exposes a narrow solve API to `rp`. Plate solving is a hang-prone, crash-prone external binary, so it runs in its own supervised process where its failure modes cannot threaten `rp`'s liveness. Stateless across requests: every solve spawns a fresh `astap_cli` subprocess under a wall-clock timeout.
+
+See [docs/services/plate-solver.md](docs/services/plate-solver.md) for design documentation.
+
+### QHY Camera 🚧
+
+ASCOM Alpaca **Camera (+ FilterWheel)** driver for real QHYCCD hardware, built natively on the published `qhyccd-rs` crate. It enumerates every connected QHY camera and CFW and exposes each as an ASCOM device on one port. **In development** — the design doc and BDD scaffold have landed; implementation is gated behind the proprietary QHYCCD SDK, so the service is excluded from the default build. See [docs/services/qhy-camera.md](docs/services/qhy-camera.md) for design documentation.
 
 ## Getting Started
 
@@ -176,20 +198,36 @@ rusty-photon/
   MODULE.bazel            Bazel module (shadow build, see docs/plans/bazel-migration.md)
   CLAUDE.md / AGENTS.md   Operating rules for AI agents and human contributors
   crates/
-    bdd-infra/             Shared BDD test infrastructure (ServiceHandle)
-    rp-auth/               Shared HTTP Basic Auth (Argon2id + axum middleware, see ADR-003)
-    rp-fits/               FITS file reader/writer wrapper (see ADR-001)
-    rp-tls/                Shared TLS/ACME helpers for inter-service comms (ADR-002)
+    bdd-infra/                       Shared BDD test infrastructure (ServiceHandle + rp-harness)
+    rp-auth/                         HTTP Basic Auth utilities (Argon2id + axum, ADR-003)
+    rp-catalog/                      Embedded Messier/NGC/IC catalog with name resolution
+    rp-ephemeris/                    Astronomical math (Ephemeris + ERFA wrapper + Site)
+    rp-fits/                         FITS reader/writer wrapper (ADR-001)
+    rp-plate-solver/                 HTTP client for the plate-solver service
+    rp-tls/                          TLS/ACME helpers for inter-service comms (ADR-002)
+    rusty-photon-config/             Config-path + first-run UniqueID + config.get/apply/schema protocol
+    rusty-photon-driver/             Shared ASCOM-driver runtime: DriverError + config-action dispatch (ADR-007)
+    rusty-photon-i18n/               Workspace Fluent i18n loader + locale resolver
+    rusty-photon-i18n-derive/        Proc-macro deriving LocalizedParser for clap structs
+    rusty-photon-service-lifecycle/  Unified lifecycle: runtime + signals + optional Windows SCM
+    rusty-photon-shared-transport/   Refcounted multi-client transport scaffolding (serial + UDP)
+    skywatcher-motor-protocol/       Sky-Watcher motor-controller wire protocol codec (USB + UDP)
   services/
-    rp/                    Main application: equipment gateway, event bus
+    rp/                    Main application: equipment gateway, event bus, safety enforcer
     filemonitor/           ASCOM SafetyMonitor (file-based)
     ppba-driver/           ASCOM Switch + ObservingConditions (serial)
     qhy-focuser/           ASCOM Focuser (serial)
+    dsd-fp2/               ASCOM CoverCalibrator — Deep Sky Dad FP2 (serial)
+    pa-falcon-rotator/     ASCOM Rotator + Switch — Pegasus Falcon (serial)
+    star-adventurer-gti/   ASCOM Telescope — Sky-Watcher GTi (USB + WiFi/UDP)
+    sky-survey-camera/     ASCOM Camera simulator backed by NASA SkyView
+    qhy-camera/            ASCOM Camera + FilterWheel — QHYCCD hardware (design + BDD scaffold; SDK-gated)
     phd2-guider/           PHD2 client library (TCP/JSON RPC)
     sentinel/              Monitoring service (HTTP consumer)
-    sentinel-app/          Leptos web frontend for sentinel dashboard
-    calibrator-flats/      Flat field calibration orchestrator (CoverCalibrator)
-    sky-survey-camera/     ASCOM Camera simulator backed by NASA SkyView
+    sentinel-app/          Leptos web frontend for the sentinel dashboard
+    calibrator-flats/      Flat-field calibration orchestrator plugin (CoverCalibrator)
+    plate-solver/          rp-managed HTTP service wrapping the ASTAP CLI
+    ui-htmx/               Server-rendered web configuration UI (BFF)
   docs/
     services/              Per-service design documentation
     skills/                How-to playbooks for agents and operators
@@ -242,6 +280,10 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT L
 [cov-dsd-fp2-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=dsd-fp2
 [cov-pa-falcon-rotator]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=pa-falcon-rotator
 [cov-pa-falcon-rotator-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=pa-falcon-rotator
+[cov-ui-htmx]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=ui-htmx
+[cov-ui-htmx-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=ui-htmx
+[cov-plate-solver]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=plate-solver
+[cov-plate-solver-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=plate-solver
 
 <!-- per-service coverage badges (Bazel shadow build, flag=bazel-<pkg>; read "unknown" until .github/workflows/bazel-coverage.yml has run on main) -->
 [cov-bazel-rp]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-rp
@@ -266,3 +308,7 @@ Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT L
 [cov-bazel-dsd-fp2-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-dsd-fp2
 [cov-bazel-pa-falcon-rotator]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-pa-falcon-rotator
 [cov-bazel-pa-falcon-rotator-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-pa-falcon-rotator
+[cov-bazel-ui-htmx]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-ui-htmx
+[cov-bazel-ui-htmx-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-ui-htmx
+[cov-bazel-plate-solver]: https://codecov.io/gh/ivonnyssen/rusty-photon/branch/main/graph/badge.svg?flag=bazel-plate-solver
+[cov-bazel-plate-solver-link]: https://codecov.io/gh/ivonnyssen/rusty-photon?flags[0]=bazel-plate-solver

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -176,7 +176,8 @@ The MVP boundary drives BDD scenario selection (Phase 2). Grounded in what
 - **Cooling** — `CoolerOn`, `CCDTemperature`, `SetCCDTemperature`, `CoolerPower`,
   `CanSetCCDTemperature`, `CanGetCoolerPower` — all gated on the `Cooler` control.
 - **Sensor type** — `Monochrome` vs `RGGB`/colour + `BayerOffsetX/Y`.
-- **`MaxADU`** = `2^OutputDataActualBits`; `SensorName` from the device id.
+- **`MaxADU`** = `(2^OutputDataActualBits) - 1` (e.g. 65535 for a 16-bit
+  sensor); `SensorName` from the device id.
 - **FilterWheel** as a second ASCOM device on the same port (when present):
   `Names`, `Position` (with moving state), `set_position`, `FocusOffsets`.
 - **Dark frames on shutter-equipped models** — `Light = false` closes the
@@ -410,7 +411,7 @@ Values are grounded in the `qhyccd-rs`-backed implementation.
 | `BinX` / `BinY` / `MaxBinX` / `MaxBinY` | Symmetric; max from valid binning modes |
 | `CanAsymmetricBin` | `false` |
 | `NumX` / `NumY` / `StartX` / `StartY` | Setters relaxed; validated at `StartExposure` |
-| `MaxADU` | `2^OutputDataActualBits` |
+| `MaxADU` | `(2^OutputDataActualBits) - 1` (65535 for 16-bit) |
 | `ElectronsPerADU` / `FullWellCapacity` | `NOT_IMPLEMENTED` (placeholder only if ConformU demands) |
 | `ExposureMin` / `Max` / `Resolution` | From SDK `get_parameter_min_max_step(Exposure)` |
 | `Gain` / `GainMin` / `GainMax` | SDK `Gain` control; `NOT_IMPLEMENTED` if absent |

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -212,9 +212,11 @@ toggle and the port.
 
 ```jsonc
 {
-  // Optional, keyed by SDK serial. A device with no entry uses SDK-derived
-  // defaults (name from model+serial; CFW filter names "Filter0".."FilterN").
-  "overrides": {
+  // Optional per-device overrides, keyed by SDK serial. A device with no
+  // entry uses SDK-derived defaults (name from model+serial; CFW filter names
+  // "Filter0".."FilterN"). Named `devices` (not `overrides`) to avoid colliding
+  // with the config.get response's own `overrides[]` (CLI-pinned paths) field.
+  "devices": {
     "QHY600M-0123456789": {
       "name": "Main Imaging",
       "description": "QHY600M @ 1000mm"
@@ -234,9 +236,10 @@ toggle and the port.
 
 Sections:
 
-- **overrides** — Optional map keyed by **SDK serial**. Lets an operator give a
-  friendly `name`/`description` to a specific camera and human `filter_names` to a
-  specific CFW. Any device without an override uses SDK-derived defaults. v0 does
+- **devices** — Optional per-device override map keyed by **SDK serial**. Lets an
+  operator give a friendly `name`/`description` to a specific camera and human
+  `filter_names` to a specific CFW. Any device without an entry uses SDK-derived
+  defaults. v0 does
   **not** carry per-camera connect-time tuning (gain/offset/target temperature) —
   with heterogeneous cameras those are per-serial concerns and clients set them
   over ASCOM; per-serial defaults are deferred (see *Future Work*).
@@ -261,10 +264,10 @@ supplies `ConfigurableDriver for QhyCameraDriver`:
 - **Hard read-only fields:** `/server/port`, `/filterwheel/enabled` (enabling
   /disabling adds/removes registered endpoints → restart-required, not a live
   apply).
-- **Editable fields:** the `overrides` map (per-serial `name` / `description` /
+- **Editable fields:** the `devices` map (per-serial `name` / `description` /
   `filter_names`).
 - **Validation** at load (parse-don't-validate): `filter_names` entries are
-  non-empty strings; override keys are free-form serial strings.
+  non-empty strings; `devices` keys are free-form serial strings.
 
 `config.apply` persists atomically, returns `status:"applying"` when a field
 changed, and fires the in-process reload (`main.rs` runs under

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -69,7 +69,7 @@ does not break the SDK-less default build.
 
 | Concern | Mechanism |
 |---|---|
-| `cargo build --all` / local dev without SDK | The package is a normal workspace member, but the SDK-less build path is `cargo build -p qhy-camera` is **expected to fail to link** without the SDK. Devs without the SDK use the rest of the workspace normally; `cargo rail`'s `merge_base=true` (affected-packages-only) means the package is only built when *its* files change. Documented in the service README and `MEMORY.md`. |
+| `cargo build --all` / local dev without SDK | The package is a normal workspace member, but **`cargo build -p qhy-camera` is expected to fail to link without the SDK**. Devs without the SDK use the rest of the workspace normally; `cargo rail`'s `merge_base=true` (affected-packages-only) means the package is only built when *its* files change. Documented in this design doc and the service README. |
 | CI | Add an explicit SDK-provisioning step that **pulls SDK 25.09.29 from the NAS / bazel-remote cache** (not a per-build qhyccd.com fetch) + installs `libusb-1.0-0-dev`, before building/testing this package, mirroring the cross-spawn pre-build pattern already in `.github/workflows/test.yml`. |
 | Raspberry Pi nightly runner | Add the SDK (25.09.29) + `libusb` install to `scripts/setup-pi-runner.sh`. **aarch64 confirmed available and linking** — `qhy-camera` is included in the Pi5 arm64 nightly matrix. |
 | Bazel (shadow build) | Tag the target `requires-cargo` initially (kept out of `bazel test //...` by `.bazelrc`'s default `-requires-cargo`). Later replace with a hand-written `crate.annotation` for `libqhyccd-sys` (link-search to the installed SDK, `static=qhyccd`, `dylib=usb-1.0`). Run `CARGO_BAZEL_REPIN=1 bazel mod tidy && bazel mod tidy` after adding `qhyccd-rs` (Rule 10). |
@@ -80,9 +80,12 @@ does not break the SDK-less default build.
   0.1.9 targets. (The `24.12.26` in the older `qhyccd-alpaca` doc is stale.)
 - **arm64: supported and linking** on the Pi5 runner — `qhy-camera` is in the
   arm64 nightly matrix.
-- **SDK distribution: cached** on the NAS / bazel-remote (10.0.0.11). CI and
-  Bazel pull the SDK 25.09.29 from the cache — **no per-build fetch from
-  qhyccd.com**, keeping builds hermetic and offline-capable.
+- **SDK distribution: cached** on the self-hosted build cache (see
+  [`bazel-remote-cache.md`](../skills/bazel-remote-cache.md)). CI and Bazel pull
+  SDK 25.09.29 from the cache — **no per-build fetch from qhyccd.com** — keeping
+  builds hermetic and offline-capable. The proprietary SDK blob must live behind
+  the authenticated/internal cache tier, **not** the anonymous-read public mirror
+  (`cache.rustyphoton.space`), pending the redistribution-terms question below.
 
 ### Open questions still to resolve before Track A lands
 
@@ -535,7 +538,6 @@ driver itself).
 - **`StopExposure`** (graceful stop with readout) — currently `NOT_IMPLEMENTED`.
 - **FastReadout** validation on real hardware.
 - **PulseGuide** / `CanPulseGuide`.
-- **Multiple cameras per service instance** (v0 binds one).
 - **Focuser consolidation.** `qhyccd-rs` also covers QHY focusers; a future
   evaluation could let this SDK supersede the serial [`qhy-focuser`](qhy-focuser.md).
 - **TLS / Basic Auth** via `rp-tls` / `rp-auth`.

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -1,0 +1,550 @@
+# Qhy-Camera Service Design
+
+> **Status:** Design phase (pre-implementation), per the design→BDD→implementation
+> workflow in
+> [`docs/skills/development-workflow.md`](../skills/development-workflow.md). No
+> code yet; this document is the specification that drives the BDD scenarios and
+> implementation. (Distinct from the *Delivery phasing* §, whose Phase 0–6 track
+> the SDK-de-risk → full-driver rollout.)
+
+## Overview
+
+The `qhy-camera` service is an ASCOM Alpaca **Camera** (and optional
+**FilterWheel**) driver for real QHYCCD hardware. It exposes a connected QHY
+camera — exposures, ROI/binning, gain/offset, cooling, readout modes — over
+ASCOM Alpaca on a fixed port so the `rp` orchestrator (and any Alpaca client:
+NINA, SGPro, SharpCap) can drive it like any other device.
+
+It is the **first hardware imaging camera** in rusty-photon, complementing the
+existing [`sky-survey-camera`](sky-survey-camera.md) *simulator* (which it reuses
+for scaffolding) and the same-vendor [`qhy-focuser`](qhy-focuser.md) driver.
+
+**Provenance.** The behaviour is derived from the author's standalone
+[`ivonnyssen/qhyccd-alpaca`](https://github.com/ivonnyssen/qhyccd-alpaca) driver
+(MIT OR Apache-2.0, same author). Rather than vendoring that ~1,350-LOC monolith,
+this service is **written natively against rusty-photon conventions on top of the
+published [`qhyccd-rs`](https://crates.io/crates/qhyccd-rs) crate** (the durable,
+reusable FFI layer), using `qhyccd-alpaca`'s device-trait code only as the
+behavioural reference. See *Delivery phasing* and
+[ADR — to be written] for why.
+
+**Not cross-platform.** Unlike `filemonitor` / `sky-survey-camera`, this service
+links a **proprietary native SDK** and is therefore gated out of the default
+workspace build. See *Native dependency & build gating* — this is the dominant
+design constraint.
+
+---
+
+## Native dependency & build gating (the crux)
+
+This is the single most consequential fact about this service and the reason it
+is delivered in two tracks.
+
+- The imaging path is `qhy-camera → qhyccd-rs (0.1.9) → libqhyccd-sys (0.1.4) →`
+  the **proprietary QHYCCD SDK** (a closed-source static lib) **+ libusb-1.0**.
+- `libqhyccd-sys` declares `links = "qhyccd"` and its `build.rs` emits
+  `cargo:rustc-link-lib=static=qhyccd` + `dylib=usb-1.0` **unconditionally** —
+  there is **no feature/cfg gate** on the link.
+- **Consequence:** *every machine that compiles this package* — dev laptops, CI
+  runners, Bazel actions — needs the QHYCCD SDK installed and discoverable, plus
+  `libusb-1.0` dev headers. Not just machines with a camera attached.
+- The `qhyccd-rs` **`simulation` feature** (which this service forwards as its own
+  `simulation` feature) makes the build **camera-free, NOT SDK-free**: it only
+  fabricates fake frames at runtime (via `rand`/`rayon`). The static `qhyccd` lib
+  is still required at link time. *(Verified against `libqhyccd-sys/build.rs` and
+  upstream CI, which installs the SDK even for `--features simulation` ConformU
+  runs.)*
+
+### Why this matters for rusty-photon specifically
+
+The workspace is **currently 100% pure-Rust at the link layer — zero
+native/system-lib dependencies**. The old `cfitsio`/`fitsio-sys` requirement was
+**purged** in [ADR-001 Amendment A](../decisions/001-fits-file-support.md) (FITS
+is now pure-Rust `fitsrs` via `rp-fits`). So `qhyccd-rs` **reintroduces the first
+native build dependency** since that purge. It does not match an existing
+precedent — it creates a new one. The doc below specifies how it is gated so it
+does not break the SDK-less default build.
+
+### Gating plan
+
+| Concern | Mechanism |
+|---|---|
+| `cargo build --all` / local dev without SDK | The package is a normal workspace member, but the SDK-less build path is `cargo build -p qhy-camera` is **expected to fail to link** without the SDK. Devs without the SDK use the rest of the workspace normally; `cargo rail`'s `merge_base=true` (affected-packages-only) means the package is only built when *its* files change. Documented in the service README and `MEMORY.md`. |
+| CI | Add an explicit SDK-provisioning step that **pulls SDK 25.09.29 from the NAS / bazel-remote cache** (not a per-build qhyccd.com fetch) + installs `libusb-1.0-0-dev`, before building/testing this package, mirroring the cross-spawn pre-build pattern already in `.github/workflows/test.yml`. |
+| Raspberry Pi nightly runner | Add the SDK (25.09.29) + `libusb` install to `scripts/setup-pi-runner.sh`. **aarch64 confirmed available and linking** — `qhy-camera` is included in the Pi5 arm64 nightly matrix. |
+| Bazel (shadow build) | Tag the target `requires-cargo` initially (kept out of `bazel test //...` by `.bazelrc`'s default `-requires-cargo`). Later replace with a hand-written `crate.annotation` for `libqhyccd-sys` (link-search to the installed SDK, `static=qhyccd`, `dylib=usb-1.0`). Run `CARGO_BAZEL_REPIN=1 bazel mod tidy && bazel mod tidy` after adding `qhyccd-rs` (Rule 10). |
+
+### Resolved facts (decided)
+
+- **SDK version: 25.09.29** — pin the install action to the version `qhyccd-rs`
+  0.1.9 targets. (The `24.12.26` in the older `qhyccd-alpaca` doc is stale.)
+- **arm64: supported and linking** on the Pi5 runner — `qhy-camera` is in the
+  arm64 nightly matrix.
+- **SDK distribution: cached** on the NAS / bazel-remote (10.0.0.11). CI and
+  Bazel pull the SDK 25.09.29 from the cache — **no per-build fetch from
+  qhyccd.com**, keeping builds hermetic and offline-capable.
+
+### Open questions still to resolve before Track A lands
+
+1. **`qhyccd-rs` churn.** Single-maintainer, pre-1.0 (0.1.7/0.1.8/0.1.9 all
+   shipped within days). Pin exactly (`=0.1.9`) and track upstream closely.
+2. **Shutter actuation API** *(Track-A verification item).* Confirm `qhyccd-rs`
+   exposes a shutter open/close call (not just `CamMechanicalShutter` presence) —
+   gates the dark-frame behaviour (E4). If only presence is queryable, v0 dark
+   support degrades to reject on all models and moves to Future Work.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD;
+    A[ASCOM Client: rp / NINA / SharpCap] -->|Alpaca HTTP :11121| B[ascom-alpaca Server];
+    B --> C[QhyCameraDevice<br/>impl Device + Camera];
+    B --> FW[QhyFilterWheelDevice<br/>impl Device + FilterWheel];
+    C --> BB[Blocking bridge<br/>tokio::task::spawn_blocking];
+    FW --> BB;
+    BB --> RS[qhyccd-rs Sdk/Camera/FilterWheel];
+    RS -->|FFI| SDK[libqhyccd-sys → QHYCCD SDK static lib];
+    SDK -->|libusb-1.0| HW[QHY camera / CFW over USB];
+    C --> CA[config_actions.rs<br/>config.get/apply/schema];
+    M[main.rs<br/>ServiceRunner] --> B;
+```
+
+**Key components**
+
+- **`main.rs`** — plain `fn main`, parses clap args, inits `tracing`, runs under
+  `ServiceRunner::new("qhy-camera").with_reload().run_with_reload(...)` per
+  [`service-lifecycle.md`](../skills/service-lifecycle.md). No hand-rolled signal
+  handling, no `materialize_identity` (identities are hardware-derived).
+- **`lib.rs`** — `ServerBuilder` that, on `build()`, opens the SDK and
+  **enumerates every connected camera** (and CFW when `filterwheel.enabled`),
+  registering each as an ASCOM device (index 0, 1, 2, …) with its serial-derived
+  UniqueID. The eager per-device connect handshake (cache CCD info, valid binning
+  modes, exposure/gain/offset min-max-step) happens on `set_connected(true)`.
+  Returns a `BoundServer`.
+- **`camera.rs`** — `QhyCameraDevice` (one instance per discovered camera)
+  implementing `Device` + `Camera` against `qhyccd-rs`. **Every blocking SDK call
+  runs inside `tokio::task::spawn_blocking`** (the same blocking-bridge discipline
+  the legacy serial drivers use) so the async runtime is never stalled.
+- **`filterwheel.rs`** — `QhyFilterWheelDevice` (one per discovered CFW)
+  implementing `Device` + `FilterWheel` (registered when `filterwheel.enabled`).
+- **`config.rs`** — typed `Config` with parse-don't-validate newtypes.
+- **`config_actions.rs`** — `ConfigurableDriver` impl + the `dispatch` the devices
+  delegate to (`config.get`/`config.apply`/`config.schema`).
+- **`mock.rs`** (feature `simulation`/`mock`) — the hardware-free test backend
+  (the `qhyccd-rs` `simulation` camera + a tiny in-crate trait seam over the SDK
+  for unit tests).
+
+**Concurrency.** The QHY SDK is blocking C FFI and is **not** safe to call from
+arbitrary threads concurrently for a single device. Device state (current ROI,
+binning, gain, target temp, exposure state machine) is held under
+`parking_lot::RwLock`; all SDK calls funnel through `spawn_blocking` and a single
+logical owner per device.
+
+---
+
+## MVP scope
+
+The MVP boundary drives BDD scenario selection (Phase 2). Grounded in what
+`qhyccd-rs` / `qhyccd-alpaca` actually support today.
+
+**In scope (v0)**
+
+- ASCOM Camera ICameraV3 for **every enumerated QHY camera** (each registered as
+  a device on the one port), 16-bit monochrome **and** one-shot-colour (Bayer)
+  sensors.
+- Startup enumeration registers all discovered cameras (+ CFWs when enabled);
+  per-device connect/disconnect lifecycle: open → single-frame mode → init →
+  16-bit transfer → cache geometry/limits.
+- Sensor geometry (`CameraXSize`/`YSize`, `PixelSizeX`/`Y`) from cached CCD info.
+- **Binning** — symmetric only (`CanAsymmetricBin = false`); `MaxBinX/Y` from the
+  SDK's valid binning modes; ROI rescaled on bin change.
+- **ROI** — `StartX/Y`/`NumX/Y` setters accept any `u32`; geometry validated at
+  `StartExposure` (ConformU "Reject Bad…" semantics).
+- **Exposure** — `ExposureMin/Max/Resolution` from the SDK; single-frame
+  `StartExposure`; `ImageReady`/`ImageArray`/`ImageArrayVariant`; `CameraState`
+  (`Idle`/`Exposing`/`Error`); `PercentCompleted` from remaining-exposure µs.
+- **Abort** — `CanAbortExposure = true` via the SDK abort path.
+- **Gain / Offset** — current value + `Min`/`Max` from the SDK; `NOT_IMPLEMENTED`
+  when the control is unavailable on the model.
+- **Readout modes** — `ReadoutMode(s)` named from the SDK; switching updates
+  cached resolution.
+- **Cooling** — `CoolerOn`, `CCDTemperature`, `SetCCDTemperature`, `CoolerPower`,
+  `CanSetCCDTemperature`, `CanGetCoolerPower` — all gated on the `Cooler` control.
+- **Sensor type** — `Monochrome` vs `RGGB`/colour + `BayerOffsetX/Y`.
+- **`MaxADU`** = `2^OutputDataActualBits`; `SensorName` from the device id.
+- **FilterWheel** as a second ASCOM device on the same port (when present):
+  `Names`, `Position` (with moving state), `set_position`, `FocusOffsets`.
+- **Dark frames on shutter-equipped models** — `Light = false` closes the
+  mechanical shutter and captures; shutterless models reject (see E4).
+- `config.get`/`config.apply`/`config.schema` actions; hardware-derived
+  `UniqueID` (camera/CFW SDK serial); in-process reload.
+- ConformU integration test driven against the `qhyccd-rs` `simulation` backend
+  (SDK installed in CI, no physical camera).
+
+**Deferred (see *Future Work*)**
+
+- **Dark/bias on shutterless cameras.** v0 captures darks only when the camera
+  has a mechanical shutter (e.g. QHY600M); shutterless models (e.g. the 5III
+  series) still reject `Light = false`. A cap-on operator workflow / explicit
+  override for shutterless darks is deferred.
+- `StopExposure` (graceful stop) — upstream returns `NOT_IMPLEMENTED`; only
+  `AbortExposure` works.
+- `FastReadout` — upstream untested; ship as `CanFastReadout` reflecting the
+  `Speed` control but mark untested.
+- `PulseGuide` (`CanPulseGuide = false`), LiveMode, multi-frame/video.
+- Per-serial connect-time tuning (gain/offset/target-temperature defaults).
+- `ElectronsPerADU` / `FullWellCapacity` (upstream `NOT_IMPLEMENTED`; supply
+  placeholders only if ConformU requires them).
+- TLS / HTTP Basic Auth (compose `rp-tls` / `rp-auth` later).
+
+---
+
+## Configuration
+
+The service **enumerates every connected QHY camera** (and CFW, when enabled) at
+startup and registers each as an ASCOM device (camera / filter-wheel index
+0, 1, 2, …) on the one port. The hardware is the source of truth — there is no
+per-camera *binding* in config. Each device's UniqueID comes from its SDK serial;
+config carries only optional per-serial display overrides plus a global CFW
+toggle and the port.
+
+```jsonc
+{
+  // Optional, keyed by SDK serial. A device with no entry uses SDK-derived
+  // defaults (name from model+serial; CFW filter names "Filter0".."FilterN").
+  "overrides": {
+    "QHY600M-0123456789": {
+      "name": "Main Imaging",
+      "description": "QHY600M @ 1000mm"
+    },
+    "CFW3L-SR-9876543210": {
+      "filter_names": ["L", "R", "G", "B", "Ha", "OIII", "SII"]
+    }
+  },
+  "filterwheel": {
+    "enabled": true                  // register discovered CFWs as FilterWheel devices
+  },
+  "server": {
+    "port": 11121
+  }
+}
+```
+
+Sections:
+
+- **overrides** — Optional map keyed by **SDK serial**. Lets an operator give a
+  friendly `name`/`description` to a specific camera and human `filter_names` to a
+  specific CFW. Any device without an override uses SDK-derived defaults. v0 does
+  **not** carry per-camera connect-time tuning (gain/offset/target temperature) —
+  with heterogeneous cameras those are per-serial concerns and clients set them
+  over ASCOM; per-serial defaults are deferred (see *Future Work*).
+- **filterwheel.enabled** — Global toggle: when `true`, discovered CFWs are
+  registered as FilterWheel devices alongside the cameras. Hard read-only
+  (toggling adds/removes endpoints → restart-required, not a live apply).
+- **server.port** — Listening port (**11121**, next free in the 1112x family;
+  11111–11120 and 11131 are taken). One port hosts all enumerated devices. Hard
+  read-only (self-lockout: a port change would make the BFF lose the devices).
+
+### Config actions
+
+Standard cross-driver protocol ([`config-actions.md`](config-actions.md)),
+implemented generically in `rusty_photon_config::actions` + the ASCOM adapter in
+[`rusty-photon-driver`](../../crates/rusty-photon-driver). `config_actions.rs`
+supplies `ConfigurableDriver for QhyCameraDriver`:
+
+- **Secrets redacted/carried forward:** none in v0 (no auth yet).
+- **Locked (identity) fields:** none — UniqueIDs are hardware-derived and not
+  stored in config, so there is no identity field to lock (a deliberate
+  divergence from the `materialize_identity` convention; see *Device identity*).
+- **Hard read-only fields:** `/server/port`, `/filterwheel/enabled` (enabling
+  /disabling adds/removes registered endpoints → restart-required, not a live
+  apply).
+- **Editable fields:** the `overrides` map (per-serial `name` / `description` /
+  `filter_names`).
+- **Validation** at load (parse-don't-validate): `filter_names` entries are
+  non-empty strings; override keys are free-form serial strings.
+
+`config.apply` persists atomically, returns `status:"applying"` when a field
+changed, and fires the in-process reload (`main.rs` runs under
+`with_reload().run_with_reload(...)`).
+
+### Device identity (UniqueID)
+
+ASCOM requires a globally-unique, never-changing `UniqueID`. **This service
+derives the UniqueID from the camera's hardware serial** (the QHYCCD SDK id,
+available from `Sdk::cameras()` at enumeration, *before* the device is opened),
+and the FilterWheel's UniqueID from the CFW's SDK id — the same scheme upstream
+`qhyccd-alpaca` uses.
+
+This is a **deliberate divergence** from the rusty-photon
+`materialize_identity` / minted-UUID convention used by the other six drivers,
+chosen because a camera exposes a genuinely stable, globally-unique hardware
+serial. The serial is a *better* ASCOM identity than a per-install minted UUID:
+it is tied to the physical camera, so it survives an OS reinstall and moving the
+camera between machines, and swapping the camera correctly yields a new id.
+
+Consequences: there is **no `unique_id` field in config**, **no
+`materialize_identity` call** in `main.rs`, and **no locked identity field** in
+the config-actions tiers. Because the service enumerates *all* cameras, there is
+no selector — every discovered camera and CFW is exposed, each carrying its own
+serial-derived UniqueID, so two identical-model cameras are naturally
+distinguished by their serials.
+
+---
+
+## Behavioral contracts
+
+Named, testable behaviours mapping 1:1 to BDD scenarios in `tests/features/`.
+ASCOM error names per [`docs/references/ascom-alpaca.md`](../references/ascom-alpaca.md).
+Values are grounded in the `qhyccd-rs`-backed implementation.
+
+### Enumeration & connection lifecycle
+
+- **C0.** At startup `build()` enumerates all connected QHY cameras (and CFWs when
+  `filterwheel.enabled`) and registers each as an ASCOM device with its
+  serial-derived UniqueID. Zero discovered cameras is **not** a hard failure — the
+  service starts with no Camera devices, logged at `warn!`; a later reload
+  re-enumerates.
+- **C1.** `set_connected(true)` on a device opens *that* camera, sets single-frame
+  mode, readout mode 0, `init()`, 16-bit transfer, and caches CCD info, effective
+  area, valid binning modes, and exposure/gain/offset/speed min-max-step. On
+  success `Connected = true`.
+- **C2.** `set_connected(true)` with the device's camera unreachable / SDK open
+  failure returns the mapped driver error and `Connected` stays `false`.
+- **C3.** `set_connected(false)` closes that device and returns `NOT_CONNECTED`
+  for subsequent operations; an in-flight exposure on it is aborted.
+- **C4.** Connect is per-device and independent: connecting/disconnecting one
+  camera does not affect the others enumerated on the same service.
+
+### Geometry, binning, ROI
+
+- **G1.** `CameraXSize`/`CameraYSize`/`PixelSizeX`/`PixelSizeY` reflect the cached
+  CCD info.
+- **B1.** `set_bin_x`/`set_bin_y` validate against the SDK's valid binning modes
+  and set symmetric binning; an unsupported bin returns `INVALID_VALUE`.
+- **B2.** `CanAsymmetricBin = false`; `MaxBinX`/`MaxBinY` come from the valid
+  modes (typically 1–4, up to 8).
+- **B3.** A bin change rescales the cached ROI by the bin ratio.
+- **R1.** `StartX/Y`/`NumX/Y` setters accept any `u32`; geometry is validated at
+  `StartExposure` (R2), not at the setter.
+- **R2.** `StartExposure` with `StartX + NumX > CameraXSize / BinX` (or the Y
+  analogue), or `NumX/NumY = 0`, returns `INVALID_VALUE`; otherwise the ROI is
+  applied to the SDK before exposing.
+
+### Exposure
+
+- **E1.** `StartExposure` while disconnected returns `NOT_CONNECTED`.
+- **E2.** `StartExposure` while exposing returns `INVALID_OPERATION`.
+- **E3.** `StartExposure` `Duration` outside `[ExposureMin, ExposureMax]` returns
+  `INVALID_VALUE`.
+- **E4.** `StartExposure` with `Light = false` (dark/bias): if the camera has a
+  mechanical shutter (`CamMechanicalShutter`), the shutter is closed and a dark
+  frame is captured; **on shutterless models it returns `NOT_IMPLEMENTED`**.
+  *(Implementation check: confirm `qhyccd-rs` exposes a shutter open/close call —
+  not just `CamMechanicalShutter` presence. If only presence is queryable, v0
+  degrades to reject on all models and dark support moves to Future Work.)*
+- **E5.** A successful light `StartExposure` sets exposure µs, runs the SDK
+  single-frame capture on the blocking bridge, and on completion produces an
+  `ImageArray` of the binned sub-frame, `ImageReady = true`,
+  `LastExposureStartTime`/`LastExposureDuration` set, `CameraState = Idle`.
+- **E6.** `CameraState` is `Exposing` during capture; `PercentCompleted` is
+  derived from remaining-exposure µs (clamped to ≤ 100), `100` once ready.
+- **E7.** `AbortExposure` during capture cancels via the SDK abort path and leaves
+  `ImageReady = false`; `CanAbortExposure = true`.
+- **E8.** `StopExposure` returns `NOT_IMPLEMENTED`; `CanStopExposure = false`.
+- **E9.** A mid-exposure SDK error transitions `CameraState = Error`, sets
+  `last_error`, leaves `ImageReady = false`, logged at `warn!`.
+
+### Gain / offset / readout
+
+- **GO1.** `Gain`/`Offset` return the current SDK value, or `NOT_IMPLEMENTED` if
+  the control is unavailable on the model.
+- **GO2.** `set_gain`/`set_offset` validate against cached `[min, max]` and apply
+  via the SDK; out-of-range returns `INVALID_VALUE`.
+- **GO3.** `GainMin/Max`, `OffsetMin/Max` reflect the cached SDK min-max.
+- **RM1.** `ReadoutModes` is the SDK's named mode list; `set_readout_mode`
+  validates the index and updates cached resolution; an invalid index returns
+  `INVALID_VALUE`.
+
+### Cooling
+
+- **K1.** `CanSetCCDTemperature` / `CanGetCoolerPower` are `true` iff the `Cooler`
+  control is available; otherwise the related getters return `NOT_IMPLEMENTED`.
+- **K2.** `CCDTemperature` returns the current sensor temperature when cooling is
+  supported.
+- **K3.** `set_set_ccd_temperature` validates `[-273.15, 80]` and sets the target;
+  `SetCCDTemperature` reads it back.
+- **K4.** `CoolerOn`/`set_cooler_on` map to the SDK PWM controls; `CoolerPower`
+  is the normalized PWM percent.
+
+### Sensor type
+
+- **ST1.** `SensorType` is `RGGB` (colour) when the colour control is present,
+  else `Monochrome`; `BayerOffsetX/Y` follow the SDK's reported Bayer pattern.
+
+### FilterWheel (when `filterwheel.enabled = true`)
+
+- **FW1.** `Names` lists `filter_names` (or generated `Filter0..N`); `Position`
+  returns the current slot, or the "moving" sentinel (`-1`/`None` → ASCOM moving)
+  while target ≠ actual.
+- **FW2.** `set_position` validates `index < filter_count` and commands the SDK;
+  out-of-range returns `INVALID_VALUE`.
+- **FW3.** `FocusOffsets` returns zeros per filter in v0.
+
+---
+
+## ASCOM Camera surface — v0 behaviour
+
+| Property / Method | v0 behaviour (backed by `qhyccd-rs`) |
+|---|---|
+| `CameraXSize` / `CameraYSize` | Cached `get_ccd_info()` width/height |
+| `PixelSizeX` / `PixelSizeY` | Cached `get_ccd_info()` pixel width/height |
+| `BinX` / `BinY` / `MaxBinX` / `MaxBinY` | Symmetric; max from valid binning modes |
+| `CanAsymmetricBin` | `false` |
+| `NumX` / `NumY` / `StartX` / `StartY` | Setters relaxed; validated at `StartExposure` |
+| `MaxADU` | `2^OutputDataActualBits` |
+| `ElectronsPerADU` / `FullWellCapacity` | `NOT_IMPLEMENTED` (placeholder only if ConformU demands) |
+| `ExposureMin` / `Max` / `Resolution` | From SDK `get_parameter_min_max_step(Exposure)` |
+| `Gain` / `GainMin` / `GainMax` | SDK `Gain` control; `NOT_IMPLEMENTED` if absent |
+| `Offset` / `OffsetMin` / `OffsetMax` | SDK `Offset` control; `NOT_IMPLEMENTED` if absent |
+| `ReadoutMode` / `ReadoutModes` | SDK named modes |
+| `SensorType` / `BayerOffsetX/Y` | Mono vs RGGB from colour control |
+| `CoolerOn` / `CCDTemperature` / `SetCCDTemperature` / `CoolerPower` | Gated on `Cooler` control |
+| `CanSetCCDTemperature` / `CanGetCoolerPower` | `true` iff `Cooler` control present |
+| `CanFastReadout` / `FastReadout` | Reflects `Speed` control (untested — see *Future Work*) |
+| `HasShutter` | `true` iff `CamMechanicalShutter` control present |
+| `CameraState` | `Idle` / `Exposing` / `Error` |
+| `PercentCompleted` | From remaining-exposure µs, clamped ≤ 100 |
+| `CanAbortExposure` / `CanStopExposure` | `true` / `false` |
+| `CanPulseGuide` | `false` |
+| `StartExposure` (`Light=false`) | Close shutter + capture if `HasShutter`; else `NOT_IMPLEMENTED` |
+| `StartExposure` / `AbortExposure` / `ImageReady` / `ImageArray` / `ImageArrayVariant` | Per *Exposure* contracts; `ImageArray` axes `[X, Y]` |
+| `StopExposure` | `NOT_IMPLEMENTED` |
+
+---
+
+## Service lifecycle (`main.rs`)
+
+Standard shape per [`service-lifecycle.md`](../skills/service-lifecycle.md):
+
+```rust
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    tracing_subscriber::fmt().with_max_level(args.log_level).init();
+
+    let config_path = rusty_photon_config::resolve_config_path("qhy-camera", args.config);
+    // No materialize_identity: ASCOM UniqueIDs are derived from the camera/CFW
+    // SDK serials at enumeration (see "Device identity"), not minted into config.
+
+    ServiceRunner::new("qhy-camera")
+        .with_reload()
+        .run_with_reload(|shutdown, reload| async move {
+            loop {
+                let bound = ServerBuilder::new()
+                    .with_config_source(&config_path, CliOverrides { port: args.port })
+                    .with_reload_signal(reload.clone())
+                    .build()
+                    .await?;           // eager SDK open + enumerate/register devices
+                tokio::select! {
+                    r = bound.start(shutdown.cancelled()) => return r,
+                    () = reload.recv() => continue,
+                }
+            }
+        })
+}
+```
+
+`info!("Service started successfully …")` only after the bind succeeds; everything
+else is `debug!` (CLAUDE.md Rule 9).
+
+---
+
+## Testing
+
+Layered per [`testing.md`](../skills/testing.md).
+
+- **Unit** — config parse/newtype validation, ROI/binning geometry math, the
+  `Camera` state machine (Idle/Exposing/Error, `ImageReady`, percent-completed),
+  gain/offset range checks, cooling gating, Bayer-offset mapping — against an
+  in-crate trait seam over the SDK (mockall doubles), so unit tests need **neither
+  hardware nor the SDK linked** where possible.
+- **BDD** (`bdd-infra::ServiceHandle`) — connection lifecycle (C1–C4), ROI/bin
+  validation (R1–R2, B1–B3), exposure happy-path + error paths (E1–E9),
+  gain/offset/readout (GO1–RM1), cooling (K1–K4), and FilterWheel (FW1–FW3 when
+  enabled), driven against the `qhyccd-rs` `simulation` backend.
+- **ConformU** (`tests/conformu_integration.rs`, gated by the `conformu` feature)
+  — launches the production binary with `--features simulation` and runs the
+  official validator via `run_conformu_tests::<dyn Camera>()` (and
+  `::<dyn FilterWheel>()` when enabled). **Reuses the upstream harness shape**,
+  which already uses the same `ascom-alpaca` helper.
+
+> **CI caveat (critical):** the `simulation` feature removes the *camera*
+> requirement, **not the SDK**. All build/test/ConformU jobs for this package
+> still link `static=qhyccd`, so CI must install the SDK first (see *Gating
+> plan*). Only `cargo check`/clippy jobs (which don't invoke the linker) can skip
+> the SDK.
+
+---
+
+## Delivery phasing (E→C)
+
+This service is built in two tracks to isolate the genuinely novel risk (the
+proprietary system dependency) from the mechanical-but-large risk (the device
+driver itself).
+
+- **Phase 0 — decision gate** *(done)*. First-class managed device confirmed;
+  enumerate-all device model; SDK pinned to **25.09.29**; arm64 confirmed.
+- **Phase 1 — `ascom-alpaca` branch reconcile.** Land
+  `fix/macos-trait-recursion-overflow` onto `integration` and repin upstream
+  `qhyccd-alpaca` to `integration`, giving the fork one shared branch (fork
+  hygiene — chosen even though it is not a compile-time prerequisite for this
+  service under Option C, since `qhyccd-rs` carries no `ascom-alpaca` dep). A
+  separate-repo operation on the `ascom-alpaca-rs` fork.
+- **Phase 2 — Track A: isolate the system-dep risk.** Add `qhyccd-rs = "=0.1.9"`
+  to `[workspace.dependencies]`. Stand up SDK (25.09.29) + `libusb` provisioning
+  (CI step, `setup-pi-runner.sh` incl. arm64, Bazel `requires-cargo` tag, repin
+  twice). Create a **bare `qhy-camera` exposing an ASCOM Camera in `simulation`
+  mode on :11121** — proving build/link, CI, Pi5 arm64, and repin end-to-end
+  **before** any device-trait work. *If the Bazel sys-crate path proves
+  intractable, fall back to the `requires-cargo` carve-out (Cargo remains
+  canonical); the camera still builds and runs under Cargo.*
+- **Phase 3 — this design doc** *(done)* + the `docs/workspace.md` row.
+- **Phase 4 — Track B: full driver (Option C, confirmed).** Implement
+  `Device + Camera` **and `+ FilterWheel`** natively against `qhyccd-rs`, using
+  `qhyccd-alpaca`'s `lib.rs` as the behavioural spec only (no vendored fork); wire
+  lifecycle, hardware-derived identity, and config-actions.
+- **Phase 5 — test + gate.** BDD + ConformU on the `simulation` backend;
+  `cargo rail run --profile commit -q` + `cargo fmt` green; verify the CI
+  pre-build path.
+- **Phase 6 — consumer + Bazel finish.** Add `CameraConfig { alpaca_url:
+  http://localhost:11121, device_number }` in `rp`; replace the `requires-cargo`
+  tag with a proper `libqhyccd-sys` `crate.annotation`; update READMEs/docs.
+
+---
+
+## Future Work
+
+- **Dark/bias on shutterless cameras** — v0 supports darks only via a mechanical
+  shutter; add a cap-on / explicit-override workflow for shutterless models
+  (e.g. the 5III series) so `calibrator-flats` darks/bias work there too.
+- **`StopExposure`** (graceful stop with readout) — currently `NOT_IMPLEMENTED`.
+- **FastReadout** validation on real hardware.
+- **PulseGuide** / `CanPulseGuide`.
+- **Multiple cameras per service instance** (v0 binds one).
+- **Focuser consolidation.** `qhyccd-rs` also covers QHY focusers; a future
+  evaluation could let this SDK supersede the serial [`qhy-focuser`](qhy-focuser.md).
+- **TLS / Basic Auth** via `rp-tls` / `rp-auth`.
+- **`ElectronsPerADU` / `FullWellCapacity`** real values if a signal model is
+  added.
+
+## References
+
+- Upstream driver (behavioural spec): https://github.com/ivonnyssen/qhyccd-alpaca
+- FFI crate: https://crates.io/crates/qhyccd-rs · https://github.com/ivonnyssen/qhyccd-rs
+- [`sky-survey-camera.md`](sky-survey-camera.md) — Camera scaffolding template
+- [`qhy-focuser.md`](qhy-focuser.md) — same-vendor hardware-driver template
+- [`config-actions.md`](config-actions.md) · [`service-lifecycle.md`](../skills/service-lifecycle.md) · [`development-workflow.md`](../skills/development-workflow.md)
+- [ADR-001 Amendment A](../decisions/001-fits-file-support.md) — the pure-Rust /
+  no-system-dep posture this service is the first exception to

--- a/docs/services/ui-htmx.md
+++ b/docs/services/ui-htmx.md
@@ -335,7 +335,7 @@ ASCOM discovery (see [Deferred](#deferred)).
       "ca_cert_path": null     // optional PEM CA for a TLS-enabled driver
     },
     "qhy-focuser": {
-      "base_url": "http://127.0.0.1:11121",
+      "base_url": "http://127.0.0.1:11113",
       "device_type": "focuser"
     }
   }

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -17,6 +17,7 @@ belong in any single service design doc.
 | [plate-solver](services/plate-solver.md) | — (rp-managed service wrapping ASTAP) | 11131 | `docs/services/plate-solver.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
+| [qhy-camera](services/qhy-camera.md) | Camera (+ FilterWheel) — QHYCCD hardware | 11121 | `docs/services/qhy-camera.md` (Phase 1 — design only; native QHYCCD SDK dep, gated out of default build) |
 | [star-adventurer-gti](services/star-adventurer-gti.md) | Telescope | 11117 | `docs/services/star-adventurer-gti.md` (Phase 2 — BDD scaffold landed; all scenarios `@wip` pending Phase 3 implementation) |
 | [pa-falcon-rotator](services/falcon-rotator.md) | Rotator + Switch (status) | 11118 | `docs/services/falcon-rotator.md` |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -17,7 +17,7 @@ belong in any single service design doc.
 | [plate-solver](services/plate-solver.md) | — (rp-managed service wrapping ASTAP) | 11131 | `docs/services/plate-solver.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
-| [qhy-camera](services/qhy-camera.md) | Camera (+ FilterWheel) — QHYCCD hardware | 11121 | `docs/services/qhy-camera.md` (Phase 1–2 — design + BDD scaffold landed, all scenarios `@wip` pending implementation; native QHYCCD SDK dep, gated out of default build) |
+| [qhy-camera](services/qhy-camera.md) | Camera (+ FilterWheel) — QHYCCD hardware | 11121 | `docs/services/qhy-camera.md` (design + BDD scaffold landed, all scenarios `@wip` pending implementation; native QHYCCD SDK dep, gated out of default build) |
 | [star-adventurer-gti](services/star-adventurer-gti.md) | Telescope | 11117 | `docs/services/star-adventurer-gti.md` (Phase 2 — BDD scaffold landed; all scenarios `@wip` pending Phase 3 implementation) |
 | [pa-falcon-rotator](services/falcon-rotator.md) | Rotator + Switch (status) | 11118 | `docs/services/falcon-rotator.md` |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -17,7 +17,7 @@ belong in any single service design doc.
 | [plate-solver](services/plate-solver.md) | — (rp-managed service wrapping ASTAP) | 11131 | `docs/services/plate-solver.md` |
 | [calibrator-flats](services/calibrator-flats.md) | — (orchestrator plugin) | 11170 | `docs/services/calibrator-flats.md` |
 | [sky-survey-camera](services/sky-survey-camera.md) | Camera (simulator) | 11116 | `docs/services/sky-survey-camera.md` |
-| [qhy-camera](services/qhy-camera.md) | Camera (+ FilterWheel) — QHYCCD hardware | 11121 | `docs/services/qhy-camera.md` (Phase 1 — design only; native QHYCCD SDK dep, gated out of default build) |
+| [qhy-camera](services/qhy-camera.md) | Camera (+ FilterWheel) — QHYCCD hardware | 11121 | `docs/services/qhy-camera.md` (Phase 1–2 — design + BDD scaffold landed, all scenarios `@wip` pending implementation; native QHYCCD SDK dep, gated out of default build) |
 | [star-adventurer-gti](services/star-adventurer-gti.md) | Telescope | 11117 | `docs/services/star-adventurer-gti.md` (Phase 2 — BDD scaffold landed; all scenarios `@wip` pending Phase 3 implementation) |
 | [pa-falcon-rotator](services/falcon-rotator.md) | Rotator + Switch (status) | 11118 | `docs/services/falcon-rotator.md` |
 | sentinel-app | — (standalone Leptos crate; `cargo leptos` build target `sentinel-dashboard`, **not yet wired into sentinel**) | — | — |

--- a/services/qhy-camera/tests/features/binning_and_roi.feature
+++ b/services/qhy-camera/tests/features/binning_and_roi.feature
@@ -1,0 +1,47 @@
+@wip @serial
+Feature: Binning and region-of-interest
+  Binning is symmetric only: CanAsymmetricBin is false (B2) and MaxBinX /
+  MaxBinY come from the SDK's valid binning modes. Setting a bin validates
+  against those modes and rejects an unsupported value with INVALID_VALUE
+  (B1); a bin change rescales the cached ROI by the bin ratio (B3). The ROI
+  setters (StartX / StartY / NumX / NumY) accept any u32 (R1) — geometry is
+  not validated at the setter but at StartExposure, which rejects a zero or
+  out-of-bounds sub-frame with INVALID_VALUE (R2). The simulated QHY178M is
+  3072x2048.
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+    And camera device 0 is connected
+
+  Scenario: Asymmetric binning is not supported
+    Then camera device 0 reports CanAsymmetricBin as false
+
+  Scenario: A supported binning mode is accepted
+    When I set BinX 2 and BinY 2 on camera device 0
+    Then camera device 0 reports BinX as 2 and BinY as 2
+
+  Scenario Outline: An unsupported binning value is rejected at the setter
+    When I try to set BinX <bin_x> and BinY <bin_y> on camera device 0
+    Then the set is rejected with ASCOM INVALID_VALUE
+
+    Examples:
+      | bin_x | bin_y |
+      | 0     | 0     |
+      | 99    | 99    |
+
+  Scenario: The ROI setters accept any value
+    When I set StartX 5000 NumX 5000 StartY 5000 NumY 5000 on camera device 0
+    Then camera device 0 accepts the ROI without error
+
+  Scenario Outline: An out-of-bounds sub-frame is rejected at StartExposure
+    When I StartExposure on camera device 0 with BinX 1 BinY 1 NumX <num_x> NumY <num_y> StartX <start_x> StartY <start_y> Duration 0.01 Light true
+    Then the exposure is rejected with ASCOM INVALID_VALUE
+
+    Examples:
+      | num_x | num_y | start_x | start_y |
+      | 0     | 100   | 0       | 0       |
+      | 100   | 0     | 0       | 0       |
+      | 4000  | 100   | 0       | 0       |
+      | 100   | 3000  | 0       | 0       |
+      | 100   | 100   | 3000    | 0       |
+      | 100   | 100   | 0       | 2000    |

--- a/services/qhy-camera/tests/features/config_actions.feature
+++ b/services/qhy-camera/tests/features/config_actions.feature
@@ -1,0 +1,48 @@
+@wip
+Feature: Configuration actions
+  The driver exposes its own configuration over HTTP as the vendor ASCOM
+  actions `config.get`, `config.apply`, and `config.schema`, mirroring the
+  cross-driver protocol in `docs/services/config-actions.md`. `config.get`
+  returns the effective configuration plus the CLI-override-pinned field
+  paths. `config.schema` returns a JSON Schema plus the editability tiers:
+  server.port and filterwheel.enabled are read-only, and there is NO locked
+  identity field because UniqueIDs are derived from the camera/CFW SDK serial
+  rather than minted into config. `config.apply` parses and validates a full
+  configuration blob: invalid input returns `status:"invalid"` with
+  field-level errors and leaves the file unchanged, while a valid change to
+  the per-serial `devices` map is persisted atomically and applied through an
+  in-process reload (`status:"applying"`). The actions work whether or not a
+  device is connected.
+
+  Background:
+    Given a running qhy-camera service with the simulation backend
+
+  Scenario: The config actions are advertised
+    When the supported actions are queried on camera device 0
+    Then the supported actions should include config.get, config.apply, and config.schema
+
+  Scenario: The configuration schema is served with its editability tiers
+    When config.schema is called
+    Then the schema should describe the devices, filterwheel, and server sections
+    And the schema should mark server.port as a read-only field
+    And the schema should mark filterwheel.enabled as a read-only field
+    And the schema should report no locked identity fields
+
+  Scenario: Read the current configuration
+    When config.get is called
+    Then the config should report an empty devices map
+    And the config should report no CLI-pinned override paths
+
+  Scenario: A per-serial device override is persisted and reloaded
+    When config.apply sets the devices override "QHY178M-SIM" name to "Main Imaging"
+    Then the apply status should be applying
+    And the reload list should include devices
+
+  Scenario: An empty filter name is rejected and not persisted
+    When config.apply sets a filter_names entry to an empty string
+    Then the apply status should be invalid
+    And the response should contain validation errors
+
+  Scenario: An unknown action is not implemented
+    When the action "config.frobnicate" is called on camera device 0
+    Then the call should fail with an action-not-implemented error

--- a/services/qhy-camera/tests/features/cooling.feature
+++ b/services/qhy-camera/tests/features/cooling.feature
@@ -1,0 +1,38 @@
+@wip @serial
+Feature: Cooling
+  Cooling is gated on the SDK Cooler control: CanSetCCDTemperature and
+  CanGetCoolerPower are true only when the control is present, and the
+  related getters return NOT_IMPLEMENTED otherwise (K1). When cooling is
+  supported, CCDTemperature reads the current sensor temperature (K2),
+  SetCCDTemperature validates the target against [-273.15, 80] and reads it
+  back (K3), and CoolerOn / CoolerPower map to the SDK PWM controls (K4).
+  The simulated QHY178M-Simulated camera has a cooler.
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+    And camera device 0 is connected
+
+  Scenario: A cooled camera advertises temperature control
+    Then camera device 0 reports CanSetCCDTemperature as true
+    And camera device 0 reports CanGetCoolerPower as true
+
+  Scenario: The current CCD temperature is readable
+    Then camera device 0 reports a finite CCDTemperature
+
+  Scenario: A valid target temperature is accepted and read back
+    When I set the target CCD temperature to -10.0 on camera device 0
+    Then camera device 0 reports SetCCDTemperature as -10.0
+
+  Scenario Outline: An out-of-range target temperature is rejected
+    When I try to set the target CCD temperature to <target> on camera device 0
+    Then the set is rejected with ASCOM INVALID_VALUE
+
+    Examples:
+      | target  |
+      | -300.0  |
+      | 100.0   |
+
+  Scenario: Turning the cooler on is reflected in CoolerOn
+    When I turn the cooler on for camera device 0
+    Then camera device 0 reports CoolerOn as true
+    And camera device 0 reports a CoolerPower between 0 and 100

--- a/services/qhy-camera/tests/features/enumeration_connection.feature
+++ b/services/qhy-camera/tests/features/enumeration_connection.feature
@@ -1,0 +1,46 @@
+@wip @serial
+Feature: Camera enumeration and connection lifecycle
+  qhy-camera enumerates every connected QHY camera (and CFW when
+  filterwheel.enabled) at startup and registers each as an ASCOM device,
+  index 0, 1, 2, ..., on one port (C0). Each device's UniqueID is derived
+  from its SDK serial, so two identical-model cameras are distinguished by
+  serial. Connect is per-device (C4): connecting or disconnecting one camera
+  does not affect the others. Opening a device (C1) caches its CCD info,
+  valid binning modes, and exposure/gain/offset limits. An open failure
+  leaves the device not connected (C2). Disconnect closes the device and
+  cancels any in-flight exposure (C3). With zero cameras discovered the
+  service still starts, registering no Camera devices and logging a warning.
+  Against the qhyccd-rs simulation backend exactly one camera
+  (QHY178M-Simulated, 3072x2048, monochrome, 16-bit) and one 7-position
+  filter wheel are present.
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+
+  Scenario: The simulated camera is registered as device 0
+    Then ASCOM camera device 0 is available
+    And camera device 0 reports a non-empty UniqueID
+
+  Scenario: A camera starts disconnected
+    Then camera device 0 reports Connected as false
+
+  Scenario: Connecting opens the camera
+    When I connect camera device 0
+    Then camera device 0 reports Connected as true
+
+  Scenario: Disconnecting leaves the camera not connected
+    When I connect camera device 0
+    And I disconnect camera device 0
+    Then camera device 0 reports Connected as false
+
+  Scenario: Disconnecting cancels an in-flight exposure
+    Given camera device 0 is connected
+    And an exposure is in flight on camera device 0
+    When I disconnect camera device 0
+    Then camera device 0 reports ImageReady as false
+    And camera device 0 reports Connected as false
+
+  Scenario: The service starts with no Camera devices when no camera is present
+    Given the qhy-camera service running with an empty simulation backend
+    Then no ASCOM camera devices are registered
+    And the service is healthy

--- a/services/qhy-camera/tests/features/exposure.feature
+++ b/services/qhy-camera/tests/features/exposure.feature
@@ -1,0 +1,78 @@
+@wip @serial
+Feature: Exposure lifecycle
+  StartExposure requires a connected device (E1, NOT_CONNECTED) and rejects
+  a second exposure while one is in flight (E2, INVALID_OPERATION). A
+  Duration outside [ExposureMin, ExposureMax] is rejected with INVALID_VALUE
+  (E3). Dark frames (Light = false) are captured by closing the mechanical
+  shutter when the model has one, and return NOT_IMPLEMENTED on shutterless
+  models (E4) — the simulated QHY178M-Simulated is shutterless. A successful
+  light exposure produces an ImageArray of the binned sub-frame with
+  ImageReady true and the last-exposure timestamps set (E5); CameraState is
+  Exposing while in flight and PercentCompleted reaches 100 once ready (E6).
+  AbortExposure cancels an in-flight exposure and CanAbortExposure is true
+  (E7); StopExposure is not implemented and CanStopExposure is false (E8).
+  Mid-exposure SDK error transitions to the Error state (E9, covered by unit
+  tests against the mock SDK seam).
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+
+  Scenario: A disconnected camera rejects StartExposure
+    Given camera device 0 is not connected
+    When I try to StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 64 StartX 0 StartY 0 Duration 0.01 Light true
+    Then the exposure is rejected with ASCOM NOT_CONNECTED
+
+  Scenario: A second exposure while one is in flight is rejected
+    Given camera device 0 is connected
+    And an exposure is in flight on camera device 0
+    When I try to StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 64 StartX 0 StartY 0 Duration 0.01 Light true
+    Then the exposure is rejected with ASCOM INVALID_OPERATION
+
+  Scenario Outline: An out-of-range duration is rejected
+    Given camera device 0 is connected
+    When I try to StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 64 StartX 0 StartY 0 Duration <duration> Light true
+    Then the exposure is rejected with ASCOM INVALID_VALUE
+
+    Examples:
+      | duration |
+      | -1.0     |
+      | 100000.0 |
+
+  Scenario: A shutterless camera rejects a dark frame
+    Given camera device 0 is connected
+    And camera device 0 reports HasShutter as false
+    When I try to StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 64 StartX 0 StartY 0 Duration 0.01 Light false
+    Then the exposure is rejected with ASCOM NOT_IMPLEMENTED
+
+  Scenario: A successful light exposure produces an image of the requested sub-frame
+    Given camera device 0 is connected
+    When I StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 48 StartX 0 StartY 0 Duration 0.01 Light true
+    And the exposure on camera device 0 completes
+    Then camera device 0 reports ImageReady as true
+    And camera device 0 returns an ImageArray of 64 by 48
+    And camera device 0 reports a set LastExposureStartTime
+    And camera device 0 reports LastExposureDuration as 0.01
+
+  Scenario: PercentCompleted is 100 once the image is ready
+    Given camera device 0 is connected
+    When I StartExposure on camera device 0 with BinX 1 BinY 1 NumX 64 NumY 64 StartX 0 StartY 0 Duration 0.01 Light true
+    And the exposure on camera device 0 completes
+    Then camera device 0 reports CameraState as Idle
+    And camera device 0 reports PercentCompleted as 100
+
+  Scenario: Aborting an in-flight exposure leaves no image ready
+    Given camera device 0 is connected
+    And camera device 0 reports CanAbortExposure as true
+    And an exposure is in flight on camera device 0
+    When I abort the exposure on camera device 0
+    Then camera device 0 reports ImageReady as false
+
+  Scenario: StopExposure is not implemented
+    Given camera device 0 is connected
+    Then camera device 0 reports CanStopExposure as false
+    When I try to StopExposure on camera device 0
+    Then the call is rejected with ASCOM NOT_IMPLEMENTED
+
+  Scenario: Pulse guiding is not supported
+    Given camera device 0 is connected
+    Then camera device 0 reports CanPulseGuide as false

--- a/services/qhy-camera/tests/features/filter_wheel.feature
+++ b/services/qhy-camera/tests/features/filter_wheel.feature
@@ -1,0 +1,40 @@
+@wip @serial
+Feature: Filter wheel
+  When filterwheel.enabled is set, qhy-camera registers each discovered CFW
+  as an ASCOM FilterWheel device alongside the cameras. Names lists the
+  configured filter_names or generated Filter0..FilterN when none are given
+  (FW1). Position returns the current slot, or the ASCOM moving sentinel
+  while the target slot differs from the actual slot. set_position validates
+  that the index is less than the filter count and rejects an out-of-range
+  index with INVALID_VALUE (FW2). FocusOffsets returns zero for every filter
+  in v0 (FW3). The simulated CFW has 7 positions.
+
+  Background:
+    Given the qhy-camera service running with the simulation backend and the filter wheel enabled
+    And filterwheel device 0 is connected
+
+  Scenario: The filter wheel exposes seven generated filter names
+    Then filterwheel device 0 reports 7 filter names
+    And filterwheel device 0 reports the generated names Filter0 through Filter6
+
+  Scenario: Moving to a valid slot updates the reported position
+    When I set filterwheel device 0 to position 3
+    And the filter wheel move on device 0 completes
+    Then filterwheel device 0 reports Position as 3
+
+  Scenario Outline: An out-of-range slot is rejected
+    When I try to set filterwheel device 0 to position <slot>
+    Then the set is rejected with ASCOM INVALID_VALUE
+
+    Examples:
+      | slot |
+      | 7    |
+      | 99   |
+
+  Scenario: Focus offsets are zero for every filter
+    Then filterwheel device 0 reports FocusOffsets of 7 zeros
+
+  Scenario: Custom filter names from config are reported
+    Given the qhy-camera service running with the filter wheel enabled and filter names L, R, G, B, Ha, OIII, SII
+    And filterwheel device 0 is connected
+    Then filterwheel device 0 reports the filter names L, R, G, B, Ha, OIII, SII

--- a/services/qhy-camera/tests/features/gain_offset_readout.feature
+++ b/services/qhy-camera/tests/features/gain_offset_readout.feature
@@ -1,0 +1,41 @@
+@wip @serial
+Feature: Gain, offset, and readout modes
+  Gain and Offset return the current SDK value, or NOT_IMPLEMENTED when the
+  model lacks the control (GO1). Setters validate against the cached
+  [min, max] and reject an out-of-range value with INVALID_VALUE (GO2);
+  GainMin / GainMax and OffsetMin / OffsetMax reflect the cached SDK limits
+  (GO3). ReadoutModes is the SDK's named mode list; setting a mode validates
+  the index, updates the cached resolution, and rejects an unknown index
+  with INVALID_VALUE (RM1).
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+    And camera device 0 is connected
+
+  Scenario: Gain limits are ordered and the current gain is within them
+    Then camera device 0 reports GainMin not greater than GainMax
+    And camera device 0 reports a Gain within GainMin and GainMax
+
+  Scenario: Setting gain to the maximum is accepted
+    When I set Gain to GainMax on camera device 0
+    Then camera device 0 reports Gain equal to GainMax
+
+  Scenario: Setting gain above the maximum is rejected
+    When I try to set Gain to one above GainMax on camera device 0
+    Then the set is rejected with ASCOM INVALID_VALUE
+
+  Scenario: Offset limits are ordered and the current offset is within them
+    Then camera device 0 reports OffsetMin not greater than OffsetMax
+    And camera device 0 reports an Offset within OffsetMin and OffsetMax
+
+  Scenario: Setting offset below the minimum is rejected
+    When I try to set Offset to one below OffsetMin on camera device 0
+    Then the set is rejected with ASCOM INVALID_VALUE
+
+  Scenario: The readout modes list is non-empty and the current mode is valid
+    Then camera device 0 reports at least one ReadoutMode
+    And camera device 0 reports a ReadoutMode index within the modes list
+
+  Scenario: Selecting an out-of-range readout mode is rejected
+    When I try to set ReadoutMode to 9999 on camera device 0
+    Then the set is rejected with ASCOM INVALID_VALUE

--- a/services/qhy-camera/tests/features/sensor_properties.feature
+++ b/services/qhy-camera/tests/features/sensor_properties.feature
@@ -1,0 +1,29 @@
+@wip @serial
+Feature: Sensor geometry and type
+  Once connected, a camera reports its sensor geometry from the cached CCD
+  info (G1): CameraXSize / CameraYSize in pixels and PixelSizeX / PixelSizeY
+  in microns. SensorType is RGGB when the colour control is present and
+  Monochrome otherwise, with BayerOffsetX / BayerOffsetY following the
+  reported Bayer pattern (ST1). MaxADU is 2^OutputDataActualBits. The
+  simulated QHY178M-Simulated camera is a 3072x2048 monochrome 16-bit sensor.
+
+  Background:
+    Given the qhy-camera service running with the simulation backend
+    And camera device 0 is connected
+
+  Scenario: Sensor geometry reflects the simulated CCD info
+    Then camera device 0 reports the sensor geometry:
+      | property    | value |
+      | CameraXSize | 3072  |
+      | CameraYSize | 2048  |
+    And camera device 0 reports a positive PixelSizeX
+    And camera device 0 reports a positive PixelSizeY
+
+  Scenario: A monochrome sensor reports SensorType Monochrome
+    Then camera device 0 reports SensorType as Monochrome
+
+  Scenario: A 16-bit sensor reports MaxADU 65535
+    Then camera device 0 reports MaxADU as 65535
+
+  Scenario: SensorName is reported and non-empty
+    Then camera device 0 reports a non-empty SensorName

--- a/services/qhy-camera/tests/features/sensor_properties.feature
+++ b/services/qhy-camera/tests/features/sensor_properties.feature
@@ -4,7 +4,8 @@ Feature: Sensor geometry and type
   info (G1): CameraXSize / CameraYSize in pixels and PixelSizeX / PixelSizeY
   in microns. SensorType is RGGB when the colour control is present and
   Monochrome otherwise, with BayerOffsetX / BayerOffsetY following the
-  reported Bayer pattern (ST1). MaxADU is 2^OutputDataActualBits. The
+  reported Bayer pattern (ST1). MaxADU is (2^OutputDataActualBits) - 1, i.e.
+  65535 for a 16-bit sensor. The
   simulated QHY178M-Simulated camera is a 3072x2048 monochrome 16-bit sensor.
 
   Background:

--- a/services/ui-htmx/src/config.rs
+++ b/services/ui-htmx/src/config.rs
@@ -157,7 +157,7 @@ mod tests {
                     "auth": { "username": "obs", "password": "secret" }
                 },
                 "qhy-focuser": {
-                    "base_url": "http://127.0.0.1:11121",
+                    "base_url": "http://127.0.0.1:11113",
                     "device_type": "focuser"
                 }
             }

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -374,7 +374,7 @@ mod tests {
         let json = r#"{
             "drivers": {
                 "dsd-fp2": { "base_url": "http://127.0.0.1:11119" },
-                "qhy-focuser": { "base_url": "http://127.0.0.1:11121", "device_type": "focuser" }
+                "qhy-focuser": { "base_url": "http://127.0.0.1:11113", "device_type": "focuser" }
             }
         }"#;
         let config: Config = serde_json::from_str(json).unwrap();


### PR DESCRIPTION
## What

Lands the **design + test scaffold** for a new service, `qhy-camera`: a
first-class rusty-photon ASCOM Alpaca **Camera (+ FilterWheel)** driver for real
QHYCCD hardware. Derived from the standalone
[`ivonnyssen/qhyccd-alpaca`](https://github.com/ivonnyssen/qhyccd-alpaca) driver,
but **reimplemented natively on the published `qhyccd-rs` crate** (Option C of the
integration analysis) so there is no vendored Alpaca-layer fork to hand-sync.

**No production code, no new dependency, no CI change yet** — this is the
design-first / test-first groundwork (the SDK-linked driver lands later, on a
machine with the QHYCCD SDK). The only Rust touched is a pre-existing `ui-htmx`
test-fixture/example port typo; `cargo rail --profile commit` is green (55/55
`ui-htmx` tests) and the pre-commit hook (`clippy --all-targets --all-features` +
`cargo fmt --check`) passes.

### Scope (this PR)

- **New** `docs/services/qhy-camera.md` (~555 lines) — Phase-1 design doc.
- **New** `services/qhy-camera/tests/features/*.feature` — **8 BDD feature files,
  47 scenarios, all `@wip`** (enumeration/connection, sensor properties,
  binning/ROI, exposure, gain/offset/readout, cooling, filter wheel,
  config-actions) derived from the behavioral contracts. Scaffold only — there's
  no `qhy-camera` Cargo package yet, so nothing compiles/runs from these.
- **Modified** `docs/workspace.md` — services-table row (port 11121).
- **Modified** `README.md` — service-index sync: added `ui-htmx`, `plate-solver`,
  and the in-development `qhy-camera`; refreshed the project-structure tree.
- **Fix** pre-existing `ui-htmx` typo — `qhy-focuser` base_url `11121` → its
  canonical **11113** in `services/ui-htmx/src/config.rs`,
  `services/ui-htmx/src/lib.rs`, `docs/services/ui-htmx.md`.
- **Review fixes** (from Copilot): removed an internal LAN IP from the design
  doc (public repo), fixed a broken `MEMORY.md` reference, removed a Future-Work
  bullet that contradicted the enumerate-all model, dropped a drifting phase
  number from the index, and corrected the `MaxADU` off-by-one
  (`2^bits` → `(2^bits) - 1`, 65535 for 16-bit).

## Key design decisions (interactively chosen)

| Decision | Choice |
|---|---|
| Integration approach | First-class in-workspace, phased **E→C** — reimplement on the published `qhyccd-rs` crate |
| Device model | **Enumerate-all** — one service registers every connected QHY camera (+ CFW) as ASCOM device 0,1,2… on port **11121** |
| FilterWheel | **In v0**, second device type, registered when present |
| Dark frames | Shutter-if-present, else `NOT_IMPLEMENTED` (shutter actuation API to be verified in Track A) |
| UniqueID | **Camera/CFW SDK serial** (hardware-stable) — drops `materialize_identity`/minted-UUID; no config identity field |
| Config | Minimal: per-serial `devices` overrides (name/description/filter_names) + global `filterwheel.enabled` + `server.port` |
| `ascom-alpaca` reconcile | Merge `fix/macos-trait-recursion-overflow` → `integration` (fork hygiene; not a compile-time blocker under Option C) |
| SDK version | **25.09.29** (the `24.12.26` in the old driver doc is stale) |
| arm64 / Pi5 | **Confirmed working** — included in the arm64 nightly matrix |
| SDK distribution | **Cached on the self-hosted build cache** — hermetic CI, no per-build qhyccd.com fetch; the proprietary blob stays behind the authenticated/internal tier, not the anonymous-read public mirror |

## The crux: first native system dependency since the cfitsio purge

The imaging path links the **proprietary QHYCCD SDK + libusb** via
`qhyccd-rs` → `libqhyccd-sys` (`links="qhyccd"`, unconditional
`rustc-link-lib=static=qhyccd`). The workspace is currently 100% pure-Rust at the
link layer (cfitsio was purged in ADR-001 Amendment A), so this is the **first
native build-dep reintroduced**. The `simulation` feature is **camera-free but
not SDK-free**. The doc specifies how it is gated out of the default build
(`cargo rail` affected-only; Bazel `requires-cargo`).

## Delivery phasing

- **Phase 1** — `ascom-alpaca` branch reconcile (fork hygiene)
- **Track A** — de-risk the SDK toolchain end-to-end (build/link, CI, Pi5 arm64,
  Bazel, repin) with a bare sim-mode camera
- **Track B** — full Camera + FilterWheel driver on `qhyccd-rs`, wired to
  service-lifecycle / config-actions / hardware-derived identity / BDD / ConformU

## Open items flagged in the doc (not blockers)

- Shutter actuation API in `qhyccd-rs` — verify during Track A (finalizes E4)
- `qhyccd-rs` is single-maintainer pre-1.0 — pin `=0.1.9`, track upstream

## Next steps (separate PR)

Track A scaffold: the `qhy-camera` workspace member (`Cargo.toml`, `main.rs`/
`lib.rs` skeleton, `bdd.rs` + world + step stubs), the `qhyccd-rs` dependency,
and the SDK/Bazel/CI gating — built on a machine with the QHYCCD SDK, which also
lets the 47 `@wip` scenarios start dropping their tags as behavior lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
