### PR TITLE
test(coverage): exclude feature-gated mock modules from coverage

### DIFF
--- a/docs/skills/pre-push.md
+++ b/docs/skills/pre-push.md
@@ -328,8 +328,12 @@ bazel coverage --config=coverage //...
 ```
 
 It mirrors the Cargo `coverage` job (nightly + `coverage_nightly`, so the
-`#[cfg(test)] mod tests` blocks stay out of the numbers) but uploads under
-distinct `bazel-<pkg>` Codecov flags. It **includes the BDD suite**
+`#[cfg(test)] mod tests` blocks stay out of the numbers — as do the
+feature-gated `mock` transport/client modules, which carry a module-level
+`#![cfg_attr(coverage_nightly, coverage(off))]` because they never ship in a
+production binary and counting them would inflate the coverage figure with
+code that never runs at the telescope) but uploads under distinct
+`bazel-<pkg>` Codecov flags. It **includes the BDD suite**
 (`--config=coverage` drops only the `requires-cargo` tag), so locally it needs
 OmniSim installed and `OMNISIM_PATH` set, the same as a
 `bazel test --test_tag_filters=bdd` run. Whether the BDD-spawned service

--- a/services/dsd-fp2/src/mock.rs
+++ b/services/dsd-fp2/src/mock.rs
@@ -5,6 +5,12 @@
 //! [`MockFrameTransport`] sharing one [`MockState`], so multiple sessions
 //! against the same factory see the same simulated device state.
 
+// `#[cfg(feature = "mock")]`-gated test-helper infrastructure that never
+// ships in production builds. Excluded from coverage so the workspace
+// coverage number reflects only production-shipped code — counting these
+// never-shipped mock lines would produce false coverage figures.
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -230,7 +236,6 @@ impl FrameTransport for MockFrameTransport {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;

--- a/services/pa-falcon-rotator/src/mock.rs
+++ b/services/pa-falcon-rotator/src/mock.rs
@@ -17,6 +17,12 @@
 //! Falcon's EEPROM keeps its `motor_reverse` setting and the mechanical
 //! position survives a power-cycle.
 
+// `#[cfg(feature = "mock")]`-gated test-helper infrastructure that never
+// ships in production builds. Excluded from coverage so the workspace
+// coverage number reflects only production-shipped code — counting these
+// never-shipped mock lines would produce false coverage figures.
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -331,7 +337,6 @@ impl MockFalconTransportFactory {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;

--- a/services/ppba-driver/src/mock.rs
+++ b/services/ppba-driver/src/mock.rs
@@ -6,6 +6,13 @@
 //! prior writes (matches the behaviour of real hardware that doesn't
 //! lose its settings when an ASCOM client cycles `Connected`).
 
+// `#[cfg(any(feature = "mock", test))]`-gated test-helper infrastructure
+// that never ships in production builds. Excluded from coverage so the
+// workspace coverage number reflects only production-shipped code —
+// counting these never-shipped mock lines would produce false coverage
+// figures.
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
@@ -207,7 +214,6 @@ impl TransportFactory for MockPpbaTransportFactory {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;

--- a/services/qhy-focuser/src/mock.rs
+++ b/services/qhy-focuser/src/mock.rs
@@ -7,6 +7,13 @@
 //! the behaviour of real hardware that doesn't lose its settings when an
 //! ASCOM client cycles `Connected`).
 
+// `#[cfg(any(feature = "mock", test))]`-gated test-helper infrastructure
+// that never ships in production builds. Excluded from coverage so the
+// workspace coverage number reflects only production-shipped code —
+// counting these never-shipped mock lines would produce false coverage
+// figures.
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -202,7 +209,6 @@ impl TransportFactory for MockQhyTransportFactory {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;

--- a/services/sky-survey-camera/src/mock.rs
+++ b/services/sky-survey-camera/src/mock.rs
@@ -15,8 +15,12 @@
 // `pub mod mock` in lib.rs is `#[cfg(feature = "mock")]`-gated, so this
 // module is test-helper infrastructure that never ships in production
 // builds. Treat it like the BDD harness code rather than production
-// source for the workspace's panic-deny lints.
+// source for both the workspace's panic-deny lints AND coverage: the
+// coverage number must reflect only production-shipped code, so counting
+// these never-shipped helpers would inflate it with lines that never run
+// at the telescope.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+#![cfg_attr(coverage_nightly, coverage(off))]
 
 use crate::survey::{SurveyClient, SurveyError, SurveyRequest};
 
@@ -168,7 +172,6 @@ fn build_synthetic_fits(width: u32, height: u32, wcs: Option<WcsHeader>) -> Vec<
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;

--- a/services/star-adventurer-gti/src/transport/mock.rs
+++ b/services/star-adventurer-gti/src/transport/mock.rs
@@ -12,7 +12,12 @@
 //! The mock is deliberately not exposed unless the `mock` feature is on
 //! so a production build cannot accidentally pick it up.
 
+// `#[cfg(feature = "mock")]`-gated test-helper infrastructure that never
+// ships in production builds. Excluded from coverage so the workspace
+// coverage number reflects only production-shipped code — counting these
+// never-shipped mock lines would produce false coverage figures.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+#![cfg_attr(coverage_nightly, coverage(off))]
 
 use std::sync::Arc;
 
@@ -608,7 +613,6 @@ impl TransportFactory for CapturingMockFactory {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

The six service `mock` modules are `#[cfg(feature = "mock")]`-gated (two are `cfg(any(feature = "mock", test))`) test-helper infrastructure that **never links into a production binary**. Counting them inflated the workspace coverage figure with code that never runs at the telescope, producing false numbers for what is actually shipped.

This adds a module-level `#![cfg_attr(coverage_nightly, coverage(off))]` to all six mocks so the whole module — generators, trait impls, helpers, and its `mod tests` — drops out of the coverage measurement:

- `services/ppba-driver/src/mock.rs`
- `services/qhy-focuser/src/mock.rs`
- `services/dsd-fp2/src/mock.rs`
- `services/pa-falcon-rotator/src/mock.rs`
- `services/star-adventurer-gti/src/transport/mock.rs`
- `services/sky-survey-camera/src/mock.rs`

The module-level attribute propagates to nested items, so the previous per-`mod tests` `coverage(off)` attrs were removed as redundant. Scoping comments that previously limited the "treat like BDD harness" framing to the panic-deny lints now extend it to coverage as well.

## Rationale

This refines — rather than reverses — the existing "no coverage exclusions on production code" convention. The boundary that matters is **ships to production vs. doesn't**: signal handlers, `main()`, `BoundServer::start` etc. all run on-sky and must stay measured, but feature-gated mocks never ship, so excluding them makes the coverage number reflect only production code.

## Docs

`docs/skills/pre-push.md` now documents the mock exclusion alongside the existing `#[cfg(test)] mod tests` note.

## Verification

- `cargo rail run --profile commit -q`: 1163 tests passed, 0 skipped.
- Pre-commit hook (`cargo clippy --all --all-targets --all-features -D warnings` + `cargo fmt --all --check`): clean.
- The `coverage(off)` attr is inert unless the `coverage_nightly` cfg is set, so stable builds/tests are unaffected; mock-gated tests still compile and run under `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)