### PR TITLE
fix(sentinel): de-flake notification-history BDD scenario

### DIFF
--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -63,7 +63,10 @@ See `examples/config.json` for a complete example.
 
 ### Notifier Types
 
-- `pushover` — Sends push notifications via the Pushover API
+- `pushover` — Sends push notifications via the Pushover API. Accepts an
+  optional `api_url` field that overrides the endpoint
+  (`https://api.pushover.net/1/messages.json` by default); set it to point at a
+  self-hosted Pushover-compatible relay, or at a local stub in tests.
 
 ### Environment Variable Overrides
 

--- a/services/sentinel/src/config.rs
+++ b/services/sentinel/src/config.rs
@@ -139,6 +139,11 @@ pub enum NotifierConfig {
         default_priority: i8,
         #[serde(default = "default_pushover_sound")]
         default_sound: String,
+        /// Override the Pushover API endpoint. Defaults to the public
+        /// `https://api.pushover.net/1/messages.json`. Set this to point at a
+        /// local stub (BDD tests) or a self-hosted Pushover-compatible relay.
+        #[serde(default)]
+        api_url: Option<String>,
     },
 }
 
@@ -278,6 +283,7 @@ mod tests {
                 default_title: default_pushover_title(),
                 default_priority: 0,
                 default_sound: default_pushover_sound(),
+                api_url: None,
             }],
             ..Config::default()
         }

--- a/services/sentinel/src/lib.rs
+++ b/services/sentinel/src/lib.rs
@@ -323,6 +323,7 @@ mod tests {
                 default_title: "Alert".to_string(),
                 default_priority: 0,
                 default_sound: "pushover".to_string(),
+                api_url: None,
             }],
             ..Config::default()
         };
@@ -420,6 +421,7 @@ mod tests {
                 default_title: "Alert".to_string(),
                 default_priority: 0,
                 default_sound: "pushover".to_string(),
+                api_url: None,
             }],
             ..Config::default()
         };

--- a/services/sentinel/src/pushover.rs
+++ b/services/sentinel/src/pushover.rs
@@ -41,9 +41,17 @@ impl PushoverNotifier {
             api_url,
         } = config;
 
-        let endpoint = api_url
-            .clone()
-            .unwrap_or_else(|| PUSHOVER_API_URL.to_string());
+        // A blank or whitespace-only override is a misconfiguration; treat it as
+        // unset and fall back to the public endpoint rather than POSTing to an
+        // empty URL (mirrors how empty env-var secrets are ignored in config.rs).
+        let endpoint = match api_url.as_deref().map(str::trim) {
+            Some(url) if !url.is_empty() => url.to_string(),
+            Some(_) => {
+                tracing::debug!("Pushover api_url is blank; using default endpoint");
+                PUSHOVER_API_URL.to_string()
+            }
+            None => PUSHOVER_API_URL.to_string(),
+        };
 
         tracing::debug!(
             "Created PushoverNotifier with title '{}' targeting {}",
@@ -119,15 +127,36 @@ mod tests {
     use super::*;
     use crate::io::{HttpResponse, MockHttpClient};
 
-    fn test_config() -> NotifierConfig {
+    fn config_with_url(api_url: Option<&str>) -> NotifierConfig {
         NotifierConfig::Pushover {
             api_token: "test-token".to_string(),
             user_key: "test-user".to_string(),
             default_title: "Test Alert".to_string(),
             default_priority: 0,
             default_sound: "pushover".to_string(),
-            api_url: None,
+            api_url: api_url.map(str::to_string),
         }
+    }
+
+    fn test_config() -> NotifierConfig {
+        config_with_url(None)
+    }
+
+    /// A mock that asserts `post_form` is called with exactly `expected_url` and
+    /// returns a 200, so the only thing under test is which endpoint is used.
+    fn mock_expecting_url(expected_url: &'static str) -> MockHttpClient {
+        let mut mock = MockHttpClient::new();
+        mock.expect_post_form()
+            .withf(move |url, _params| url == expected_url)
+            .returning(|_, _| {
+                Box::pin(async {
+                    Ok(HttpResponse {
+                        status: 200,
+                        body: r#"{"status":1}"#.to_string(),
+                    })
+                })
+            });
+        mock
     }
 
     fn test_notification() -> Notification {
@@ -162,6 +191,31 @@ mod tests {
             });
 
         let notifier = PushoverNotifier::new(&test_config(), Arc::new(mock));
+        notifier.notify(&test_notification()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn posts_to_configured_api_url_override() {
+        let mock = mock_expecting_url("https://relay.example/1/messages.json");
+        let config = config_with_url(Some("https://relay.example/1/messages.json"));
+        let notifier = PushoverNotifier::new(&config, Arc::new(mock));
+        notifier.notify(&test_notification()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn blank_api_url_falls_back_to_default_endpoint() {
+        let mock = mock_expecting_url(PUSHOVER_API_URL);
+        // Whitespace-only override must be ignored, not POSTed to verbatim.
+        let config = config_with_url(Some("   "));
+        let notifier = PushoverNotifier::new(&config, Arc::new(mock));
+        notifier.notify(&test_notification()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn api_url_override_is_trimmed() {
+        let mock = mock_expecting_url("https://relay.example/msg");
+        let config = config_with_url(Some("  https://relay.example/msg  "));
+        let notifier = PushoverNotifier::new(&config, Arc::new(mock));
         notifier.notify(&test_notification()).await.unwrap();
     }
 

--- a/services/sentinel/src/pushover.rs
+++ b/services/sentinel/src/pushover.rs
@@ -23,6 +23,9 @@ pub struct PushoverNotifier {
     default_priority: i8,
     #[debug(skip)]
     default_sound: String,
+    /// API endpoint to POST to. Defaults to [`PUSHOVER_API_URL`]; overridden
+    /// by the notifier config's `api_url` (stub server in tests, self-hosted relay).
+    endpoint: String,
     #[debug(skip)]
     http: Arc<dyn HttpClient>,
 }
@@ -35,9 +38,18 @@ impl PushoverNotifier {
             default_title,
             default_priority,
             default_sound,
+            api_url,
         } = config;
 
-        tracing::debug!("Created PushoverNotifier with title '{}'", default_title);
+        let endpoint = api_url
+            .clone()
+            .unwrap_or_else(|| PUSHOVER_API_URL.to_string());
+
+        tracing::debug!(
+            "Created PushoverNotifier with title '{}' targeting {}",
+            default_title,
+            endpoint
+        );
 
         Self {
             api_token: api_token.clone(),
@@ -45,6 +57,7 @@ impl PushoverNotifier {
             default_title: default_title.clone(),
             default_priority: *default_priority,
             default_sound: default_sound.clone(),
+            endpoint,
             http,
         }
     }
@@ -85,7 +98,7 @@ impl Notifier for PushoverNotifier {
             priority
         );
 
-        let response = self.http.post_form(PUSHOVER_API_URL, &params).await?;
+        let response = self.http.post_form(&self.endpoint, &params).await?;
 
         if response.status != 200 {
             return Err(crate::SentinelError::Notifier(format!(
@@ -113,6 +126,7 @@ mod tests {
             default_title: "Test Alert".to_string(),
             default_priority: 0,
             default_sound: "pushover".to_string(),
+            api_url: None,
         }
     }
 

--- a/services/sentinel/tests/bdd.rs
+++ b/services/sentinel/tests/bdd.rs
@@ -23,6 +23,10 @@ bdd_infra::bdd_main! {
                     if let Some(fm) = world.filemonitor.as_mut() {
                         fm.stop().await;
                     }
+                    // Shut down the Pushover stub server, if this scenario started one.
+                    if let Some(stub) = world.pushover_stub.take() {
+                        stub.abort();
+                    }
                 }
             })
         })

--- a/services/sentinel/tests/bdd/steps/monitoring_steps.rs
+++ b/services/sentinel/tests/bdd/steps/monitoring_steps.rs
@@ -83,36 +83,29 @@ fn file_changes(world: &mut SentinelWorld, content: String) {
     std::fs::write(path, content).expect("failed to write to temp file");
 }
 
-#[when("I wait for the state to change")]
-async fn wait_for_state_change(world: &mut SentinelWorld) {
-    world.wait_for_state_change().await;
-}
-
 // --- Then steps ---
 
 #[then(expr = "the dashboard status should show {string} for {string}")]
 async fn dashboard_status_shows(world: &mut SentinelWorld, expected_state: String, name: String) {
-    let statuses = world.get_status().await;
-    let monitor = statuses
-        .iter()
-        .find(|m| m["name"].as_str() == Some(&name))
-        .unwrap_or_else(|| panic!("Monitor '{}' not found in status response", name));
-    let state = monitor["state"]
-        .as_str()
-        .expect("monitor has no 'state' field");
+    let state = world.wait_for_status(&name, &expected_state).await;
     assert_eq!(
-        state, expected_state,
-        "Expected '{}' to be in state '{}', but got '{}'",
-        name, expected_state, state
+        state.as_deref(),
+        Some(expected_state.as_str()),
+        "Expected '{}' to reach state '{}', but last observed {:?}",
+        name,
+        expected_state,
+        state
     );
 }
 
 #[then(expr = "the dashboard history should contain a record for {string}")]
 async fn dashboard_history_contains(world: &mut SentinelWorld, monitor_name: String) {
-    let history = world.get_history().await;
+    let history = world
+        .wait_for_history(|h| h["monitor_name"].as_str() == Some(monitor_name.as_str()))
+        .await;
     let found = history
         .iter()
-        .any(|h| h["monitor_name"].as_str() == Some(&monitor_name));
+        .any(|h| h["monitor_name"].as_str() == Some(monitor_name.as_str()));
     assert!(
         found,
         "Expected notification history to contain record for '{}', but it didn't. History: {:?}",
@@ -122,7 +115,14 @@ async fn dashboard_history_contains(world: &mut SentinelWorld, monitor_name: Str
 
 #[then(expr = "the history record message should contain {string}")]
 async fn history_record_message_contains(world: &mut SentinelWorld, expected: String) {
-    let history = world.get_history().await;
+    let history = world
+        .wait_for_history(|h| {
+            h["message"]
+                .as_str()
+                .map(|m| m.contains(&expected))
+                .unwrap_or(false)
+        })
+        .await;
     let found = history.iter().any(|h| {
         h["message"]
             .as_str()

--- a/services/sentinel/tests/bdd/world.rs
+++ b/services/sentinel/tests/bdd/world.rs
@@ -35,6 +35,11 @@ pub struct SentinelWorld {
 
     // TLS test state
     pub tls_pki_dir: Option<TempDir>,
+
+    // Local Pushover API stub so notification scenarios never hit the real
+    // api.pushover.net (slow, non-hermetic, rejects test credentials).
+    pub pushover_stub: Option<tokio::task::JoinHandle<()>>,
+    pub pushover_stub_url: Option<String>,
 }
 
 impl SentinelWorld {
@@ -105,11 +110,16 @@ impl SentinelWorld {
         });
 
         if self.sentinel_has_notifiers {
-            config["notifiers"] = serde_json::json!([{
+            let mut pushover = serde_json::json!({
                 "type": "pushover",
                 "api_token": "test-token",
                 "user_key": "test-user"
-            }]);
+            });
+            // Point the notifier at the local stub instead of api.pushover.net.
+            if let Some(url) = &self.pushover_stub_url {
+                pushover["api_url"] = serde_json::json!(url);
+            }
+            config["notifiers"] = serde_json::json!([pushover]);
         }
 
         // Set polling interval on all monitors
@@ -151,8 +161,36 @@ impl SentinelWorld {
         }));
     }
 
+    /// Start a local stub that mimics the Pushover API, replying 200 to any
+    /// request. Lets notification scenarios exercise the dispatch path without
+    /// the real api.pushover.net round-trip (slow, network-dependent, and the
+    /// source of the flaky "history is empty" race the fixed sleep used to mask).
+    pub async fn start_pushover_stub(&mut self) {
+        use axum::Router;
+
+        let app = Router::new().fallback(|| async {
+            axum::Json(serde_json::json!({ "status": 1, "request": "stub" }))
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind pushover stub listener");
+        let addr = listener
+            .local_addr()
+            .expect("pushover stub listener has no local addr");
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        self.pushover_stub = Some(handle);
+        self.pushover_stub_url = Some(format!("http://{addr}/1/messages.json"));
+    }
+
     /// Start sentinel binary with the accumulated config.
     pub async fn start_sentinel(&mut self) {
+        // Stand up the Pushover stub before sentinel so its URL can be baked
+        // into the config the child process loads.
+        if self.sentinel_has_notifiers && self.pushover_stub_url.is_none() {
+            self.start_pushover_stub().await;
+        }
         let config_json = self.build_sentinel_config();
         let dir = self
             .temp_dir
@@ -209,10 +247,44 @@ impl SentinelWorld {
         panic!("sentinel did not poll within 30 seconds");
     }
 
-    /// Wait for a state change to propagate through filemonitor polling + sentinel polling.
-    pub async fn wait_for_state_change(&self) {
-        // Need to wait for filemonitor to re-read the file AND sentinel to re-poll
-        tokio::time::sleep(Duration::from_secs(4)).await;
+    /// Poll `/api/status` until `name` reports `expected_state`, or ~15s elapses.
+    /// Returns the last observed state for that monitor (so a timeout produces a
+    /// useful assertion message). Replaces a blind fixed sleep, removing the race
+    /// against filemonitor + sentinel polling latency.
+    pub async fn wait_for_status(&self, name: &str, expected_state: &str) -> Option<String> {
+        let mut last = None;
+        for _ in 0..60 {
+            for monitor in self.get_status().await {
+                if monitor["name"].as_str() == Some(name) {
+                    let state = monitor["state"].as_str().map(str::to_string);
+                    if state.as_deref() == Some(expected_state) {
+                        return state;
+                    }
+                    last = state;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        last
+    }
+
+    /// Poll `/api/history` until a record matches `predicate`, or ~15s elapses.
+    /// Returns the final history snapshot regardless, so the caller can assert and
+    /// print it on failure. Waits for the notification record to actually land
+    /// rather than assuming a fixed delay is enough.
+    pub async fn wait_for_history<F>(&self, predicate: F) -> Vec<serde_json::Value>
+    where
+        F: Fn(&serde_json::Value) -> bool,
+    {
+        let mut history = self.get_history().await;
+        for _ in 0..60 {
+            if history.iter().any(&predicate) {
+                return history;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            history = self.get_history().await;
+        }
+        history
     }
 
     /// GET a dashboard endpoint and return the response body as string.

--- a/services/sentinel/tests/features/end_to_end_monitoring.feature
+++ b/services/sentinel/tests/features/end_to_end_monitoring.feature
@@ -27,7 +27,6 @@ Feature: End-to-end safety monitoring
     When I wait for sentinel to poll
     Then the dashboard status should show "Safe" for "Roof Monitor"
     When the monitoring file changes to "CLOSED"
-    And I wait for the state to change
     Then the dashboard status should show "Unsafe" for "Roof Monitor"
 
   Scenario: State transition is recorded in notification history
@@ -38,7 +37,6 @@ Feature: End-to-end safety monitoring
     And sentinel is running
     When I wait for sentinel to poll
     And the monitoring file changes to "CLOSED"
-    And I wait for the state to change
     Then the dashboard history should contain a record for "Roof Monitor"
     And the history record message should contain "Unsafe"
 


### PR DESCRIPTION
## Problem

The nightly `scheduled / ubuntu / nightly` job intermittently failed at `cargo test --test bdd` on the sentinel **"State transition is recorded in notification history"** scenario with `History: []` (e.g. [run 27516014166](https://github.com/ivonnyssen/rusty-photon/actions/runs/27516014166/job/81324725655)).

**Root cause — a real-network race, not a regression:**
- The BDD test configured a Pushover notifier with a junk `test-token`, and `PushoverNotifier::notify()` POSTs to the **live `https://api.pushover.net`**.
- The notification-history record is only written **after** that HTTP call returns (`engine.rs::dispatch_notifications`).
- The scenario synchronized on a fixed `sleep(4s)` that waited for the dashboard *status* to flip — **not** for the record to land. When the real pushover.net round-trip ran long (~0.6s past the window in the failing run), the history assertion raced ahead and read `[]`.

Every other recent run (including the genuine `schedule` runs) passed, confirming a flake. (No tracking issue was opened for that run because `notify-on-failure` is gated `if: failure() && github.event_name == 'schedule'`, and that run was push-triggered — working as designed.)

## Fix (belt and suspenders)

1. **Hermetic notifier endpoint.** Add an optional `api_url` to the Pushover notifier config (defaults to the public endpoint; also useful for self-hosted Pushover-compatible relays). The BDD world spins up a local `axum` stub that replies `200` to any request and points the spawned sentinel at it — scenarios never touch api.pushover.net.
2. **Poll instead of sleep.** Replace the fixed `wait_for_state_change` sleep with `wait_for_status` / `wait_for_history` helpers that poll the dashboard API until the expected state / record appears (~15s cap). The status- and history-assertion steps now wait for their own condition, and the redundant `And I wait for the state to change` steps are dropped from the feature file.

Also documents `api_url` in `docs/services/sentinel.md`.

## Verification
- 64 sentinel unit tests pass.
- **5/5 consecutive BDD runs green**, with no real Pushover contact and no notify failures.
- `cargo clippy --all --all-targets --all-features -- -D warnings` clean (full-workspace pre-commit hook).
- `cargo rail run --profile commit` (check + nextest on affected packages) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)