### PR TITLE
fix(qhyccd-rs): serialize mockall static-FFI tests to stop sanitizer SIGABRT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,11 @@ jobs:
       cargo-args: ${{ steps.scope.outputs.cargo-args }}
       bdd-packages: ${{ steps.bdd.outputs.packages }}
       has-bdd: ${{ steps.bdd.outputs.has_bdd }}
+      # `-p <pkg>` args for ONLY the affected packages that have a `bdd` test
+      # target (a subset of cargo-args). Used to scope `cargo test --test bdd`
+      # so it never targets a library crate without a bdd target (e.g.
+      # qhyccd-rs), which `cargo test -p <pkg> --test bdd` rejects outright.
+      bdd-cargo-args: ${{ steps.bdd.outputs.cargo-args }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -113,6 +118,8 @@ jobs:
           COUNT=$(echo "$BDD_PACKAGES" | jq 'length')
           echo "packages=$BDD_PACKAGES" >> $GITHUB_OUTPUT
           echo "has_bdd=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # `-p <pkg>` list for the bdd-having packages, for `cargo test --test bdd`.
+          echo "cargo-args=$(echo "$BDD_PACKAGES" | jq -r 'map("-p " + .) | join(" ")')" >> $GITHUB_OUTPUT
           echo "BDD packages ($COUNT): $BDD_PACKAGES"
   required:
     needs: plan
@@ -155,7 +162,11 @@ jobs:
         run: cargo build --locked --package filemonitor --package rp --package dsd-fp2 --all-features --all-targets
       # BDD tests use custom harness (bdd_main!) incompatible with nextest
       - name: cargo test --test bdd
-        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
+        # Scope to packages that actually have a bdd target. Skipped entirely
+        # when no affected package has one (e.g. a qhyccd-rs-only change),
+        # which would otherwise fail with `no test target named bdd`.
+        if: needs.plan.outputs.has-bdd == 'true'
+        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.bdd-cargo-args }} --all-features --test bdd
       # OmniSim's stdout/stderr now lands in target/bdd-infra-omnisim-logs/
       # (see crates/bdd-infra/src/rp_harness/omnisim.rs::OmniSimProcess::log_dir).
       # Uploading on failure preserves the only off-runner copy of those logs
@@ -203,7 +214,11 @@ jobs:
         if: needs.plan.outputs.has-bdd == 'true' && needs.plan.outputs.infra != 'true'
         run: cargo build --locked --package filemonitor --package rp --package dsd-fp2 --all-features --all-targets
       - name: cargo test --test bdd
-        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.cargo-args }} --all-features --test bdd
+        # Scope to packages that actually have a bdd target. Skipped entirely
+        # when no affected package has one (e.g. a qhyccd-rs-only change),
+        # which would otherwise fail with `no test target named bdd`.
+        if: needs.plan.outputs.has-bdd == 'true'
+        run: cargo test --locked ${{ needs.plan.outputs.infra == 'true' && '--workspace' || needs.plan.outputs.bdd-cargo-args }} --all-features --test bdd
       - name: Upload OmniSim logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v7

--- a/crates/qhyccd-rs/src/tests/camera_tests.rs
+++ b/crates/qhyccd-rs/src/tests/camera_tests.rs
@@ -28,6 +28,7 @@ fn new_camera() -> Camera {
 
 #[test]
 fn set_stream_mode_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDStreamMode_context();
     ctx.expect()
@@ -43,6 +44,7 @@ fn set_stream_mode_success() {
 
 #[test]
 fn set_stream_mode_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDStreamMode_context();
     ctx.expect().times(1).return_const_st(QHYCCD_ERROR);
@@ -62,6 +64,7 @@ fn set_stream_mode_fail() {
 
 #[test]
 fn set_readout_mode_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDReadMode_context();
     ctx.expect()
@@ -77,6 +80,7 @@ fn set_readout_mode_success() {
 
 #[test]
 fn set_readout_mode_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDReadMode_context();
     ctx.expect().times(1).return_const_st(QHYCCD_ERROR);
@@ -96,6 +100,7 @@ fn set_readout_mode_fail() {
 
 #[test]
 fn get_model_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDModel_context();
     ctx.expect().times(1).returning_st(|_handle, model| unsafe {
@@ -114,6 +119,7 @@ fn get_model_success() {
 
 #[test]
 fn get_model_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDModel_context();
     ctx.expect().times(1).return_const(QHYCCD_ERROR);
@@ -126,6 +132,7 @@ fn get_model_fail() {
 
 #[test]
 fn get_model_utf8_error() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDModel_context();
     ctx.expect().times(1).returning_st(|_handle, model| unsafe {
@@ -147,6 +154,7 @@ fn get_model_utf8_error() {
 
 #[test]
 fn init_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = InitQHYCCD_context();
     ctx.expect()
@@ -162,6 +170,7 @@ fn init_success() {
 
 #[test]
 fn init_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = InitQHYCCD_context();
     ctx.expect()
@@ -184,6 +193,7 @@ fn init_fail() {
 
 #[test]
 fn get_firmware_version_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDFWVersion_context();
     ctx.expect()
@@ -221,6 +231,7 @@ fn get_firmware_version_success() {
 
 #[test]
 fn get_firmware_version_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDFWVersion_context();
     ctx.expect()
@@ -243,6 +254,7 @@ fn get_firmware_version_fail() {
 
 #[test]
 fn get_number_of_readout_modes_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDNumberOfReadModes_context();
     ctx.expect()
@@ -262,6 +274,7 @@ fn get_number_of_readout_modes_success() {
 
 #[test]
 fn get_number_of_readout_modes_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDNumberOfReadModes_context();
     ctx.expect()
@@ -281,6 +294,7 @@ fn get_number_of_readout_modes_fail() {
 
 #[test]
 fn get_readout_mode_name_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadModeName_context();
     ctx.expect()
@@ -302,6 +316,7 @@ fn get_readout_mode_name_success() {
 
 #[test]
 fn get_readout_mode_name_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadModeName_context();
     ctx.expect()
@@ -321,6 +336,7 @@ fn get_readout_mode_name_fail() {
 
 #[test]
 fn get_readout_mode_name_utf8_error() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadModeName_context();
     ctx.expect()
@@ -345,6 +361,7 @@ fn get_readout_mode_name_utf8_error() {
 
 #[test]
 fn get_readout_mode_resolution_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadModeResolution_context();
     ctx.expect()
@@ -366,6 +383,7 @@ fn get_readout_mode_resolution_success() {
 
 #[test]
 fn get_readout_mode_resolution_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadModeResolution_context();
     ctx.expect()
@@ -385,6 +403,7 @@ fn get_readout_mode_resolution_fail() {
 
 #[test]
 fn get_readout_mode_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadMode_context();
     ctx.expect()
@@ -404,6 +423,7 @@ fn get_readout_mode_success() {
 
 #[test]
 fn get_readout_mode_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDReadMode_context();
     ctx.expect()
@@ -423,6 +443,7 @@ fn get_readout_mode_fail() {
 
 #[test]
 fn get_type_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDType_context();
     ctx.expect()
@@ -439,6 +460,7 @@ fn get_type_success() {
 
 #[test]
 fn get_type_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDType_context();
     ctx.expect()
@@ -458,6 +480,7 @@ fn get_type_fail() {
 
 #[test]
 fn set_bin_mode_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDBinMode_context();
     ctx.expect()
@@ -475,6 +498,7 @@ fn set_bin_mode_success() {
 
 #[test]
 fn set_bin_mode_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDBinMode_context();
     ctx.expect()
@@ -499,6 +523,7 @@ fn set_bin_mode_fail() {
 
 #[test]
 fn set_debayer_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDDebayerOnOff_context();
     ctx.expect()
@@ -514,6 +539,7 @@ fn set_debayer_success() {
 
 #[test]
 fn set_debayer_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDDebayerOnOff_context();
     ctx.expect()
@@ -536,6 +562,7 @@ fn set_debayer_fail() {
 
 #[test]
 fn set_roi_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDResolution_context();
     ctx.expect()
@@ -562,6 +589,7 @@ fn set_roi_success() {
 
 #[test]
 fn set_roi_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDResolution_context();
     ctx.expect()
@@ -595,6 +623,7 @@ fn set_roi_fail() {
 
 #[test]
 fn begin_live_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = BeginQHYCCDLive_context();
     ctx.expect()
@@ -610,6 +639,7 @@ fn begin_live_success() {
 
 #[test]
 fn begin_live_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = BeginQHYCCDLive_context();
     ctx.expect()
@@ -632,6 +662,7 @@ fn begin_live_fail() {
 
 #[test]
 fn end_live_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = StopQHYCCDLive_context();
     ctx.expect()
@@ -647,6 +678,7 @@ fn end_live_success() {
 
 #[test]
 fn end_live_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = StopQHYCCDLive_context();
     ctx.expect()
@@ -669,6 +701,7 @@ fn end_live_fail() {
 
 #[test]
 fn get_image_size_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDMemLength_context();
     ctx.expect()
@@ -685,6 +718,7 @@ fn get_image_size_success() {
 
 #[test]
 fn get_image_size_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDMemLength_context();
     ctx.expect()
@@ -704,6 +738,7 @@ fn get_image_size_fail() {
 
 #[test]
 fn get_live_frame_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDLiveFrame_context();
     ctx.expect()
@@ -737,6 +772,7 @@ fn get_live_frame_success() {
 
 #[test]
 fn get_live_frame_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDLiveFrame_context();
     ctx.expect()
@@ -759,6 +795,7 @@ fn get_live_frame_fail() {
 
 #[test]
 fn get_single_frame_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDSingleFrame_context();
     ctx.expect()
@@ -792,6 +829,7 @@ fn get_single_frame_success() {
 
 #[test]
 fn get_single_frame_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDSingleFrame_context();
     ctx.expect()
@@ -814,6 +852,7 @@ fn get_single_frame_fail() {
 
 #[test]
 fn get_overscan_area_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDOverScanArea_context();
     ctx.expect()
@@ -844,6 +883,7 @@ fn get_overscan_area_success() {
 
 #[test]
 fn get_overscan_area_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDOverScanArea_context();
     ctx.expect()
@@ -866,6 +906,7 @@ fn get_overscan_area_fail() {
 
 #[test]
 fn get_effective_area_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDEffectiveArea_context();
     ctx.expect()
@@ -896,6 +937,7 @@ fn get_effective_area_success() {
 
 #[test]
 fn get_effective_area_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDEffectiveArea_context();
     ctx.expect()
@@ -918,6 +960,7 @@ fn get_effective_area_fail() {
 
 #[test]
 fn start_single_frame_exposure_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = ExpQHYCCDSingleFrame_context();
     ctx.expect()
@@ -933,6 +976,7 @@ fn start_single_frame_exposure_success() {
 
 #[test]
 fn start_single_frame_exposure_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = ExpQHYCCDSingleFrame_context();
     ctx.expect()
@@ -955,6 +999,7 @@ fn start_single_frame_exposure_fail() {
 
 #[test]
 fn get_remaining_exposure_us_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDExposureRemaining_context();
     ctx.expect()
@@ -981,6 +1026,7 @@ fn get_remaining_exposure_us_success() {
 
 #[test]
 fn get_remaining_exposure_us_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDExposureRemaining_context();
     ctx.expect()
@@ -1000,6 +1046,7 @@ fn get_remaining_exposure_us_fail() {
 
 #[test]
 fn stop_exposure_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CancelQHYCCDExposing_context();
     ctx.expect()
@@ -1015,6 +1062,7 @@ fn stop_exposure_success() {
 
 #[test]
 fn stop_exposure_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CancelQHYCCDExposing_context();
     ctx.expect()
@@ -1037,6 +1085,7 @@ fn stop_exposure_fail() {
 
 #[test]
 fn abort_exposure_and_readout_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CancelQHYCCDExposingAndReadout_context();
     ctx.expect()
@@ -1052,6 +1101,7 @@ fn abort_exposure_and_readout_success() {
 
 #[test]
 fn abort_exposure_and_readout_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CancelQHYCCDExposingAndReadout_context();
     ctx.expect()
@@ -1074,6 +1124,7 @@ fn abort_exposure_and_readout_fail() {
 
 #[test]
 fn is_control_available_success_some() {
+    let _mock = super::mock_guard();
     //given
     let ctx = IsQHYCCDControlAvailable_context();
     ctx.expect()
@@ -1090,6 +1141,7 @@ fn is_control_available_success_some() {
 
 #[test]
 fn is_control_available_success_none() {
+    let _mock = super::mock_guard();
     //given
     let ctx = IsQHYCCDControlAvailable_context();
     ctx.expect()
@@ -1105,6 +1157,7 @@ fn is_control_available_success_none() {
 
 #[test]
 fn get_ccd_info_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDChipInfo_context();
     ctx.expect()
@@ -1147,6 +1200,7 @@ fn get_ccd_info_success() {
 
 #[test]
 fn get_ccd_info_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDChipInfo_context();
     ctx.expect()
@@ -1173,6 +1227,7 @@ fn get_ccd_info_fail() {
 
 #[test]
 fn set_bit_mode_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDBitsMode_context();
     ctx.expect()
@@ -1188,6 +1243,7 @@ fn set_bit_mode_success() {
 
 #[test]
 fn set_bit_mode_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDBitsMode_context();
     ctx.expect()
@@ -1210,6 +1266,7 @@ fn set_bit_mode_fail() {
 
 #[test]
 fn get_parameter_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDParam_context();
     ctx.expect()
@@ -1228,6 +1285,7 @@ fn get_parameter_success() {
 
 #[test]
 fn get_parameter_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDParam_context();
     ctx.expect()
@@ -1252,6 +1310,7 @@ fn get_parameter_fail() {
 
 #[test]
 fn get_parameter_min_max_step_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDParamMinMaxStep_context();
     ctx.expect()
@@ -1275,6 +1334,7 @@ fn get_parameter_min_max_step_success() {
 
 #[test]
 fn get_parameter_min_max_step_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = GetQHYCCDParamMinMaxStep_context();
     ctx.expect()
@@ -1299,6 +1359,7 @@ fn get_parameter_min_max_step_fail() {
 
 #[test]
 fn set_parameter_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDParam_context();
     ctx.expect()
@@ -1316,6 +1377,7 @@ fn set_parameter_success() {
 
 #[test]
 fn set_parameter_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = SetQHYCCDParam_context();
     ctx.expect()
@@ -1340,6 +1402,7 @@ fn set_parameter_fail() {
 
 #[test]
 fn set_if_available_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_get = IsQHYCCDControlAvailable_context();
     ctx_get
@@ -1367,6 +1430,7 @@ fn set_if_available_success() {
 
 #[test]
 fn set_if_available_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_get = IsQHYCCDControlAvailable_context();
     ctx_get
@@ -1433,6 +1497,7 @@ fn set_if_available_fail() {
 
 #[test]
 fn open_success() {
+    let _mock = super::mock_guard();
     //given
     let cam = Camera::new("test_camera".to_owned());
     let ctx_open = OpenQHYCCD_context();
@@ -1446,6 +1511,7 @@ fn open_success() {
 
 #[test]
 fn open_already_open() {
+    let _mock = super::mock_guard();
     //given
     let cam = Camera::new("test_camera".to_owned());
     let ctx_open = OpenQHYCCD_context();
@@ -1459,6 +1525,7 @@ fn open_already_open() {
 
 #[test]
 fn open_fail() {
+    let _mock = super::mock_guard();
     //given
     let cam = Camera::new("test_camera".to_owned());
     let ctx = OpenQHYCCD_context();
@@ -1474,6 +1541,7 @@ fn open_fail() {
 }
 #[test]
 fn open_nulerror() {
+    let _mock = super::mock_guard();
     //given
     let cam = Camera::new("test_\0camera".to_owned());
     let ctx = OpenQHYCCD_context();
@@ -1490,6 +1558,7 @@ fn open_nulerror() {
 
 #[test]
 fn close_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CloseQHYCCD_context();
     ctx.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -1502,6 +1571,7 @@ fn close_success() {
 
 #[test]
 fn close_already_closed() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CloseQHYCCD_context();
     ctx.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -1515,6 +1585,7 @@ fn close_already_closed() {
 
 #[test]
 fn close_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx = CloseQHYCCD_context();
     ctx.expect().times(1).return_const_st(QHYCCD_ERROR);
@@ -1534,6 +1605,7 @@ fn close_fail() {
 
 #[test]
 fn bayer_mode_try_from() {
+    let _mock = super::mock_guard();
     assert_eq!(BayerMode::try_from(1).unwrap(), BayerMode::GBRG);
     assert_eq!(BayerMode::try_from(2).unwrap(), BayerMode::GRBG);
     assert_eq!(BayerMode::try_from(3).unwrap(), BayerMode::BGGR);

--- a/crates/qhyccd-rs/src/tests/filter_wheel_tests.rs
+++ b/crates/qhyccd-rs/src/tests/filter_wheel_tests.rs
@@ -17,6 +17,7 @@ fn new_filter_wheel() -> FilterWheel {
 
 #[test]
 fn open_success() {
+    let _mock = super::mock_guard();
     //given
     let fw = new_filter_wheel();
     //when
@@ -28,6 +29,7 @@ fn open_success() {
 
 #[test]
 fn open_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_open = OpenQHYCCD_context();
     ctx_open.expect().times(1).return_const_st(std::ptr::null());
@@ -41,6 +43,7 @@ fn open_fail() {
 
 #[test]
 fn is_open_true() {
+    let _mock = super::mock_guard();
     //given
     let fw = new_filter_wheel();
     //when
@@ -51,6 +54,7 @@ fn is_open_true() {
 
 #[test]
 fn is_open_false() {
+    let _mock = super::mock_guard();
     //given
     let camera = Camera::new("test_camera".to_owned());
     let fw = FilterWheel::new(camera);
@@ -62,6 +66,7 @@ fn is_open_false() {
 
 #[test]
 fn close_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_open = OpenQHYCCD_context();
     ctx_open.expect().once().return_const_st(TEST_HANDLE);
@@ -80,6 +85,7 @@ fn close_success() {
 
 #[test]
 fn is_cfw_plugged_in_true() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDCFWPlugged_context();
     ctx_available
@@ -96,6 +102,7 @@ fn is_cfw_plugged_in_true() {
 
 #[test]
 fn is_cfw_plugged_in_false() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDCFWPlugged_context();
     ctx_available
@@ -112,6 +119,7 @@ fn is_cfw_plugged_in_false() {
 
 #[test]
 fn get_number_of_filters_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -138,6 +146,7 @@ fn get_number_of_filters_success() {
 
 #[test]
 fn get_number_of_filters_fail_no_filter_wheel() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -156,6 +165,7 @@ fn get_number_of_filters_fail_no_filter_wheel() {
 
 #[test]
 fn get_number_of_filters_fail_get_parameter() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -182,6 +192,7 @@ fn get_number_of_filters_fail_get_parameter() {
 
 #[test]
 fn get_fw_position_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -204,6 +215,7 @@ fn get_fw_position_success() {
 
 #[test]
 fn get_fw_position_fail_no_filter_wheel() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -220,6 +232,7 @@ fn get_fw_position_fail_no_filter_wheel() {
 
 #[test]
 fn get_fw_position_fail_get_parameter() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -242,6 +255,7 @@ fn get_fw_position_fail_get_parameter() {
 
 #[test]
 fn set_fw_position_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -267,6 +281,7 @@ fn set_fw_position_success() {
 
 #[test]
 fn set_fw_position_fail_no_filter_wheel() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available
@@ -283,6 +298,7 @@ fn set_fw_position_fail_no_filter_wheel() {
 
 #[test]
 fn set_fw_position_fail_set_parameter() {
+    let _mock = super::mock_guard();
     //given
     let ctx_available = IsQHYCCDControlAvailable_context();
     ctx_available

--- a/crates/qhyccd-rs/src/tests/mod.rs
+++ b/crates/qhyccd-rs/src/tests/mod.rs
@@ -7,3 +7,30 @@
 mod camera_tests;
 mod filter_wheel_tests;
 mod sdk_tests;
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Serializes every test that programs the process-global mockall FFI mocks.
+///
+/// `#[automock]` stores each `*_context()` expectation in process-global
+/// state, so two of these tests running concurrently in the same process
+/// corrupt each other's expectations — surfacing as `Fragile`
+/// "destructor ran on wrong thread" panics and `called 0 time(s) which is
+/// fewer than expected 1` failures, which abort the test binary (SIGABRT).
+///
+/// `cargo nextest` (the project's standard runner, used by `cargo rail`)
+/// isolates each test in its own process and hides this. Plain `cargo test`
+/// runs them as threads in one process — that includes the nightly safety
+/// sanitizer workflow and a local `cargo test -p qhyccd-rs`. Every `#[test]`
+/// in this module's submodules therefore takes this guard as its first line
+/// and holds it for the whole body. See issue #384.
+static MOCK_FFI_MTX: Mutex<()> = Mutex::new(());
+
+/// Acquire the [`MOCK_FFI_MTX`] guard. Tolerates poisoning: these tests
+/// `assert!` and panic on failure, which would otherwise poison the mutex and
+/// cascade a single real failure into spurious failures of every later test.
+pub(super) fn mock_guard() -> MutexGuard<'static, ()> {
+    MOCK_FFI_MTX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/crates/qhyccd-rs/src/tests/sdk_tests.rs
+++ b/crates/qhyccd-rs/src/tests/sdk_tests.rs
@@ -68,6 +68,7 @@ fn new_sdk() -> Sdk {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_success() {
+    let _mock = super::mock_guard();
     //given
     //when
     let ctx_release = ReleaseQHYCCDResource_context();
@@ -84,6 +85,7 @@ fn new_success() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn version_success() {
+    let _mock = super::mock_guard();
     //given
     let ctx_version = GetQHYCCDSDKVersion_context();
     ctx_version
@@ -120,6 +122,7 @@ fn version_success() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn version_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_version = GetQHYCCDSDKVersion_context();
     ctx_version
@@ -148,6 +151,7 @@ fn version_fail() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn filter_wheels_success() {
+    let _mock = super::mock_guard();
     //given
     //filter wheels context is set up in new_sdk()
     let ctx_release = ReleaseQHYCCDResource_context();
@@ -165,6 +169,7 @@ fn filter_wheels_success() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_init_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_ERROR);
@@ -186,6 +191,7 @@ fn new_init_fail() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_scan_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -203,6 +209,7 @@ fn new_scan_fail() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_get_id_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -228,6 +235,7 @@ fn new_get_id_fail() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_get_id_invalid_utf8_fail() {
+    let _mock = super::mock_guard();
     //given
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
@@ -257,6 +265,7 @@ fn new_get_id_invalid_utf8_fail() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_with_broken_filter_wheel() {
+    let _mock = super::mock_guard();
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
     let ctx_scan = ScanQHYCCD_context();
@@ -321,6 +330,7 @@ fn new_with_broken_filter_wheel() {
 #[test]
 #[cfg(not(feature = "simulation"))]
 fn new_fail_close() {
+    let _mock = super::mock_guard();
     let ctx_init = InitQHYCCDResource_context();
     ctx_init.expect().times(1).return_const_st(QHYCCD_SUCCESS);
     let ctx_scan = ScanQHYCCD_context();

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -746,9 +746,13 @@ async fn test_focuser_position_not_connected() {
 
 Hand-written mocks (`MockSerialReader`, `MockSerialWriter`, `MockSerialPortFactory`) are defined in the test files that use them. They are NOT feature-gated. The `#[cfg(feature = "mock")]` flag is reserved for the feature-gated `MockSerialPortFactory` in `src/` used by ConformU and server tests.
 
-#### 6.6 Serialize Server Tests
+#### 6.6 Serialize Tests That Share Process-Global State
 
-Server integration tests that bind to ports must use a static `Mutex<()>` to prevent parallel execution conflicts with the discovery service:
+Tests that touch process-global state cannot run concurrently in the same
+process. Guard each one with a shared static `Mutex<()>` held for the whole
+test body. Two cases occur in this repo:
+
+**Server tests that bind to ports** conflict with the discovery service:
 
 ```rust
 static SERVER_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -759,6 +763,38 @@ async fn test_server_starts() {
     // ... start server on port 0 ...
 }
 ```
+
+**mockall static-function / `#[automock]`-on-a-module mocks** (e.g. the FFI
+mocks in `qhyccd-rs`, where `OpenQHYCCD_context()` and friends are generated
+from `#[cfg_attr(test, automock)] mod libqhyccd_sys`). mockall stores every
+`*_context()` expectation in **process-global** state, so two such tests
+running on different threads in one process corrupt each other's
+expectations — surfacing as `fragile` "destructor ran on wrong thread"
+panics and `called 0 time(s) which is fewer than expected 1` failures that
+abort the test binary (SIGABRT). Every such test must hold a shared guard as
+its first line:
+
+```rust
+static MOCK_FFI_MTX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+// Tolerate poisoning: these tests `assert!`/panic on failure, which would
+// otherwise poison the mutex and cascade into spurious later-test failures.
+fn mock_guard() -> std::sync::MutexGuard<'static, ()> {
+    MOCK_FFI_MTX.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+#[test]
+fn open_succeeds() {
+    let _mock = mock_guard(); // FIRST line, before any *_context() call
+    // ... program OpenQHYCCD_context() etc. ...
+}
+```
+
+`cargo nextest` (the project's standard runner, used by `cargo rail`)
+isolates each test in its own process and hides this — but plain
+`cargo test` runs them as threads. That includes the nightly **safety**
+sanitizer workflow and a developer running `cargo test -p qhyccd-rs`, both
+of which abort without the guard. See issue #384 for the original failure.
 
 #### 6.7 Mock Strategy: Hand-Written vs mockall vs axum stub
 


### PR DESCRIPTION
Closes #384

## Problem

The nightly `safety` (ASan/LSan) workflow aborted in the `qhyccd-rs` unit-test binary with `destructor of fragile object ran on wrong thread` and `Expectation called 0 time(s) which is fewer than expected 1`, ending in SIGABRT. **Despite the framing, it is not a memory leak** — it's a test-isolation defect.

## Root cause

`qhyccd-rs` mocks its FFI via `#[cfg_attr(test, automock)] mod libqhyccd_sys`, so `OpenQHYCCD_context()` and friends store their expectations in **process-global** state. The 98 camera / filter-wheel / sdk unit tests never serialized, so when run as parallel threads in one process they corrupt each other's expectations and abort the binary.

Regular CI is green only because `cargo nextest` (via `cargo rail`) runs each test in its **own process**. The `safety` workflow uses plain threaded `cargo test` — as does a local `cargo test -p qhyccd-rs`. PR #367 added `qhyccd-rs` to the sanitizer matrix, which is when it began surfacing. Reproduced locally at ~100% (40/40 threaded runs fail).

## Fix

Add a shared, poison-tolerant `mock_guard()` (`static Mutex<()>`) in `crates/qhyccd-rs/src/tests/mod.rs` and take it as the **first line** of every `#[test]` in the camera, filter-wheel, and sdk test modules, held for the whole body. This makes the suite correct under **any** runner — fixing both the sanitizer workflow and local `cargo test`. The pattern is documented in `docs/skills/testing.md` §6.6.

## Verification

- Test binary: **40/40 fail → 130/130 pass**, across the default-feature build *and* the `--all-features`/simulation build.
- `cargo rail run --profile commit`: **271/271 green**.
- Pre-commit hook: clippy `-D warnings`, `cargo fmt --check`, Bazel buildifier — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)