### PR TITLE
fix(bdd-infra): serialize OmniSim restart PUTs across concurrent scenario hooks

### DIFF
--- a/crates/bdd-infra/BUILD.bazel
+++ b/crates/bdd-infra/BUILD.bazel
@@ -93,6 +93,40 @@ rust_test(
     ),
 )
 
+# Unit tests of the feature-gated rp_harness / sky_survey_camera_harness
+# modules. The base :bdd-infra_unit_test compiles WITHOUT the rp-harness
+# feature, so those modules' tests (OmniSim restart serialization, config
+# builders, stubs, SSE parsing) are cfg'd out of it — and it is tagged
+# requires-cargo anyway, so per-PR `bazel test //...` never ran them; they
+# only ran in the nightly Cargo safety net. This target compiles the
+# rp-harness variant and positively filters to the two feature-gated
+# module trees, skipping the base `tests::` module whose run_once_* tests
+# shell out to cargo. All filtered-in tests are hermetic (localhost axum
+# stubs, tempfiles, pure parsing), so no requires-cargo tag: they run on
+# every PR — including the #431 restart-serialization regression test.
+rust_test(
+    name = "bdd-infra_rp_harness_unit_test",
+    size = "small",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    args = [
+        "rp_harness::",
+        "sky_survey_camera_harness::",
+    ],
+    crate = ":bdd-infra_rp_harness",
+    crate_features = ["rp-harness"],
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+    deps = ["//crates/rp-fits"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)
+
 rust_test(
     name = "service_handle",
     size = "small",

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -198,12 +198,15 @@ impl OmniSimHandle {
     /// scenario hooks run concurrently — see the mutex docs for the
     /// OmniSim deadlock (#431) this prevents.
     async fn restart_device_at(base_url: &str, class: &str, n: u32) -> Result<(), String> {
-        let _serialized = RESTART_SERIALIZER.lock().await;
         let url = format!("{}/simulator/v1/{}/{}/restart", base_url, class, n);
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
             .build()
             .map_err(|e| format!("reqwest client build failed: {e}"))?;
+        // Lock only around the request itself — client construction and
+        // URL formatting don't touch OmniSim and would just lengthen the
+        // critical section when many hooks queue here.
+        let _serialized = RESTART_SERIALIZER.lock().await;
         let resp = client
             .put(&url)
             .send()

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -32,6 +32,24 @@ struct OmniSimProcess {
 /// Global singleton — one OmniSim process shared by all scenarios.
 static OMNISIM: OnceCell<OmniSimProcess> = OnceCell::const_new();
 
+/// Process-wide serialization of `/restart` PUTs. OmniSim's restart
+/// handler (`DriverManager.Load{Class}(n)`) mutates unsynchronised
+/// process-wide static state, so concurrent restarts race inside the
+/// simulator. `reset_all_devices` already issues its 5 PUTs
+/// sequentially (#171), but that only serialises *within* one hook —
+/// cucumber runs untagged scenarios concurrently, and every
+/// concurrently-drawn scenario runs its own before-hook. In the
+/// pi-nightly failure behind #431 the 11 non-`@serial` rp scenarios
+/// were all drawn at once after the `@serial` queue drained, their 11
+/// hooks issued ~11 concurrent restarts per device class, and OmniSim
+/// deadlocked mid-wave (log torn then silent, no stderr, subsequent
+/// PUTs timing out) — failing the remaining hooks loud. Holding this
+/// mutex across each PUT caps in-flight restarts at one per test
+/// process, which removes the trigger. Known limitation: it cannot
+/// serialise across *processes* (e.g. two Bazel bdd actions sharing
+/// one OmniSim on port 32323).
+static RESTART_SERIALIZER: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 impl OmniSimHandle {
     /// Get or start the shared OmniSim process. Returns a lightweight handle.
     ///
@@ -94,7 +112,11 @@ impl OmniSimHandle {
     /// `invalid type: null, expected struct ConfiguredDevice` and
     /// silently registered the device as disconnected — which is the
     /// camera/calibrator/focuser "not connected" cascade in #171.
-    /// Sequential PUTs eliminate that race.
+    /// Sequential PUTs eliminate that race *within* one hook; the
+    /// process-wide [`RESTART_SERIALIZER`] taken inside each PUT
+    /// eliminates it *across* concurrently-running hooks too — the
+    /// end-of-run burst of non-`@serial` scenarios deadlocked OmniSim
+    /// on the Pi nightly (#431).
     ///
     /// The wall-time cost is small: 5 localhost round-trips serialised
     /// is ~10-25 ms per scenario depending on runner.
@@ -170,7 +192,13 @@ impl OmniSimHandle {
     /// tests can drive the HTTP path against an axum stub without
     /// touching the global `OMNISIM` singleton. See the `tests` module
     /// at the bottom of this file.
+    ///
+    /// The PUT is issued under [`RESTART_SERIALIZER`], so at most one
+    /// restart is in flight per test process no matter how many
+    /// scenario hooks run concurrently — see the mutex docs for the
+    /// OmniSim deadlock (#431) this prevents.
     async fn restart_device_at(base_url: &str, class: &str, n: u32) -> Result<(), String> {
+        let _serialized = RESTART_SERIALIZER.lock().await;
         let url = format!("{}/simulator/v1/{}/{}/restart", base_url, class, n);
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(5))
@@ -529,6 +557,66 @@ mod tests {
             .expect_err("expected an error for 500 response");
         assert!(err.contains("500"), "expected 500 in error: {err}");
         let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn restart_device_serializes_concurrent_restarts() {
+        use std::sync::atomic::{AtomicI32, Ordering};
+        use std::sync::Arc;
+
+        // Stub that records whether two restart requests were ever in
+        // flight at the same time. Each handler bumps an in-flight
+        // counter, holds the request open briefly, then decrements —
+        // without RESTART_SERIALIZER, 16 concurrent PUTs overlap here
+        // reliably (this test failed before the mutex was added).
+        let in_flight = Arc::new(AtomicI32::new(0));
+        let overlapped = Arc::new(AtomicI32::new(0));
+        let (in_flight_h, overlapped_h) = (in_flight.clone(), overlapped.clone());
+        let app = Router::new().route(
+            "/simulator/v1/camera/0/restart",
+            put(move || {
+                let in_flight = in_flight_h.clone();
+                let overlapped = overlapped_h.clone();
+                async move {
+                    if in_flight.fetch_add(1, Ordering::SeqCst) > 0 {
+                        overlapped.fetch_add(1, Ordering::SeqCst);
+                    }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    StatusCode::OK
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        let puts: Vec<_> = (0..16)
+            .map(|_| {
+                let base_url = base_url.clone();
+                tokio::spawn(async move {
+                    OmniSimHandle::restart_device_at(&base_url, "camera", 0).await
+                })
+            })
+            .collect();
+        for put in puts {
+            put.await.unwrap().unwrap();
+        }
+        assert_eq!(
+            overlapped.load(Ordering::SeqCst),
+            0,
+            "restart PUTs overlapped despite RESTART_SERIALIZER"
+        );
+        let _ = tx.send(());
     }
 
     #[tokio::test]

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -244,7 +244,14 @@ Scenarios with `@serial` (on scenario, rule, or feature level) run sequentially.
   `reset_filter_wheel` / `reset_focuser` /
   `reset_cover_calibrator` each wrap the matching
   `/simulator/v1/{class}/0/restart` endpoint, and
-  `reset_all_devices` issues them in parallel.
+  `reset_all_devices` issues them sequentially. Every restart PUT
+  additionally takes a process-wide mutex, so at most one restart is
+  in flight per test process regardless of how many scenario hooks
+  run concurrently — OmniSim's restart handler mutates
+  unsynchronised static state, and concurrent restarts have both
+  corrupted its device list (#171) and deadlocked the simulator
+  outright (#431, the end-of-run burst of non-`@serial` scenarios
+  on the Pi nightly).
 
 - `services/rp/tests/bdd.rs` and
   `services/calibrator-flats/tests/bdd.rs` — the cucumber

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -638,12 +638,17 @@ issue #143 is the specific case we already hit; the fix generalises to
 every device class.
 
 The pattern is to call `OmniSimHandle::reset_all_devices()` from a
-cucumber `before(scenario)` hook. The helper issues parallel
+cucumber `before(scenario)` hook. The helper issues sequential
 `PUT /simulator/v1/{class}/{n}/restart` requests to OmniSim's private
 restart endpoint for every class our suites touch (`telescope`,
 `camera`, `filterwheel`, `focuser`, `covercalibrator`); see
-`crates/bdd-infra/src/rp_harness/omnisim.rs`. Total per-scenario
-overhead is one localhost round-trip. Before the singleton has been
+`crates/bdd-infra/src/rp_harness/omnisim.rs`. Each PUT also takes a
+process-wide mutex, so hooks of concurrently-running scenarios never
+have more than one restart in flight — OmniSim's restart handler
+mutates unsynchronised static state, and concurrent restarts have
+corrupted its device list (#171) and deadlocked it outright (#431).
+Total per-scenario overhead is five localhost round-trips
+(~10-25 ms). Before the singleton has been
 initialised the helper falls back to the default OmniSim base URL
 (`http://127.0.0.1:32323`), so a pre-existing OmniSim from a prior
 dev session is reset before scenario 1 reuses it; if no OmniSim is
@@ -677,11 +682,16 @@ scenario is queued, so tagging every OmniSim-touching feature with
 `services/rp/tests/features/*.feature` and
 `services/calibrator-flats/tests/features/*.feature` for the expected
 pattern: a single `@serial` tag on the line above `Feature:`. Adding
-a new feature that touches OmniSim? Tag it `@serial` too. (Other
-features in this repo are already tagged `@serial` for their own
-reasons — auth tests share an Argon2id keying constant, TLS / ACME
-tests touch shared cert directories — so don't take their tagging as
-evidence one way or the other about OmniSim.)
+a new feature that touches OmniSim? Tag it `@serial` too. (Some
+other features are tagged `@serial` for their own reasons — auth
+tests share an Argon2id keying constant — so don't take tagging as
+evidence one way or the other about OmniSim. The TLS / ACME features
+are deliberately untagged: their scenarios use per-scenario temp
+dirs and never touch OmniSim devices. Note cucumber refuses to
+drain Concurrent scenarios while `@serial` ones are queued, so all
+untagged scenarios launch simultaneously once the serial queue
+empties — their before-hooks fire as one burst, which is why the
+restart PUTs are serialized process-wide; see #431.)
 
 ---
 


### PR DESCRIPTION
Fixes #431.

## What happened in the nightly

The 2026-07-04 pi-nightly run ([28697945651](https://github.com/ivonnyssen/rusty-photon/actions/runs/28697945651)) failed in rp's BDD suite: 267/274 scenarios passed, then the final 7 failed in their before-hooks with `OmniSim device reset failed: PUT .../covercalibrator/0/restart failed`.

The uploaded OmniSim log shows the cause: at +519s, ~11 restart requests per device class landed simultaneously, the log lines become torn/interleaved, and OmniSim goes permanently silent (empty stderr). The 7 failing hooks each timed out after exactly 5 s — OmniSim deadlocked, it didn't crash.

## Root cause

The burst is deterministic. cucumber-rs refuses to start Concurrent scenarios while `@serial` ones are queued, and exactly three rp features are untagged — `acme_setup` (5 scenarios), `tls` (2), `tls_setup` (4). Those 11 scenarios all launch at once after the serial queue drains, at the end of **every** rp:bdd run. Each before-hook fires 5 restart PUTs, and OmniSim's restart handler (`DriverManager.Load{Class}(n)`) mutates unsynchronised static state — the same race as #171, whose fix only serialised the 5 PUTs *within* one hook, not across concurrently-running hooks. Every nightly rolls these dice; the Pi was finally slow/unlucky enough to deadlock. The loud-reset panic (#172) then correctly failed the remaining scenarios.

This may also explain the older rp:bdd / calibrator-flats OmniSim cascades seen under Bazel. The June 21–24 pi-nightly failures were unrelated (`cargo build` breakage).

## Fix

- Hold a process-wide `tokio::sync::Mutex` across every restart PUT in `bdd-infra`, capping in-flight restarts at one per test process regardless of hook concurrency. All three BDD harnesses (rp, calibrator-flats, operation-watchdog-e2e) route through the same helper and inherit the fix. Known limitation (documented): it cannot serialise across separate test *processes* sharing one OmniSim.
- Regression test: 16 concurrent restarts against an overlap-detecting axum stub — verified it fails with the mutex removed and passes with it.
- Doc corrections: `docs/references/omnisim.md` and `docs/skills/testing.md` still described the resets as running "in parallel" (stale since #171), and testing.md wrongly claimed the TLS/ACME features are tagged `@serial`. The three features stay deliberately concurrent — their scenarios use per-scenario temp dirs and never touch OmniSim devices; the mutex removes the only hazard (rationale now in testing.md §5.5).

## Verification

- `bazel build //...` + `bazel test //...` ✅
- `bazel test --test_tag_filters=bdd //...` with OmniSim: all 15 suites pass, including rp:bdd (414 s) and calibrator-flats ✅
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` ✅
- New regression test demonstrably catches the bug (fails without the mutex) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)