### PR TITLE
fix(bazel): export spawned-binary main.rs in coverage reports

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -231,17 +231,23 @@ test:conformu --test_env=CONFORMU_PATH
 # `bazel coverage --config=coverage` needs OmniSim installed + OMNISIM_PATH set,
 # exactly like a local `bazel test --test_tag_filters=bdd` run.
 #
-# Child-process coverage (two halves): under `bazel coverage //...` the spawned
+# Child-process coverage (three stages): under `bazel coverage //...` the spawned
 # service binaries ARE instrumented (first-party targets matching the filter).
 # (1) COLLECT: bdd-infra's spawn path sets a per-child
 # LLVM_PROFILE_FILE=$COVERAGE_DIR/<pkg>-%8m.profraw when COVERAGE_DIR is set
 # (child_coverage_profile_var in crates/bdd-infra/src/lib.rs; the `%8m`
 # online-merge pool — not `%p-%m` — bounds the profraw volume, see PR #342), so
 # each child's counters land in the merged profdata. (2) EXPORT: a pinned rules_rust patch
-# (MODULE.bazel single_version_override) adds each spawned binary as an
+# (third_party/patches/collect_coverage_extra_objects.patch) adds each spawned binary as an
 # `llvm-cov export -object` via the RUST_COVERAGE_EXTRA_OBJECTS env var set on the
 # BDD/integration targets — without it the merged child counters have no covmap
-# to bind to and are dropped. See docs/plans/bazel-migration.md.
+# to bind to and are dropped. (3) MANIFEST: a second pinned patch
+# (instrumented_files_include_data.patch) adds `data` to the rust rules' coverage
+# dependency_attributes, so the spawned binary's sources (src/main.rs) join the test's
+# instrumented_files manifest. Without it Bazel's post-collector LcovMerger intersects the
+# exported report against that manifest and silently DROPS main.rs (it is reached only via
+# `data`, not `deps`). Both patches are wired in MODULE.bazel single_version_override and
+# guarded in parity.yml. See docs/plans/bazel-migration.md.
 coverage:coverage --@rules_rust//rust/toolchain/channel=nightly
 coverage:coverage --@rules_rust//rust/settings:extra_rustc_flags=--cfg=coverage_nightly
 coverage:coverage --instrumentation_filter=^//crates,^//services

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -64,14 +64,23 @@ jobs:
       # in the test's instrumented_files manifest and survives Bazel's post-collector
       # LcovMerger intersection. Without it, the (1) EXPORT patch's main.rs coverage is
       # silently filtered back out. A rules_rust bump that drops/relocates this hunk would
-      # regress main.rs coverage with no test failure, so assert the patched line survives.
+      # regress main.rs coverage with no test failure, so assert the patched hunk survives.
       - name: Guard - rules_rust instrumented-files (data) patch applied & effective
         run: |
           # Force fetch+patch of rules_rust (the .bzl source is not itself a target).
           bazel build --nobuild @rules_rust//util/collect_coverage:collect_coverage
           src="$(bazel info output_base)/external/rules_rust+/rust/private/rustc.bzl"
-          if ! grep -Eq '"dependency_attributes": \[.*"data".*\]' "$src"; then
-            echo "::error::instrumented_files patch not effective: $src no longer has \"data\" in the coverage dependency_attributes. A rules_rust upgrade likely needs the patch re-rebased (third_party/patches/instrumented_files_include_data.patch)."
+          # Anchor the check to the coverage `instrumented_files_kwargs` block specifically,
+          # not just any dependency_attributes list that happens to contain "data" (rules_rust
+          # has unrelated ["data", "compile_data"] lists elsewhere). awk so the assertion is
+          # identical on GNU grep / BSD / CI; matches only `data` inside the kwargs `{ ... }`.
+          if ! awk '
+            /instrumented_files_kwargs = \{/ { inblk = 1 }
+            inblk && /"dependency_attributes":/ && /"data"/ { found = 1 }
+            inblk && /\}/ { inblk = 0 }
+            END { exit(found ? 0 : 1) }
+          ' "$src"; then
+            echo "::error::instrumented_files patch not effective: the coverage instrumented_files_kwargs block in $src no longer carries \"data\" in dependency_attributes. A rules_rust upgrade likely needs the patch re-rebased (third_party/patches/instrumented_files_include_data.patch)."
             exit 1
           fi
           echo "rules_rust instrumented-files (data) patch is applied and effective."

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -57,3 +57,21 @@ jobs:
             exit 1
           fi
           echo "rules_rust collect_coverage patch is applied and effective."
+
+      # Guard the SECOND pinned coverage patch (MODULE.bazel single_version_override ->
+      # third_party/patches/instrumented_files_include_data.patch). It adds `data` to the
+      # rust rules' coverage dependency_attributes so a spawned binary's src/main.rs lands
+      # in the test's instrumented_files manifest and survives Bazel's post-collector
+      # LcovMerger intersection. Without it, the (1) EXPORT patch's main.rs coverage is
+      # silently filtered back out. A rules_rust bump that drops/relocates this hunk would
+      # regress main.rs coverage with no test failure, so assert the patched line survives.
+      - name: Guard - rules_rust instrumented-files (data) patch applied & effective
+        run: |
+          # Force fetch+patch of rules_rust (the .bzl source is not itself a target).
+          bazel build --nobuild @rules_rust//util/collect_coverage:collect_coverage
+          src="$(bazel info output_base)/external/rules_rust+/rust/private/rustc.bzl"
+          if ! grep -Eq '"dependency_attributes": \[.*"data".*\]' "$src"; then
+            echo "::error::instrumented_files patch not effective: $src no longer has \"data\" in the coverage dependency_attributes. A rules_rust upgrade likely needs the patch re-rebased (third_party/patches/instrumented_files_include_data.patch)."
+            exit 1
+          fi
+          echo "rules_rust instrumented-files (data) patch is applied and effective."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,20 +21,37 @@ module(
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
-# Pinned single-file patch to rules_rust's coverage collector. BDD rust_tests
-# spawn the service binary as a child process; the collector merges the child's
-# profraw but `llvm-cov export` only emits coverage for functions in an -object
-# on its command line, and stock rules_rust passes ONLY the test binary. The
-# patch appends each spawned binary (RUST_COVERAGE_EXTRA_OBJECTS, set on the BDD
-# targets) as an extra -object so spawned-binary src/ coverage is exported.
-# Inert when the var is unset. Upstream has no equivalent hook (PRs #3490/#3808
-# unmerged; HEAD identical), so this is carried until upstreamed. The
-# `bazel/cargo target parity` CI job guards that the patch still applies and is
-# effective. See docs/plans/bazel-migration.md "Coverage under Bazel".
+# Two pinned patches to rules_rust, both serving spawned-service-binary coverage
+# (the two halves of getting a BDD/integration child binary's src/ — including
+# src/main.rs — into the report). See docs/plans/bazel-migration.md.
+#
+# 1. collect_coverage_extra_objects.patch — BDD rust_tests spawn the service
+#    binary as a child process; the collector merges the child's profraw but
+#    `llvm-cov export` only emits coverage for functions in an -object on its
+#    command line, and stock rules_rust passes ONLY the test binary. The patch
+#    appends each spawned binary (RUST_COVERAGE_EXTRA_OBJECTS, set on the BDD
+#    targets) as an extra -object so spawned-binary src/ coverage is EXPORTED.
+#    Inert when the var is unset.
+#
+# 2. instrumented_files_include_data.patch — adds `data` to the rust rules'
+#    coverage `dependency_attributes`. llvm-cov (via patch 1) emits main.rs, but
+#    bazel's lcov_merger then INTERSECTS that report with the test's
+#    instrumented-files manifest, which is built only from `deps`/`crate`/`srcs`
+#    — so a spawned binary reached via `data` (its src/main.rs) is filtered back
+#    out. Including `data` puts the instrumented service binary's sources in the
+#    manifest so main.rs survives the merge. Without this, patch 1's exported
+#    main.rs coverage is silently dropped.
+#
+# Upstream has no equivalent hooks (collect_coverage PRs #3490/#3808 unmerged;
+# HEAD identical), so these are carried until upstreamed. The `bazel/cargo
+# target parity` CI job guards that the patches still apply and are effective.
 single_version_override(
     module_name = "rules_rust",
     patch_strip = 1,
-    patches = ["//third_party/patches:collect_coverage_extra_objects.patch"],
+    patches = [
+        "//third_party/patches:collect_coverage_extra_objects.patch",
+        "//third_party/patches:instrumented_files_include_data.patch",
+    ],
 )
 
 # --- Rust toolchain --------------------------------------------------------

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -472,7 +472,7 @@
     },
     "@@rules_rust+//crate_universe:extension.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "zE8yHvXMtDUiPQ+Cyq39u73tk8hC5YAlSh9RfjXXPjs=",
+        "bzlTransitiveDigest": "ArUjjtgZb+vEn6uC4MEkYXtgbY4Qe0r/0pBaii2XIx0=",
         "usagesDigest": "6qni3jvstpF/aGbXbYi3ZaJKVny4hFi1ss0PrSsuerU=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",

--- a/docs/plans/bazel-migration.md
+++ b/docs/plans/bazel-migration.md
@@ -691,19 +691,43 @@ The fix (three parts, all landed on this branch):
   binary-only caveat below — the one file Bazel omits, `main.rs`, is *below* the lib average,
   so omitting it inflates rather than deflates the Bazel number.)
 
-**KNOWN systemic residual — binary-only `main.rs` is not exported under Bazel coverage.**
-For every spawn-driven service (star-adventurer-gti, phd2-guider, …) `src/main.rs` is
-**absent** from the Bazel combined report, while cargo captures it (e.g. phd2-guider's
-284-line CLI `main.rs` at 86% under cargo). `main.rs` lives only in the spawned *binary*,
-not in the `rust_test` binary, and despite the `RUST_COVERAGE_EXTRA_OBJECTS` patch adding the
-binary as an `llvm-cov export -object`, the binary-only counters do not surface in CI-faithful
-runs (the earlier "filemonitor main.rs 100%" was a local spike that does not reproduce here —
-the covmap/profraw binding for an object whose source is in *no* other `-object` is the open
-question). Impact is **usually small and in Bazel's favour** (services keep logic in libs, so
-`main.rs` is thin — star-adventurer matched cargo to +0.04pp with `main.rs` absent on both-ish
-sides), but it is a real accuracy blind spot for a service whose CLI lives in `main.rs`
-(phd2-guider). Closing it is a separate rules_rust-collector investigation, out of scope here;
-the same-commit parity gate (above) will surface any service where it flips to bazel < cargo.
+**RESOLVED — binary-only `main.rs` is now exported under Bazel coverage** (was a known
+systemic residual). For every spawn-driven service (filemonitor, star-adventurer-gti,
+phd2-guider, …) `src/main.rs` used to be **absent** from the Bazel combined report while
+cargo captured it. The earlier framing — "a local spike that does not reproduce in CI",
+"the covmap/profraw binding for an object whose source is in no other `-object`" — was a
+**misdiagnosis**. Root-caused empirically (2026-06-14):
+
+- `main.rs` coverage is **fully and deterministically computed**. The
+  `RUST_COVERAGE_EXTRA_OBJECTS` patch makes `llvm-cov export` emit a complete, counter-bound
+  `main.rs` record into the collector's *intermediate* `coverage.dat` (verified:
+  filemonitor `FNF:3 FNH:3 LF:14 LH:14`; one workflow run measured phd2-guider `main.rs`
+  243/284 ≈ 86%). The "local spike" was simply someone reading that pre-filter intermediate.
+- It was then dropped by the **second, post-collector stage**: Bazel's LcovMerger
+  (the coverage `output_generator`, rules_rust `rust/private/rust.bzl:851-855`) **intersects**
+  each test's intermediate report with that target's `InstrumentedFilesInfo` manifest
+  (`<test>.instrumented_files`, passed as `--source_file_manifest`). `rust_test` builds that
+  manifest with `dependency_attributes = ["deps", "crate"]` (`rust/private/rustc.bzl:1768`),
+  so a binary reached **only via `data`** (the spawned `:<svc>` binary, whose sole source is
+  `main.rs`) is not on the manifest and is filtered back out. `lib.rs` survived because it is
+  linked into the test binary via `deps`. Proven by re-running the LcovMerger with `main.rs`
+  appended to the manifest: `main.rs` then survives the merge.
+
+**The fix (two complementary rules_rust patches, both in `third_party/patches/`):**
+1. `collect_coverage_extra_objects.patch` — makes `llvm-cov export` *emit* spawned-binary
+   coverage (the EXPORT half; pre-existing).
+2. `instrumented_files_include_data.patch` — adds `data` to the rust rules' coverage
+   `dependency_attributes` so the instrumented spawned binary's `main.rs` lands in the test's
+   manifest and *survives* the LcovMerger intersection (the MANIFEST half; new).
+
+End-to-end verified on `filemonitor`: `main.rs` now appears in the per-test `coverage.dat`,
+the `--combined_report=lcov` output, and the `split_lcov.py` `filemonitor` bucket
+(`FNF:3 FNH:3 LF:12 LH:12`). The fix is generic — it requires no per-service BUILD change and
+covers every spawn-driven service at once. Whole-repo analysis (`bazel build --nobuild //...`)
+is unaffected; `data` deps without instrumented Rust sources contribute nothing (the
+`extensions=["rs"]` + instrumentation-filter gates still apply), so no stray files enter the
+report. The same-commit parity gate (above) plus the new patch-guard in `parity.yml` keep it
+from regressing under a rules_rust bump.
 
 Confirmed **NEUTRAL** (ruled out — do not chase): the `%8m` vs `%p-%16m` pool (lossless),
 doctests (none runnable), `build.rs` / `OUT_DIR` codegen (none in-workspace), benches

--- a/third_party/patches/instrumented_files_include_data.patch
+++ b/third_party/patches/instrumented_files_include_data.patch
@@ -1,0 +1,17 @@
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -1765,7 +1765,13 @@
+     executable = crate_info.output if crate_info.type == "bin" or crate_info.is_test else None
+ 
+     instrumented_files_kwargs = {
+-        "dependency_attributes": ["deps", "crate"],
++        # rusty-photon patch (instrumented_files_include_data): include `data` so a
++        # spawned, instrumented service binary (e.g. //services/<svc>:<svc>, a data dep
++        # of the BDD/integration rust_test) contributes its sources (src/main.rs) to the
++        # test coverage manifest. Without it, bazel's lcov_merger intersects the llvm-cov
++        # report with the manifest and DROPS main.rs even though the collect_coverage
++        # patch made llvm-cov emit it. The other half: collect_coverage_extra_objects.patch.
++        "dependency_attributes": ["deps", "crate", "data"],
+         "extensions": ["rs"],
+         "source_attributes": ["srcs"],
+     }


### PR DESCRIPTION
## Problem

Spawn-driven services (`filemonitor`, `phd2-guider`, `star-adventurer-gti`, …) were missing `src/main.rs` from the **Bazel** combined coverage report, while cargo-llvm-cov captured it. `main.rs` lives only in the spawned service *binary*, which the BDD/integration `rust_test` reaches via `data`. This is the "KNOWN systemic residual" flagged in `docs/plans/bazel-migration.md`.

## Root cause (it was a misdiagnosis)

Not the covmap/profraw binding the doc guessed. Bazel coverage runs in **three stages**, and the drop was in stage 3:

| Stage | What happens | main.rs? |
|---|---|---|
| **1. COLLECT** | bdd-infra routes the spawned child's `LLVM_PROFILE_FILE` into `COVERAGE_DIR/<pkg>-%8m.profraw`; merged into profdata | ✅ counters present |
| **2. EXPORT** | `collect_coverage_extra_objects.patch` adds the spawned binary as `llvm-cov export -object` → **intermediate** `coverage.dat` | ✅ `FNF:3 FNH:3 LF:14 LH:14` |
| **3. MERGE** | Bazel's `LcovMerger` (coverage `output_generator`, `rules_rust rust/private/rust.bzl:851-855`) **intersects** that report with the test's `instrumented_files` manifest | ❌ **dropped** |

The manifest is built from `dependency_attributes = ["deps", "crate"]` (`rust/private/rustc.bzl:1768`). A binary reached **only via `data`** is not an instrumentation edge, so `main.rs` isn't on the manifest and the merger strips it. `lib.rs` survives because it's linked into the test binary via `deps`.

Proven directly: re-running the `LcovMerger` with `main.rs` appended to the manifest makes it survive (control → `lib.rs` only; treatment → `lib.rs` + `main.rs`). The "local spike that didn't reproduce in CI" was just someone reading the *pre-merge* intermediate artifact — it's fully deterministic. A 5-agent investigation independently converged on the same conclusion.

## Fix

A second pinned rules_rust patch, `third_party/patches/instrumented_files_include_data.patch`, adds `data` to the coverage `dependency_attributes`:

```diff
-        "dependency_attributes": ["deps", "crate"],
+        "dependency_attributes": ["deps", "crate", "data"],
```

The instrumented spawned binary's sources now land in the manifest and survive the merge. **Generic** — no per-service BUILD change; covers every spawn-driven service (and their `_mock` binaries) at once.

## Validation (real `bazel coverage --config=coverage`)

- **filemonitor**: `main.rs` now in per-test `coverage.dat`, the combined report, and the `split_lcov.py` `filemonitor` bucket — `FNF:3 FNH:3 LF:12 LH:12`.
- **phd2-guider**: `main.rs` **LH:241 LF:282 (~85.5%, matching cargo's ~86%)**, plus `src/bin/mock_phd2.rs` now covered too.
- **Blast radius**: whole-repo `bazel build --nobuild //...` analysis clean; no stray files (`extensions=["rs"]` + instrumentation filter still gate).

## Also in this PR

- **`.github/workflows/parity.yml`** — guard asserting the new patch stays effective across rules_rust bumps (mirrors the `collect_coverage` guard).
- **`.bazelrc`** + **`docs/plans/bazel-migration.md`** — document the 3-stage mechanism; mark the residual **RESOLVED** and correct the earlier misdiagnosis.

## Expected consequence

Services whose `main.rs` scores below their lib average (e.g. phd2-guider) will see their `bazel-<svc>` Codecov number tick **down** slightly — the number becoming *more* accurate and converging toward cargo parity, which is the goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)