### PR TITLE
chore(dsd-fp2): re-enable rolling ConformU run on 4.4.0 (#293)

### DIFF
--- a/docs/services/dsd-fp2.md
+++ b/docs/services/dsd-fp2.md
@@ -110,8 +110,7 @@ What is **not** in this crate (because the shared-transport crate owns it):
   The driver therefore returns `MethodNotImplementedException`
   (Alpaca error code 0x400) from `HaltCover` — which is what the
   [ASCOM ICoverCalibratorV2 spec][cc-spec] explicitly mandates "if cover
-  movement cannot be interrupted". (See [Known limitations](#known-limitations)
-  for the ConformU divergence on this point.)
+  movement cannot be interrupted".
 
   [cc-spec]: https://ascom-standards.org/newdocs/covercalibrator.html
 - **Heater**: optional dew-heater channel with a thermistor. Present if
@@ -622,28 +621,15 @@ and points ConformU at it. The same approach `qhy-focuser` uses.
 
 ## Known Limitations
 
-### ConformU 4.3 flags spec-compliant `HaltCover` as an issue
-
-The driver returns `MethodNotImplementedException` from `HaltCover`,
-exactly as the [ASCOM ICoverCalibratorV2 spec][cc-spec] mandates "if
-cover movement cannot be interrupted". The FP2 firmware exposes no
-halt-motion opcode, so this is the spec-correct response.
-
-ConformU 4.3's `CoverCalibratorTester.TestHaltCover` (file
-`ConformU/Conform/CoverCalibratorTester.cs`) flags this as an issue
-anyway, because in its async-cover branch every exception type — including
-the spec-mandated `MethodNotImplementedException` — is treated as
-`Required.MustBeImplemented`. A ConformU run against this driver
-reports:
-
-> HaltCover  ISSUE  CoverStatus indicates that the device has cover capability and a NotImplementedException error was returned, this method must function per the ASCOM specification.
-
-The driver is intentionally not changed to silence this — the upstream
-divergence is filed at
-<https://github.com/ASCOMInitiative/ConformU/issues/30>. For that
-reason this service does **not** declare a `[package.metadata.conformu]`
-entry, so the rolling ConformU workflow does not include it. Re-enable
-once the upstream issue lands and the test passes cleanly.
+The driver returns `MethodNotImplementedException` from `HaltCover`
+(the FP2 firmware exposes no halt-motion opcode), exactly as the
+[ASCOM ICoverCalibratorV2 spec][cc-spec] mandates "if cover movement
+cannot be interrupted". ConformU 4.3 incorrectly flagged this
+spec-compliant response as an issue
+([ASCOMInitiative/ConformU#30](https://github.com/ASCOMInitiative/ConformU/issues/30));
+the fix shipped in **ConformU 4.4.0**, which now logs `HaltCover` as OK.
+The service therefore declares a `[package.metadata.conformu]` entry and
+is included in the rolling ConformU workflow.
 
 [cc-spec]: https://ascom-standards.org/newdocs/covercalibrator.html
 

--- a/services/dsd-fp2/Cargo.toml
+++ b/services/dsd-fp2/Cargo.toml
@@ -20,9 +20,8 @@ conformu = ["mock"]
 [lints]
 workspace = true
 
-# NOTE: no `[package.metadata.conformu]` entry — see `docs/services/dsd-fp2.md`
-# "Known limitations" for why dsd-fp2 is excluded from the rolling ConformU
-# matrix until the upstream `HaltCover` issue is resolved.
+[package.metadata.conformu]
+command = "cargo test -p dsd-fp2 --features conformu --test conformu_integration -- --nocapture"
 
 [dependencies]
 ascom-alpaca = { workspace = true, features = ["server", "cover_calibrator", "client"] }


### PR DESCRIPTION
Closes #293.

ConformU 4.4.0 is now the latest **stable** release (published 2026-06-26, `prerelease: false`). It addresses [ASCOMInitiative/ConformU#30](https://github.com/ASCOMInitiative/ConformU/issues/30) — the async-cover branch bug where `HaltCover` returning the spec-mandated `MethodNotImplementedException` was wrongly flagged as an issue. `HaltCover` now logs OK, so `dsd-fp2` passes ConformU cleanly and can rejoin the rolling matrix.

## Changes

- **`services/dsd-fp2/Cargo.toml`** — add `[package.metadata.conformu]` so the rolling `conformu.yml` workflow (which discovers services via `cargo metadata`) picks dsd-fp2 back up. Confirmed dsd-fp2 now appears in the discovery list.
- **`docs/services/dsd-fp2.md`** — replace the "ConformU 4.3 flags spec-compliant `HaltCover`" Known Limitations section with a one-liner noting it's resolved in 4.4.0; drop the now-stale cross-reference in Hardware Constraints.

## On the issue's checklist

- **Version pin:** the rolling workflow installs ConformU via `ivonnyssen/conformu-install` (defaults to `latest`), so no pin needs bumping. The only literal pin in the repo is `scripts/test-conformance.sh` (`v4.1.0`), a separate legacy *filemonitor* manual smoke script unrelated to the rolling workflow — left untouched.
- **Verified locally against ConformU 4.4.0 stable:** ran `cargo test -p dsd-fp2 --features conformu --test conformu_integration` with `CONFORMU_PATH` pointed at a freshly downloaded 4.4.0 build. Both the `alpacaprotocol` and `conformance` suites pass with **0 errors / 0 issues**, and `HaltCover` logs `OK — Optional member returned a NotImplementedException error`.

## Acceptance

- [x] Rolling ConformU workflow will run against dsd-fp2 (now discovered) and passes (verified locally on 4.4.0).
- [x] "Known Limitations" no longer references the ConformU 4.3 divergence.

Worth a manual `workflow_dispatch` run of `conformu.yml` after merge to confirm the full cross-OS matrix is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
