### PR TITLE
fix(dsd-fp2): settle mock cover move over one poll cycle instead of instantly

### DIFF
--- a/docs/services/dsd-fp2.md
+++ b/docs/services/dsd-fp2.md
@@ -619,6 +619,23 @@ The service exposes a `conformu = ["mock", "ascom-alpaca/test"]` feature.
 `tests/conformu_integration.rs` launches the binary against a mock port
 and points ConformU at it. The same approach `qhy-focuser` uses.
 
+#### Mock move-settling model
+
+`mock.rs`'s `[SMOV]` applies the target `cover_angle` immediately but
+reports the motor running (`[GMOV]` → `(1)`) for exactly one read, then
+clears it — mirroring `pa-falcon-rotator`'s `is_moving` (cleared on the
+next `FA`). An earlier version resolved `[SMOV]` instantly (position
+*and* motor-stopped in the same round trip), which raced the driver's
+own optimistic `CoverState = Moving` write (`device.rs::execute_move`):
+the very next `while_open` poll tick could observe the mock already
+stopped and correct the cache within a few milliseconds of the
+optimistic write, and if that landed between ConformU's back-to-back
+`CoverState`/`CoverMoving` reads it saw two different snapshots
+([#423](https://github.com/ivonnyssen/rusty-photon/issues/423)). The
+one-shot clear guarantees at least one full `polling_interval` of
+stable `Moving` state before the cache can flip, which comfortably
+exceeds any HTTP round trip.
+
 ## Known Limitations
 
 The driver returns `MethodNotImplementedException` from `HaltCover`

--- a/services/dsd-fp2/src/device.rs
+++ b/services/dsd-fp2/src/device.rs
@@ -473,10 +473,11 @@ mod mock_tests {
         // Moving.
         device.close_cover().await.unwrap();
         // After close, our local optimistic write set motor_running =
-        // Some(true). Our mock completes moves instantly inside `[SMOV]`,
-        // so the motor is no longer running on the device side; the next
-        // poll would correct the cache. For now we just verify the call
-        // succeeded and exercise the open path too.
+        // Some(true). The mock reports the motor running for exactly one
+        // `[GMOV]` poll after `[SMOV]` before settling (mock.rs), so the
+        // cache stays consistent with the optimistic write across the
+        // next poll cycle. For now we just verify the call succeeded and
+        // exercise the open path too.
         device.open_cover().await.unwrap();
         device.set_connected(false).await.unwrap();
     }

--- a/services/dsd-fp2/src/manager.rs
+++ b/services/dsd-fp2/src/manager.rs
@@ -377,7 +377,12 @@ mod mock_tests {
             .unwrap()
             .parse_ok()
             .unwrap();
-        // Confirm the cover state observable through GOPS.
+        // The mock reports the motor running for exactly one `[GMOV]`
+        // read after `[SMOV]` (matches real hardware's async settle;
+        // see mock.rs), same as `poll_once` consuming it each cycle.
+        let m = session.request(Command::GetMotorState).await.unwrap();
+        assert!(m.parse_bool().unwrap());
+        // Confirm the cover state observable through GOPS once settled.
         let s = session.request(Command::GetCoverState).await.unwrap();
         assert_eq!(s.parse_int().unwrap(), 0); // 0 = closed
         session.close().await.unwrap();

--- a/services/dsd-fp2/src/mock.rs
+++ b/services/dsd-fp2/src/mock.rs
@@ -161,13 +161,22 @@ impl MockFrameTransport {
                 format!("({})", v)
             }
             "GPOS" => format!("({})", inner.cover_angle),
-            "GMOV" => format!("({})", if inner.motor_running { 1 } else { 0 }),
+            "GMOV" => {
+                // One-shot: running for exactly the first `[GMOV]` read
+                // after `[SMOV]`, then clears — mirrors pa-falcon-rotator's
+                // mock (`is_moving` cleared on next `FA`). An instant
+                // arrival raced the driver's optimistic `Moving` write
+                // (device.rs `execute_move`) against the next poll tick;
+                // see issue #423.
+                let resp = format!("({})", if inner.motor_running { 1 } else { 0 });
+                inner.motor_running = false;
+                resp
+            }
             "SMOV" => {
                 if let Some(t) = inner.target_angle.take() {
-                    // Immediate arrival; real device takes ~3s.
                     inner.cover_angle = t;
                 }
-                inner.motor_running = false;
+                inner.motor_running = true;
                 "(OK)".to_string()
             }
             "GLON" => format!("({})", if inner.light_on { 1 } else { 0 }),
@@ -279,7 +288,14 @@ mod tests {
         let state = MockState::default();
         assert_eq!(round_trip(&state, "[STRG270]").await, "(OK)");
         assert_eq!(round_trip(&state, "[SMOV]").await, "(OK)");
+        // Position arrives immediately...
         assert_eq!(round_trip(&state, "[GPOS]").await, "(270)");
+        // ...but the motor is reported running for exactly one `[GMOV]`
+        // read, so `[GOPS]` still reports "in-between" (255) until that
+        // read happens.
+        assert_eq!(round_trip(&state, "[GOPS]").await, "(255)");
+        assert_eq!(round_trip(&state, "[GMOV]").await, "(1)");
+        assert_eq!(round_trip(&state, "[GMOV]").await, "(0)");
         assert_eq!(round_trip(&state, "[GOPS]").await, "(0)");
     }
 

--- a/services/dsd-fp2/src/mock.rs
+++ b/services/dsd-fp2/src/mock.rs
@@ -175,8 +175,8 @@ impl MockFrameTransport {
             "SMOV" => {
                 if let Some(t) = inner.target_angle.take() {
                     inner.cover_angle = t;
+                    inner.motor_running = true;
                 }
-                inner.motor_running = true;
                 "(OK)".to_string()
             }
             "GLON" => format!("({})", if inner.light_on { 1 } else { 0 }),
@@ -297,6 +297,14 @@ mod tests {
         assert_eq!(round_trip(&state, "[GMOV]").await, "(1)");
         assert_eq!(round_trip(&state, "[GMOV]").await, "(0)");
         assert_eq!(round_trip(&state, "[GOPS]").await, "(0)");
+    }
+
+    #[tokio::test]
+    async fn smov_without_a_target_does_not_start_the_motor() {
+        let state = MockState::default();
+        assert_eq!(round_trip(&state, "[SMOV]").await, "(OK)");
+        assert_eq!(round_trip(&state, "[GMOV]").await, "(0)");
+        assert_eq!(round_trip(&state, "[GOPS]").await, "(0)"); // unmoved default (closed)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes #423 — nightly ConformU flake on `dsd-fp2` (macOS): `CloseCover ISSUE CoverMoving and CoverStatus do not match: CoverMoving: False, CoverState: Moving`.
- Root cause: the mock's `[SMOV]` resolved a cover move instantly (position *and* `motor_running=false` in the same round trip), which raced the driver's optimistic `CoverState = Moving` write (`device.rs::execute_move`) against the very next `while_open` poll tick — occasionally landing between ConformU's back-to-back `CoverState`/`CoverMoving` reads and producing two different snapshots.
- Fix: `[GMOV]` now reports the motor running for exactly one read after `[SMOV]`, then clears — mirroring `pa-falcon-rotator`'s mock (`is_moving` cleared on next `FA`). This guarantees at least one full `polling_interval` of stable `Moving` state before the cache can flip, comfortably exceeding any HTTP round trip.
- Updated the two mock-adjacent unit tests that assumed instant `[SMOV]` completion, and documented the model in `docs/services/dsd-fp2.md`.

## Test plan
- [x] `cargo test -p dsd-fp2 --features mock --lib` — 107 passed
- [x] `cargo test -p dsd-fp2 --features mock,conformu --test bdd` — 17/17 scenarios passed
- [x] `cargo test -p dsd-fp2 --features mock,conformu --test conformu_integration` — run 4x locally, zero `CoverMoving`/`CoverState` mismatches (previously flaky); remaining `HaltCover` ISSUE is the pre-existing, already-documented ConformU 4.3.0 divergence (local binary only — fixed upstream in 4.4.0, which CI installs)
- [x] `cargo fmt --check`, `cargo clippy -p dsd-fp2 --all-targets --all-features -- -D warnings`
- [x] `bazel build //...` && `bazel test //...`
- [x] `bazel test --test_tag_filters=bdd //services/dsd-fp2/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)