### PR TITLE
fix(zwo-camera): replace fixed-count/accumulated-nap poll loops with real-clock deadlines

### DIFF
--- a/services/zwo-camera/src/backend.rs
+++ b/services/zwo-camera/src/backend.rs
@@ -67,6 +67,12 @@ const STOP_NONE: u8 = 0;
 const STOP_ABORT: u8 = 1;
 const STOP_PRESERVE: u8 = 2;
 
+/// Real-clock budget for the post-integration readout-completion poll. Only a
+/// safety bound on the stop-responsive courtesy poll — `download_exposure` still
+/// blocks until the frame is actually ready — but expressed as a deadline (not a
+/// fixed nap count) so it cannot drift under blocking-pool oversubscription.
+const READOUT_TIMEOUT: Duration = Duration::from_millis(2500);
+
 /// The blocking camera operations the ASCOM `Camera` device drives. Every method
 /// is synchronous (the SDK is blocking C FFI); the device offloads the long
 /// [`capture`](CameraHandle::capture) onto `spawn_blocking`.
@@ -274,7 +280,12 @@ impl CameraHandle for ZwoCameraHandle {
             return Ok(None);
         };
         if !preserve {
-            for _ in 0..250 {
+            // Poll the SDK to readout completion against a real-clock DEADLINE,
+            // for the same reason as the integration wait above: a fixed nap
+            // count drifts unpredictably under blocking-pool oversubscription.
+            let readout_deadline = std::time::Instant::now() + READOUT_TIMEOUT;
+            let step = Duration::from_millis(10);
+            loop {
                 match self.stop.load(Ordering::SeqCst) {
                     STOP_ABORT => {
                         let _ = camera.stop_exposure();
@@ -288,11 +299,15 @@ impl CameraHandle for ZwoCameraHandle {
                 }
                 match camera.exposure_status()? {
                     zwo_rs::ExposureStatus::Success | zwo_rs::ExposureStatus::Idle => break,
-                    zwo_rs::ExposureStatus::Working => {
-                        std::thread::sleep(Duration::from_millis(10))
-                    }
                     zwo_rs::ExposureStatus::Failed => {
                         return Err(BackendError("exposure failed".to_string()))
+                    }
+                    zwo_rs::ExposureStatus::Working => {
+                        let now = std::time::Instant::now();
+                        if now >= readout_deadline {
+                            break;
+                        }
+                        std::thread::sleep(step.min(readout_deadline - now));
                     }
                 }
             }
@@ -586,17 +601,22 @@ pub(crate) mod mock {
         fn capture(&self, request: CaptureRequest) -> BackendResult<Option<Vec<u8>>> {
             self.stop.store(STOP_NONE, Ordering::SeqCst);
             let delay = *self.capture_delay.lock();
-            let mut slept = Duration::ZERO;
+            // Mirror the production handle: sleep against a real-clock DEADLINE,
+            // not accumulated *intended* nap time, so the simulated capture can't
+            // drift under a contended runtime.
+            let deadline = std::time::Instant::now() + delay;
             let step = Duration::from_millis(10);
-            while slept < delay {
+            loop {
                 match self.stop.load(Ordering::SeqCst) {
                     STOP_ABORT => return Ok(None),
                     STOP_PRESERVE => break,
                     _ => {}
                 }
-                let nap = step.min(delay - slept);
-                std::thread::sleep(nap);
-                slept += nap;
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                std::thread::sleep(step.min(deadline - now));
             }
             if self.stop.load(Ordering::SeqCst) == STOP_ABORT {
                 return Ok(None);

--- a/services/zwo-camera/src/camera.rs
+++ b/services/zwo-camera/src/camera.rs
@@ -1225,24 +1225,27 @@ mod tests {
         device
     }
 
+    // Deadline-bounded polls (no fixed nap count): `tokio::time::timeout` caps
+    // the wait in real time, so a contended runtime can't turn a fixed iteration
+    // count into an unbounded wall-clock wait.
     async fn wait_image_ready(device: &ZwoCamera) {
-        for _ in 0..400 {
-            if device.image_ready().await.unwrap() {
-                return;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !device.image_ready().await.unwrap() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
             }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        panic!("exposure did not complete");
+        })
+        .await
+        .expect("exposure did not complete");
     }
 
     async fn wait_camera_state(device: &ZwoCamera, want: CameraState) {
-        for _ in 0..400 {
-            if device.camera_state().await.unwrap() == want {
-                return;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while device.camera_state().await.unwrap() != want {
+                tokio::time::sleep(Duration::from_millis(5)).await;
             }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-        panic!("camera did not reach {want:?}");
+        })
+        .await
+        .unwrap_or_else(|_| panic!("camera did not reach {want:?}"));
     }
 
     // --- pure helpers -----------------------------------------------------------
@@ -1766,13 +1769,14 @@ mod tests {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(30)).await;
         device.abort_exposure().await.unwrap();
-        // No fresh frame is ready after an abort.
-        for _ in 0..200 {
-            if !device.state.exposure_in_flight.load(Ordering::Acquire) {
-                break;
+        // No fresh frame is ready after an abort. Best-effort, deadline-bounded
+        // wait (not a fixed nap count) for the in-flight flag to clear.
+        let _ = tokio::time::timeout(Duration::from_secs(1), async {
+            while device.state.exposure_in_flight.load(Ordering::Acquire) {
+                tokio::time::sleep(Duration::from_millis(5)).await;
             }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
+        })
+        .await;
         assert!(!device.image_ready().await.unwrap());
         assert_eq!(
             device.image_array().await.unwrap_err().code,


### PR DESCRIPTION
## Motivation

Busy-wait poll loops that bound themselves by a **fixed iteration count** or by **summing *intended* nap time** drift badly under scheduling pressure: when the blocking pool is oversubscribed (e.g. ConformU firing a storm of concurrent `spawn_blocking` property reads — especially with several cameras on one service), each `thread::sleep` overshoots, so an N-iteration loop runs far longer in wall-clock than intended. The capture *integration* wait was already hardened to a real-clock `Instant` deadline for exactly this reason; this PR extends the same discipline to **every** remaining wait loop in the capture path so the pattern is gone.

## Changes

**Production** (`backend.rs`, `ZwoCameraHandle::capture`):
- The post-integration **readout-completion poll** went from `for _ in 0..250 { … sleep(10ms) }` to a real-clock deadline (`Instant::now() + READOUT_TIMEOUT`, 2500 ms) with a guarded `deadline - now`. No panic path — the subtraction is guarded by the `now >= deadline { break }` check (same shape as the integration loop), and `download_exposure` still blocks until the frame is actually ready, so this is only a stop-responsive courtesy poll, never a correctness boundary.

**Test backends** (`#[cfg(test)]` only — never compiled into the shipping binary):
- `mock` `capture`: `while slept < delay { slept += nap }` → `Instant` deadline.
- `wait_image_ready` / `wait_camera_state` / abort-settle poll: fixed `for _ in 0..N` counts → `tokio::time::timeout`-bounded polls (the idiomatic async deadline).

## Notes

- **No new panics in production code.** The `.expect()`/`panic!()` are all inside `#[cfg(test)]` modules (test helpers + the simulated backends). An audit of production `camera.rs`/`backend.rs` (above their test-module boundaries) finds zero `unwrap`/`expect`/`panic!`/`unreachable!`.
- Gate green: `cargo rail --profile commit` (check + nextest, `--all-features --all-targets`) — **59/59 tests pass**; clippy `--all-features` + fmt clean.
- Companion to #378 (which documents the concurrent 3-camera real-hardware ConformU pass that motivated this hardening). The design doc's *Concurrency* note in #378 describes this deadline discipline; this PR realizes it in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)