### PR TITLE
build(bazel): exclude .claude/ from buildifier walk so worktrees can't block commits

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,16 +15,30 @@ exports_files(
 # `bazel run //:buildifier` formats every BUILD / *.bzl / MODULE.bazel file in the
 # workspace in place. Pinned via MODULE.bazel (buildifier_prebuilt) so every dev
 # machine and CI run the identical formatter with no system install.
+# `exclude_patterns` keeps the formatter out of nested agent git worktrees under
+# `.claude/` (see `buildifier_check` below for the full rationale).
 buildifier(
     name = "buildifier",
+    exclude_patterns = ["./.claude/*"],
     mode = "fix",
 )
 
 # `bazel test //:buildifier_check` fails if any BUILD / *.bzl file is unformatted.
 # Runs non-sandboxed over the real tree (rooted at MODULE.bazel) so it covers every
 # package, not just this one. Wire into the Bazel shadow CI as the format gate.
+#
+# `exclude_patterns` prunes `.claude/` from the walk. In `no_sandbox` + `workspace`
+# mode this rule's generated runner does a literal `cd <repo-root> && find . -name
+# '*.bazel' ... | xargs buildifier`. Agent git worktrees are nested *inside* the
+# checkout at `.claude/worktrees/<name>/`, each a full repo copy with its own BUILD
+# files, so the bare `find .` descends into them and lints their (often stale, e.g.
+# pre-buildifier-adoption) BUILD files — failing the check and blocking every commit
+# via the pre-commit hook. `.bazelignore` does NOT help: it only governs Bazel's
+# loading phase (`//...`, `glob()`), not a non-sandboxed test that shells out to
+# `find`, which honors neither `.bazelignore` nor git-worktree boundaries.
 buildifier_test(
     name = "buildifier_check",
+    exclude_patterns = ["./.claude/*"],
     lint_mode = "warn",
     mode = "diff",
     no_sandbox = True,


### PR DESCRIPTION
## Problem

`//:buildifier_check` (the pre-commit + Bazel-shadow-CI format gate) was failing on **`BUILD.bazel` files that don't belong to the current branch** — they live in nested agent git worktrees under `.claude/worktrees/<name>/`. Because those worktrees pre-date the repo-wide buildifier adoption (2026-06-17), their stale BUILD files fail the check, which **blocks every commit** in the repo via the pre-commit hook.

## Why it reaches into the worktrees

`buildifier_check` is a `buildifier_test(no_sandbox = True, workspace = "//:MODULE.bazel")`. In that mode the generated runner does, at test time, a literal:

```sh
cd "$(dirname "$(realpath MODULE.bazel)")"   # repo root
find . -type f \( -name '*.bazel' -o -name BUILD -o -name '*.bzl' ... \) -print | xargs buildifier -mode=diff -lint=warn
```

A bare `find .` recurses into every subdirectory under the repo root. The nested worktrees are real subdirectories (full repo copies), so `find` descends into them and lints their files. `.bazelignore` (which *does* list `.claude`) doesn't help — it only governs Bazel's loading phase (`//...`, `glob()`), not a non-sandboxed test that shells out to `find`, which honors neither `.bazelignore` nor git-worktree boundaries.

## Fix

Add `exclude_patterns = ["./.claude/*"]` to both the `buildifier` (fix) and `buildifier_test` (check) targets. The rule compiles each pattern into a `-path './.claude/*' -prune` clause in the find walk, so agent worktrees — which come and go — can never block a commit again.

## Verification

- `bazel test //:buildifier_check --nocache_test_results` → **PASSED** with the stale worktrees still on disk.
- The fix commit itself passed the full pre-commit hook (clippy + fmt + buildifier_check) with no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)