### PR TITLE
fix(ci): bump install-omnisim to OmniSim v0.5.0-326.4 (closes #319)

### DIFF
--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -24,7 +24,7 @@ runs:
     # #326, #319): 326.1 locked the slew-engine writers + IsSlewing/RA/Dec
     # readers; 326.2 adds the AtPark/SlewState readers (closes the park-poll
     # hang); 326.3 disposes the prior slew timer on Init() (was leaking one
-    # live timer per per-scenario reset) and resets the slew state under
+    # live timer on each per-scenario reset) and resets the slew state under
     # hardwareLock; 326.4 closes the center_on_target IsSlewing wedge proper
     # (issue #319) — a GEM goto whose short-path rotation crossed the
     # hour-angle limit pinned IsSlewing=true forever; DoSlew now takes the

--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: OmniSim release version
     required: false
-    default: "v0.5.0-326.3"
+    default: "v0.5.0-326.4"
 
 runs:
   using: composite
@@ -19,13 +19,17 @@ runs:
     # Per-OS table. SHA-256 values are pinned against the OmniSim
     # release assets named below. They currently point at the patched
     # fork ivonnyssen/ASCOM.Alpaca.Simulators (default `repo` input,
-    # tag v0.5.0-326.3), which carries the issue #326 TelescopeHardware
-    # locking fix (ivonnyssen/rusty-photon#326) — 326.1 locked the
-    # slew-engine writers + IsSlewing/RA/Dec readers; 326.2 adds the
-    # AtPark/SlewState readers (closes the park-poll hang); 326.3 disposes
-    # the prior slew timer on Init() (was leaking one live timer per
-    # per-scenario reset) and resets the slew state under hardwareLock
-    # (closes the center_on_target IsSlewing wedge). To revert to upstream,
+    # tag v0.5.0-326.4). The 326.x series fixes TelescopeHardware slew
+    # bugs behind the center_on_target hang/flake (ivonnyssen/rusty-photon
+    # #326, #319): 326.1 locked the slew-engine writers + IsSlewing/RA/Dec
+    # readers; 326.2 adds the AtPark/SlewState readers (closes the park-poll
+    # hang); 326.3 disposes the prior slew timer on Init() (was leaking one
+    # live timer per per-scenario reset) and resets the slew state under
+    # hardwareLock; 326.4 closes the center_on_target IsSlewing wedge proper
+    # (issue #319) — a GEM goto whose short-path rotation crossed the
+    # hour-angle limit pinned IsSlewing=true forever; DoSlew now takes the
+    # limit-avoiding rotation to the same target (pier side unchanged), plus
+    # a no-progress guard. ConformU-clean vs upstream. To revert to upstream,
     # set `repo` to ASCOMInitiative/ASCOM.Alpaca.Simulators and `version`
     # back to v0.5.0, then refresh every SHA below. Bumping either input
     # requires refreshing the SHAs — the verify step fails closed on any
@@ -37,23 +41,23 @@ runs:
         case "${{ runner.os }}-${{ runner.arch }}" in
           Linux-X64)
             ASSET="ascom.alpaca.simulators.linux-x64.tar.xz"
-            SHA256="3883f928c6ef935775dca114347ead573ae0f1e49a6c97ddebbabc51f5e84974"
+            SHA256="74d96ae5b1c41f4eae27336c5dafc47e8264939ce8946f2178949eb3fcbf0153"
             ;;
           Linux-ARM64)
             ASSET="ascom.alpaca.simulators.linux-aarch64.tar.xz"
-            SHA256="04d49b455bfaac0c2c2e2c2e1b84aea207a6eca6bb4cf31e748fbd27e86dfe7a"
+            SHA256="5218f57038cc520139b63454265eb53f6ecbbb7b8cee9374ad74dd759af48e30"
             ;;
           macOS-ARM64)
             ASSET="ascom.alpaca.simulators.macos-arm64.zip"
-            SHA256="100a972050544e0b8852752f2e863d4436b4c2fae95b7bc8a00258e181d09adb"
+            SHA256="54c0d8aaf18222f572e348fc36addc884013a5ab734ace1f3c475b9603c57ee5"
             ;;
           macOS-X64)
             ASSET="ascom.alpaca.simulators.macos-x64.zip"
-            SHA256="d7b4056e34867bb3b5e1a47ab05b57942ce3c5bf672b2518b3952bb12b3f6ea6"
+            SHA256="1af188a340dfc46f0d86391af67007202a47e377b2eac0d21d0b7b26b1234336"
             ;;
           Windows-X64)
             ASSET="ascom.alpaca.simulators.windows-x64.zip"
-            SHA256="78cea87a4d2cc3f8eef10281361e108b70206f852b3b80b29996929d3ebbd067"
+            SHA256="4aacde332d3c92ddd27924d0609d50bde020e1294d14ec6f4844a87df0a9d938"
             ;;
           *)
             echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -3440,8 +3440,8 @@ a build of upstream `v0.5.0` plus a series of `TelescopeHardware` fixes
 for the `center_on_target` slew-state hang/flake (issues #326, #319):
 326.1/.2 put the slew-engine writers and the
 `IsSlewing`/RA/Dec/`AtPark`/`SlewState` readers under `hardwareLock`;
-326.3 disposes the per-`Init()` slew timer (it leaked one live timer per
-per-scenario "restart to clean state" reset, accumulating tick sources
+326.3 disposes the per-`Init()` slew timer (it leaked one live timer on
+each per-scenario "restart to clean state" reset, accumulating tick sources
 that raced the single static slew engine) and resets the slew state —
 including the `slewing` flag — under `hardwareLock`. Those addressed the
 locking/leak races but **not** the underlying wedge: 326.4 fixes it
@@ -3456,8 +3456,10 @@ rotation to the *same* target (pier side unchanged, so ConformU stays
 clean) and adds a no-progress guard. The action's `repo`
 and `version` inputs revert to upstream
 [`v0.5.0`](https://github.com/ASCOMInitiative/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0)
-in one line once the fix lands upstream. For local runs upstream `v0.5.0`
-is fine unless you're specifically reproducing #326.
+in one line once the fix lands upstream. For local runs, use the pinned
+fork as well — upstream `v0.5.0` still carries both the #326 races and
+the sidereal-time-gated #319 wedge, so it can hang `center_on_target`
+intermittently and is not recommended for local BDD runs.
 
 #### Graceful Shutdown and Coverage
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -3435,15 +3435,25 @@ of the environment variables above. In CI, the
 automatically.
 
 **CI pins a patched fork**, not upstream: the action defaults to
-[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-326.3`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-326.3),
+[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-326.4`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-326.4),
 a build of upstream `v0.5.0` plus a series of `TelescopeHardware` fixes
-for the `center_on_target` slew-state hang (issue #326): 326.1/.2 put the
-slew-engine writers and the `IsSlewing`/RA/Dec/`AtPark`/`SlewState`
-readers under `hardwareLock`; 326.3 disposes the per-`Init()` slew timer
-(it leaked one live timer per per-scenario "restart to clean state"
-reset, accumulating tick sources that raced the single static slew
-engine) and resets the slew state — including the `slewing` flag — under
-`hardwareLock`. The action's `repo`
+for the `center_on_target` slew-state hang/flake (issues #326, #319):
+326.1/.2 put the slew-engine writers and the
+`IsSlewing`/RA/Dec/`AtPark`/`SlewState` readers under `hardwareLock`;
+326.3 disposes the per-`Init()` slew timer (it leaked one live timer per
+per-scenario "restart to clean state" reset, accumulating tick sources
+that raced the single static slew engine) and resets the slew state —
+including the `slewing` flag — under `hardwareLock`. Those addressed the
+locking/leak races but **not** the underlying wedge: 326.4 fixes it
+(issue #319). The real cause is geometric — a GEM goto whose
+shortest-path primary rotation crosses the hour-angle software limit
+(`180 + hourAngleLimit`) gets undone by `CheckAxisLimits` every tick, so
+the slew never finishes and `IsSlewing` stays `true` forever.
+`center_on_target`'s sync-then-slew-to-near-the-same-coords triggers it
+for the `RA < 180` off-target row at certain sidereal times (hence the
+intermittent CI flake). 326.4 makes `DoSlew` take the limit-avoiding
+rotation to the *same* target (pier side unchanged, so ConformU stays
+clean) and adds a no-progress guard. The action's `repo`
 and `version` inputs revert to upstream
 [`v0.5.0`](https://github.com/ASCOMInitiative/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0)
 in one line once the fix lands upstream. For local runs upstream `v0.5.0`


### PR DESCRIPTION
## What

Bumps the `install-omnisim` action to **OmniSim `v0.5.0-326.4`** (version default + all 5 pinned asset SHA-256s) and updates `docs/services/rp.md`. 326.4 fixes the actual `center_on_target` slew wedge behind the intermittent nightly `rolling` failures.

Closes #319.

## Root cause (proven)

Not a race — a GEM **geometry** bug in the OmniSim simulator. `center_on_target` does `sync_to(off_target)` then `slew_to(target)`, both ≈ the same sky point. OmniSim's sync preserves the current pier side but the goto picks the natural side, so a ~0″ sky move becomes a ~180° **axis** flip. For the `RA < 180` off-target row, `DoSlew`'s shortest-path rotation drives the primary axis **into** the hour-angle software limit (`X = 180 + hourAngleLimit = 200°`); `CheckAxisLimits` undoes the step every 100 ms tick, so the slew never finishes and `IsSlewing` stays `true` forever → rp's poll times out (`"timeout waiting for mount to settle"`). It is sidereal-time gated (OmniSim's longitude is locked on UTC CI runners), which is why it presented as an intermittent flake hitting one of three Examples rows.

The earlier `326.1-.3` work fixed locking / timer-leak races but **not** this wedge — this PR also corrects the `action.yml` and `rp.md` notes that wrongly credited 326.3 with closing it.

## The fix (in OmniSim `v0.5.0-326.4`)

[`ivonnyssen/ASCOM.Alpaca.Simulators@323ff1b`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-326.4), `TelescopeHardware.cs`:
- **`DoSlew` direction fix:** when the shortest-path primary rotation would leave the GEM mechanical range but the *same* target is reachable the other way round, take the longer rotation. Reaches the identical target axes → **pier side unchanged** (no conformance impact); no-op when the short path stays in range.
- **No-progress guard:** stop a slew that can't advance for 0.5 s instead of reporting `IsSlewing` forever (backstop for genuinely unreachable targets).

## Verification

- **ConformU** telescope conformance on the 326.4 binary: **0 issues** ("passes ASCOM validation", `SideOfPier Write OK`), matching **upstream `v0.5.0`** and **fork `326.3`** — zero conformance regressions. (An earlier pier-side-*preference* approach regressed `SideOfPier` write and was rejected in favour of this direction fix.)
- **Direct wedge repro** (LST dialed via `SiteLongitude`): the former-wedge geometry now **converges in ~10 s** to the target on the natural pier side, vs the prior 45 s+ hang.
- The published `linux-x64` asset's SHA-256 matches the pin in this PR (CI's verify step will pass).

> Note: this PR's own BDD CI exercises `@e2e-centering` against 326.4, but the wedge is sidereal-time gated, so a green CI run here is necessary-not-sufficient — the deterministic proof is the ConformU + LST-controlled repro above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
