### PR TITLE
docs: design the imaging workflow DSL + session-runner orchestrator

### DIFF
--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -150,11 +150,13 @@ committable on its own.
       document format, instruction/trigger vocabulary, expression semantics,
       blackboard + re-entrancy contract, validation, configuration, MVP
       boundary.
-- [ ] Publish the workflow-document **JSON Schema**
+- [x] Publish the workflow-document **JSON Schema**
       (`services/session-runner/schema/workflow-v1.schema.json`) — the
       contract for authors, the future UI, and LLM generation. Written by
       hand (the schema *is* the format spec); `schemars` is not the source
       of truth here because the schema outlives any one Rust representation.
+      Validated (draft 2020-12) against both shipped golden documents and a
+      battery of negative cases derived from the spec's own stated rules.
 
 ### Phase B — Expression layer
 

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -1,0 +1,243 @@
+# Imaging Workflow DSL + `session-runner` Orchestrator Plugin
+
+## Status
+
+**Design stage.** Direction decided 2026-07-01 after a research pass over the
+astrophotography-automation ecosystem and the Rust workflow/DSL solution
+space. The service design doc is
+[`docs/services/session-runner.md`](../services/session-runner.md); this plan
+is the decision record and phase breakdown behind it, per the design → BDD →
+implementation flow in
+[`docs/skills/development-workflow.md`](../skills/development-workflow.md).
+No code exists yet.
+
+## Motivation
+
+`rp` deliberately contains no workflow logic (design tenet: orchestration is
+a plugin concern). The docs envision four orchestrators — `deep-sky`,
+`planetary`, `calibrator-flats`, `sky-flat` — of which only `calibrator-flats`
+exists, as a hand-written Rust plugin. Before building the second one, decide
+how workflow logic should be *expressed*, because the answer changes what we
+build:
+
+- **Hand-written Rust per session type** scales to a handful of first-party
+  workflows but makes every new session shape (and every user adaptation —
+  "same as deep-sky but refocus only on narrowband filters") a Rust PR.
+- A **workflow definition format** lets one generic engine execute many
+  workflows, lets power users author and share them as files, gives a future
+  `ui-htmx` editor something to edit, and gives an LLM a validatable target
+  format to generate.
+
+## Research summary (2026-07-01)
+
+Two research passes inform the decisions below.
+
+### What the astro ecosystem converged on
+
+Surveyed: N.I.N.A. (Advanced Sequencer + Target Scheduler plugin), Voyager
+(DragScript + RoboTarget), ACP Expert (text plans + dispatch Scheduler),
+KStars/Ekos (Scheduler + `.esq` capture queues), SGPro, RTS2 (professional).
+
+1. **Every mature system is a three-layer hybrid**: an imperative *session
+   procedure* (startup/shutdown/recovery choreography), a *cross-cutting
+   reactive overlay* (meridian flip, refocus-on-HFR, park-on-unsafe — always
+   triggers/conditions, never sequence steps), and a *declarative dispatch
+   core* for target choice (targets + constraints + progress in a database, a
+   planner asked "what now?" one step at a time). Every sequential-first
+   product grew a dispatch layer (NINA → Target Scheduler, Voyager →
+   RoboTarget); SGPro never did and lost its user base. Professional
+   observatories (RTS2) are dispatch-only.
+2. **Resume-after-crash is a property of the data model, not the runtime.**
+   Ekos counts frames on disk; Target Scheduler/RoboTarget keep acquisition
+   state in a DB. Nobody snapshots a running sequence.
+3. **Every declarative system grew a scripting escape hatch in the dark**
+   (NINA's Sequencer Powerups plugin is a programming language grafted onto
+   the GUI; Home Assistant YAML and GitHub Actions `${{ }}` are the same
+   cautionary tale from adjacent ecosystems). Design the expression story up
+   front.
+4. **Astronomers demonstrably author and share JSON instruction trees** —
+   NINA's Advanced Sequencer (a JSON tree of instructions + triggers + loop
+   conditions with community-shared templates) is its single most-cited
+   feature.
+5. **Workflow-level parallelism is marginal** (NINA's parallel container
+   forfeits conditions/triggers; nobody else bothered). Concurrency in this
+   domain is device-level (guiding while exposing), which `rp` tools already
+   encapsulate.
+
+Key sources: NINA Advanced Sequencer
+(<https://nighttime-imaging.eu/docs/master/site/sequencer/advanced/advanced/>),
+Target Scheduler (<https://tcpalmer.github.io/nina-scheduler/>), Voyager
+DragScript (<https://wiki.starkeeper.it/index.php/DragScript>), ACP plan
+format (<http://solo.dc3.com/ar/RefDocs/HelpFiles/ACP81Help/planfmt.html>),
+Ekos Scheduler
+(<https://kstars-docs.kde.org/en/user_manual/ekos-scheduler.html>), RTS2
+dispatch scheduling (<https://arxiv.org/pdf/1005.1014>).
+
+### What the Rust solution space says
+
+Evaluated: plain Rust orchestrators; embedded scripting (Rhai, mlua/Luau,
+Rune, Steel, Starlark, PyO3, rquickjs/Boa, Koto); declarative formats (Amazon
+States Language-style state machines, statecharts, behavior trees, HTN/GOAP);
+durable-execution engines (Temporal, Restate, LittleHorse, Obelisk/WASM, DIY
+event-sourced replay); LLM-as-orchestrator.
+
+1. **No embedded interpreter can snapshot a suspended script** (Rhai issue
+   #769 open; Lua's Eris is dead). Crash-resume comes from either
+   *event-sourced replay* (Temporal-style deterministic re-execution against
+   a result log) or *re-deriving position from persisted domain state*
+   (behavior-tree style re-tick against device state + a progress
+   blackboard).
+2. **A declarative reactive-tree DSL is the strongest primary format** for
+   this project: instruction leaves map 1:1 onto the JSON-schema'd MCP tools
+   (validation for free), triggers give reactivity, interpreter state is
+   trivially persistable, it tests against the existing OmniSim + `rp` BDD
+   stack, and the interpreter is a few thousand lines of owned,
+   dependency-light Rust.
+3. **If scripting is ever needed, Luau via `mlua` is the standout**: real
+   async (a script awaiting a tool call is a coroutine yield the host can
+   `select!` against safety events), industry-grade sandboxing, ~1–2 MB,
+   very active. Rune has the best async syntax but a bus-factor risk; Python
+   cannot be sandboxed (PyO3 says so explicitly) — and Python users already
+   have an escape hatch, because orchestrators are separate processes: they
+   can write an external MCP client in any language.
+4. **Heavyweight engines don't fit a Pi 5 appliance**: Temporal's server is a
+   multi-service Go deployment; Restate is a plausible single binary but
+   another always-on stateful service that still doesn't solve
+   user-authorability. The replay *pattern* is buildable in-process if ever
+   needed.
+5. **LLM-as-orchestrator is the wrong executor for unattended nights**
+   (compounding per-step error over hundreds of steps) but a natural
+   *author* of workflow documents — which a validatable declarative format
+   enables safely.
+
+Key sources: mlua (<https://github.com/mlua-rs/mlua>), Rhai checkpoint issue
+(<https://github.com/rhaiscript/rhai/issues/769>), CEL spec + Rust
+interpreter (<https://crates.io/crates/cel-interpreter>), Amazon States
+Language (<https://states-language.net/>), BehaviorTree.CPP / Nav2
+(<https://www.behaviortree.dev/>,
+<https://docs.nav2.org/behavior_trees/overview/detailed_behavior_tree_walkthrough.html>),
+Temporal Rust SDK status (<https://crates.io/crates/temporalio-sdk>), Restate
+(<https://www.restate.dev/>), Obelisk (<https://obeli.sk/>), PyO3 sandboxing
+statement (<https://docs.rs/pyo3/latest/pyo3/>), Home Assistant YAML
+complexity backlash
+(<https://homecore.tech/en/home-assistant-yaml-or-node-red/>), GitHub Actions
+expression-language critique
+(<https://www.iankduncan.com/engineering/2026-02-05-github-actions-killing-your-team/>).
+
+## Decisions
+
+| # | Decision | Rationale | Rejected alternatives |
+|---|----------|-----------|----------------------|
+| D1 | Workflows are **declarative reactive-tree documents in JSON**, executed by one generic **`session-runner`** orchestrator plugin (port 11171). | Matches the ecosystem-converged shape (procedure tree + trigger overlay + dispatch via `rp`'s planner); leaves validate against MCP tool schemas; authorable by power users now, a `ui-htmx` editor and LLMs later. | Embedded scripting as the *primary* format (no UI story, users must program); plain Rust per session type (every variation is a PR); YAML/KDL/TOML/custom text surface (weaker schema + round-trip tooling; JSON chosen deliberately). |
+| D2 | **Rust orchestrators remain first-class.** The plugin protocol is unchanged and language-agnostic; `calibrator-flats` keeps shipping as Rust until its DSL port is proven equivalent, and future workflows may still be Rust when that fits better. | The DSL is an addition, not a replacement; the process boundary is also the escape hatch for users who prefer real languages (external MCP clients). | Mandating the DSL for all workflows. |
+| D3 | **Escape hatch designed up front**: CEL-style **bounded expressions** in `when` / `until` / `set` / `$expr` positions in v1 — pure, total, no I/O, reading only the document's namespaces. The document schema **reserves a `script` node type** for sandboxed Luau handlers later, so scripting can land without a format break. | Avoids the accreted-expression-language failure mode (HA, GH Actions, NINA Powerups) while keeping v1 small; expressions stay pure so resume and UI round-tripping stay sound. | Pure-declarative v1 (vocabulary explosion, retrofitted expressions later); full Luau in v1 (second authoring surface before the first has users). |
+| D4 | **Resume = re-derive from state.** On (re-)invocation the engine re-executes the document from the root against the persisted blackboard + live device state; documents must be written re-entrant (progress guards, `rp` planner progress counters, `once` markers). No replay log, no interpreter snapshots. | Matches how Ekos / Target Scheduler resume; rides `rp`'s existing session-persistence design; smallest machinery. Replay becomes necessary only if long-running scripts ever drive sessions — and the Luau-handler design (stateless per-event, state in blackboard) is chosen precisely so they don't. | Event-sourced replay (more machinery than v1 needs); interpreter snapshots (not implementable). |
+| D5 | **Safety stays exclusively in `rp`.** A workflow document cannot express, delay, or override park-on-unsafe; the engine just gets its MCP session cancelled and is re-invoked with recovery context later. | Already an `rp` tenet; reinforced by the Home Assistant lesson (safety logic lives in the simplest, most reliable layer). | Safety triggers in documents. |
+| D6 | **Dispatch is delegated to `rp`'s planner tools** (`get_next_target`, `record_exposure`, …). The DSL expresses *procedure* and *reaction*; target/filter *choice* stays a pure function in `rp`. | The ecosystem's dispatch cores are DBs + planners, not workflow syntax; `rp` already owns this. | Target-selection logic in documents. |
+| D7 | **v1 proves the engine on two workflows**: the deep-sky session (new value) *and* a port of `calibrator-flats` (generalization proof, diffed against its existing BDD suite). | A single workflow can't show the format generalizes; the flats port has a known-good behavioral oracle. | Engine + deep-sky only; port-flats-first only. |
+
+## Phases
+
+Phase boundaries follow design → BDD → implementation per
+[`development-workflow.md`](../skills/development-workflow.md). Each phase is
+committable on its own.
+
+### Phase A — Design + document schema *(this PR)*
+
+- [x] Research passes (ecosystem + Rust solution space) and decisions above.
+- [x] Service design doc
+      [`docs/services/session-runner.md`](../services/session-runner.md):
+      document format, instruction/trigger vocabulary, expression semantics,
+      blackboard + re-entrancy contract, validation, configuration, MVP
+      boundary.
+- [ ] Publish the workflow-document **JSON Schema**
+      (`services/session-runner/schema/workflow-v1.schema.json`) — the
+      contract for authors, the future UI, and LLM generation. Written by
+      hand (the schema *is* the format spec); `schemars` is not the source
+      of truth here because the schema outlives any one Rust representation.
+
+### Phase B — Expression layer
+
+- [ ] **Spike (time-boxed)**: `cel-interpreter` vs a hand-rolled Pratt-parsed
+      expression grammar. Evaluate: no-I/O purity enforcement, error message
+      quality (authors will read these at 2 a.m.), footprint, maintenance
+      status. The *semantics* are fixed either way (see design doc §
+      Expressions); the spike only picks the implementation.
+- [ ] Implement the expression module with exhaustive unit tests (every
+      operator, every namespace, every error case).
+
+### Phase C — Engine core + `calibrator-flats` port (the equivalence proof)
+
+- [ ] BDD scaffold for `session-runner` (rp-harness: OmniSim + `rp` +
+      `session-runner`), `@wip`-tagged per testing.md §2.7 until green.
+- [ ] Engine core: document loading + schema validation, static tool-call
+      validation against `tools/list`, `sequence` / `tool` / `set` / `if` /
+      `repeat` / `try`-`finally` / `wait` / `log` execution, blackboard with
+      atomic persistence, MCP client, `/invoke` + `/health` + `/validate`
+      routes, completion posting.
+- [ ] `workflows/calibrator_flats.json` shipped as a first-party document.
+- [ ] Port `calibrator-flats`' BDD scenarios to run against `session-runner`
+      executing that document; behavior must match the Rust plugin (same
+      events, same frame counts, same cleanup-on-failure). The Rust
+      `calibrator-flats` service is **not** retired in this plan — retirement
+      is a separate decision after the port has real-world mileage.
+
+### Phase D — Triggers, events, resume
+
+- [ ] SSE event client (`/api/events/subscribe`, `Last-Event-ID` = the
+      envelope's `event_seq`).
+- [ ] Trigger engine: `event` and `poll` sources, `when` gating, safe-point
+      interleaving, `once` / `cooldown`.
+- [ ] Resume: recovery invocation → blackboard reload → re-execution;
+      BDD scenarios for kill-mid-session → re-invoke → session continues
+      without repeating completed work (frame counts prove it).
+
+### Phase E — Deep-sky workflow
+
+- [ ] `workflows/deep_sky.json`: startup → dispatch loop
+      (`get_next_target` → slew → `center_on_target` → `auto_focus` →
+      guide → capture loop with dither/refocus/meridian-flip triggers) →
+      shutdown, per the flow sketched in `rp.md` § Orchestration.
+- [ ] BDD scenarios against OmniSim for the full night-cycle happy path,
+      target switch, refocus trigger, and safety interruption + resume.
+- [ ] Any `rp` planner v1 gaps this exposes (documented in `rp.md` § Dynamic
+      Planner) get issues filed — closing them is `rp` work, not
+      `session-runner` work.
+
+### Phase F — Polish and adoption
+
+- [ ] Authoring documentation (`docs/references/workflow-documents.md`):
+      the format, the expression grammar, the re-entrancy contract, worked
+      examples.
+- [ ] Update `rp.md` § Orchestration to describe `session-runner` as the
+      home of the deep-sky / sky-flat / planetary workflows.
+- [ ] Example documents beyond the two v1 workflows (sky-flat is the natural
+      third: it exercises the expression layer's convergence-loop ceiling).
+
+### Deferred (explicitly out of scope for v1)
+
+- **Luau script nodes** (`{"script": …}` is reserved in the schema; handlers
+  will be stateless per-event with state in the blackboard, so D4 resume
+  survives their arrival).
+- **`ui-htmx` workflow editor** (the JSON Schema is designed to round-trip;
+  building the editor is a `ui-htmx` plan).
+- **LLM-authored documents** (nothing to build here beyond the schema — an
+  LLM generates a document, `/validate` checks it; operational guidance
+  belongs in authoring docs).
+- **Parallel containers** (research: marginal value, real complexity;
+  device-level concurrency already lives inside `rp` tools).
+- **Sub-workflow imports / template composition** (wait for real duplication
+  pressure across shipped documents).
+- **Event-sourced replay** (only if long-running scripts ever land).
+
+## Open questions
+
+- Whether the document/engine layer should later extract into an `rp-*`
+  crate for reuse (e.g. by a future `sky-flat`-specialized runner). Per the
+  workspace convention, it stays service-local until a second consumer
+  exists.
+- Exact expression function set beyond the v1 list in the design doc —
+  grows with worked examples, gated by the purity rules.
+- Document versioning policy beyond `"version": 1` (pre-1.0 stance: breaking
+  changes to the format are acceptable; the field exists so the engine can
+  reject documents it doesn't understand with a clear error).

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -130,7 +130,7 @@ expression-language critique
 |---|----------|-----------|----------------------|
 | D1 | Workflows are **declarative reactive-tree documents in JSON**, executed by one generic **`session-runner`** orchestrator plugin (port 11171). | Matches the ecosystem-converged shape (procedure tree + trigger overlay + dispatch via `rp`'s planner); leaves validate against MCP tool schemas; authorable by power users now, a `ui-htmx` editor and LLMs later. | Embedded scripting as the *primary* format (no UI story, users must program); plain Rust per session type (every variation is a PR); YAML/KDL/TOML/custom text surface (weaker schema + round-trip tooling; JSON chosen deliberately). |
 | D2 | **Rust orchestrators remain first-class.** The plugin protocol is unchanged and language-agnostic; `calibrator-flats` keeps shipping as Rust until its DSL port is proven equivalent, and future workflows may still be Rust when that fits better. | The DSL is an addition, not a replacement; the process boundary is also the escape hatch for users who prefer real languages (external MCP clients). | Mandating the DSL for all workflows. |
-| D3 | **Escape hatch designed up front**: CEL-style **bounded expressions** in `when` / `until` / `set` / `$expr` positions in v1 — pure, total, no I/O, reading only the document's namespaces. The document schema **reserves a `script` node type** for sandboxed Luau handlers later, so scripting can land without a format break. | Avoids the accreted-expression-language failure mode (HA, GH Actions, NINA Powerups) while keeping v1 small; expressions stay pure so resume and UI round-tripping stay sound. | Pure-declarative v1 (vocabulary explosion, retrofitted expressions later); full Luau in v1 (second authoring surface before the first has users). |
+| D3 | **Escape hatch designed up front**: CEL-style **bounded expressions** in `when` / `until` / `set` / `$expr` positions in v1 — pure, total, no I/O, reading only the document's namespaces plus a single sanctioned clock read (`seconds_until()`, for dawn/flip math — tenet 4 in the design doc). The document schema **reserves a `script` node type** for sandboxed Luau handlers later, so scripting can land without a format break. | Avoids the accreted-expression-language failure mode (HA, GH Actions, NINA Powerups) while keeping v1 small; expressions stay pure so resume and UI round-tripping stay sound. | Pure-declarative v1 (vocabulary explosion, retrofitted expressions later); full Luau in v1 (second authoring surface before the first has users). |
 | D4 | **Resume = re-derive from state.** On (re-)invocation the engine re-executes the document from the root against the persisted blackboard + live device state; documents must be written re-entrant (progress guards, `rp` planner progress counters, `once` markers). No replay log, no interpreter snapshots. | Matches how Ekos / Target Scheduler resume; rides `rp`'s existing session-persistence design; smallest machinery. Replay becomes necessary only if long-running scripts ever drive sessions — and the Luau-handler design (stateless per-event, state in blackboard) is chosen precisely so they don't. | Event-sourced replay (more machinery than v1 needs); interpreter snapshots (not implementable). |
 | D5 | **Safety stays exclusively in `rp`.** A workflow document cannot express, delay, or override park-on-unsafe; the engine just gets its MCP session cancelled and is re-invoked with recovery context later. | Already an `rp` tenet; reinforced by the Home Assistant lesson (safety logic lives in the simplest, most reliable layer). | Safety triggers in documents. |
 | D6 | **Dispatch is delegated to `rp`'s planner tools** (`get_next_target`, `record_exposure`, …). The DSL expresses *procedure* and *reaction*; target/filter *choice* stays a pure function in `rp`. | The ecosystem's dispatch cores are DBs + planners, not workflow syntax; `rp` already owns this. | Target-selection logic in documents. |
@@ -158,13 +158,44 @@ committable on its own.
 
 ### Phase B — Expression layer
 
-- [ ] **Spike (time-boxed)**: `cel-interpreter` vs a hand-rolled Pratt-parsed
-      expression grammar. Evaluate: no-I/O purity enforcement, error message
-      quality (authors will read these at 2 a.m.), footprint, maintenance
-      status. The *semantics* are fixed either way (see design doc §
-      Expressions); the spike only picks the implementation.
+- [ ] **Spike (time-boxed)**: pick the parser. An implementation-research
+      pass (2026-07-02, verified against crates.io/GitHub) found that **no
+      off-the-shelf interpreter implements the fixed semantics** — every
+      live candidate deviates on f64-only numbers, strict
+      null/division-by-zero, or grammar subsettability — so the evaluator
+      is hand-written in every arm and the spike compares parser
+      strategies:
+      1. **Hand-rolled** lexer + Pratt parser (~800 LOC, zero deps;
+         `miette` optional for dual human/structured diagnostics;
+         `proptest` round-trip + `cargo-fuzz` as the test harness).
+      2. **The `cel` crate as parser only** (the `cel-interpreter` crate
+         was renamed `cel` at 0.11 — actively maintained, MIT, pure Rust,
+         multi-maintainer): parse-only API with per-node spans and a
+         public AST, but a deny-by-default AST walk must reject
+         comprehension macros (expanded at parse time, no off switch) and
+         rewrite int literals to f64, and its stock evaluator is unusable
+         as-is (error-absorbing `&&`/`||`, IEEE-infinity float division,
+         raise-on-missing-key).
+      3. **`oxc_parser` JS-expression subset**: the specced grammar is a
+         JavaScript expression subset and JS numbers are f64 — parse with
+         oxc, allowlist AST node kinds plus lexical checks (comments, hex
+         and `_`-separator literals share node kinds), evaluate strictly
+         by hand. Cost: oxc's rapid 0.x release churn (pin + adapter).
+      Evaluate: exactness of grammar subsetting (tenet 5 — anything the
+      parser accepts becomes de-facto format), span quality mapped to
+      JSON-Pointer `/validate` errors (incl. structured/serializable error
+      types), error-message quality at 2 a.m., footprint, maintenance.
+      Rejected up front by the same research: Rhai expression-mode (no
+      `?:`, irremovable i64, silent cross-type comparisons), `evalexpr`
+      (AGPL-3.0-only since v12), `zen-expression` (Decimal arithmetic,
+      division by zero yields null), JEXL (no function-call grammar,
+      silent Infinity), and the JSON-tree family (JsonLogic/jq/JMESPath/
+      FEEL — lenient-null semantics and/or unreadable authoring contradict
+      tenets 4–5).
 - [ ] Implement the expression module with exhaustive unit tests (every
-      operator, every namespace, every error case).
+      operator, every namespace, every error case), property tests
+      (parse ↔ pretty-print round-trip), and a fuzz target (the parser
+      must never panic on operator-authored input).
 
 ### Phase C — Engine core + `calibrator-flats` port (the equivalence proof)
 
@@ -172,9 +203,14 @@ committable on its own.
       `session-runner`), `@wip`-tagged per testing.md §2.7 until green.
 - [ ] Engine core: document loading + schema validation, static tool-call
       validation against `tools/list`, `sequence` / `tool` / `set` / `if` /
-      `repeat` / `try`-`finally` / `wait` / `log` execution, blackboard with
+      `repeat` / `try`-`catch`-`finally` / `fail` / `wait` / `log`
+      execution, blackboard with
       atomic persistence, MCP client, `/invoke` + `/health` + `/validate`
       routes, completion posting.
+- [ ] `rp`: forward the orchestrator registration's `config` object
+      verbatim in the `/invoke` POST (the protocol addition documented in
+      `rp.md` § Orchestrator Invocation Protocol; `rp` today sends only
+      `workflow_id` / `session_id` / `mcp_server_url` / `recovery`).
 - [ ] `workflows/calibrator_flats.json` shipped as a first-party document.
 - [ ] Port `calibrator-flats`' BDD scenarios to run against `session-runner`
       executing that document; behavior must match the Rust plugin (same
@@ -186,8 +222,9 @@ committable on its own.
 
 - [ ] SSE event client (`/api/events/subscribe`, `Last-Event-ID` = the
       envelope's `event_seq`).
-- [ ] Trigger engine: `event` and `poll` sources, `when` gating, safe-point
-      interleaving, `once` / `cooldown`.
+- [ ] Trigger engine: `event`, `poll`, and the synthetic
+      `correction_requested` sources; `when` gating and `while`
+      phase-gates; safe-point interleaving; `once` / `cooldown`.
 - [ ] Resume: recovery invocation → blackboard reload → re-execution;
       BDD scenarios for kill-mid-session → re-invoke → session continues
       without repeating completed work (frame counts prove it).
@@ -210,7 +247,8 @@ committable on its own.
       the format, the expression grammar, the re-entrancy contract, worked
       examples.
 - [ ] Update `rp.md` § Orchestration to describe `session-runner` as the
-      home of the deep-sky / sky-flat / planetary workflows.
+      home of the deep-sky and sky-flat workflow documents (the Phase A
+      edit only cross-references the plan there).
 - [ ] Example documents beyond the two v1 workflows (sky-flat is the natural
       third: it exercises the expression layer's convergence-loop ceiling).
 
@@ -238,6 +276,10 @@ committable on its own.
   exists.
 - Exact expression function set beyond the v1 list in the design doc —
   grows with worked examples, gated by the purity rules.
+- Numeric edge semantics to pin during Phase B: whether f64 overflow to
+  ±Infinity raises at the producing operation or at `set` persistence
+  (JSON cannot represent it), and string ordered-comparison semantics
+  (`'a' < 'b'` — lexicographic or a type error).
 - Document versioning policy beyond `"version": 1` (pre-1.0 stance: breaking
   changes to the format are acceptable; the field exists so the engine can
   reject documents it doesn't understand with a clear error).

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1540,9 +1540,15 @@ invokes it when a session starts:
   "type": "orchestrator",
   "invoke_url": "http://localhost:11160/invoke",
   "requires_tools": ["slew", "capture", "start_guiding", "stop_guiding",
-                      "dither", "get_next_target", "record_exposure"]
+                      "dither", "get_next_target", "record_exposure"],
+  "config": { "camera_id": "main-cam", "focuser_id": "main-focuser" }
 }
 ```
+
+The optional `config` object is opaque to `rp`: it is stored with the
+registration and passed through verbatim at invocation (see below).
+`calibrator-flats` carries its flat plan here; `session-runner` uses it to
+name the workflow document to execute and that document's parameters.
 
 #### Orchestrator Invocation Protocol
 
@@ -1557,12 +1563,23 @@ Content-Type: application/json
   "workflow_id": "wf-550e8400-e29b-41d4",
   "session_id": "session-2026-03-01",
   "mcp_server_url": "http://localhost:11115/mcp",
-  "recovery": null
+  "recovery": null,
+  "config": { "camera_id": "main-cam", "focuser_id": "main-focuser" }
 }
 ```
 
 On recovery after a safety event or power failure, `recovery` contains
 the last known session state so the orchestrator can resume.
+
+`config` is the orchestrator's registered `config` object, passed through
+verbatim — `rp` never interprets it. A hand-written orchestrator may
+equally read settings from its own service configuration; document-driven
+orchestrators (`session-runner`) rely on the pass-through so one service
+can run many workflows.
+
+> **Implementation status.** `rp` currently sends only the first four
+> fields; the `config` pass-through lands with `session-runner` Phase C
+> ([`docs/plans/workflow-dsl.md`](../plans/workflow-dsl.md)).
 
 The orchestrator acknowledges with timing estimates computed from the
 session context it just received:

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1789,6 +1789,15 @@ Different imaging types use different orchestrators:
 | `calibrator-flats` | close cover → calibrator on → per-filter: find exposure time iteratively → capture N flats → calibrator off → open cover |
 | `sky-flat` | point at clear sky → per-filter during twilight: capture with per-frame exposure adjustment → handle changing sky brightness |
 
+> **How orchestrators are built.** An orchestrator can be a hand-written
+> service in any language (like `calibrator-flats`, Rust) **or** a
+> declarative **workflow document** executed by the generic
+> [`session-runner`](session-runner.md) plugin (design stage — see
+> [`docs/plans/workflow-dsl.md`](../plans/workflow-dsl.md)). The
+> `deep-sky-orchestrator` and `sky-flat` rows above are planned as workflow
+> documents, not standalone binaries; `rp` cannot tell the difference —
+> both shapes follow the same plugin protocol.
+
 ### What `rp` Owns vs. What the Orchestrator Owns
 
 **`rp` owns** (enforced regardless of which orchestrator runs):

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -28,10 +28,14 @@ Decision record and phase plan:
    against the workflow schema, and every tool call in it is checked against
    `rp`'s live tool catalog, before the first instruction runs. Authoring
    errors surface at load, at the `/validate` endpoint, or at session start
-   — never mid-night.
-4. **Expressions are pure.** The bounded expression language reads document
-   state and computes values. It cannot perform I/O, call tools, loop, or
-   observe wall-clock time. Anything effectful is an instruction.
+   — never in the middle of the night.
+4. **Expressions are pure — with one sanctioned exception.** The bounded
+   expression language reads document state and computes values. It cannot
+   perform I/O, call tools, or loop. The single sanctioned observation of
+   the outside world is `seconds_until()`, which reads the engine clock at
+   evaluation time — dawn/flip math is impossible without it (see
+   [Expressions](#expressions)). Everything else effectful is an
+   instruction.
 5. **The document format is the API.** The published JSON Schema is the
    contract for hand-authors, the future `ui-htmx` editor, and LLM
    generation alike. The engine's internals may change; the format versions
@@ -95,7 +99,7 @@ A workflow document is a single JSON file. Top-level structure:
 |-------|---------|
 | `version` | Format version. The engine rejects documents whose version it does not implement, naming the supported version(s) in the error. |
 | `name` / `description` | Identification for logs, events, and the completion payload. |
-| `parameters` | Declared invocation parameters. Each has a `type` (`string`, `integer`, `number`, `boolean`, `duration`), and either `required: true` or a `default`. Values supplied at invocation are type-checked against the declaration; missing required parameters fail validation before anything runs. Available to expressions as `params.*`. |
+| `parameters` | Declared invocation parameters. Each has a `type` (`string`, `integer`, `number`, `boolean`, `duration`), and either `required: true` or a `default`. Values supplied at invocation are type-checked against the declaration; missing required parameters fail validation before anything runs. Available to expressions as `params.*`. Names beginning with `_` are reserved for the engine — declaring one is a validation error. |
 | `estimated_duration` / `max_duration` | The acknowledgment durations returned to `rp` from `/invoke` (humantime strings). Optional; engine defaults apply when absent (see [Invocation](#invocation)). |
 | `triggers` | Document-global reactive rules, evaluated alongside the procedure tree. |
 | `root` | The procedure tree — a single container instruction. |
@@ -104,7 +108,8 @@ A workflow document is a single JSON file. Top-level structure:
 
 The v1 instruction vocabulary. Every instruction is a JSON object with
 exactly one *discriminant* key (`tool`, `sequence`, `repeat`, `if`, `set`,
-`try`, `wait`, `log`) plus the optional common keys `id` (a string used in
+`try`, `fail`, `wait`, `log` — plus `script`, reserved but rejected in v1)
+plus the optional common keys `id` (a string used in
 logs and error messages) and `once` (see
 [Re-entrancy Contract](#re-entrancy-contract)). Unknown keys are a
 validation error — misspellings must not silently no-op.
@@ -123,8 +128,8 @@ validation error — misspellings must not silently no-op.
   strings (humantime durations, filter names) unambiguous and lets static
   validation type-check every literal argument against the tool's JSON
   Schema.
-- The tool's structured result becomes `result` for the **next** instruction
-  in the same block (see [Expressions](#expressions)).
+- The tool's structured result becomes `result` for the instructions that
+  follow (see [`result` scoping](#result-scoping)).
 - Optional `retry`: on tool error, retry up to `max_attempts` total attempts
   with a fixed `backoff` delay between attempts. Default: no retry.
 - A tool error (after retries) raises a workflow error that propagates
@@ -159,10 +164,12 @@ such as `capture`-while-guiding).
 - Exactly one of `until` (expression, checked **after** each pass), `while`
   (expression, checked **before** each pass), or `count` (integer or
   `$expr`) is required.
-- `max_iterations` is **required** alongside `until`/`while` — unbounded
-  loops are a validation error. When `max_iterations` is exhausted without
-  the condition being met, the loop *completes* and sets
-  `result.converged = false` (plus `result.iterations`); the document
+- `max_iterations` (integer or `$expr` — evaluated once at loop entry, and
+  a workflow error unless it yields a positive integer) is **required**
+  alongside `until`/`while` — unbounded loops are a validation error. When
+  `max_iterations` is exhausted without the condition being met, the loop
+  still *completes*, with `result.converged = false` (see
+  [`result` scoping](#result-scoping)); the document
   decides whether that is fatal (an `if` + `fail` pattern) or a warning
   (`log`). This mirrors `calibrator-flats`' non-converged-exposure warning
   behavior.
@@ -183,6 +190,8 @@ such as `capture`-while-guiding).
 ```
 
 - Keys must be `session.*` paths; values are always expressions.
+- All values are evaluated before any key is written — a `set` cannot read
+  its own writes.
 - `set` is the **only** way state crosses instruction boundaries or survives
   a crash. `result` is transient by design — anything worth keeping is
   copied to the blackboard explicitly, which makes the resume semantics
@@ -209,9 +218,17 @@ such as `capture`-while-guiding).
   it re-raises via `fail`. In `catch` and `finally` (on the error path),
   expressions can read `error.message`, `error.instruction_id`, and
   `error.tool` (null when the error was not a tool error).
-- `{ "fail": { "message": "<expression or literal string>" } }` is accepted
-  inside `catch`/`then`/`else`/anywhere an instruction is, and raises a
-  workflow error deliberately.
+
+#### `fail` — raise a workflow error
+
+```jsonc
+{ "fail": { "message": "'exposure never converged'" } }
+```
+
+Accepted anywhere an instruction is (`catch`, `then`, `else`, a `repeat`
+body, …) and raises a workflow error deliberately; inside `catch` it
+re-raises, propagating the failure outward. `message` is an expression —
+quote it (as above) for a fixed string.
 
 #### `wait` — pause at a safe point
 
@@ -247,6 +264,27 @@ expressions, rendered into the structured log record.
 documents written against a future version fail comprehensibly on an old
 engine.
 
+### `result` scoping
+
+`result` is always the structured result of the most recently completed
+result-producing instruction on the current execution path. Concretely:
+
+- `tool` calls produce their structured result. A completed `repeat`
+  produces a loop summary — `result.iterations`, plus `result.converged`
+  for `until`/`while` loops (`true` when the condition was met, `false`
+  when `max_iterations` ran out).
+- `set`, `log`, and `wait` produce no result and leave `result` unchanged;
+  containers (`sequence`, `if`, `try`) leave whatever the last instruction
+  executed inside them left. In particular, the first instruction of a
+  `then`/`else`/`catch`/`finally` block sees the `result` that was in
+  scope when the branch was taken — an `if` condition reads `result`
+  without consuming it.
+- A `repeat`'s `until` expression is evaluated with the `result` left by
+  the pass that just completed; `while` is evaluated with the `result` in
+  scope before the upcoming pass.
+- `result` is `null` at the start of a session and at the start of a
+  trigger `do` block.
+
 ### Triggers
 
 Triggers are the reactive overlay: cross-cutting rules that fire while the
@@ -256,20 +294,29 @@ procedure tree runs. They are declared at the document top level.
 {
   "id": "refocus-on-hfr-degradation",
   "on": { "event": "exposure_complete" },
-  "when": "event.hfr != null && session.last_focus_hfr != null && event.hfr > session.last_focus_hfr * 1.2",
+  "when": "session.last_focus_hfr != null",
   "while": "session.imaging == true",
   "cooldown": "15m",
   "do": [
-    { "tool": "auto_focus", "args": { /* … */ } },
-    { "set": { "session.last_focus_hfr": "result.best_hfr" } }
+    { "tool": "measure_basic", "args": { "document_id": { "$expr": "event.document_id" } } },
+    { "if": "result.hfr != null && result.hfr > session.last_focus_hfr * 1.2",
+      "then": [
+        { "tool": "auto_focus", "args": { /* … */ } },
+        { "set": { "session.last_focus_hfr": "result.best_hfr" } } ] }
   ]
 }
 ```
 
+(`exposure_complete`'s payload carries `document_id` / `file_path` only —
+`rp.md` § Events — so the trigger measures HFR itself before deciding; the
+`when` gate keeps it idle until the first `auto_focus` has seeded
+`session.last_focus_hfr`, and `cooldown` bounds how often the measurement
+itself runs.)
+
 | Field | Meaning |
 |-------|---------|
 | `id` | Required, unique within the document. Names the trigger in logs and in the `session._triggers.*` bookkeeping state. |
-| `on` | The source. `{ "event": "<rp event name>" }` — an envelope from the SSE stream; the envelope's `payload` becomes `event.*`. `{ "poll": { "tool": "<name>", "args": { … }, "interval": "30s" } }` — the engine calls the tool on the interval and the result becomes `event.*`. `{ "event": "correction_requested" }` — the synthetic source fired when a tool result carries a correction (payload: `event.action`, `event.reason`, `event.urgency`, `event.source`). |
+| `on` | The source. `{ "event": "<rp event name>" }` — an envelope from the SSE stream; the envelope's `payload` becomes `event.*`. `{ "poll": { "tool": "<name>", "args": { … }, "interval": "30s" } }` — the engine calls the tool on the interval and the result becomes `event.*`. `{ "event": "correction_requested" }` — the synthetic source fired when a tool result carries a correction (payload: `event.action`, `event.reason`, `event.source`, plus engine-synthesized `event.delivery` — `"immediate"` when the tool result was `aborted`, `"after_current"` for `pending_correction`). |
 | `when` | Optional expression over `event.*` + the usual namespaces. The trigger fires only when it evaluates to `true`. Absent = always fire. |
 | `while` | Optional expression gate evaluated at fire time; lets a document scope a trigger to a phase via a blackboard flag (e.g. set `session.imaging = true` when the capture loop starts). This is the v1 substitute for container-scoped triggers, which are deferred. |
 | `cooldown` | Optional minimum interval between firings (humantime). Last-fired timestamps live in the blackboard, so cooldowns survive resume. |
@@ -299,9 +346,9 @@ Expressions are strings in a small, pure, CEL-style language. They appear in
 
 | Namespace | Contents | Lifetime |
 |-----------|----------|----------|
-| `params.*` | Invocation parameters after defaulting/type-check. | Session (immutable). |
+| `params.*` | Invocation parameters after defaulting/type-check; on recovery invocations the engine also injects `params._recovery.*` ([Re-entrancy Contract](#re-entrancy-contract)). | Session (immutable). |
 | `session.*` | The blackboard. | Session (persisted, survives crash/resume). |
-| `result.*` | Structured result of the immediately preceding instruction in the same block (`null` for the first instruction of a block). | One instruction. |
+| `result.*` | Structured result of the most recent result-producing instruction ([`result` scoping](#result-scoping)). | Until the next result-producing instruction. |
 | `event.*` | The triggering envelope payload (in trigger `when`/`do`) or poll result. | One trigger firing. |
 | `error.*` | `message`, `instruction_id`, `tool` inside `catch`/`finally`. | One error scope. |
 
@@ -316,8 +363,8 @@ Expressions are strings in a small, pure, CEL-style language. They appear in
   `humantime(secs)` (f64 seconds → humantime string, for building tool
   args), `has(session.x)` (path exists and is non-null),
   `seconds_until("<RFC3339>")` (evaluated against the engine's clock at
-  evaluation time — the single sanctioned time observation, needed for
-  dawn/flip math).
+  evaluation time — the one sanctioned exception to tenet 4's purity rule,
+  needed for dawn/flip math).
 - **No** loops, user function definitions, assignment, tool calls, string
   interpolation, or regular expressions. Anything effectful is an
   instruction; anything algorithmic beyond this belongs in a built-in `rp`
@@ -327,10 +374,13 @@ Expressions are strings in a small, pure, CEL-style language. They appear in
   that instruction. Authors guard with `has()` / `!= null` (as the trigger
   example above does). This is deliberate: silent `null` propagation in a
   system that moves telescopes is worse than a loud 2 a.m. error.
-- Division by zero raises. There is no implicit type coercion.
+- Division or remainder by zero raises. There is no implicit type
+  coercion.
 
-The concrete implementation (the `cel-interpreter` crate vs a hand-rolled
-parser) is a Phase B spike; the semantics above are the contract either way.
+The concrete implementation (reusing the `cel` crate's parser, an
+`oxc_parser` JS-expression subset, or a hand-rolled parser — the evaluator
+is hand-written in every arm; see the plan's Phase B) is a Phase B spike;
+the semantics above are the contract either way.
 
 ## Blackboard and Persistence
 
@@ -423,8 +473,13 @@ smell the authoring docs will warn about.
 
 The engine consumes `rp`'s SSE stream (`/api/events/subscribe`) for trigger
 sources. The SSE `id` is the envelope's `event_seq`; on reconnect the engine
-sends `Last-Event-ID` so no envelope is missed across a stream drop
-(`rp.md` § Real-Time Stream). Events that arrive while no trigger matches
+sends `Last-Event-ID`, and replay is exact within `rp`'s retention window
+(the most recent 512 envelopes — `rp.md` § Real-Time Stream). If the engine
+was gone long enough that its cursor was evicted, the stream leads with a
+`stream_gap` event instead: the engine logs the gap at `info!` and simply
+continues — poll triggers re-observe current state on their next cycle, and
+the re-entrancy contract already assumes events can be missed across an
+outage. Events that arrive while no trigger matches
 are discarded — the engine keeps no event history. The stream URL is derived
 from the invocation's `mcp_server_url` origin unless overridden in
 configuration.
@@ -450,6 +505,8 @@ purely a *consumer* of the stream plus an MCP *client*.
 }
 ```
 
+- `config` is this plugin's registered `config` object, forwarded verbatim
+  by `rp` (`rp.md` § Orchestrator Invocation Protocol).
 - `config.workflow` names a document: `<name>.json` resolved in the
   configured `workflows_dir`, or an absolute path. Resolution outside
   `workflows_dir` for relative names is rejected.
@@ -475,7 +532,8 @@ Three layers, all sharing one implementation:
 
 1. **Schema validation** — the document against
    `schema/workflow-v1.schema.json`: structure, discriminant keys, unknown
-   keys, unique trigger `id`s / `once` keys, loop-bound requirements,
+   keys, reserved names (`_`-prefixed parameters, `session._*` writes),
+   unique trigger `id`s / `once` keys, loop-bound requirements,
    expression fields parse-checked.
 2. **Catalog validation** (requires `rp`) — every `tool` node's name exists
    in `tools/list`; literal args type-check against the tool's parameter
@@ -488,7 +546,11 @@ Three layers, all sharing one implementation:
 `POST /validate` with `{ "document": { … } }` (or `{ "workflow": "<name>" }`)
 runs layers 1–2 and returns a structured list of errors with JSON-Pointer
 locations — the hook for CI on shared workflow repositories, the future UI,
-and LLM authoring loops. `/invoke` runs all three layers before executing.
+and LLM authoring loops. Standalone `/validate` reaches `rp` through the
+configured `mcp_server_url`; when that is unset or `rp` is unreachable, it
+runs layer 1 only and marks catalog validation as skipped in the response.
+`/invoke`, which always carries a live `mcp_server_url`, runs all three
+layers before executing.
 
 ## Configuration
 
@@ -499,6 +561,7 @@ and LLM authoring loops. `/invoke` runs all three layers before executing.
   "port": 11171,
   "workflows_dir": "/var/lib/rusty-photon/workflows",
   "state_dir": "/var/lib/rusty-photon/session-runner",
+  "mcp_server_url": null,       // rp MCP endpoint for standalone /validate only
   "events_url": null            // override; default derives from mcp_server_url origin
 }
 ```
@@ -508,6 +571,7 @@ and LLM authoring loops. `/invoke` runs all three layers before executing.
 | `port` | int | 11171 | HTTP listen port for `/invoke`, `/validate`, `/health` |
 | `workflows_dir` | path | required | Directory of workflow documents; first-party documents ship in the package |
 | `state_dir` | path | required | Blackboard persistence directory |
+| `mcp_server_url` | string or null | null | `rp` MCP endpoint used only by standalone `/validate` catalog validation; invocations always use the URL delivered in the `/invoke` payload |
 | `events_url` | string or null | null | Explicit SSE endpoint; null derives `<mcp origin>/api/events/subscribe` |
 
 ## Example Documents
@@ -556,7 +620,7 @@ for a single filter for brevity:
                                            "duration": { "$expr": "humantime(session.duration)" } } },
             { "tool": "compute_image_stats", "args": { "document_id": { "$expr": "result.document_id" } } },
             { "set": { "session.median_adu": "result.median_adu",
-                       "session.duration": "clamp(session.duration * (session.target_adu / max(result.median_adu, 1.0)), session.exp_min, session.exp_max)" } } ] },
+                       "session.duration": "clamp(result.median_adu == 0 ? session.duration * 2 : session.duration * (session.target_adu / result.median_adu), session.exp_min, session.exp_max)" } } ] },
         { "if": "result.converged == false",
           "then": [ { "log": { "level": "info", "message": "exposure did not converge",
                                "values": { "filter": "params.filter" } } } ] },
@@ -591,11 +655,13 @@ behavioral spec either way.)
   "triggers": [
     { "id": "refocus-on-hfr",
       "on": { "event": "exposure_complete" },
-      "when": "has(session.last_focus_hfr) && event.hfr != null && event.hfr > session.last_focus_hfr * 1.2",
+      "when": "has(session.last_focus_hfr)",
       "while": "session.imaging == true",
       "cooldown": "15m",
-      "do": [ { "tool": "auto_focus", "args": { /* … */ } },
-              { "set": { "session.last_focus_hfr": "result.best_hfr" } } ] },
+      "do": [ { "tool": "measure_basic", "args": { "document_id": { "$expr": "event.document_id" } } },
+              { "if": "result.hfr != null && result.hfr > session.last_focus_hfr * 1.2",
+                "then": [ { "tool": "auto_focus", "args": { /* … */ } },
+                          { "set": { "session.last_focus_hfr": "result.best_hfr" } } ] } ] },
     { "id": "flip-when-due",
       "on": { "poll": { "tool": "get_meridian_status", "interval": "60s" } },
       "when": "event.time_to_flip_seconds < 300",
@@ -610,12 +676,14 @@ behavioral spec either way.)
     { "repeat": { "while": "session.session_over != true", "max_iterations": 1000 },
       "body": [
         { "tool": "get_next_target" },
-        { "if": "result.reason == 'WaitForTwilight'",
-          "then": [ { "wait": { "duration": "5m" } } ],
-          "else": [ { "if": "result.reason == 'EndOfSession'",
-              "then": [ { "set": { "session.session_over": "true" } } ],
+        { "if": "result.reason == 'end_of_session'",
+          "then": [ { "set": { "session.session_over": "true" } } ],
+          "else": [ { "if": "result.target == null",
+              "then": [ { "wait": { "duration": "5m" } } ],  // wait_for_twilight, all_below_min_altitude, …
               "else": [
-                { "set": { "session.target_name": "result.target", "session.target_ra": "result.ra", "session.target_dec": "result.dec" } },
+                { "set": { "session.target_name": "result.target.name",
+                           "session.target_ra": "result.target.ra_hours",
+                           "session.target_dec": "result.target.dec_degrees" } },
                 /* slew → center_on_target → auto_focus → start_guiding,
                    set session.imaging = true, capture + record_exposure loop
                    re-asking get_next_target after each frame; dither every
@@ -640,7 +708,7 @@ persisted progress.
 | Expression error (null arithmetic, division by zero) | Workflow error at that instruction, same propagation as tool errors. |
 | `wait` timeout | Workflow error. |
 | Loop `max_iterations` exhausted (`until`/`while`) | Loop completes with `result.converged = false`; not an error. |
-| SSE stream drops | Reconnect with `Last-Event-ID`; no envelopes lost; poll triggers unaffected. |
+| SSE stream drops | Reconnect with `Last-Event-ID`; exact replay within `rp`'s 512-event retention; on `stream_gap`, log and continue (§ Event Subscription). |
 | Poll-trigger tool call fails | `debug!` log, skip cycle. |
 | MCP session terminated by `rp` (safety) | Best-effort `finally`, persist blackboard, exit without completion; await re-invocation. |
 | Engine crash / power failure | Blackboard reflects every completed `set`; recovery invocation re-executes per the re-entrancy contract. |
@@ -688,8 +756,8 @@ Testing follows [`docs/skills/testing.md`](../skills/testing.md).
 ### Unit tests
 
 - Document parsing and validation: every instruction type, every schema
-  error (unknown key, missing loop bound, duplicate trigger id, `script`
-  reservation message).
+  error (unknown key, missing loop bound, duplicate trigger id, reserved
+  names, `script` reservation message).
 - Expression evaluation: every operator/function, every namespace, null
   handling, division by zero — table-driven, exhaustive.
 - Engine semantics against a mock MCP-client trait: sequencing, `result`

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1,0 +1,734 @@
+# session-runner — Generic Workflow Orchestrator Design
+
+## Overview
+
+`session-runner` is an orchestrator plugin that executes **workflow
+documents** — declarative JSON descriptions of an imaging session — against
+`rp`'s MCP tool catalog. One generic engine replaces the need for a
+hand-written Rust orchestrator per session type: the deep-sky night, the
+flat-calibration run, and the twilight sky-flat session become documents,
+not binaries. Rust orchestrators (such as today's `calibrator-flats`)
+remain first-class citizens of the unchanged plugin protocol; the DSL is an
+addition, not a replacement.
+
+Decision record and phase plan:
+[`docs/plans/workflow-dsl.md`](../plans/workflow-dsl.md).
+
+### Tenets
+
+1. **Documents describe procedure and reaction, never choice or safety.**
+   Target/filter selection is delegated to `rp`'s planner tools; safety
+   enforcement belongs exclusively to `rp` and cannot be expressed, delayed,
+   or overridden by a document.
+2. **Position is derived, not stored.** The engine never persists "where it
+   is" in the tree. Resume re-executes the document from the root against
+   the persisted blackboard and live device state; documents are written
+   re-entrant (see [Re-entrancy Contract](#re-entrancy-contract)).
+3. **Everything validates before anything moves.** A document is checked
+   against the workflow schema, and every tool call in it is checked against
+   `rp`'s live tool catalog, before the first instruction runs. Authoring
+   errors surface at load, at the `/validate` endpoint, or at session start
+   — never mid-night.
+4. **Expressions are pure.** The bounded expression language reads document
+   state and computes values. It cannot perform I/O, call tools, loop, or
+   observe wall-clock time. Anything effectful is an instruction.
+5. **The document format is the API.** The published JSON Schema is the
+   contract for hand-authors, the future `ui-htmx` editor, and LLM
+   generation alike. The engine's internals may change; the format versions
+   deliberately.
+
+## Architecture
+
+`session-runner` is a standalone HTTP service following the orchestrator
+plugin protocol defined in [`rp.md`](rp.md): `rp` POSTs `/invoke` when a
+session starts, the plugin connects back to `rp`'s MCP server and drives the
+session with tool calls, and posts a completion when it finishes. In
+addition, `session-runner` subscribes to `rp`'s SSE event stream to feed
+trigger evaluation.
+
+```
+  rp (equipment gateway)              session-runner (generic orchestrator)
+  ┌─────────────────────┐             ┌──────────────────────────────┐
+  │                     │ POST /invoke│  load document               │
+  │  session start ─────┼────────────►│  validate vs schema + tools  │
+  │                     │             │  load/restore blackboard     │
+  │  MCP server    ◄────┼─────────────┤  execute procedure tree      │
+  │  /mcp               │  tool calls │   ├─ instructions            │
+  │                     │             │   └─ trigger actions         │
+  │  SSE            ────┼────────────►│  evaluate triggers           │
+  │  /api/events/       │   events    │                              │
+  │  subscribe          │             │                              │
+  │                     │             │                              │
+  │  REST API      ◄────┼─────────────┤  post completion             │
+  │  /api/plugins/      │  completion │                              │
+  │  {wf_id}/complete   │             │                              │
+  └─────────────────────┘             └──────────────────────────────┘
+```
+
+### Port
+
+11171 (configurable) — in the orchestrator-plugin range next to
+`calibrator-flats` (11170).
+
+## Workflow Documents
+
+A workflow document is a single JSON file. Top-level structure:
+
+```jsonc
+{
+  "version": 1,
+  "name": "deep-sky",
+  "description": "Classic multi-target deep-sky imaging session",
+  "parameters": {
+    "camera_id":   { "type": "string", "required": true },
+    "focuser_id":  { "type": "string", "required": true },
+    "dither_every": { "type": "integer", "default": 3 }
+  },
+  "estimated_duration": "8h",
+  "max_duration": "12h",
+  "triggers": [ /* trigger objects — see Triggers */ ],
+  "root": { "sequence": [ /* instructions — see Instructions */ ] }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `version` | Format version. The engine rejects documents whose version it does not implement, naming the supported version(s) in the error. |
+| `name` / `description` | Identification for logs, events, and the completion payload. |
+| `parameters` | Declared invocation parameters. Each has a `type` (`string`, `integer`, `number`, `boolean`, `duration`), and either `required: true` or a `default`. Values supplied at invocation are type-checked against the declaration; missing required parameters fail validation before anything runs. Available to expressions as `params.*`. |
+| `estimated_duration` / `max_duration` | The acknowledgment durations returned to `rp` from `/invoke` (humantime strings). Optional; engine defaults apply when absent (see [Invocation](#invocation)). |
+| `triggers` | Document-global reactive rules, evaluated alongside the procedure tree. |
+| `root` | The procedure tree — a single container instruction. |
+
+### Instructions
+
+The v1 instruction vocabulary. Every instruction is a JSON object with
+exactly one *discriminant* key (`tool`, `sequence`, `repeat`, `if`, `set`,
+`try`, `wait`, `log`) plus the optional common keys `id` (a string used in
+logs and error messages) and `once` (see
+[Re-entrancy Contract](#re-entrancy-contract)). Unknown keys are a
+validation error — misspellings must not silently no-op.
+
+#### `tool` — call an MCP tool
+
+```jsonc
+{ "tool": "capture",
+  "args": { "camera_id": { "$expr": "params.camera_id" },
+            "duration": "300s" },
+  "retry": { "max_attempts": 3, "backoff": "10s" } }
+```
+
+- `args` values are **literal JSON by default**. A value that must be
+  computed is wrapped as `{ "$expr": "<expression>" }`. This keeps literal
+  strings (humantime durations, filter names) unambiguous and lets static
+  validation type-check every literal argument against the tool's JSON
+  Schema.
+- The tool's structured result becomes `result` for the **next** instruction
+  in the same block (see [Expressions](#expressions)).
+- Optional `retry`: on tool error, retry up to `max_attempts` total attempts
+  with a fixed `backoff` delay between attempts. Default: no retry.
+- A tool error (after retries) raises a workflow error that propagates
+  outward through enclosing `try` instructions (see `try`), ultimately
+  failing the workflow.
+- If the tool result carries a **correction** (`rp` returns
+  `pending_correction` on natural completion or `status: "aborted"` +
+  `correction` on an immediate correction, per `rp.md` § Corrections), the
+  engine fires the synthetic `correction_requested` trigger source (see
+  [Triggers](#triggers)) with the correction as the event payload, then
+  continues. An `aborted` tool result is **not** a workflow error — the
+  document decides how to react via a trigger.
+
+#### `sequence` — ordered container
+
+```jsonc
+{ "sequence": [ /* instructions, executed in order */ ] }
+```
+
+There is deliberately no parallel container in v1 (research finding:
+marginal value; device-level concurrency already lives inside `rp` tools
+such as `capture`-while-guiding).
+
+#### `repeat` — loop
+
+```jsonc
+{ "repeat": { "until": "abs(result.median_adu - session.target_adu) / session.target_adu <= 0.05",
+              "max_iterations": 10 },
+  "body": [ /* instructions */ ] }
+```
+
+- Exactly one of `until` (expression, checked **after** each pass), `while`
+  (expression, checked **before** each pass), or `count` (integer or
+  `$expr`) is required.
+- `max_iterations` is **required** alongside `until`/`while` — unbounded
+  loops are a validation error. When `max_iterations` is exhausted without
+  the condition being met, the loop *completes* and sets
+  `result.converged = false` (plus `result.iterations`); the document
+  decides whether that is fatal (an `if` + `fail` pattern) or a warning
+  (`log`). This mirrors `calibrator-flats`' non-converged-exposure warning
+  behavior.
+
+#### `if` — conditional
+
+```jsonc
+{ "if": "event.hfr > session.last_focus_hfr * 1.2",
+  "then": [ /* instructions */ ],
+  "else": [ /* optional */ ] }
+```
+
+#### `set` — write the blackboard
+
+```jsonc
+{ "set": { "session.last_focus_hfr": "result.best_hfr",
+           "session.target_adu": "result.max_adu * params.target_fraction" } }
+```
+
+- Keys must be `session.*` paths; values are always expressions.
+- `set` is the **only** way state crosses instruction boundaries or survives
+  a crash. `result` is transient by design — anything worth keeping is
+  copied to the blackboard explicitly, which makes the resume semantics
+  visible in the document itself.
+- Each `set` persists the blackboard atomically before the next instruction
+  runs (see [Blackboard](#blackboard-and-persistence)).
+
+#### `try` — cleanup and error handling
+
+```jsonc
+{ "try": [ /* body */ ],
+  "catch": [ /* optional: runs on body error; error.* in scope */ ],
+  "finally": [ /* optional: always runs */ ] }
+```
+
+- Semantics follow the `calibrator-flats` cleanup guard: `finally` runs
+  whether the body succeeded, failed, or was cancelled by safety — with the
+  caveat that after a safety cancellation `rp` has already secured the
+  equipment and torn down the MCP session, so `finally` instructions that
+  call tools will themselves fail; the engine runs them best-effort, logs
+  each failure, and does not let a `finally` failure mask the original
+  error.
+- `catch` handles the error (the workflow continues after the `try`) unless
+  it re-raises via `fail`. In `catch` and `finally` (on the error path),
+  expressions can read `error.message`, `error.instruction_id`, and
+  `error.tool` (null when the error was not a tool error).
+- `{ "fail": { "message": "<expression or literal string>" } }` is accepted
+  inside `catch`/`then`/`else`/anywhere an instruction is, and raises a
+  workflow error deliberately.
+
+#### `wait` — pause at a safe point
+
+```jsonc
+{ "wait": { "duration": "30s" } }
+{ "wait": { "until_event": "guide_settled", "timeout": "5m" } }
+{ "wait": { "until": "seconds_until(session.flip_at) <= 0", "poll_interval": "10s", "timeout": "2h" } }
+```
+
+- Exactly one of `duration`, `until_event` (an `rp` event name), or `until`
+  (expression re-evaluated every `poll_interval`, default `"10s"`).
+- `until_event` and `until` require a `timeout`; expiry raises a workflow
+  error. Triggers keep firing during a `wait` — a `wait` is one long safe
+  point.
+
+#### `log` — operator-visible message
+
+```jsonc
+{ "log": { "level": "info",
+           "message": "exposure converged",
+           "values": { "duration": "session.duration" } } }
+```
+
+`level` is `debug` (default) or `info`, matching the workspace logging rule
+(`info` only where the operator derives clear value). `values` entries are
+expressions, rendered into the structured log record.
+
+#### Reserved: `script`
+
+`{ "script": … }` is **reserved** for a future sandboxed Luau handler node
+(decision D3 in the plan). v1 validation rejects it with an explicit
+"reserved for a future format version" error rather than "unknown key", so
+documents written against a future version fail comprehensibly on an old
+engine.
+
+### Triggers
+
+Triggers are the reactive overlay: cross-cutting rules that fire while the
+procedure tree runs. They are declared at the document top level.
+
+```jsonc
+{
+  "id": "refocus-on-hfr-degradation",
+  "on": { "event": "exposure_complete" },
+  "when": "event.hfr != null && session.last_focus_hfr != null && event.hfr > session.last_focus_hfr * 1.2",
+  "while": "session.imaging == true",
+  "cooldown": "15m",
+  "do": [
+    { "tool": "auto_focus", "args": { /* … */ } },
+    { "set": { "session.last_focus_hfr": "result.best_hfr" } }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `id` | Required, unique within the document. Names the trigger in logs and in the `session._triggers.*` bookkeeping state. |
+| `on` | The source. `{ "event": "<rp event name>" }` — an envelope from the SSE stream; the envelope's `payload` becomes `event.*`. `{ "poll": { "tool": "<name>", "args": { … }, "interval": "30s" } }` — the engine calls the tool on the interval and the result becomes `event.*`. `{ "event": "correction_requested" }` — the synthetic source fired when a tool result carries a correction (payload: `event.action`, `event.reason`, `event.urgency`, `event.source`). |
+| `when` | Optional expression over `event.*` + the usual namespaces. The trigger fires only when it evaluates to `true`. Absent = always fire. |
+| `while` | Optional expression gate evaluated at fire time; lets a document scope a trigger to a phase via a blackboard flag (e.g. set `session.imaging = true` when the capture loop starts). This is the v1 substitute for container-scoped triggers, which are deferred. |
+| `cooldown` | Optional minimum interval between firings (humantime). Last-fired timestamps live in the blackboard, so cooldowns survive resume. |
+| `once` | Optional boolean: fire at most once per session (recorded in the blackboard). |
+| `do` | Instructions, same vocabulary as the tree (nested triggers excepted). |
+
+**Interleaving contract (safe points).** Trigger `do` blocks never preempt
+an in-flight instruction. When a trigger fires, its action is queued; queued
+actions run at the next **safe point** — after the current instruction
+completes, or continuously during a `wait`. Multiple queued triggers run in
+document order. A trigger whose action is queued or running does not queue
+again. Only `rp` (safety) and Sentinel (watchdog) ever abort an in-flight
+operation; a document that wants "stop the current exposure when X" reacts
+to the *correction* `rp` delivers rather than aborting on its own.
+
+**Poll lifecycle.** Poll triggers start when the workflow starts and stop
+when it completes or is cancelled. A poll whose tool call fails logs at
+`debug!` and skips that cycle — a flaky poll must not kill the session.
+
+### Expressions
+
+Expressions are strings in a small, pure, CEL-style language. They appear in
+`when` / `while` / `until` / `if` / `set` values / `$expr` wrappers /
+`fail.message` / `log.values`.
+
+**Namespaces** (read-only except via `set`):
+
+| Namespace | Contents | Lifetime |
+|-----------|----------|----------|
+| `params.*` | Invocation parameters after defaulting/type-check. | Session (immutable). |
+| `session.*` | The blackboard. | Session (persisted, survives crash/resume). |
+| `result.*` | Structured result of the immediately preceding instruction in the same block (`null` for the first instruction of a block). | One instruction. |
+| `event.*` | The triggering envelope payload (in trigger `when`/`do`) or poll result. | One trigger firing. |
+| `error.*` | `message`, `instruction_id`, `tool` inside `catch`/`finally`. | One error scope. |
+
+**Semantics:**
+
+- Types: `null`, boolean, number (f64), string, plus JSON arrays/objects
+  from tool results (member access and indexing only).
+- Operators: `== != < <= > >=`, `+ - * / %`, `&& || !`, `?:` (conditional),
+  parentheses.
+- Functions (v1): `abs`, `min`, `max`, `clamp(x, lo, hi)`, `floor`, `ceil`,
+  `round`, `seconds("1m30s")` (humantime string → f64 seconds),
+  `humantime(secs)` (f64 seconds → humantime string, for building tool
+  args), `has(session.x)` (path exists and is non-null),
+  `seconds_until("<RFC3339>")` (evaluated against the engine's clock at
+  evaluation time — the single sanctioned time observation, needed for
+  dawn/flip math).
+- **No** loops, user function definitions, assignment, tool calls, string
+  interpolation, or regular expressions. Anything effectful is an
+  instruction; anything algorithmic beyond this belongs in a built-in `rp`
+  tool or (future) a `script` node.
+- Accessing a missing path yields `null`; `null` in arithmetic or comparison
+  (other than `==`/`!=`) raises an expression error → workflow error at
+  that instruction. Authors guard with `has()` / `!= null` (as the trigger
+  example above does). This is deliberate: silent `null` propagation in a
+  system that moves telescopes is worse than a loud 2 a.m. error.
+- Division by zero raises. There is no implicit type coercion.
+
+The concrete implementation (the `cel-interpreter` crate vs a hand-rolled
+parser) is a Phase B spike; the semantics above are the contract either way.
+
+## Blackboard and Persistence
+
+The blackboard (`session.*`) is the workflow's only mutable state. It is a
+JSON object persisted to `<state_dir>/<session_id>.json` with the workspace
+atomic-write pattern (sibling temp file, fsync, rename, fsync parent
+directory — same as `rp`'s exposure documents).
+
+Writes happen after **every** mutation: each `set`, each `once` completion
+marker, each trigger bookkeeping update (cooldown timestamps, once flags).
+Mutations are small and infrequent (human-scale session cadence), so write
+amplification is a non-issue; the invariant "the file always reflects every
+completed `set`" is what makes tenet 2 sound.
+
+Engine bookkeeping lives under reserved keys the schema forbids documents
+from setting directly: `session._once.*` (completed once-markers),
+`session._triggers.<id>.*` (last-fired, fired-once flags).
+
+The file is deleted when a session completes and the completion has been
+acknowledged by `rp`; a leftover file at `/invoke` time for a **new**
+session (no `recovery` context, different `session_id`) is ignored and
+replaced.
+
+## Re-entrancy Contract
+
+Resume is re-execution: on a recovery invocation, the engine reloads the
+blackboard and runs the document from the root. For this to continue the
+session rather than repeat it, documents must be **re-entrant**:
+
+> Running the document from the top with the persisted blackboard and the
+> current device state must converge to *continuing* the session, not
+> redoing completed work.
+
+The format provides three tools for this, in preference order:
+
+1. **Dispatch-driven loops.** A capture loop that asks `get_next_target`
+   and records progress with `record_exposure` is naturally re-entrant —
+   `rp`'s persisted progress counters *are* the resume state. This is the
+   ecosystem lesson (Ekos counts frames on disk; Target Scheduler keeps a
+   DB) applied through `rp`'s planner.
+2. **Idempotent procedure.** Startup steps that are safe to repeat (cool
+   the camera to a setpoint, unpark, connect) simply re-run.
+3. **`once` markers** for steps that are *not* safe or sensible to repeat:
+
+   ```jsonc
+   { "tool": "calibrator_on", "args": { "calibrator_id": "flat-panel" },
+     "once": "panel-on" }
+   ```
+
+   When the instruction completes, `session._once["panel-on"]` is recorded;
+   on re-execution the instruction is skipped. `once` keys must be unique
+   within a document (validated). Use sparingly — a document that needs many
+   `once` markers is usually missing a dispatch loop.
+
+Resume behavior at `/invoke` with a non-null `recovery`:
+
+1. Reload the blackboard for `session_id`. A missing blackboard file is not
+   an error — the document starts with an empty `session.*` (first-run
+   equivalent), because a crash can predate the first `set`.
+2. Re-validate the document against the live tool catalog (equipment may
+   have changed across the outage).
+3. Log the recovery context (`reason`, interruption time) at `info!` and
+   expose it as `params._recovery.*` so a document *may* branch on it
+   (e.g. re-run `center_on_target` after any interruption) — but a correct
+   document does not need to.
+4. Execute from the root.
+
+## Safety Behavior
+
+On an unsafe transition `rp` — not `session-runner` — aborts exposures,
+stops guiding, parks the mount, and terminates the plugin's MCP session
+(per `rp.md` § Safety). From the engine's perspective: the in-flight tool
+call fails with a terminated-session error. The engine then:
+
+1. Stops trigger evaluation and abandons queued trigger actions.
+2. Runs any enclosing `finally` blocks best-effort (their tool calls will
+   fail; failures are logged, not raised).
+3. Persists the blackboard (already current, by the write-on-mutation
+   invariant).
+4. Exits the run **without** posting a completion — the session is not
+   over; `rp` re-invokes with recovery context on the safe transition, and
+   the [re-entrancy contract](#re-entrancy-contract) takes it from there.
+
+A document cannot subscribe to `safety_changed` to *countermand* any of
+this; it may subscribe to it (e.g. to `log`), but by the time the trigger
+would run, the MCP session is gone. Safety-reaction logic in documents is a
+smell the authoring docs will warn about.
+
+## Event Subscription
+
+The engine consumes `rp`'s SSE stream (`/api/events/subscribe`) for trigger
+sources. The SSE `id` is the envelope's `event_seq`; on reconnect the engine
+sends `Last-Event-ID` so no envelope is missed across a stream drop
+(`rp.md` § Real-Time Stream). Events that arrive while no trigger matches
+are discarded — the engine keeps no event history. The stream URL is derived
+from the invocation's `mcp_server_url` origin unless overridden in
+configuration.
+
+Webhook delivery is not used: `session-runner` registers no
+`subscribes_to`/`barrier_gates` and never blocks `rp`'s tool pipeline. It is
+purely a *consumer* of the stream plus an MCP *client*.
+
+## Invocation
+
+`rp` POSTs `/invoke` per the orchestrator protocol:
+
+```jsonc
+{
+  "workflow_id": "wf-550e8400-e29b-41d4",
+  "session_id": "session-2026-07-01",
+  "mcp_server_url": "http://localhost:11115/mcp",
+  "recovery": null,
+  "config": {
+    "workflow": "deep_sky",
+    "parameters": { "camera_id": "main-cam", "focuser_id": "main-foc" }
+  }
+}
+```
+
+- `config.workflow` names a document: `<name>.json` resolved in the
+  configured `workflows_dir`, or an absolute path. Resolution outside
+  `workflows_dir` for relative names is rejected.
+- `config.parameters` is validated against the document's `parameters`
+  declarations (unknown parameter names are errors; missing required
+  parameters are errors; types must match).
+- The acknowledgment returns the document's `estimated_duration` /
+  `max_duration` (engine defaults `"1h"` / `"14h"` when the document omits
+  them — `max_duration` must comfortably exceed a full night because `rp`
+  treats its expiry as plugin timeout).
+- Any validation failure (unknown document, schema violation, unknown tool,
+  bad parameters) is returned as the `/invoke` error response — the session
+  fails to start loudly, before any hardware moves.
+- Completion is posted to `POST /api/plugins/{workflow_id}/complete` with
+  `status` and a result payload: `{ "workflow": "<name>", "outcome":
+  "complete" | "failed", "error": "<message when failed>" }` plus any
+  values the document placed under `session.report.*` (the conventional
+  place for a document to accumulate its summary — e.g. frames per filter).
+
+## Validation
+
+Three layers, all sharing one implementation:
+
+1. **Schema validation** — the document against
+   `schema/workflow-v1.schema.json`: structure, discriminant keys, unknown
+   keys, unique trigger `id`s / `once` keys, loop-bound requirements,
+   expression fields parse-checked.
+2. **Catalog validation** (requires `rp`) — every `tool` node's name exists
+   in `tools/list`; literal args type-check against the tool's parameter
+   schema; required tool parameters are present (as literal or `$expr`);
+   `$expr` argument types are checked at runtime when the call is made.
+   Poll-trigger tools validate the same way.
+3. **Parameter validation** — invocation `parameters` against the
+   document's declarations.
+
+`POST /validate` with `{ "document": { … } }` (or `{ "workflow": "<name>" }`)
+runs layers 1–2 and returns a structured list of errors with JSON-Pointer
+locations — the hook for CI on shared workflow repositories, the future UI,
+and LLM authoring loops. `/invoke` runs all three layers before executing.
+
+## Configuration
+
+`session-runner`'s own config file (via `rusty-photon-config` conventions):
+
+```jsonc
+{
+  "port": 11171,
+  "workflows_dir": "/var/lib/rusty-photon/workflows",
+  "state_dir": "/var/lib/rusty-photon/session-runner",
+  "events_url": null            // override; default derives from mcp_server_url origin
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | int | 11171 | HTTP listen port for `/invoke`, `/validate`, `/health` |
+| `workflows_dir` | path | required | Directory of workflow documents; first-party documents ship in the package |
+| `state_dir` | path | required | Blackboard persistence directory |
+| `events_url` | string or null | null | Explicit SSE endpoint; null derives `<mcp origin>/api/events/subscribe` |
+
+## Example Documents
+
+Shipped first-party documents live in `services/session-runner/workflows/`.
+
+### `calibrator_flats.json` (the generalization proof, abridged)
+
+The port of the existing Rust orchestrator's algorithm
+([`calibrator-flats.md`](calibrator-flats.md)) — its BDD scenarios are the
+behavioral oracle. Filters are supplied as a parameterized plan; shown here
+for a single filter for brevity:
+
+```jsonc
+{
+  "version": 1,
+  "name": "calibrator-flats",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true },
+    "filter_wheel_id": { "type": "string", "required": true },
+    "calibrator_id": { "type": "string", "required": true },
+    "target_adu_fraction": { "type": "number", "default": 0.5 },
+    "tolerance": { "type": "number", "default": 0.05 },
+    "max_iterations": { "type": "integer", "default": 10 },
+    "initial_duration": { "type": "duration", "default": "1s" },
+    "filter": { "type": "string", "required": true },
+    "count": { "type": "integer", "required": true }
+  },
+  "triggers": [],
+  "root": { "sequence": [
+    { "tool": "get_camera_info", "args": { "camera_id": { "$expr": "params.camera_id" } } },
+    { "set": { "session.target_adu": "result.max_adu * params.target_adu_fraction",
+               "session.exp_min": "result.exposure_min",
+               "session.exp_max": "result.exposure_max",
+               "session.duration": "seconds(params.initial_duration)" } },
+    { "try": [
+        { "tool": "close_cover", "args": { "calibrator_id": { "$expr": "params.calibrator_id" } } },
+        { "tool": "calibrator_on", "args": { "calibrator_id": { "$expr": "params.calibrator_id" } } },
+        { "tool": "set_filter", "args": { "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+                                          "filter_name": { "$expr": "params.filter" } } },
+        { "id": "find-exposure",
+          "repeat": { "until": "abs(session.median_adu - session.target_adu) / session.target_adu <= params.tolerance",
+                      "max_iterations": { "$expr": "params.max_iterations" } },
+          "body": [
+            { "tool": "capture", "args": { "camera_id": { "$expr": "params.camera_id" },
+                                           "duration": { "$expr": "humantime(session.duration)" } } },
+            { "tool": "compute_image_stats", "args": { "document_id": { "$expr": "result.document_id" } } },
+            { "set": { "session.median_adu": "result.median_adu",
+                       "session.duration": "clamp(session.duration * (session.target_adu / max(result.median_adu, 1.0)), session.exp_min, session.exp_max)" } } ] },
+        { "if": "result.converged == false",
+          "then": [ { "log": { "level": "info", "message": "exposure did not converge",
+                               "values": { "filter": "params.filter" } } } ] },
+        { "repeat": { "count": { "$expr": "params.count" } },
+          "body": [
+            { "tool": "capture", "args": { "camera_id": { "$expr": "params.camera_id" },
+                                           "duration": { "$expr": "humantime(session.duration)" } } } ] }
+      ],
+      "finally": [
+        { "tool": "calibrator_off", "args": { "calibrator_id": { "$expr": "params.calibrator_id" } } },
+        { "tool": "open_cover", "args": { "calibrator_id": { "$expr": "params.calibrator_id" } } } ] }
+  ] }
+}
+```
+
+(The full document loops over a filter-plan array; array-valued parameters
+and per-element iteration are settled in Phase A schema work — either an
+array parameter with `repeat`-over-array, or one invocation per filter
+driven by `rp`'s plugin config. The single-filter core above is the
+behavioral spec either way.)
+
+### `deep_sky.json` (skeleton)
+
+```jsonc
+{
+  "version": 1,
+  "name": "deep-sky",
+  "parameters": { "camera_id": { "type": "string", "required": true },
+                  "focuser_id": { "type": "string", "required": true },
+                  "guide": { "type": "boolean", "default": true },
+                  "dither_every": { "type": "integer", "default": 3 } },
+  "triggers": [
+    { "id": "refocus-on-hfr",
+      "on": { "event": "exposure_complete" },
+      "when": "has(session.last_focus_hfr) && event.hfr != null && event.hfr > session.last_focus_hfr * 1.2",
+      "while": "session.imaging == true",
+      "cooldown": "15m",
+      "do": [ { "tool": "auto_focus", "args": { /* … */ } },
+              { "set": { "session.last_focus_hfr": "result.best_hfr" } } ] },
+    { "id": "flip-when-due",
+      "on": { "poll": { "tool": "get_meridian_status", "interval": "60s" } },
+      "when": "event.time_to_flip_seconds < 300",
+      "while": "session.imaging == true",
+      "do": [ /* stop guiding, slew (flip), re-center, re-focus, resume guiding */ ] },
+    { "id": "handle-correction",
+      "on": { "event": "correction_requested" },
+      "do": [ /* branch on event.action: focus → auto_focus, center → center_on_target */ ] }
+  ],
+  "root": { "sequence": [
+    /* startup: unpark, set_tracking, cool camera — idempotent, safe to re-run */
+    { "repeat": { "while": "session.session_over != true", "max_iterations": 1000 },
+      "body": [
+        { "tool": "get_next_target" },
+        { "if": "result.reason == 'WaitForTwilight'",
+          "then": [ { "wait": { "duration": "5m" } } ],
+          "else": [ { "if": "result.reason == 'EndOfSession'",
+              "then": [ { "set": { "session.session_over": "true" } } ],
+              "else": [
+                { "set": { "session.target_name": "result.target", "session.target_ra": "result.ra", "session.target_dec": "result.dec" } },
+                /* slew → center_on_target → auto_focus → start_guiding,
+                   set session.imaging = true, capture + record_exposure loop
+                   re-asking get_next_target after each frame; dither every
+                   params.dither_every frames; on target change: stop guiding,
+                   session.imaging = false, continue outer loop */ ] } ] } ] },
+    /* shutdown: stop_guiding, park */ ] }
+}
+```
+
+The dispatch loop (`get_next_target` after every frame + `record_exposure`
+progress in `rp`) is what makes this document re-entrant with **zero**
+`once` markers: after a crash, the same loop simply continues from the
+persisted progress.
+
+## Error Handling Summary
+
+| Failure | Behavior |
+|---------|----------|
+| Document fails schema/catalog/parameter validation | `/invoke` returns the error; nothing executes. |
+| Tool call errors (after `retry`) | Workflow error → nearest `catch`, `finally` blocks run; uncaught → workflow fails, completion posted with `outcome: "failed"`. |
+| Tool result carries a correction | Synthetic `correction_requested` trigger; not an error. |
+| Expression error (null arithmetic, division by zero) | Workflow error at that instruction, same propagation as tool errors. |
+| `wait` timeout | Workflow error. |
+| Loop `max_iterations` exhausted (`until`/`while`) | Loop completes with `result.converged = false`; not an error. |
+| SSE stream drops | Reconnect with `Last-Event-ID`; no envelopes lost; poll triggers unaffected. |
+| Poll-trigger tool call fails | `debug!` log, skip cycle. |
+| MCP session terminated by `rp` (safety) | Best-effort `finally`, persist blackboard, exit without completion; await re-invocation. |
+| Engine crash / power failure | Blackboard reflects every completed `set`; recovery invocation re-executes per the re-entrancy contract. |
+| Blackboard write fails | Workflow error (fail loud — continuing with unpersistable state would silently break resume). |
+
+## MVP Scope
+
+**In scope (v1):** the instruction vocabulary above; expressions per the
+semantics above; `event` / `poll` / `correction_requested` triggers with
+`when`/`while`/`once`/`cooldown`; blackboard persistence + re-derive resume;
+schema + catalog + parameter validation and `/validate`; SSE consumption
+with replay; the two shipped documents (`calibrator_flats.json`,
+`deep_sky.json`).
+
+**Deferred:** Luau `script` nodes (schema key reserved); container-scoped
+triggers (use `while` gates); parallel containers; sub-workflow
+imports/templates; a `ui-htmx` document editor; array-parameter ergonomics
+beyond what the flats port needs; retirement of the Rust `calibrator-flats`
+service (separate decision after the port has mileage).
+
+## Module Structure
+
+```
+services/session-runner/
+  schema/workflow-v1.schema.json   The published document schema
+  workflows/                       First-party documents (installed with the service)
+  src/
+    main.rs            CLI entry point (rusty-photon-service-lifecycle)
+    lib.rs             ServerBuilder (two-phase: build → start)
+    config.rs          Service configuration
+    error.rs           SessionRunnerError (thiserror)
+    document/          Document model, JSON Schema + catalog validation
+    expr/              Expression parsing + evaluation (Phase B)
+    blackboard.rs      session.* state + atomic persistence
+    engine/            Tree execution, safe points, trigger queue, resume
+    events.rs          SSE client (Last-Event-ID replay)
+    mcp_client.rs      rmcp Streamable HTTP client to rp's /mcp
+    routes.rs          Axum router: POST /invoke, POST /validate, GET /health
+```
+
+## Testing Strategy
+
+Testing follows [`docs/skills/testing.md`](../skills/testing.md).
+
+### Unit tests
+
+- Document parsing and validation: every instruction type, every schema
+  error (unknown key, missing loop bound, duplicate trigger id, `script`
+  reservation message).
+- Expression evaluation: every operator/function, every namespace, null
+  handling, division by zero — table-driven, exhaustive.
+- Engine semantics against a mock MCP-client trait: sequencing, `result`
+  scoping, `set` persistence ordering, `try`/`catch`/`finally` paths
+  (including finally-does-not-mask), `retry`, loop bounds and
+  `result.converged`, trigger safe-point interleaving, `once`/`cooldown`
+  bookkeeping.
+- Blackboard: atomic write, reload, reserved-key protection.
+
+### BDD tests (Cucumber, rp-harness)
+
+Full three-process topology (OmniSim + `rp` + `session-runner`) via
+`bdd_infra::rp_harness`, mirroring `calibrator-flats`' suite:
+
+| Design section | Feature file | Representative scenarios |
+|----------------|--------------|--------------------------|
+| Invocation + validation | `invocation.feature` | invalid document rejected at `/invoke`; unknown tool named in error; parameter type mismatch |
+| Flats port equivalence | `flat_calibration.feature` | the scenarios from `calibrator-flats`' suite, run against the document — same events, frame counts, cleanup-on-failure |
+| Triggers | `triggers.feature` | refocus fires between exposures, not during; cooldown respected; poll trigger fires flip action |
+| Resume | `recovery.feature` | kill mid-capture-loop → re-invoke with recovery → progress continues without repeated frames; `once` marker not re-run |
+| Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes |
+
+### Golden documents
+
+The shipped `workflows/*.json` are validated in CI against the published
+schema (a unit test walks the directory), so a schema change that breaks a
+first-party document fails the build.
+
+## Future Considerations
+
+- **Luau script handlers** (`script` nodes): stateless per-event handlers
+  with blackboard-only state, preserving the re-derive resume model; the
+  coroutine-yield boundary is where deterministic replay would attach if
+  ever needed.
+- **Document editor in `ui-htmx`** driven by the JSON Schema, including an
+  expression condition-builder.
+- **Sub-workflow composition** (`{"call": "…"}`) once shipped documents
+  show real duplication.
+- **Sky-flat document** — the stress test for the expression layer's
+  ceiling (per-frame exposure adaptation against a brightening/darkening
+  sky); if it doesn't fit the bounded expressions, it becomes the motivating
+  case for `script` nodes rather than for growing the expression language.

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -102,7 +102,7 @@ A workflow document is a single JSON file. Top-level structure:
 | `parameters` | Declared invocation parameters. Each has a `type` (`string`, `integer`, `number`, `boolean`, `duration`), and either `required: true` or a `default`. Values supplied at invocation are type-checked against the declaration; missing required parameters fail validation before anything runs. Available to expressions as `params.*`. Names beginning with `_` are reserved for the engine — declaring one is a validation error. |
 | `estimated_duration` / `max_duration` | The acknowledgment durations returned to `rp` from `/invoke` (humantime strings). Optional; engine defaults apply when absent (see [Invocation](#invocation)). |
 | `triggers` | Document-global reactive rules, evaluated alongside the procedure tree. |
-| `root` | The procedure tree — a single container instruction. |
+| `root` | The procedure tree — conventionally a `sequence` container, though any instruction is structurally valid as the root. |
 
 ### Instructions
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -23,6 +23,7 @@ belong in any single service design doc.
 | [pa-falcon-rotator](services/falcon-rotator.md) | Rotator + Switch (status) | 11118 | `docs/services/falcon-rotator.md` |
 | [dsd-fp2](services/dsd-fp2.md) | CoverCalibrator | 11119 | `docs/services/dsd-fp2.md` (first adopter of `rusty-photon-shared-transport`) |
 | [ui-htmx](services/ui-htmx.md) | — (web config UI / BFF, not an ASCOM device) | 11120 | `docs/services/ui-htmx.md` |
+| [session-runner](services/session-runner.md) | — (generic workflow-orchestrator plugin) | 11171 | `docs/services/session-runner.md` (design stage; service not yet built — executes declarative JSON workflow documents against `rp`'s MCP tools; see [workflow-dsl.md](plans/workflow-dsl.md)) |
 
 ## Documentation Index
 
@@ -62,6 +63,7 @@ belong in any single service design doc.
 | **Plans** (in-flight initiatives — see [docs/plans/](plans/)) | |
 | [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
 | [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
+| [workflow-dsl.md](plans/workflow-dsl.md) | Imaging workflow DSL: declarative JSON workflow documents executed by the generic `session-runner` orchestrator plugin (CEL-style bounded expressions, trigger overlay, re-derive resume); decision record + phases behind [`docs/services/session-runner.md`](services/session-runner.md) |
 | [ui-testing.md](plans/ui-testing.md) | ui-htmx UI-behavior testing strategy: BDD-embedded `scraper` DOM assertions + cross-OS `insta` snapshots + an advisory `thirtyfour` browser layer, with an anticipatory spike plan; Bazel-primary aware; Gherkin stays the source of truth |
 | [zwo-driver.md](plans/zwo-driver.md) | ZWO ASI camera + EFW filter-wheel Alpaca driver (`zwo-camera`, port 11122) + author-maintained `zwo-rs`/`libzwo-sys` FFI; the ZWO analogue of `qhy-camera` (MIT SDK → public cache, but no pre-existing Rust FFI). See [`docs/services/zwo-camera.md`](services/zwo-camera.md) + [ADR-008](decisions/008-zwo-camera-native-sdk-ffi.md) |
 

--- a/services/session-runner/schema/workflow-v1.schema.json
+++ b/services/session-runner/schema/workflow-v1.schema.json
@@ -1,0 +1,471 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "workflow-v1.schema.json",
+  "title": "rusty-photon workflow document (v1)",
+  "description": "Structural schema for session-runner workflow documents, per docs/services/session-runner.md. This is schema-validation layer 1 of 3 (docs/services/session-runner.md § Validation): it checks document shape, discriminant keys, reserved names, and loop-bound requirements. Two invariants it cannot express are enforced by the validator alongside this schema: (1) trigger `id` values and instruction `once` keys must each be unique within a document; (2) `tool` node names and their `args` must exist and type-check against rp's live tool catalog (layer 2, requires a live rp connection) — this schema only checks that `args` is an object, not its contents. Expression strings (see $defs/expression) are opaque here; their grammar is checked by the Phase B expression parser.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Format version. This schema file validates version 1 only; a document with a different version is rejected by the engine before this schema even runs, naming the supported version(s) in the error."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identification for logs, events, and the completion payload. Need not match the document's filename or the `config.workflow` value used to select it."
+    },
+    "description": {
+      "type": "string"
+    },
+    "parameters": {
+      "type": "object",
+      "description": "Declared invocation parameters, available to expressions as params.*.",
+      "propertyNames": {
+        "$ref": "#/$defs/identifier"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/parameterDeclaration"
+      }
+    },
+    "estimated_duration": {
+      "$ref": "#/$defs/humantime"
+    },
+    "max_duration": {
+      "$ref": "#/$defs/humantime"
+    },
+    "triggers": {
+      "type": "array",
+      "description": "Document-global reactive rules, evaluated alongside the procedure tree. Trigger `id` values must be unique within the document (enforced by the validator, not expressible in this schema).",
+      "items": {
+        "$ref": "#/$defs/trigger"
+      }
+    },
+    "root": {
+      "$ref": "#/$defs/instruction",
+      "description": "The procedure tree. Conventionally a `sequence` container, though any instruction is structurally valid as the root."
+    }
+  },
+  "required": ["version", "name", "root"],
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+      "description": "Starts with a letter, so a name cannot begin with `_` — the reserved prefix for engine-injected names (e.g. params._recovery)."
+    },
+    "expression": {
+      "type": "string",
+      "minLength": 1,
+      "description": "A bounded, pure, CEL-style expression string (docs/services/session-runner.md § Expressions). Grammar is validated by the expression parser (Phase B), not by this JSON Schema."
+    },
+    "exprWrapper": {
+      "type": "object",
+      "description": "Marks a tool-arg value as computed rather than literal JSON.",
+      "properties": {
+        "$expr": {
+          "$ref": "#/$defs/expression"
+        }
+      },
+      "required": ["$expr"],
+      "additionalProperties": false
+    },
+    "countBound": {
+      "description": "repeat.count: a literal non-negative integer, or an expression evaluated once at loop entry.",
+      "oneOf": [
+        { "type": "integer", "minimum": 0 },
+        { "$ref": "#/$defs/exprWrapper" }
+      ]
+    },
+    "positiveBound": {
+      "description": "repeat.max_iterations: a literal positive integer, or an expression evaluated once at loop entry (must yield a positive integer or the loop entry raises a workflow error).",
+      "oneOf": [
+        { "type": "integer", "minimum": 1 },
+        { "$ref": "#/$defs/exprWrapper" }
+      ]
+    },
+    "humantime": {
+      "type": "string",
+      "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h|d|w|y)\\s*)+$",
+      "description": "A humantime duration string (e.g. \"300s\", \"1h30m\"). This pattern is a sanity check, not the authoritative grammar — the engine's humantime parser is the source of truth."
+    },
+    "instructionId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "A label used in logs and error messages. No uniqueness requirement."
+    },
+    "onceKey": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The re-entrancy-contract idempotency key for this instruction (session._once.<key>). Must be unique within a document (enforced by the validator, not expressible in this schema)."
+    },
+    "parameterDeclaration": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": ["string", "integer", "number", "boolean", "duration"]
+        },
+        "required": {
+          "const": true
+        },
+        "default": {}
+      },
+      "required": ["type"],
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["required"] },
+        { "required": ["default"] }
+      ],
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "string" } } },
+          "then": { "properties": { "default": { "type": "string" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "integer" } } },
+          "then": { "properties": { "default": { "type": "integer" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "number" } } },
+          "then": { "properties": { "default": { "type": "number" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "boolean" } } },
+          "then": { "properties": { "default": { "type": "boolean" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "duration" } } },
+          "then": { "properties": { "default": { "$ref": "#/$defs/humantime" } } }
+        }
+      ]
+    },
+    "instruction": {
+      "description": "Exactly one discriminant key (tool, sequence, repeat, if, set, try, fail, wait, log), plus the optional common keys id/once. `script` is recognized structurally but is reserved: v1 documents must not use it (docs/services/session-runner.md § Reserved: script) — the validator rejects it with a dedicated 'reserved for a future format version' error rather than a generic unknown-key error.",
+      "oneOf": [
+        { "$ref": "#/$defs/toolInstruction" },
+        { "$ref": "#/$defs/sequenceInstruction" },
+        { "$ref": "#/$defs/repeatInstruction" },
+        { "$ref": "#/$defs/ifInstruction" },
+        { "$ref": "#/$defs/setInstruction" },
+        { "$ref": "#/$defs/tryInstruction" },
+        { "$ref": "#/$defs/failInstruction" },
+        { "$ref": "#/$defs/waitInstruction" },
+        { "$ref": "#/$defs/logInstruction" },
+        { "$ref": "#/$defs/scriptInstructionReserved" }
+      ]
+    },
+    "toolInstruction": {
+      "type": "object",
+      "properties": {
+        "tool": {
+          "type": "string",
+          "minLength": 1,
+          "description": "An MCP tool name, checked against rp's live tool catalog at catalog-validation time (layer 2)."
+        },
+        "args": {
+          "type": "object",
+          "description": "Values are literal JSON by default; a computed value is wrapped as {\"$expr\": \"<expression>\"}. Literal args are type-checked against the tool's parameter schema at catalog-validation time (layer 2); $expr arg types are checked at call time."
+        },
+        "retry": {
+          "type": "object",
+          "properties": {
+            "max_attempts": { "type": "integer", "minimum": 1 },
+            "backoff": { "$ref": "#/$defs/humantime" }
+          },
+          "required": ["max_attempts", "backoff"],
+          "additionalProperties": false
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["tool"],
+      "additionalProperties": false
+    },
+    "sequenceInstruction": {
+      "type": "object",
+      "properties": {
+        "sequence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" }
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["sequence"],
+      "additionalProperties": false
+    },
+    "repeatOptions": {
+      "type": "object",
+      "properties": {
+        "until": { "$ref": "#/$defs/expression" },
+        "while": { "$ref": "#/$defs/expression" },
+        "count": { "$ref": "#/$defs/countBound" },
+        "max_iterations": { "$ref": "#/$defs/positiveBound" }
+      },
+      "additionalProperties": false,
+      "description": "Exactly one of until/while/count. max_iterations is required alongside until/while and optional (but permitted) alongside count.",
+      "oneOf": [
+        {
+          "required": ["until", "max_iterations"],
+          "not": { "anyOf": [{ "required": ["while"] }, { "required": ["count"] }] }
+        },
+        {
+          "required": ["while", "max_iterations"],
+          "not": { "anyOf": [{ "required": ["until"] }, { "required": ["count"] }] }
+        },
+        {
+          "required": ["count"],
+          "not": { "anyOf": [{ "required": ["until"] }, { "required": ["while"] }] }
+        }
+      ]
+    },
+    "repeatInstruction": {
+      "type": "object",
+      "properties": {
+        "repeat": { "$ref": "#/$defs/repeatOptions" },
+        "body": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["repeat", "body"],
+      "additionalProperties": false
+    },
+    "ifInstruction": {
+      "type": "object",
+      "properties": {
+        "if": { "$ref": "#/$defs/expression" },
+        "then": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["if", "then"],
+      "additionalProperties": false
+    },
+    "setInstruction": {
+      "type": "object",
+      "properties": {
+        "set": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "pattern": "^session(\\.[A-Za-z][A-Za-z0-9_]*)+$",
+            "description": "session.* paths only, one or more dot-separated segments, each starting with a letter — excludes the reserved session._once.* / session._triggers.* engine bookkeeping keys, which cannot start a segment with an underscore."
+          },
+          "additionalProperties": { "$ref": "#/$defs/expression" }
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["set"],
+      "additionalProperties": false
+    },
+    "tryInstruction": {
+      "type": "object",
+      "properties": {
+        "try": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "catch": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "finally": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["try"],
+      "additionalProperties": false
+    },
+    "failInstruction": {
+      "type": "object",
+      "properties": {
+        "fail": {
+          "type": "object",
+          "properties": {
+            "message": { "$ref": "#/$defs/expression" }
+          },
+          "required": ["message"],
+          "additionalProperties": false
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["fail"],
+      "additionalProperties": false
+    },
+    "waitInstruction": {
+      "type": "object",
+      "properties": {
+        "wait": { "$ref": "#/$defs/waitOptions" },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["wait"],
+      "additionalProperties": false
+    },
+    "waitOptions": {
+      "type": "object",
+      "properties": {
+        "duration": { "$ref": "#/$defs/humantime" },
+        "until_event": {
+          "type": "string",
+          "minLength": 1,
+          "description": "An rp event name."
+        },
+        "until": { "$ref": "#/$defs/expression" },
+        "timeout": {
+          "$ref": "#/$defs/humantime",
+          "description": "Required with until_event or until; expiry raises a workflow error."
+        },
+        "poll_interval": {
+          "$ref": "#/$defs/humantime",
+          "description": "Re-evaluation interval for until. Default \"10s\" when omitted."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Exactly one of duration/until_event/until. timeout is required with until_event/until and not used with duration. poll_interval only applies to until.",
+      "oneOf": [
+        {
+          "required": ["duration"],
+          "not": {
+            "anyOf": [
+              { "required": ["until_event"] },
+              { "required": ["until"] },
+              { "required": ["timeout"] },
+              { "required": ["poll_interval"] }
+            ]
+          }
+        },
+        {
+          "required": ["until_event", "timeout"],
+          "not": {
+            "anyOf": [
+              { "required": ["duration"] },
+              { "required": ["until"] },
+              { "required": ["poll_interval"] }
+            ]
+          }
+        },
+        {
+          "required": ["until", "timeout"],
+          "not": {
+            "anyOf": [{ "required": ["duration"] }, { "required": ["until_event"] }]
+          }
+        }
+      ]
+    },
+    "logInstruction": {
+      "type": "object",
+      "properties": {
+        "log": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "enum": ["debug", "info"],
+              "description": "Default \"debug\" when omitted."
+            },
+            "message": { "type": "string", "minLength": 1 },
+            "values": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/expression" }
+            }
+          },
+          "required": ["message"],
+          "additionalProperties": false
+        },
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["log"],
+      "additionalProperties": false
+    },
+    "scriptInstructionReserved": {
+      "type": "object",
+      "description": "Reserved for a future sandboxed Luau handler node (decision D3, docs/plans/workflow-dsl.md). Matches structurally so the validator can reject it with an explicit 'reserved for a future format version' error instead of a generic unknown-key error; v1 documents must not use this discriminant.",
+      "properties": {
+        "script": true,
+        "id": { "$ref": "#/$defs/instructionId" },
+        "once": { "$ref": "#/$defs/onceKey" }
+      },
+      "required": ["script"],
+      "additionalProperties": false
+    },
+    "trigger": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/instructionId",
+          "description": "Required, unique within the document (uniqueness enforced by the validator, not expressible in this schema)."
+        },
+        "on": {
+          "description": "The trigger source: an rp SSE event, or a polled tool call.",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "event": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "An rp event name, or the synthetic \"correction_requested\" source."
+                }
+              },
+              "required": ["event"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "poll": {
+                  "type": "object",
+                  "properties": {
+                    "tool": { "type": "string", "minLength": 1 },
+                    "args": { "type": "object" },
+                    "interval": { "$ref": "#/$defs/humantime" }
+                  },
+                  "required": ["tool", "interval"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["poll"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "when": { "$ref": "#/$defs/expression" },
+        "while": { "$ref": "#/$defs/expression" },
+        "cooldown": { "$ref": "#/$defs/humantime" },
+        "once": {
+          "type": "boolean",
+          "description": "Fire at most once per session. Unlike an instruction's `once` (an idempotency key string), this is a plain boolean."
+        },
+        "do": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/instruction" },
+          "minItems": 1,
+          "description": "Same instruction vocabulary as the procedure tree; nested triggers are not part of the instruction vocabulary and so cannot appear here."
+        }
+      },
+      "required": ["id", "on", "do"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Design-stage PR (docs only, no code) answering "how should imaging workflows be expressed?" — decided after a research pass over the astro-automation ecosystem (NINA, Voyager, ACP, Ekos, RTS2) and the Rust workflow/DSL solution space.

- **`docs/plans/workflow-dsl.md`** — decision record: research summary with sources, decisions D1–D7 with rejected alternatives, and phases A–F.
- **`docs/services/session-runner.md`** — behavioral spec for the new generic orchestrator plugin (port 11171), written to be BDD-derivable per `development-workflow.md`.
- `docs/workspace.md` — index both docs; `docs/services/rp.md` — cross-reference from § Orchestration.

## Decisions

- **Declarative reactive-tree workflow documents in JSON**, executed by one generic `session-runner` orchestrator plugin: procedure tree of MCP tool-call instructions + NINA-style trigger overlay, with target/filter *choice* delegated to `rp`'s planner tools. Rust orchestrators (`calibrator-flats`) remain first-class — the plugin protocol is unchanged.
- **Escape hatch designed up front**: CEL-style bounded expressions (pure, no I/O) in `when`/`until`/`set`/`$expr` positions in v1; the schema *reserves* a `script` node for sandboxed Luau handlers later.
- **Resume = re-derive from state**: re-execute the document from the root against the persisted blackboard + live device state, under an explicit re-entrancy contract (dispatch-driven loops, idempotent steps, `once` markers). No replay log, no interpreter snapshots.
- **Safety stays exclusively in `rp`** — a document cannot express, delay, or override park-on-unsafe.
- **v1 proves the engine on two workflows**: the deep-sky session (new value) and a port of `calibrator-flats` (generalization proof, diffed against its existing BDD suite; the Rust service is not retired in this plan).

## Review focus

- The instruction/trigger vocabulary and expression semantics in `session-runner.md` — these become the BDD contract in Phase C.
- The `$expr` convention (tool args literal by default, computed values wrapped) and the strict null/division-by-zero expression semantics.
- Open item deliberately left to Phase A schema work: how the flats document iterates a filter-plan array (array parameter + repeat-over-array vs one invocation per filter).

## Testing

Docs-only. Local gate green: `bazel build //... && bazel test //...` (52/52), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, buildifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)