### PR TITLE
fix(bdd): eliminate broken-pipe log spam in CI + consolidate service logging to stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3246,7 +3245,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3298,7 +3296,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
- "tracing-subscriber",
  "wcs",
 ]
 
@@ -4122,7 +4119,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -4504,6 +4500,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "windows-service",
 ]
 
@@ -4669,7 +4666,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -5790,7 +5786,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/bdd-infra/src/bin/test_service.rs
+++ b/crates/bdd-infra/src/bin/test_service.rs
@@ -6,6 +6,9 @@
 //!
 //! If the config file contains the text "fail", exits immediately
 //! with code 1 (simulates a service that fails to start).
+//!
+//! `--epipe-probe <marker>` enables the broken-pipe regression probe used by
+//! the `ServiceHandle` shutdown tests — see [`run_epipe_probe`].
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 
@@ -31,8 +34,104 @@ fn main() {
     let addr = listener.local_addr().unwrap();
     println!("bound_addr={}", addr);
 
-    // Block until killed (SIGTERM default handler terminates the process)
+    // In `--epipe-probe` mode hand off to the probe runner, which keeps the
+    // process alive past SIGTERM (so it can write during shutdown) using
+    // tokio's safe signal API. `listener` stays bound for the duration.
+    if let Some(idx) = args.iter().position(|a| a == "--epipe-probe") {
+        if let Some(marker) = args.get(idx + 1).cloned() {
+            run_probe_mode(marker);
+            return;
+        }
+    }
+
+    // Block until killed (SIGTERM default disposition terminates the process).
     for stream in listener.incoming() {
         drop(stream);
     }
+}
+
+/// Drive `--epipe-probe` mode: spawn the blocking stdout probe, then await
+/// SIGTERM via tokio's **safe** signal API (the same `tokio::signal::unix`
+/// mechanism `ServiceRunner` uses) and tell the probe to run its shutdown
+/// burst. Using tokio keeps this fixture free of `unsafe`/`libc` signal
+/// handling. On non-Unix there is no SIGTERM to await and the probe writes
+/// until the process is terminated — the regression tests are Unix-gated.
+fn run_probe_mode(marker: String) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let probe_flag = Arc::clone(&shutdown);
+    std::thread::spawn(move || run_epipe_probe(marker, probe_flag));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+            term.recv().await;
+            shutdown.store(true, Ordering::SeqCst);
+        }
+        #[cfg(not(unix))]
+        let _ = &shutdown;
+        // The probe thread terminates the process once its burst completes;
+        // park here until then.
+        std::future::pending::<()>().await
+    });
+}
+
+/// Regression probe for the stdout-drain shutdown race.
+///
+/// Writes to stdout steadily, then — once SIGTERM has been requested — emits a
+/// short "shutdown" burst, just like a real service logging while it tears down.
+/// A correct `ServiceHandle` keeps draining our stdout until we have exited, so
+/// every write (including the shutdown burst) succeeds and `marker` is left
+/// untouched. The old buggy ordering aborted the drain (closing the read end of
+/// the pipe) *before* the child exited; the shutdown-burst writes then fail with
+/// `BrokenPipe` — exactly the condition that made services' `tracing_subscriber`
+/// echo "Unable to write an event ... Broken pipe" to the inherited stderr. We
+/// record that broken pipe to `marker` so the test can assert it never happens.
+/// We use `write_all` (not `println!`, which *panics* on a broken pipe) so we
+/// can observe the error instead of dying on it.
+fn run_epipe_probe(marker: String, shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+    use std::io::Write;
+    use std::sync::atomic::Ordering;
+    let line = [b'x'; 64];
+
+    // Steady state: keep the harness's drain task busy until shutdown.
+    while !shutdown.load(Ordering::SeqCst) {
+        let mut out = std::io::stdout().lock();
+        if out
+            .write_all(&line)
+            .and_then(|()| out.write_all(b"\n"))
+            .and_then(|()| out.flush())
+            .is_err()
+        {
+            // A failure here (before shutdown) means the reader is already
+            // gone for some unrelated reason; don't misattribute it.
+            return;
+        }
+        drop(out);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    // Shutdown burst: this is the window where the bug bites.
+    for _ in 0..50 {
+        let mut out = std::io::stdout().lock();
+        let wrote = out.write_all(b"shutting down\n").and_then(|()| out.flush());
+        if let Err(e) = wrote {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                let _ = std::fs::write(&marker, b"EPIPE");
+            }
+            break;
+        }
+        drop(out);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    std::process::exit(0);
 }

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -315,9 +315,6 @@ impl ServiceHandle {
     ///
     /// Graceful shutdown allows the process to flush coverage data (profraw files).
     pub async fn stop(&mut self) {
-        if let Some(handle) = self.stdout_drain.take() {
-            handle.abort();
-        }
         if let Some(mut child) = self.child.take() {
             if let Some(pid) = child.id() {
                 send_sigterm(pid);
@@ -335,14 +332,46 @@ impl ServiceHandle {
                 let _ = child.wait().await;
             }
         }
+
+        // Stop draining stdout only *after* the child has exited. With the
+        // child's stdout write end now closed, the drain task observes EOF and
+        // finishes on its own, so we join it rather than aborting it.
+        //
+        // Aborting the drain *before* the child exits (the previous behaviour)
+        // closed the read end of the stdout pipe while the child was still
+        // running its SIGTERM shutdown path. Every shutdown-path log line the
+        // child then wrote to stdout hit a broken pipe (EPIPE); because the
+        // services build their subscriber with `tracing_subscriber::fmt()`
+        // (whose builder defaults `log_internal_errors = true`),
+        // tracing-subscriber echoed each failure as
+        // "[tracing-subscriber] Unable to write an event ... Broken pipe
+        // (os error 32)" to the inherited stderr, polluting the BDD/CI logs.
+        //
+        // The 1s cap + abort is a belt-and-braces guard against the join
+        // hanging; with the child already reaped it cannot itself break a pipe.
+        if let Some(mut handle) = self.stdout_drain.take() {
+            if tokio::time::timeout(Duration::from_secs(1), &mut handle)
+                .await
+                .is_err()
+            {
+                handle.abort();
+            }
+        }
     }
 }
 
 impl Drop for ServiceHandle {
     fn drop(&mut self) {
-        if let Some(handle) = self.stdout_drain.take() {
-            handle.abort();
-        }
+        // Request graceful shutdown, but deliberately do NOT abort the stdout
+        // drain task. Aborting closes the read end of the child's stdout pipe
+        // while the child is still alive, so the child's shutdown-path log
+        // writes hit a broken pipe and tracing-subscriber prints
+        // "[tracing-subscriber] Unable to write an event ... Broken pipe" to
+        // the inherited stderr, polluting test logs (see [`ServiceHandle::stop`]
+        // for the full chain). Dropping the `stdout_drain` JoinHandle along with
+        // the rest of the struct *detaches* the task rather than cancelling it,
+        // so the read end stays open until the child exits; `kill_on_drop` on
+        // the child handle guarantees that — and thus the drain's EOF — arrives.
         if let Some(ref mut child) = self.child {
             if let Some(pid) = child.id() {
                 send_sigterm(pid);

--- a/crates/bdd-infra/tests/service_handle.rs
+++ b/crates/bdd-infra/tests/service_handle.rs
@@ -174,6 +174,71 @@ async fn test_port_is_actually_listening() {
     handle.stop().await;
 }
 
+/// Read the broken-pipe probe marker, treating "file absent" as "no broken
+/// pipe observed". The probe (see `test_service`'s `--epipe-probe`) only writes
+/// the file if one of its stdout writes failed with `BrokenPipe`.
+#[cfg(unix)]
+fn probe_observed_broken_pipe(marker: &std::path::Path) -> bool {
+    std::fs::read_to_string(marker)
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+}
+
+/// Regression guard for the stdout-drain shutdown race that flooded BDD/CI logs
+/// with "[tracing-subscriber] Unable to write an event ... Broken pipe".
+///
+/// `stop()` must keep draining the child's stdout until the child has exited.
+/// The probe child (test_service `--epipe-probe`) installs a SIGTERM handler and
+/// keeps writing to stdout through its shutdown window; if `stop()` aborts the
+/// drain *before* the child exits (the old bug), those writes hit a broken pipe
+/// and the child records it. A correct `stop()` leaves the marker empty.
+///
+/// Unix-gated because the probe relies on a SIGTERM handler to keep writing
+/// during shutdown; multi-threaded to match the real `#[tokio::main]` BDD
+/// harness, where the aborted drain is dropped on another worker promptly.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stop_does_not_break_child_stdout_pipe() {
+    init_test_binary_env();
+    let config = empty_config();
+    let marker = tempfile::NamedTempFile::new().unwrap();
+    let marker_path = marker.path().to_path_buf();
+
+    let mut handle = ServiceHandle::start_with_args(
+        "test-service",
+        &[
+            "--config",
+            config.path().to_str().unwrap(),
+            "--epipe-probe",
+            marker_path.to_str().unwrap(),
+        ],
+    )
+    .await;
+
+    // Let the probe reach steady state (the harness draining its stdout).
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    handle.stop().await;
+
+    // Allow any late probe write to land before we read the marker.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert!(
+        !probe_observed_broken_pipe(&marker_path),
+        "child saw a broken stdout pipe during stop() — the drain was aborted \
+         before the child exited (regressing the broken-pipe-log fix)"
+    );
+}
+
+// Note: the `Drop` path shares the same "don't abort the drain before the child
+// exits" invariant, and `Drop`'s no-abort logic is what enforces it there. We
+// deliberately do not add a `Drop` analogue of the probe test: on `Drop` the
+// child handle's `kill_on_drop(true)` SIGKILLs the child near-instantly, so the
+// probe's shutdown burst is cut off before it can deterministically observe the
+// broken pipe under the *old* ordering — such a test passes under both orderings
+// and would be a vacuous guard. `test_drop_cleans_up_process` covers `Drop`'s
+// process teardown; the `stop()` probe above guards the broken-pipe invariant.
+
 /// Graceful shutdown must complete well under the 5-second SIGKILL fallback
 /// timeout. If the shutdown signal is not delivered (e.g. a no-op
 /// `send_sigterm`), `stop()` would wait the full 5 seconds before hard-killing.

--- a/crates/bdd-infra/tests/service_handle.rs
+++ b/crates/bdd-infra/tests/service_handle.rs
@@ -174,14 +174,21 @@ async fn test_port_is_actually_listening() {
     handle.stop().await;
 }
 
-/// Read the broken-pipe probe marker, treating "file absent" as "no broken
-/// pipe observed". The probe (see `test_service`'s `--epipe-probe`) only writes
-/// the file if one of its stdout writes failed with `BrokenPipe`.
+/// Did the probe child record a broken stdout pipe? The probe (see
+/// `test_service`'s `--epipe-probe`) writes `EPIPE` to the marker only if one of
+/// its stdout writes failed with `BrokenPipe`.
+///
+/// The marker is a pre-created temp file, so it normally exists and is empty
+/// unless the probe wrote to it. We deliberately do *not* swallow arbitrary I/O
+/// errors: an absent marker is unambiguously "no broken pipe", but any other
+/// read failure is a test-infra problem and must fail loudly rather than pass.
 #[cfg(unix)]
 fn probe_observed_broken_pipe(marker: &std::path::Path) -> bool {
-    std::fs::read_to_string(marker)
-        .map(|s| !s.is_empty())
-        .unwrap_or(false)
+    match std::fs::read_to_string(marker) {
+        Ok(contents) => contents.contains("EPIPE"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(e) => panic!("failed to read probe marker {}: {e}", marker.display()),
+    }
 }
 
 /// Regression guard for the stdout-drain shutdown race that flooded BDD/CI logs

--- a/crates/rusty-photon-service-lifecycle/Cargo.toml
+++ b/crates/rusty-photon-service-lifecycle/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 windows-service = { version = "0.8", optional = true }
 
 [features]

--- a/crates/rusty-photon-service-lifecycle/src/lib.rs
+++ b/crates/rusty-photon-service-lifecycle/src/lib.rs
@@ -24,6 +24,9 @@
 //! * [`ReloadSignal`] — opt-in (via [`ServiceRunner::with_reload`]) reload
 //!   notifier, driven by `SIGHUP` on Unix or `ServiceControl::ParamChange` in
 //!   SCM mode. On Windows console mode it never fires.
+//! * [`init_tracing`] — installs the shared tracing subscriber: logs to stderr
+//!   (stdout is reserved for the `bound_addr=` handshake), filtered by `RUST_LOG`
+//!   or a fallback level. Every service binary calls this at startup.
 //!
 //! ## Minimal example
 //!
@@ -57,10 +60,12 @@
 
 #![deny(unsafe_code)]
 
+mod logging;
 mod reload;
 mod runner;
 mod shutdown;
 
+pub use logging::init_tracing;
 pub use reload::ReloadSignal;
 pub use runner::ServiceRunner;
 pub use shutdown::Shutdown;

--- a/crates/rusty-photon-service-lifecycle/src/logging.rs
+++ b/crates/rusty-photon-service-lifecycle/src/logging.rs
@@ -1,15 +1,25 @@
 //! Tracing/logging initialization shared by every Rusty Photon service binary.
 //!
-//! All service binaries log to **stderr**, never stdout. Stdout is reserved for
-//! the machine-readable `bound_addr=<host>:<port>` line that `bdd-infra`'s
-//! `ServiceHandle` parses to discover a test-spawned service's port (and, more
-//! generally, for any structured handshake a supervisor might read). Routing
-//! logs to stdout meant the BDD harness's stdout-drain task silently swallowed
-//! every line, and — because the drain's read end is closed during shutdown —
-//! produced a flood of `[tracing-subscriber] Unable to write an event ... Broken
-//! pipe` noise in CI. Stderr is the conventional place for diagnostics and is
-//! inherited by child processes by default, so logs flow to the same place as
-//! the test binary's own output without extra wiring.
+//! All service binaries log to **stderr**, never stdout, for two standing
+//! reasons:
+//!
+//! 1. Stdout is reserved for the machine-readable `bound_addr=<host>:<port>`
+//!    line that `bdd-infra`'s `ServiceHandle` parses to discover a test-spawned
+//!    service's port (and, more generally, for any structured handshake a
+//!    supervisor might read).
+//! 2. The BDD harness drains and *discards* a service's stdout, so anything
+//!    logged there is invisible during tests. Stderr is the conventional place
+//!    for diagnostics and is inherited by child processes by default, so logs
+//!    flow to the same destination as the test binary's own output without extra
+//!    wiring.
+//!
+//! Historically, logging to stdout also produced a flood of
+//! `[tracing-subscriber] Unable to write an event ... Broken pipe` noise in CI:
+//! the harness aborted its stdout-drain task before the child exited, closing
+//! the pipe's read end while the child was still writing shutdown-path logs.
+//! That harness defect has since been fixed (the drain stays open until the
+//! child exits), so stderr logging is no longer *required* to avoid the EPIPE —
+//! but it remains the right destination for reasons 1 and 2.
 //!
 //! Filtering follows `RUST_LOG` when set, otherwise falls back to the level the
 //! binary passes in (typically its `--log-level` flag, defaulting to `info`).

--- a/crates/rusty-photon-service-lifecycle/src/logging.rs
+++ b/crates/rusty-photon-service-lifecycle/src/logging.rs
@@ -1,0 +1,93 @@
+//! Tracing/logging initialization shared by every Rusty Photon service binary.
+//!
+//! All service binaries log to **stderr**, never stdout. Stdout is reserved for
+//! the machine-readable `bound_addr=<host>:<port>` line that `bdd-infra`'s
+//! `ServiceHandle` parses to discover a test-spawned service's port (and, more
+//! generally, for any structured handshake a supervisor might read). Routing
+//! logs to stdout meant the BDD harness's stdout-drain task silently swallowed
+//! every line, and — because the drain's read end is closed during shutdown —
+//! produced a flood of `[tracing-subscriber] Unable to write an event ... Broken
+//! pipe` noise in CI. Stderr is the conventional place for diagnostics and is
+//! inherited by child processes by default, so logs flow to the same place as
+//! the test binary's own output without extra wiring.
+//!
+//! Filtering follows `RUST_LOG` when set, otherwise falls back to the level the
+//! binary passes in (typically its `--log-level` flag, defaulting to `info`).
+//! This is the same `stderr` + `EnvFilter` pattern `rp` and `plate-solver` used
+//! inline, hoisted here so all services share one implementation.
+
+use tracing::Level;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+
+/// Build the [`EnvFilter`] for [`init_tracing`]: honor `RUST_LOG` when present
+/// and parseable, otherwise fall back to `default_level`.
+///
+/// Split out from [`init_tracing`] so the filter logic is unit-testable without
+/// installing a process-global subscriber. `RUST_LOG` takes precedence over
+/// `default_level`, matching the convention `rp`/`plate-solver` established.
+fn build_env_filter(default_level: Level) -> EnvFilter {
+    EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(LevelFilter::from_level(default_level).to_string()))
+}
+
+/// Initialize the global tracing subscriber for a service binary.
+///
+/// Logs are written to stderr (see the module docs for why), filtered by
+/// `RUST_LOG` if set, otherwise at `default_level`. Idempotent: a redundant call
+/// (e.g. from a test that already installed a subscriber) is ignored rather than
+/// panicking, matching [`try_init`](tracing_subscriber::fmt::SubscriberBuilder::try_init)
+/// semantics.
+pub fn init_tracing(default_level: Level) {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(build_env_filter(default_level))
+        .try_init();
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // `RUST_LOG` is process-global; serialize the tests that read or write it so
+    // they don't observe each other's mutations under `cargo test` (which runs
+    // tests as threads in one process for the coverage job).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn falls_back_to_default_level_when_rust_log_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var_os("RUST_LOG");
+        std::env::remove_var("RUST_LOG");
+
+        let hint = build_env_filter(Level::DEBUG).max_level_hint();
+
+        if let Some(v) = saved {
+            std::env::set_var("RUST_LOG", v);
+        }
+        assert_eq!(hint, Some(LevelFilter::DEBUG));
+    }
+
+    #[test]
+    fn rust_log_overrides_default_level() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var_os("RUST_LOG");
+        std::env::set_var("RUST_LOG", "trace");
+
+        let hint = build_env_filter(Level::INFO).max_level_hint();
+
+        match saved {
+            Some(v) => std::env::set_var("RUST_LOG", v),
+            None => std::env::remove_var("RUST_LOG"),
+        }
+        assert_eq!(hint, Some(LevelFilter::TRACE));
+    }
+
+    #[test]
+    fn init_tracing_is_idempotent() {
+        // Two calls must not panic — the second is swallowed by `try_init`.
+        init_tracing(Level::INFO);
+        init_tracing(Level::INFO);
+    }
+}

--- a/docs/crates/rusty-photon-service-lifecycle.md
+++ b/docs/crates/rusty-photon-service-lifecycle.md
@@ -26,13 +26,17 @@ this doc covers the crate's own design.
 - Cooperative-shutdown propagation: the handle is a
   `CancellationToken`-backed clone, so spawned subtasks observe the
   same cancellation as the main loop.
+- Install the shared tracing subscriber ([`init_tracing`]): logs go to
+  stderr (stdout is reserved for the `bound_addr=` handshake the BDD
+  harness parses), filtered by `RUST_LOG` when set, otherwise at a
+  caller-supplied fallback level. Idempotent. Every service binary calls
+  this once at startup so logging is configured identically everywhere.
 
 Out of scope:
 
-- Initializing `tracing` / logging. Services vary on log filters,
-  formats, and CLI flags; the runner does not own this.
 - Owning CLI argument parsing. Services keep `clap`; the runner takes
-  a service name and a closure.
+  a service name and a closure. (Services still own their `--log-level`
+  flag and pass its value to [`init_tracing`] as the fallback level.)
 - Defining what graceful shutdown means for any particular server.
   Services compose `shutdown.cancelled()` into their own server stop
   (a `tokio::select!` race, `axum::with_graceful_shutdown(...)`, or
@@ -45,7 +49,8 @@ Out of scope:
 
 ## Public API
 
-Three types. [`Shutdown`] is constructed only by the runner.
+Three types and one free function ([`init_tracing`]).
+[`Shutdown`] is constructed only by the runner.
 [`ReloadSignal`] has a public constructor so integration tests can
 drive a service's run loop with synthetic reload events, and so
 non-signal-driven reload sources (e.g. a file-watcher) can share the
@@ -65,6 +70,8 @@ Shutdown::is_cancelled() -> bool
 ReloadSignal::new()      -> ReloadSignal      // for tests / alt sources
 ReloadSignal::notify(&self)                   // wake one waiter
 ReloadSignal::recv(&self) -> impl Future<Output = ()> + '_
+
+init_tracing(default_level: tracing::Level)   // stderr + RUST_LOG/EnvFilter subscriber; idempotent
 ```
 
 The closure passed to `run` / `run_with_reload` is `FnOnce(...) -> Fut`
@@ -353,6 +360,7 @@ in the crate; the service binary just opts in.
 ```
 crates/rusty-photon-service-lifecycle/src/
 ├── lib.rs       # crate root: //! docs, module decls, re-exports
+├── logging.rs   # init_tracing — shared stderr + EnvFilter subscriber
 ├── shutdown.rs  # Shutdown — thin wrapper over CancellationToken
 ├── reload.rs    # ReloadSignal — thin wrapper over Arc<Notify>
 └── runner.rs    # ServiceRunner — builder + run/run_with_reload

--- a/services/calibrator-flats/Cargo.toml
+++ b/services/calibrator-flats/Cargo.toml
@@ -19,7 +19,6 @@ humantime = { workspace = true }
 humantime-serde = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }

--- a/services/calibrator-flats/src/main.rs
+++ b/services/calibrator-flats/src/main.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use rusty_photon_service_lifecycle::ServiceRunner;
-use tracing::debug;
-use tracing_subscriber::EnvFilter;
+use tracing::{debug, Level};
 
 #[derive(Parser)]
 #[command(
@@ -24,18 +23,14 @@ struct Cli {
     bind_address: String,
 
     /// Log level (trace, debug, info, warn, error)
-    #[arg(long, default_value = "info")]
-    log_level: String,
+    #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+    log_level: Level,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&cli.log_level)),
-        )
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(cli.log_level);
 
     ServiceRunner::new("calibrator-flats").run(move |shutdown| async move {
         debug!(config_path = %cli.config.display(), "loading configuration");

--- a/services/dsd-fp2/Cargo.toml
+++ b/services/dsd-fp2/Cargo.toml
@@ -36,7 +36,6 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rusty-photon-shared-transport = { workspace = true }
 rusty-photon-service-lifecycle = { workspace = true }
@@ -49,6 +48,7 @@ directories = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 tokio-test = { workspace = true }
 cucumber = { workspace = true }
 reqwest = { workspace = true }

--- a/services/dsd-fp2/src/main.rs
+++ b/services/dsd-fp2/src/main.rs
@@ -48,9 +48,7 @@ fn parse_log_level(s: &str) -> Result<Level, String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: config={:?}, port={:?}, server_port={:?}, log_level={:?}",

--- a/services/filemonitor/Cargo.toml
+++ b/services/filemonitor/Cargo.toml
@@ -25,7 +25,6 @@ clap = { workspace = true }
 regex = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 rp-tls = { workspace = true }
 rp-auth = { workspace = true }

--- a/services/filemonitor/src/main.rs
+++ b/services/filemonitor/src/main.rs
@@ -25,9 +25,7 @@ struct Args {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: config={:?}, log_level={:?}, service={}",

--- a/services/pa-falcon-rotator/Cargo.toml
+++ b/services/pa-falcon-rotator/Cargo.toml
@@ -36,13 +36,13 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
 rp-auth = { workspace = true }
 axum = { workspace = true }
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 bdd-infra = { workspace = true, features = ["conformu"] }
 tokio-test = { workspace = true }
 mockall = { workspace = true }

--- a/services/pa-falcon-rotator/src/main.rs
+++ b/services/pa-falcon-rotator/src/main.rs
@@ -51,9 +51,7 @@ fn parse_log_level(s: &str) -> Result<Level, String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: config={:?}, port={:?}, server_port={:?}, log_level={:?}",

--- a/services/phd2-guider/Cargo.toml
+++ b/services/phd2-guider/Cargo.toml
@@ -19,7 +19,6 @@ humantime = { workspace = true }
 humantime-serde = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 rp-fits = { workspace = true }

--- a/services/phd2-guider/src/main.rs
+++ b/services/phd2-guider/src/main.rs
@@ -122,9 +122,7 @@ enum Commands {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: host={}, port={}, log_level={:?}",

--- a/services/plate-solver/Cargo.toml
+++ b/services/plate-solver/Cargo.toml
@@ -20,7 +20,6 @@ humantime-serde = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }

--- a/services/plate-solver/src/main.rs
+++ b/services/plate-solver/src/main.rs
@@ -7,10 +7,10 @@
 
 use clap::Parser;
 use plate_solver::{load_config, ServerBuilder};
-use rusty_photon_service_lifecycle::ServiceRunner;
+use rusty_photon_service_lifecycle::{init_tracing, ServiceRunner};
 use std::path::PathBuf;
 use std::process::ExitCode;
-use tracing_subscriber::EnvFilter;
+use tracing::Level;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -22,17 +22,16 @@ struct Cli {
     /// Path to the JSON config file.
     #[arg(short, long)]
     config: PathBuf,
+
+    /// Log level (trace, debug, info, warn, error)
+    #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+    log_level: Level,
 }
 
 fn main() -> ExitCode {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .with_writer(std::io::stderr)
-        .try_init();
-
     let cli = Cli::parse();
+
+    init_tracing(cli.log_level);
 
     let config = match load_config(&cli.config) {
         Ok(c) => c,

--- a/services/ppba-driver/Cargo.toml
+++ b/services/ppba-driver/Cargo.toml
@@ -40,7 +40,6 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
 rp-auth = { workspace = true }
@@ -60,6 +59,7 @@ command = "cargo test -p ppba-driver --features conformu --test conformu_integra
 #command = "cargo miri test -p ppba-driver"
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 ascom-alpaca = { workspace = true, features = ["client", "switch", "observing_conditions"] }
 bdd-infra = { workspace = true, features = ["conformu"] }
 tokio-test = { workspace = true }

--- a/services/ppba-driver/src/main.rs
+++ b/services/ppba-driver/src/main.rs
@@ -75,9 +75,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse_localized(&loader);
 
     // Setup tracing
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     match i18n_status {
         Ok(()) => {}

--- a/services/qhy-focuser/Cargo.toml
+++ b/services/qhy-focuser/Cargo.toml
@@ -36,7 +36,6 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
 rp-auth = { workspace = true }
@@ -49,6 +48,7 @@ command = "cargo test -p qhy-focuser --features conformu --test conformu_integra
 command = "cargo miri test -p qhy-focuser"
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 bdd-infra = { workspace = true, features = ["conformu"] }
 tokio-test = { workspace = true }
 mockall = { workspace = true }

--- a/services/qhy-focuser/src/main.rs
+++ b/services/qhy-focuser/src/main.rs
@@ -50,9 +50,7 @@ fn parse_log_level(s: &str) -> Result<Level, String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: config={:?}, port={:?}, server_port={:?}, log_level={:?}",

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -20,7 +20,6 @@ humantime-serde = { workspace = true }
 clap = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }

--- a/services/rp/src/main.rs
+++ b/services/rp/src/main.rs
@@ -1,9 +1,8 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use rusty_photon_service_lifecycle::{ServiceRunner, Shutdown};
-use tracing::debug;
-use tracing_subscriber::EnvFilter;
+use rusty_photon_service_lifecycle::{init_tracing, ServiceRunner, Shutdown};
+use tracing::{debug, Level};
 
 #[derive(Parser)]
 #[command(name = "rp", about = "Rusty Photon - equipment gateway and event bus")]
@@ -16,8 +15,8 @@ struct Cli {
     config: Option<PathBuf>,
 
     /// Log level (trace, debug, info, warn, error)
-    #[arg(long, default_value = "info")]
-    log_level: String,
+    #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+    log_level: Level,
 }
 
 #[derive(Subcommand)]
@@ -29,14 +28,14 @@ enum Commands {
         config: PathBuf,
 
         /// Log level (trace, debug, info, warn, error)
-        #[arg(long, default_value = "info")]
-        log_level: String,
+        #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+        log_level: Level,
     },
     /// Hash a password for use in service auth configuration
     HashPassword {
         /// Log level (trace, debug, info, warn, error)
-        #[arg(long, default_value = "info")]
-        log_level: String,
+        #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+        log_level: Level,
 
         /// Read password from stdin (no prompt, no confirmation)
         #[arg(long)]
@@ -81,8 +80,8 @@ enum Commands {
         staging: bool,
 
         /// Log level (trace, debug, info, warn, error)
-        #[arg(long, default_value = "info")]
-        log_level: String,
+        #[arg(long, default_value = "info", value_parser = clap::value_parser!(Level))]
+        log_level: Level,
     },
 }
 
@@ -91,11 +90,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Some(Commands::Serve { config, log_level }) => {
-            init_tracing(&log_level);
+            init_tracing(log_level);
             run_serve(config)
         }
         Some(Commands::HashPassword { log_level, stdin }) => {
-            init_tracing(&log_level);
+            init_tracing(log_level);
             rp::hash_password_cmd::run(stdin)
         }
         Some(Commands::InitTls {
@@ -110,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             staging,
             log_level,
         }) => {
-            init_tracing(&log_level);
+            init_tracing(log_level);
             if acme {
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -136,29 +135,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let config = cli.config.ok_or(
                 "no subcommand given. Use `rp serve --config <path>` or `rp --config <path>`",
             )?;
-            init_tracing(&cli.log_level);
+            init_tracing(cli.log_level);
             run_serve(config)
         }
     }
-}
-
-fn init_tracing(log_level: &str) {
-    // Tracing goes to stderr, not stdout. rp's stdout is reserved for
-    // the `Bound rp server bound_addr=...` line that the BDD harness
-    // and ServiceHandle parse to discover the bound port; if tracing
-    // landed on stdout, the harness's drain task would silently
-    // swallow every log line (which is exactly what was happening
-    // before — rp's `error!()` and `info!()` from `connect_*` retry
-    // logging never reached CI logs). Stderr is also the conventional
-    // place for diagnostics, and a child process's stderr is
-    // inherited by default, so rp's logs flow to the same destination
-    // as the test binary's own output without any extra wiring.
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level)),
-        )
-        .init();
 }
 
 fn run_serve(config_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {

--- a/services/sentinel/Cargo.toml
+++ b/services/sentinel/Cargo.toml
@@ -20,7 +20,6 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 tokio-util = { workspace = true }

--- a/services/sentinel/src/main.rs
+++ b/services/sentinel/src/main.rs
@@ -30,9 +30,7 @@ struct Args {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     tracing::debug!(
         "Parsed command line arguments: config={:?}, dashboard_port={:?}, log_level={:?}",

--- a/services/sky-survey-camera/Cargo.toml
+++ b/services/sky-survey-camera/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = { workspace = true }
 derive_more = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 axum = { workspace = true }
 reqwest = { workspace = true }
 ndarray = { workspace = true }
@@ -49,6 +48,7 @@ base64 = { workspace = true }
 command = "cargo test -p sky-survey-camera --features conformu --test conformu_integration -- --nocapture"
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 bdd-infra = { workspace = true, features = ["conformu"] }
 cucumber = { workspace = true }
 tempfile = { workspace = true }

--- a/services/sky-survey-camera/src/main.rs
+++ b/services/sky-survey-camera/src/main.rs
@@ -22,9 +22,7 @@ struct Args {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     let config_path = rusty_photon_config::resolve_config_path("sky-survey-camera", args.config)?;
     debug!(config = ?config_path, "starting sky-survey-camera");

--- a/services/star-adventurer-gti/Cargo.toml
+++ b/services/star-adventurer-gti/Cargo.toml
@@ -33,7 +33,6 @@ clap = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 rp-tls = { workspace = true }
 rp-auth = { workspace = true }
@@ -73,6 +72,7 @@ tempfile = { workspace = true }
 # `docs/services/star-adventurer-gti.md` §"Running ConformU manually".
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
 bdd-infra = { workspace = true, features = ["conformu"] }
 tokio-test = { workspace = true }
 mockall = { workspace = true }

--- a/services/star-adventurer-gti/src/main.rs
+++ b/services/star-adventurer-gti/src/main.rs
@@ -54,9 +54,7 @@ fn parse_log_level(s: &str) -> Result<Level, String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     debug!(
         "Parsed command line arguments: config={:?}, transport={:?}, port={:?}, server_port={:?}, log_level={:?}",

--- a/services/ui-htmx/Cargo.toml
+++ b/services/ui-htmx/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 rp-tls = { workspace = true }
 rusty-photon-config = { workspace = true }

--- a/services/ui-htmx/src/main.rs
+++ b/services/ui-htmx/src/main.rs
@@ -34,9 +34,7 @@ fn parse_log_level(s: &str) -> Result<Level, String> {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(args.log_level)
-        .init();
+    rusty_photon_service_lifecycle::init_tracing(args.log_level);
 
     let mut config = match &args.config {
         Some(path) => {


### PR DESCRIPTION
## Summary

Our BDD suites flooded CI (and local) logs with this harmless-but-noisy line —
**~1,374 occurrences in a single nightly `rolling` run** (e.g. run 27060210797):

```
[tracing-subscriber] Unable to write an event to the Writer for this Subscriber! Error: Broken pipe (os error 32)
```

This PR removes that noise at the root, then consolidates service logging so the
underlying smell can't recur.

## Root cause

1. 11 of 13 service binaries built their subscriber with `tracing_subscriber::fmt().init()` → tracing events went to **stdout**, and that builder defaults `log_internal_errors = true`.
2. `bdd-infra`'s `ServiceHandle` pipes the child's stdout, parses the `bound_addr=` line, then drains the rest in a background task that owns the read end.
3. On `stop()`/`Drop` it **aborted the drain first** (closing the pipe's read end) and only then sent SIGTERM.
4. The SIGTERM handler emits `tracing::info!("…terminating")` → a write to the now-closed stdout → **EPIPE** → `log_internal_errors=true` echoed each failure to the inherited stderr → CI spam.

## Changes

**1. Harness broken-pipe fix — `crates/bdd-infra` (commit 1)**
- Reorder `ServiceHandle::stop()`/`Drop` so the stdout drain stays alive until the child has exited (`stop()` reaps then joins the drain with a 1s cap + abort fallback; `Drop` detaches the drain instead of aborting it). Public API unchanged.
- Deterministic regression guard: `test_service` gains an `--epipe-probe` mode (safe `tokio::signal`, **no `unsafe`**) and a `service_handle` test that fails if the child observes a broken stdout pipe during `stop()`.

**2. Shared logging consolidation — `service-lifecycle` + all 13 services (commit 2)**
- New `rusty_photon_service_lifecycle::init_tracing(Level)`: logs to **stderr** (stdout reserved for the `bound_addr=` handshake), filtered by `RUST_LOG` when set else a fallback level, idempotent. Unit-tested. Lives in the one crate every service already depends on.
- All 13 binaries now route through it (zero `tracing_subscriber::` refs remain in any `main.rs`).
- `rp` `--log-level` `String` → `Level`; `plate-solver` gains a `--log-level` flag so all 13 expose it uniformly.
- `tracing-subscriber` removed from `[dependencies]` where now unused; relocated to `[dev-dependencies]` for the 6 services (incl. `pa-falcon-rotator`) that use it only in tests.

## Behavior change (intentional)

- Service logs now reach test output on stderr → **visible for diagnostics** (they were previously silently drained on stdout).
- `RUST_LOG` is now honored by every service (it was ignored under `with_max_level`). At the default level, verbosity is unchanged; CI doesn't set `RUST_LOG` for the BDD jobs.

## Verification

- **Full `cargo rail run --profile commit` gate: 2,261 tests pass, 0 broken-pipe lines.**
- filemonitor BDD: **29–31 → 0** broken-pipe lines; service logs now visible on stderr.
- Regression guard proven effective (fails under the old abort-first ordering; passes with the fix).
- Workspace type-checks clean (`--all-features --all-targets`); `cargo fmt` clean.

## Out of scope / notes

- `sentinel-app` (a `cdylib`/`rlib` WASM frontend, no `main.rs`/subscriber) and `qhy-camera` (design-doc scaffold, no binary) are correctly untouched.
- The 6 i18n services keep their *localized* `--log-level` parser; `sentinel` uses clap's auto-derive. These are flag-parsing details — all produce a `Level` for the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
