### PR TITLE
fix(pi-nightly): symlink libusb for the QHYCCD static link (sudo-free) (#402)

### DIFF
--- a/.github/actions/install-zwo-sdk/action.yml
+++ b/.github/actions/install-zwo-sdk/action.yml
@@ -200,9 +200,10 @@ runs:
           echo "install-zwo-sdk (sudo-free): $linkname -> $found"
         }
         # Suggested remedy package matches setup-pi-runner.sh §1 + the runner
-        # docs: libusb-1.0-0-dev provides libusb-1.0.so.0 (via its libusb-1.0-0
-        # runtime dep); libudev.so.1 ships with systemd (libudev1).
-        link_runtime_lib libusb-1.0.so.0 libusb-1.0.so libusb-1.0-0-dev
+        # docs: libusb-1.0-0 (the runtime) provides libusb-1.0.so.0 — the
+        # symlink target shared with the QHYCCD sudo-free link path, so no -dev
+        # package is needed; libudev.so.1 ships with systemd (libudev1).
+        link_runtime_lib libusb-1.0.so.0 libusb-1.0.so libusb-1.0-0
         link_runtime_lib libudev.so.1   libudev.so    libudev1
 
         {

--- a/.github/actions/install-zwo-sdk/action.yml
+++ b/.github/actions/install-zwo-sdk/action.yml
@@ -184,7 +184,10 @@ runs:
         link_runtime_lib() {
           soname="$1"; linkname="$2"; pkg="$3"; found=""
           if command -v ldconfig >/dev/null 2>&1; then
-            found="$(ldconfig -p 2>/dev/null | awk -v s="$soname" '$1 == s { print $NF; exit }')"
+            # `|| true`: with pipefail, a failing `ldconfig -p` makes this
+            # assignment non-zero, which under `set -e` would abort before the
+            # directory-scan fallback below. Swallow it so the fallback runs.
+            found="$(ldconfig -p 2>/dev/null | awk -v s="$soname" '$1 == s { print $NF; exit }')" || true
           fi
           if [ -z "$found" ]; then
             for d in /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu \

--- a/.github/workflows/pi-nightly.yml
+++ b/.github/workflows/pi-nightly.yml
@@ -119,7 +119,11 @@ jobs:
           : "${QHYCCD_SDK_DIR:?QHYCCD_SDK_DIR not set — the QHYCCD SDK step must run first}"
           rt=""
           if command -v ldconfig >/dev/null 2>&1; then
-            rt="$(ldconfig -p 2>/dev/null | awk '/libusb-1\.0\.so\.0/{print $NF; exit}')"
+            # `|| true`: with pipefail, a failing `ldconfig -p` makes this
+            # assignment non-zero, which under `set -e` would abort the step
+            # before the directory-scan fallback below ever runs. Swallow it so
+            # the fallback can still find libusb-1.0.so.0.
+            rt="$(ldconfig -p 2>/dev/null | awk '/libusb-1\.0\.so\.0/{print $NF; exit}')" || true
           fi
           if [ -z "$rt" ]; then
             for d in /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib /lib; do

--- a/.github/workflows/pi-nightly.yml
+++ b/.github/workflows/pi-nightly.yml
@@ -91,17 +91,47 @@ jobs:
       # sudo-less (public-repo defense-in-depth — see
       # docs/skills/raspberry-pi-runner.md), so it cannot system-install the SDK
       # into /usr/local. `install: env` extracts the SDK under the workspace and
-      # exports QHYCCD_SDK_DIR; libqhyccd-sys's build.rs reads that var and links
-      # libqhyccd.a statically (no .so chain, no ldconfig, no LD_LIBRARY_PATH).
-      # This makes the runner self-healing: a new native-SDK service or version
-      # bump no longer requires re-running setup-pi-runner.sh by hand. Keep the
-      # version in lockstep with the x86 jobs (scheduled.yml / native.yml /
-      # bazel*.yml all pin 26.06.04).
+      # exports QHYCCD_SDK_DIR; libqhyccd-sys's build.rs reads that var to find
+      # libqhyccd.a (linked statically). This makes the runner self-healing: a
+      # new native-SDK service or version bump no longer requires re-running
+      # setup-pi-runner.sh by hand. Keep the version in lockstep with the x86
+      # jobs (scheduled.yml / native.yml / bazel*.yml all pin 26.06.04).
       - name: Install QHYCCD SDK (sudo-free)
         uses: ivonnyssen/qhyccd-sdk-install@v4
         with:
           version: "26.06.04"
           install: env
+
+      # The static libqhyccd.a still pulls in a *dynamic* `-lusb-1.0`, and
+      # libqhyccd-sys's build.rs only adds `-L $QHYCCD_SDK_DIR` to the link
+      # search (the SDK dir holds libqhyccd.a, no libusb). On a sudo-less runner
+      # there is no libusb-1.0-0-dev, hence no unversioned `libusb-1.0.so` for
+      # the linker to find, and the build fails with "cannot find -lusb-1.0"
+      # (issue #402). Drop that linker-name symlink into $QHYCCD_SDK_DIR — the
+      # one dir build.rs searches — pointing at the libusb-1.0 *runtime* .so.0
+      # (the libusb-1.0-0 package installed once by setup-pi-runner.sh §1). This
+      # mirrors install-zwo-sdk's sudo-free symlink for libzwo-sys, keeping the
+      # runner self-healing and free of -dev packages.
+      - name: Symlink libusb for the QHYCCD static link (sudo-free)
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${QHYCCD_SDK_DIR:?QHYCCD_SDK_DIR not set — the QHYCCD SDK step must run first}"
+          rt=""
+          if command -v ldconfig >/dev/null 2>&1; then
+            rt="$(ldconfig -p 2>/dev/null | awk '/libusb-1\.0\.so\.0/{print $NF; exit}')"
+          fi
+          if [ -z "$rt" ]; then
+            for d in /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib /lib; do
+              if [ -e "$d/libusb-1.0.so.0" ]; then rt="$d/libusb-1.0.so.0"; break; fi
+            done
+          fi
+          if [ -z "$rt" ]; then
+            echo "::error::pi-nightly: libusb-1.0 runtime (libusb-1.0.so.0) not found. It is installed once at runner setup (scripts/setup-pi-runner.sh §1 / docs/skills/raspberry-pi-runner.md). Install it and re-run: sudo apt-get install -y libusb-1.0-0"
+            exit 1
+          fi
+          ln -sf "$rt" "$QHYCCD_SDK_DIR/libusb-1.0.so"
+          echo "pi-nightly: linked $QHYCCD_SDK_DIR/libusb-1.0.so -> $rt"
 
       # Provision the ZWO ASI/EFW SDK without sudo, mirroring the QHYCCD step.
       # zwo-camera links libzwo-sys, whose build.rs emits -lASICamera2 /

--- a/docs/skills/raspberry-pi-runner.md
+++ b/docs/skills/raspberry-pi-runner.md
@@ -76,7 +76,7 @@ sudo apt-get install -y \
   jq \
   libssl-dev \
   libcfitsio-dev \
-  libusb-1.0-0-dev \
+  libusb-1.0-0 \
   unzip \
   ca-certificates
 ```
@@ -85,8 +85,10 @@ sudo apt-get install -y \
 the `rp-fits`, `filemonitor`, and `sky-survey-camera` packages fail to
 compile (this is the "use `-p <package>`" caveat that the user-level
 `MEMORY.md` references). `libssl-dev` is required by transitive C-FFI
-crates in the workspace. `libusb-1.0-0-dev` is required by the QHYCCD SDK
-that `qhy-camera` links (next paragraph).
+crates in the workspace. The **libusb-1.0 runtime** (`libusb-1.0-0`) is the
+shared symlink target for both the QHYCCD and ZWO sudo-free link paths (next
+two subsections); the `-dev` package is deliberately **not** installed — the
+unversioned `libusb-1.0.so` linker name is provided per-run instead.
 
 #### QHYCCD SDK (for `qhy-camera`)
 
@@ -99,8 +101,19 @@ its sudo-free **`install: env`** mode: the action downloads the SDK from
 **qhyccd.com** (publicly, no auth), extracts it under the workspace, and exports
 `QHYCCD_SDK_DIR` (the directory holding `libqhyccd.a`). `libqhyccd-sys`'s
 `build.rs` prefers `QHYCCD_SDK_DIR` on Linux (falling back to `/usr/local/lib`)
-and links `libqhyccd.a` **statically**, so no `.so` runtime chain, no `ldconfig`,
-and no `LD_LIBRARY_PATH` are needed and nothing is written into `/usr/local`.
+and adds **only that one dir** to the link search; `libqhyccd.a` itself is
+linked **statically**, so no QHYCCD `.so` runtime chain, no `ldconfig`, and no
+`LD_LIBRARY_PATH` are needed and nothing is written into `/usr/local`.
+
+The static `libqhyccd.a` does, however, pull in a *dynamic* `-lusb-1.0`. On a
+sudo-less runner there is no `libusb-1.0-0-dev`, hence no unversioned
+`libusb-1.0.so` for the linker — so the **Symlink libusb for the QHYCCD static
+link** step in `pi-nightly.yml` drops that linker-name symlink into
+`QHYCCD_SDK_DIR` (the one dir `build.rs` searches), pointing at the libusb-1.0
+*runtime* `.so.0`. Without it the build fails with `cannot find -lusb-1.0`
+(this was [issue #402](https://github.com/ivonnyssen/rusty-photon/issues/402)).
+This mirrors the ZWO sudo-free symlink (next subsection); both share the one
+`libusb-1.0` runtime package installed in §1.
 
 This is what keeps the runner **sudo-less** (public-repo safety — the job user
 has no root, so a dependency `build.rs` cannot escalate) *and* self-healing: a
@@ -141,8 +154,9 @@ no longer pre-provisions it — `pi-nightly.yml` runs the local
 
 The two prerequisites the sudo-free step cannot install itself are stable host
 packages installed once by §1 of `setup-pi-runner.sh`: **clang + libclang-dev**
-(bindgen) and the **libusb-1.0 runtime** (`libusb-1.0-0-dev` pulls it; it is
-both the `libusb-1.0.so` symlink target and the blob's own runtime dependency).
+(bindgen) and the **libusb-1.0 runtime** (`libusb-1.0-0`; it is the
+`libusb-1.0.so` symlink target for both the ZWO and QHYCCD link paths, and the
+blob's own runtime dependency).
 `libudev.so.1` ships with systemd. If the step ever errors with `… not found`,
 install the named package once and re-run — see Troubleshooting. This keeps the
 runner sudo-less *and* self-healing for ZWO exactly as for QHYCCD; the
@@ -395,6 +409,22 @@ A manual `/usr/local/lib` install (the old `setup-pi-runner.sh §1b` behaviour)
 still satisfies the link via `build.rs`'s fallback, but is no longer required or
 performed by setup.
 
+### `cargo build` fails with `cannot find -lusb-1.0` (compiling `libqhyccd-sys`)
+
+The static `libqhyccd.a` pulls in a dynamic `-lusb-1.0`, but the sudo-less
+runner has no `libusb-1.0-0-dev` (no unversioned `libusb-1.0.so` linker name).
+This was [issue #402](https://github.com/ivonnyssen/rusty-photon/issues/402).
+The **Symlink libusb for the QHYCCD static link (sudo-free)** step in
+`pi-nightly.yml` fixes it by linking `libusb-1.0.so` → the runtime `.so.0`
+inside `QHYCCD_SDK_DIR`. Check, in order:
+
+- That step ran and printed `linked …/libusb-1.0.so -> …/libusb-1.0.so.0`
+  before `cargo build` (it runs right after the QHYCCD SDK step).
+- The step did **not** abort with `libusb-1.0 runtime … not found`. That means
+  the host lacks the libusb-1.0 runtime — install it once with sudo and re-run:
+  `sudo apt-get install -y libusb-1.0-0` (it is in §1 of `setup-pi-runner.sh`,
+  so re-running the setup script is the catch-all fix).
+
 ### `cargo build` fails with `cannot find -lASICamera2` / `-lEFWFilter` / `-lusb-1.0` / `-ludev`
 
 `libzwo-sys` could not find the ZWO SDK (or the libusb/libudev link names) on
@@ -407,7 +437,7 @@ provided per-run by the **Install ZWO SDK (sudo-free)** step
   still resolves under `https://github.com/indilib/indi-3rdparty/raw/<ref>/libasi/armv8/`.
 - The step did **not** abort with `… not found`. That message means the host is
   missing a runtime prerequisite the sudo-free path symlinks against — install it
-  once with sudo and re-run: `sudo apt-get install -y libusb-1.0-0-dev` (provides
+  once with sudo and re-run: `sudo apt-get install -y libusb-1.0-0` (provides
   `libusb-1.0.so.0`) — `libudev.so.1` ships with systemd. `clang`/`libclang-dev`
   (bindgen) must also be present; all three are in §1 of `setup-pi-runner.sh`, so
   re-running it is the catch-all fix.

--- a/scripts/setup-pi-runner.sh
+++ b/scripts/setup-pi-runner.sh
@@ -75,7 +75,7 @@ sudo apt-get install -y \
   jq \
   libssl-dev \
   libcfitsio-dev \
-  libusb-1.0-0-dev \
+  libusb-1.0-0 \
   clang \
   libclang-dev \
   unzip \
@@ -90,14 +90,20 @@ sudo apt-get install -y \
 # longer necessary: `pi-nightly.yml` now provisions the SDK per-run with
 # `ivonnyssen/qhyccd-sdk-install@v4` `install: env` — a sudo-free mode that
 # extracts the SDK under the workspace and exports QHYCCD_SDK_DIR, which
-# libqhyccd-sys's build.rs reads to link libqhyccd.a statically. Provisioning in
-# the workflow (rather than at setup time) makes the runner self-healing: a new
-# native-SDK service or an SDK version bump no longer requires re-running this
-# script by hand. The build.rs fallback to /usr/local/lib still works if an
-# operator has installed the SDK there manually, so nothing breaks if it is.
+# libqhyccd-sys's build.rs reads to find libqhyccd.a (linked statically).
+# Provisioning in the workflow (rather than at setup time) makes the runner
+# self-healing: a new native-SDK service or an SDK version bump no longer
+# requires re-running this script by hand. The build.rs fallback to
+# /usr/local/lib still works if an operator has installed the SDK there
+# manually, so nothing breaks if it is.
 #
-# (ZWO is still pre-provisioned below — see §1.5 — until it gets the same
-# sudo-free, per-run treatment.)
+# The static libqhyccd.a still pulls in a *dynamic* `-lusb-1.0`. On a sudo-less
+# runner there is no libusb-1.0-0-dev (no unversioned `libusb-1.0.so` for the
+# linker), so `pi-nightly.yml` symlinks the linker name to the libusb-1.0
+# *runtime* `.so.0` inside QHYCCD_SDK_DIR per-run — exactly like §1.5's ZWO
+# step. That is why §1 above installs only the libusb-1.0 *runtime* package
+# (libusb-1.0-0), not the -dev package: it is just the symlink target, shared
+# by both the QHYCCD and ZWO sudo-free link paths.
 
 # === 1.5. ZWO ASI/EFW SDK — now provisioned sudo-free per-run by the workflow ===
 #


### PR DESCRIPTION
## Summary

The `pi-nightly` ARM64 build has failed every night since 2026-06-21 with a deterministic link error (the auto-labeler tags it `ci-flake`, but it is **not** a flake):

```
/usr/bin/aarch64-linux-gnu-ld.bfd: cannot find -lusb-1.0: No such file or directory
error: could not compile `libqhyccd-sys` (lib test)
```

## Root cause

The static `libqhyccd.a` pulls in a **dynamic** `-lusb-1.0`, but `libqhyccd-sys`'s `build.rs` only adds `-L $QHYCCD_SDK_DIR` to the link search — and that dir holds `libqhyccd.a`, no libusb. The fix relies on the **system** `libusb-1.0.so` dev symlink, which `libusb-1.0-0-dev` provides.

The first failure (06-21) was on a **docs-only commit**, proving the trigger was environmental: the Pi was migrated to the **sudo-less** runner model and lost both the `/usr/local` QHYCCD SDK *and* `libusb-1.0-0-dev`. The follow-up migrations fixed the SDKs and ZWO's libusb but left `libqhyccd-sys` behind:

- **#387** made the QHYCCD SDK sudo-free per-run (fixed `-lqhyccd`).
- **#397** made the ZWO SDK sudo-free per-run — it symlinks the runtime libusb into `ZWO_SDK_LIB_DIR` for `libzwo-sys` (fixed `-lASICamera2 / -lEFWFilter / -ludev / -lusb-1.0` *for zwo-camera*).
- **`libqhyccd-sys` never got the equivalent treatment**, so it still required the system `-dev` symlink that no longer exists → today's `-lusb-1.0` failure.

Only the sudo-less Pi is affected — every x86 job (`scheduled.yml` / `native.yml` / `bazel*.yml`) apt-installs `libusb-1.0-0-dev`.

## Fix

Mirror the ZWO sudo-free pattern for QHYCCD:

- **`pi-nightly.yml`**: after the QHYCCD SDK step, symlink `libusb-1.0.so` → the libusb-1.0 runtime `.so.0` inside `$QHYCCD_SDK_DIR` (the one dir `build.rs` searches). The linker resolves `-lusb-1.0` there; at runtime the recorded SONAME is `libusb-1.0.so.0`, found via the system ldconfig cache — exactly what `libusb-1.0-0-dev` would have provided.
- **`scripts/setup-pi-runner.sh`**: install the libusb-1.0 **runtime** (`libusb-1.0-0`) instead of the `-dev` package. Nothing on the Pi needs the libusb headers or its pkg-config `.pc` (libqhyccd-sys ships pregenerated bindings; libzwo-sys' bindgen reads *vendored* headers). Both sudo-free link paths now share this one runtime symlink target.
- **`install-zwo-sdk`**: align the sudo-free remediation hint to `libusb-1.0-0` (comment + the suggested-package string; no behavior change).
- **`docs/skills/raspberry-pi-runner.md`**: document the runtime-only model and add a troubleshooting entry for the `-lusb-1.0` failure.

## Validation

- `shellcheck` clean (setup script + the new workflow step); YAML parses; `cargo rail plan` scope is empty (docs/infra only — no Rust touched); pre-commit hook passed (`clippy`, `fmt --check`, `buildifier`).
- **Cannot be exercised on a branch**: `pi-nightly.yml` pins `ref: main` on checkout and gates on `if: github.ref == 'refs/heads/main'`, so the Pi only ever runs main's workflow. After merge, trigger it via **Actions → pi-nightly → Run workflow** (`workflow_dispatch`) to confirm rather than waiting for 04:00 UTC.

Fixes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)