### PR TITLE
perf(ci): decouple --jobs from CPU count on Bazel CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -160,7 +160,17 @@ build:ci --color=yes
 build:ci --show_timestamps
 build:ci --announce_rc
 build:ci --remote_download_outputs=toplevel  # build-without-the-bytes
-build:ci --jobs=auto
+# `--jobs` and `--local_resources=cpu=N` are separate knobs: `--jobs` caps how
+# many actions may be outstanding at once, the CPU resource pool (left on
+# auto-detect, i.e. the runner's real core count) caps how many can actively
+# compile. `auto` ties both to the GitHub-hosted runners' small core count
+# (4 vCPU), so network-bound remote-cache checks queue behind the same tiny
+# ceiling as CPU-bound compilation, even though they don't need a core to be
+# in flight. A fixed, higher --jobs decouples the two: local testing (holding
+# CPU fixed at a real 4-core budget) measured elapsed-vs-critical-path
+# overhead dropping from 52% at --jobs=4 to 15% at --jobs=50 on the same
+# 2,500-action graph. 64 leaves headroom above that without over-dispatching.
+build:ci --jobs=64
 build:ci --experimental_ui_max_stdouterr_bytes=10485760
 test:ci --test_output=errors
 test:ci --test_summary=terse


### PR DESCRIPTION
## Summary
- `build:ci --jobs=auto` currently ties the concurrency ceiling for *every* Bazel action — CPU-bound compiles and network-bound remote-cache checks alike — to the GitHub-hosted runners' small core count (4 vCPU). Remote-cache-check traffic doesn't need a dedicated core to be in flight, so it was needlessly queuing behind the same 4 slots as compilation.
- Changed to a fixed `build:ci --jobs=64`. `--local_resources` is left on auto-detect, so actual compute still respects the runner's real core count — only the dispatch ceiling moves, nothing thrashes.

## Evidence
Investigated why `bazel.yml`/`bazel-coverage.yml` jobs frequently take 10+ minutes. CI's own logs showed 70–86% of `bazel build`/`bazel coverage` wall time was overhead (elapsed time vs. Bazel's reported critical path), not real work — reproduced and isolated locally in a throwaway worktree against the real remote cache:

| Local run (CPU pinned to a real 4-core budget in both) | Elapsed | Critical path | Overhead |
|---|---|---|---|
| `--jobs=4 --local_resources=cpu=4` (matches `--jobs=auto` on a 4 vCPU runner) | 179.5s | 85.4s | 52% |
| `--jobs=50 --local_resources=cpu=4` (same CPU budget, dispatch ceiling raised) | 130.7s | 111.2s | 15% |

Holding compute constant, raising `--jobs` alone cut wall time 27% and the overhead share from 52% to 15%, on the same 2,509-action graph. Larger GitHub-hosted runners aren't an option here (personal-account repo — larger runners are an org-only, always-billed feature even on public repos), so this gets most of the benefit for free.

## Test plan
- [x] `bazel build //...` — passes locally (warm cache)
- [x] `bazel test //...` — 52/52 tests pass locally
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Watch this PR's own `bazel / ubuntu-latest`, `bazel / macos-latest`, `bazel / windows-latest`, and `bazel coverage` checks — compare their elapsed times against the sampled averages (ubuntu ~10min, macos ~10min, windows ~13min, coverage ~10.5min) to confirm the improvement holds on real GitHub-hosted infrastructure and network path to `cache.rustyphoton.space`, not just the local dev-box reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)