### PR TITLE
docs: family-wide service packaging plan + ADR-012/ADR-013

### DIFF
--- a/docs/decisions/012-service-packaging-architecture.md
+++ b/docs/decisions/012-service-packaging-architecture.md
@@ -1,0 +1,118 @@
+# ADR-012: System packaging architecture — native `.deb`/`.rpm` for all services
+
+## Status
+
+Accepted (2026-07-04); implemented by
+[`docs/plans/service-packaging.md`](../plans/service-packaging.md).
+Supersedes the per-service packaging decisions embodied in
+[`docs/plans/archive/filemonitor-packaging.md`](../plans/archive/filemonitor-packaging.md)
+(package/binary/unit naming, conffile config, per-service user).
+
+## Context
+
+The first deployment target is a Debian 13 arm64 observatory machine running
+the full driver family unattended at night (tenets #1/#2). Two questions had
+to be settled before packaging could scale beyond filemonitor:
+
+**Containers vs native packages.** Docker was considered and rejected: the
+drivers talk to USB cameras and serial adapters (QHY cameras re-enumerate
+after a host-side firmware upload), which forces privileged device
+passthrough with host-level udev rules and firmware anyway; ASCOM Alpaca
+discovery is UDP broadcast (port 32227), which forces `--network host`. A
+privileged, host-networked container with host udev/firmware keeps Docker's
+daemon and image pipeline while discarding its isolation — the worst
+quadrant. Rust's static-ish binaries already deliver the "one artifact"
+benefit containers usually buy. systemd + journald is one fewer failure
+layer at 2am.
+
+**Does the filemonitor pattern generalize?** Mostly. Three of its choices do
+not:
+
+1. *Config as a dpkg conffile in `/etc`.* Six services rewrite their own
+   config at runtime (`config.apply` actions and `materialize_identity`
+   minting device UUIDs on first start, via `crates/rusty-photon-config`).
+   A root-owned conffile blocks those writes; a service-writable conffile
+   triggers a conffile prompt on every upgrade. Conffile semantics assume
+   the *operator* is the only writer — false here by design (ui-htmx edits
+   driver config over HTTP; drivers persist it themselves).
+2. *Per-service system users.* At 15 packages this multiplies passwd
+   entries and forces divergent maintainer scripts, and rp ↔ plate-solver
+   exchange FITS files by absolute path, which same-uid solves trivially.
+3. *Bare names* (`filemonitor` package, `/usr/bin/filemonitor`,
+   `filemonitor.service`). Generic names in shared namespaces
+   (`/usr/bin/rp`!) and no family grouping in apt/dnf.
+
+## Decision
+
+1. **Native packages, cargo tooling.** `.deb` via cargo-deb and `.rpm` via
+   cargo-generate-rpm, extending the proven metadata-in-`Cargo.toml` pattern.
+   No Bazel packaging layer (`rules_pkg`) — Bazel remains the build/test
+   gate; release artifacts stay Cargo-built. Formats for the family are
+   deb + rpm only; MSI and Homebrew remain filemonitor-only until a real
+   Windows/macOS deployment need exists.
+2. **Family naming.** Package `rusty-photon-<svc>`, installed binary
+   `/usr/bin/rusty-photon-<svc>` (renamed via asset mapping; Cargo bin names
+   unchanged), unit `rusty-photon-<svc>.service`. filemonitor's existing
+   bare-named artifacts are renamed — a breaking change accepted pre-1.0.
+3. **Config is user-based XDG, owned by the service.** Packages ship no
+   config file; units pass no `--config` flag. Services use their existing
+   `resolve_config_path` XDG default, which — with the service user's home
+   at `/var/lib/rusty-photon` — puts live config at
+   `/var/lib/rusty-photon/.config/rusty-photon/<svc>.json`, self-created on
+   first start. Packaged behavior is byte-identical to dev behavior, there
+   are no conffile/seed/permission mechanics at all, and config is honestly
+   modeled as service-owned data. postinst creates an `/etc/rusty-photon`
+   symlink to that directory for operator discoverability. `dpkg -P` removes
+   the purged service's config + state; the shared user/home/symlink stay.
+4. **One shared system user `rusty-photon`** (system account, home
+   `/var/lib/rusty-photon`, no shell). Hardware privilege is scoped per
+   *unit*, not per user, via `SupplementaryGroups=dialout` (serial class)
+   and `SupplementaryGroups=plugdev` (camera class). Maintainer scripts stay
+   byte-identical across packages (service name derived from
+   `$DPKG_MAINTSCRIPT_PACKAGE`), enforced by `scripts/check-pkg-assets.sh`.
+5. **Hardened unit template with three service classes** (serial / USB
+   camera / network-only), `ProtectSystem=strict` +
+   `ReadWritePaths=/var/lib/rusty-photon`, `StateDirectory=rusty-photon/<svc>`;
+   `ConfigurationDirectory=` is deliberately avoided (root-owned dir would
+   break the config crate's atomic rename). Full template and class matrix
+   in the plan.
+6. **Asset layout: committed per-service `pkg/` dirs, no generator**, with
+   canonical shared maintainer scripts under `packaging/` and a checker
+   script asserting convergence. Explicitness wins; `git grep` must find the
+   real bytes that ship.
+7. **ARM64 packages are built natively on the rig for now**
+   (`scripts/build-packages.sh`); CI arm64 packaging is deferred.
+
+## Consequences
+
+- One `apt install rusty-photon-<svc>` per service yields a supervised,
+  hardened, auto-restarting daemon whose config appears on first start and
+  is editable via ui-htmx or at `/etc/rusty-photon/<svc>.json` (symlink).
+- Upgrades never prompt about config and never touch it.
+- The six write-back services and the nine hand-edit-only services follow
+  ONE pattern; nothing special-cases.
+- Operators looking for config in `/etc` find it (via the symlink), but
+  backup tooling must know config lives under `/var/lib/rusty-photon`
+  (documented in `docs/packaging.md`).
+- sentinel needs a small code fix to adopt `resolve_config_path` (it
+  currently ignores XDG entirely) — tracked in the plan, PR-2.
+- Renames break any existing install of the old `filemonitor` package and
+  the current Homebrew formula/tarball names; `release.yml` and the tap are
+  reconciled in the plan's PR-7.
+- Editing 15 service `Cargo.toml`s (metadata blocks) changes crate_universe
+  manifest hashes → `CARGO_BAZEL_REPIN=1 bazel mod tidy && bazel mod tidy`
+  accompanies those PRs.
+
+## References
+
+- Plan (design detail, verification matrix, phases):
+  [`docs/plans/service-packaging.md`](../plans/service-packaging.md)
+- Native SDK payload policy: [ADR-013](013-native-sdk-payload-policy.md)
+- Config machinery this leans on: `crates/rusty-photon-config`
+  (`resolve_config_path`, `materialize_identity`, atomic `save()`),
+  [`docs/services/config-actions.md`](../services/config-actions.md)
+- Service lifecycle (signals, stderr logging, SIGHUP reload):
+  [ADR-011](011-error-reporting-layers.md),
+  `crates/rusty-photon-service-lifecycle`
+- Superseded precedent:
+  [`docs/plans/archive/filemonitor-packaging.md`](../plans/archive/filemonitor-packaging.md)

--- a/docs/decisions/012-service-packaging-architecture.md
+++ b/docs/decisions/012-service-packaging-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (2026-07-04); implemented by
+Accepted (2026-07-04); implementation tracked by
 [`docs/plans/service-packaging.md`](../plans/service-packaging.md).
 Supersedes the per-service packaging decisions embodied in
 [`docs/plans/archive/filemonitor-packaging.md`](../plans/archive/filemonitor-packaging.md)

--- a/docs/decisions/013-native-sdk-payload-policy.md
+++ b/docs/decisions/013-native-sdk-payload-policy.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Accepted (2026-07-04); implemented by
-[`docs/plans/service-packaging.md`](../plans/service-packaging.md) (PR-4 /
-PR-5). Resolves the redistribution question left open by
+Accepted (2026-07-04); implementation planned in phases PR-4 / PR-5 of
+[`docs/plans/service-packaging.md`](../plans/service-packaging.md).
+Resolves the redistribution question left open by
 [ADR-009](009-vendor-qhyccd-rs.md).
 
 ## Context

--- a/docs/decisions/013-native-sdk-payload-policy.md
+++ b/docs/decisions/013-native-sdk-payload-policy.md
@@ -1,0 +1,80 @@
+# ADR-013: Native SDK payload policy — redistribute ZWO, download QHY
+
+## Status
+
+Accepted (2026-07-04); implemented by
+[`docs/plans/service-packaging.md`](../plans/service-packaging.md) (PR-4 /
+PR-5). Resolves the redistribution question left open by
+[ADR-009](009-vendor-qhyccd-rs.md).
+
+## Context
+
+Two camera services link vendor SDKs ([ADR-008](008-zwo-camera-native-sdk-ffi.md),
+[ADR-009](009-vendor-qhyccd-rs.md), [ADR-010](010-vendor-zwo-rs.md)), and
+their `.deb`/`.rpm` packages must get the runtime pieces onto target
+machines. The two SDKs differ in exactly the two dimensions that matter:
+
+|  | QHYCCD | ZWO ASI/EFW |
+|--|--------|-------------|
+| License | Proprietary, redistribution rights unresolved | MIT |
+| Linkage | `libqhyccd.a` **static** → baked into our binary | `libASICamera2.so` / `libEFWFilter.so` **dynamic** |
+| Runtime needs beyond libusb/libstdc++ | Camera **firmware files** + udev device access | The two `.so` blobs (no SONAME) + libudev + udev device access |
+
+Publishing proprietary QHYCCD firmware inside our public GitHub artifacts
+would be redistribution we have no right to. Meanwhile ZWO's MIT blobs are
+explicitly redistributable (the same blobs ship in indi-3rdparty).
+
+## Decision
+
+1. **ZWO: redistribute in-package.** `rusty-photon-zwo-camera` bundles
+   `libASICamera2.so` + `libEFWFilter.so` (taken at build time from the same
+   pinned indi-3rdparty commit CI uses) into the private libdir
+   `/usr/lib/rusty-photon/`, plus the MIT license text in the package
+   docdir. Because the blobs carry no SONAME, loader resolution uses
+   **RUNPATH** (`-Wl,-rpath,/usr/lib/rusty-photon`, injected via RUSTFLAGS
+   by the package build script — not `build.rs`, keeping Bazel untouched;
+   not `ld.so.conf.d`, which is unreliable without SONAMEs; not
+   `LD_LIBRARY_PATH` units). The deb declares explicit `depends` because
+   dpkg-shlibdeps cannot resolve SONAME-less private libs.
+2. **QHY: never redistribute; download on the target.**
+   `rusty-photon-qhy-camera` ships our binary (SDK statically linked — the
+   *library* needs no separate distribution) plus
+   `/usr/sbin/rusty-photon-qhy-firmware-install`, a root-only helper that
+   downloads the SDK archive **pinned to the same version CI pins**
+   (26.06.04), verifies a **pinned sha256**, and installs only the firmware
+   files to `/lib/firmware/qhy`. The package postinst prints a pointer but
+   never downloads (offline installs must not fail). Model: Debian's
+   downloader packages for non-redistributable payloads.
+3. **udev rules are authored by us, in both packages** (trivial
+   vendor-ID match rules; no copied SDK content): group-scoped access
+   (`GROUP="plugdev", MODE="0660"` — not world-writable 0666) plus the
+   usbfs memory bump, installed under `/usr/lib/udev/rules.d/`. The camera
+   units run with `SupplementaryGroups=plugdev`.
+
+## Consequences
+
+- No proprietary bytes in our published artifacts; the QHY pin+hash makes
+  the downloaded payload reproducible and tamper-evident.
+- QHY operators run one extra documented command
+  (`rusty-photon-qhy-firmware-install`) before first camera use; ZWO
+  operators need nothing extra.
+- The QHY SDK version is pinned in two shipped places (build script,
+  firmware helper) — `scripts/check-pkg-assets.sh` asserts they match, and
+  an SDK bump is a deliberate two-line PR.
+- zwo-camera's lintian emits `custom-library-search-path` (RUNPATH) —
+  documented as expected, not suppressed.
+- If QHYCCD ever grants explicit redistribution permission, the helper can
+  be replaced by a firmware payload in the package with no other layout
+  change.
+
+## References
+
+- Plan: [`docs/plans/service-packaging.md`](../plans/service-packaging.md)
+- SDK linkage ground truth: `crates/qhyccd-rs/libqhyccd-sys/build.rs`
+  (static + `QHYCCD_SDK_DIR`), `crates/zwo-rs/libzwo-sys/build.rs`
+  (dynamic + `ZWO_SDK_LIB_DIR`)
+- CI provisioning precedents: `ivonnyssen/qhyccd-sdk-install@v4` (archive
+  naming/URLs), `.github/actions/install-zwo-sdk` (pinned indi-3rdparty
+  blob source)
+- Prior SDK ADRs: [ADR-008](008-zwo-camera-native-sdk-ffi.md),
+  [ADR-009](009-vendor-qhyccd-rs.md), [ADR-010](010-vendor-zwo-rs.md)

--- a/docs/plans/archive/filemonitor-packaging.md
+++ b/docs/plans/archive/filemonitor-packaging.md
@@ -1,5 +1,16 @@
 # Filemonitor Packaging Plan
 
+**Status: SUPERSEDED (archived 2026-07-04).** The in-repo packaging work
+shipped in PR #33 (`88f2d98`) and proved the cargo-deb / cargo-generate-rpm /
+cargo-wix / Homebrew pattern. Family-wide packaging is now driven by
+[`service-packaging.md`](../service-packaging.md) per
+[ADR-012](../../decisions/012-service-packaging-architecture.md), which
+supersedes this plan's per-service decisions (bare `filemonitor`
+package/binary/unit names → `rusty-photon-*`; `/etc` conffile config →
+user-based XDG; per-service system user → shared `rusty-photon` user). The
+two unfinished manual steps below (Homebrew tap repo + `HOMEBREW_TAP_TOKEN`
+secret) carry over to that plan's PR-7 phase.
+
 ## Goal
 
 Create platform-specific installable packages for the filemonitor service so users can install it without a Rust toolchain.

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -1,0 +1,348 @@
+# Service Packaging Plan — `.deb` / `.rpm` for the whole family
+
+## Goal
+
+Provide installable `.deb` and `.rpm` packages for every rusty-photon service
+so an observatory machine (first target: the Debian 13 arm64 test rig) can be
+provisioned with `apt install` — no Rust toolchain, no hand-copied binaries —
+with systemd supervising every service. This generalizes the proven
+single-service pattern from
+[`filemonitor-packaging.md`](archive/filemonitor-packaging.md) (PR #33),
+superseding several of its per-service decisions; the architecture is recorded
+in [ADR-012](../decisions/012-service-packaging-architecture.md) and the
+native-SDK payload policy in
+[ADR-013](../decisions/013-native-sdk-payload-policy.md).
+
+Deployment is native packages, not containers, by explicit decision: the
+drivers' USB/udev/firmware needs and ASCOM Alpaca's UDP discovery would force
+`--network host` + privileged device passthrough, erasing container isolation
+while keeping host-level setup anyway (see ADR-012 Context).
+
+## Implementation Status
+
+| Phase | Description | Status | Branch / PR |
+|-------|-------------|--------|-------------|
+| PR-1 | This plan + ADR-012 + ADR-013 + archive old plan | In progress | `feature/service-packaging-plan` |
+| PR-2 | Migrate filemonitor to the new pattern (template proof) + sentinel XDG fix + `check-pkg-assets.sh` | Pending | |
+| PR-3 | 11 pure-Rust daemons + `phd2-guider` CLI package | Pending | |
+| PR-4 | `qhy-camera` package + firmware downloader helper | Pending | |
+| PR-5 | `zwo-camera` package with bundled MIT SDK blobs | Pending | |
+| PR-6 | `build-packages.sh` + `verify-packages.sh` + `docs/packaging.md`; first on-rig install | Pending | |
+| PR-7 | `release.yml` generalization (x86_64 matrix, Homebrew rename) | Deferred | |
+
+Carried over from the superseded plan (still open, now owned by PR-7):
+create the `ivonnyssen/homebrew-rusty-photon` tap content and add the
+`HOMEBREW_TAP_TOKEN` secret.
+
+## Decisions (fixed — see ADR-012 / ADR-013 for rationale)
+
+- **Scope:** all services. 14 systemd-supervised daemons + `phd2-guider`
+  packaged as a plain CLI (it is a clap subcommand tool, not a daemon).
+  Test-double bins (`mock_phd2`, `mock_astap`) are never packaged.
+- **Naming:** `rusty-photon-` prefix on packages **and** installed binaries
+  **and** units: package `rusty-photon-<svc>`, `/usr/bin/rusty-photon-<svc>`,
+  `rusty-photon-<svc>.service`. Cargo bin names are unchanged; the rename
+  happens in the packaging asset mapping. filemonitor's bare-named
+  package/binary/unit are renamed (breaking; acceptable pre-1.0).
+- **Config is user-based XDG, owned by the service** — packages ship **no
+  config file** and units pass **no `--config` flag**. Services resolve
+  `~/.config/rusty-photon/<svc>.json` via `resolve_config_path`
+  (`crates/rusty-photon-config`) and self-create it on first start
+  (`materialize_identity`). With the shared system user's home at
+  `/var/lib/rusty-photon`, live config lands at
+  `/var/lib/rusty-photon/.config/rusty-photon/<svc>.json`. postinst creates
+  an `/etc/rusty-photon` → `/var/lib/rusty-photon/.config/rusty-photon`
+  symlink for operator discoverability. No dpkg conffiles anywhere (six
+  services rewrite their config at runtime via `config.apply` /
+  `materialize_identity`; conffile semantics cannot express that).
+- **One shared system user** `rusty-photon` (home `/var/lib/rusty-photon`,
+  no login shell). Hardware privileges are scoped per unit via
+  `SupplementaryGroups=` (`dialout` for serial, `plugdev` for cameras), not
+  via the user. Enables the shared-home XDG config model and the
+  rp ↔ plate-solver shared FITS tree, and keeps deb maintainer scripts
+  byte-identical across packages.
+- **Formats:** `.deb` + `.rpm` only for the family. MSI and Homebrew remain
+  filemonitor-only until there is a real Windows/macOS deployment need.
+- **ARM64 packages are built natively on the rig for now** via
+  `scripts/build-packages.sh`; CI packaging for arm64 is deferred (PR-7 keeps
+  x86_64 in `release.yml`).
+- **Native SDK payloads (ADR-013):** ZWO's MIT-licensed `.so` blobs are
+  redistributed inside `rusty-photon-zwo-camera`; QHYCCD's proprietary
+  firmware is **never** redistributed — a pinned, checksum-verified
+  downloader helper installs it on the target machine.
+
+## Design
+
+### Asset layout — per-service `pkg/` dirs + a consistency checker
+
+Plain committed files, no generator (explicitness over DRY; `git grep` must
+not lie). Shared canonical copies live in `packaging/`; a checker keeps the
+per-service instances convergent.
+
+```
+packaging/
+  postinst.common        # canonical; every daemon pkg/postinst is byte-identical
+  postrm.common          # canonical; ditto (qhy/zwo: documented +udevadm variant)
+  README.md              # invariants, how to add a service
+scripts/
+  check-pkg-assets.sh    # asserts the invariants below
+  build-packages.sh      # on-device package build (PR-6)
+  verify-packages.sh     # container install/upgrade/purge verification (PR-6)
+services/<svc>/pkg/
+  rusty-photon-<svc>.service
+  postinst               # copy of packaging/postinst.common
+  postrm                 # copy of packaging/postrm.common
+```
+
+Extras: `services/qhy-camera/pkg/` adds `70-rusty-photon-qhy.rules` +
+`rusty-photon-qhy-firmware-install`; `services/zwo-camera/pkg/` adds
+`70-rusty-photon-zwo.rules` + a gitignored `lib/` dir into which the build
+script stages the ZWO blobs + license before `cargo deb` runs.
+
+`check-pkg-assets.sh` asserts, per daemon crate: unit file named
+`rusty-photon-<dir>.service` with `ExecStart=/usr/bin/rusty-photon-<dir>`
+(no `--config`); `postinst`/`postrm` byte-identical to the canonical copies
+(or to the documented camera variant); `[package.metadata.deb] name`,
+`unit-name`, and `[package.metadata.generate-rpm] name` all equal
+`rusty-photon-<dir>`; reload-capable services have `ExecReload`; the QHY SDK
+version pinned in `build-packages.sh` matches the one in
+`rusty-photon-qhy-firmware-install`.
+
+### systemd unit template
+
+```ini
+[Unit]
+Description=Rusty Photon <svc> — <role> (port <port>)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/rusty-photon-<svc>
+ExecReload=/bin/kill -HUP $MAINPID        # reload-capable services only
+Restart=on-failure
+RestartSec=5
+User=rusty-photon
+Group=rusty-photon
+Environment=RUST_LOG=info
+Environment=HOME=/var/lib/rusty-photon
+WorkingDirectory=/var/lib/rusty-photon
+StateDirectory=rusty-photon/<svc>
+
+# Hardening — hobby-rig level; must not break config write-back, serial, USB.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/rusty-photon
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Notes: `ConfigurationDirectory=` is deliberately **not** used (systemd
+creates it root-owned, which would break the config crate's atomic
+tmp+rename+fsync-dir write-back). `HOME` is set explicitly as belt-and-braces
+even though the `dirs` crate falls back to the passwd entry.
+`ReadWritePaths=/var/lib/rusty-photon` covers both the XDG config write-back
+and the rp ↔ plate-solver shared FITS tree.
+
+Per-class deltas:
+
+| Class | Services | Delta |
+|-------|----------|-------|
+| serial | ppba-driver, qhy-focuser, pa-falcon-rotator, dsd-fp2, star-adventurer-gti | `SupplementaryGroups=dialout` |
+| USB camera | qhy-camera, zwo-camera | `SupplementaryGroups=plugdev`, `RestrictAddressFamilies` += `AF_NETLINK` (libusb hotplug), no `MemoryDenyWriteExecute` (vendor blob caution) |
+| network-only | filemonitor, sentinel, rp, ui-htmx, plate-solver, calibrator-flats, sky-survey-camera | `PrivateDevices=yes`, `MemoryDenyWriteExecute=yes` |
+
+Reload-capable (get `ExecReload`): filemonitor, zwo-camera,
+pa-falcon-rotator, star-adventurer-gti, dsd-fp2, qhy-camera, ppba-driver,
+sky-survey-camera, qhy-focuser.
+
+Ports (for unit descriptions): filemonitor 11111, ppba-driver 11112,
+qhy-focuser 11113, sentinel 11114, rp 11115, sky-survey-camera 11116,
+pa-falcon-rotator 11118, dsd-fp2 11119, ui-htmx 11120, qhy-camera 11121,
+zwo-camera 11122, plate-solver 11131, calibrator-flats 11170,
+star-adventurer-gti 11880.
+
+### Maintainer scripts
+
+`packaging/postinst.common` (deb; byte-identical in every daemon package):
+
+```sh
+#!/bin/sh
+set -e
+if ! getent passwd rusty-photon > /dev/null; then
+    adduser --system --group --home /var/lib/rusty-photon --quiet rusty-photon
+fi
+install -d -m 0750 -o rusty-photon -g rusty-photon /var/lib/rusty-photon
+if [ ! -e /etc/rusty-photon ]; then
+    ln -s /var/lib/rusty-photon/.config/rusty-photon /etc/rusty-photon
+fi
+#DEBHELPER#
+```
+
+`packaging/postrm.common`:
+
+```sh
+#!/bin/sh
+set -e
+SVC="${DPKG_MAINTSCRIPT_PACKAGE#rusty-photon-}"
+if [ "$1" = "purge" ]; then
+    rm -f "/var/lib/rusty-photon/.config/rusty-photon/$SVC.json"
+    rm -rf "/var/lib/rusty-photon/$SVC"
+fi
+#DEBHELPER#
+```
+
+The shared user, home, and `/etc/rusty-photon` symlink are never removed on
+purge (shared across packages; Debian convention keeps system users). The
+camera packages' postinst appends a `udevadm control --reload-rules &&
+udevadm trigger || true` stanza — the one sanctioned variant, checked by
+`check-pkg-assets.sh`.
+
+RPM mirrors this via `post_install_script` / `pre_uninstall_script` /
+`post_uninstall_script` (plain `systemctl` calls — cargo-generate-rpm does
+not process rpm macros). Camera packages additionally
+`getent group plugdev >/dev/null || groupadd -r plugdev` (the group is not
+standard on RPM distros).
+
+### Code change required (PR-2)
+
+`sentinel` is the one service without the XDG fallback: it loads config only
+when `--config` is passed, else silently runs on `Config::default()`. Switch
+it to `resolve_config_path` like every other service so the no-flag packaged
+unit behaves identically to the rest. Verify no other service bypasses
+`resolve_config_path`.
+
+### qhy-camera (PR-4)
+
+- `libqhyccd.a` is linked **statically** → runtime NEEDED is only
+  `libusb-1.0.so.0` + `libstdc++.so.6`; deb `depends = "$auto"` resolves them
+  via dpkg-shlibdeps.
+- Own-authored udev rule `70-rusty-photon-qhy.rules` →
+  `/usr/lib/udev/rules.d/` (never `/etc/udev/rules.d` from a package):
+
+  ```
+  SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", GROUP="plugdev", MODE="0660"
+  ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb'"
+  ```
+
+- `/usr/sbin/rusty-photon-qhy-firmware-install` (root-only, run manually;
+  postinst prints a pointer but never downloads — offline installs must not
+  fail): downloads the QHYCCD SDK pinned at **26.06.04** from
+  `https://www.qhyccd.com/file/repository/publish/SDK/260604/` —
+  `sdk_linux_arm64_26.06.04.tar.gz` (aarch64) or
+  `sdk_linux64_26.06.04.tar.gz` (x86_64) — verifies a pinned sha256, and
+  installs **only the firmware files** to `/lib/firmware/qhy`. It installs
+  neither `libqhyccd.so` (we link statically) nor the SDK's udev rules (we
+  ship our own). `--force` re-installs.
+
+### zwo-camera (PR-5)
+
+- MIT blobs `libASICamera2.so` + `libEFWFilter.so` (from the same pinned
+  indi-3rdparty commit `.github/actions/install-zwo-sdk` uses) are packaged
+  at `/usr/lib/rusty-photon/`, license at
+  `/usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt`.
+- The blobs carry **no SONAME** → loader resolution via **RUNPATH**:
+  `build-packages.sh` exports
+  `RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/lib/rusty-photon"` for the release
+  build (uniform across binaries; harmless where unused; deliberately not a
+  `build.rs` change, which would ripple into Bazel/repin). Expected lintian
+  finding `custom-library-search-path` is documented, not fixed.
+- deb `depends` are **explicit** (`libc6, libgcc-s1, libstdc++6,
+  libusb-1.0-0, libudev1`) — dpkg-shlibdeps cannot map SONAME-less private
+  blobs and `$auto` would fail.
+- Build staging: blobs downloaded into gitignored
+  `services/zwo-camera/pkg/lib/`; `ZWO_SDK_LIB_DIR` points there for the
+  link; `cargo deb` picks them up as plain assets.
+
+### phd2-guider (PR-3)
+
+CLI package: binary asset (`/usr/bin/rusty-photon-phd2-guider`) only. No
+unit, no user, no maintainer scripts beyond defaults.
+
+### plate-solver note
+
+ASTAP is an external runtime dependency (Recommends-level, not a hard dep):
+the operator installs it separately (arm64 `.deb` from the ASTAP site) and
+points the service config at the binary. Documented in `docs/packaging.md`.
+
+### On-device build — `scripts/build-packages.sh` (PR-6)
+
+Runs on Debian arm64 (the rig) and x86_64 dev boxes:
+
+1. apt prereqs (idempotent): `build-essential pkg-config curl git libssl-dev
+   libcfitsio-dev libusb-1.0-0-dev libudev-dev clang libclang-dev dpkg-dev
+   ca-certificates`; `cargo install --locked cargo-deb` (3.6.x);
+   `cargo-generate-rpm` only with `--rpm`.
+2. Stage QHY SDK into `~/.cache/rusty-photon-pkg/` (same pinned URL + sha256
+   as the firmware helper — the checker asserts the pins match), export
+   `QHYCCD_SDK_DIR=<extracted>/usr/local/lib`.
+3. Stage ZWO blobs into `services/zwo-camera/pkg/lib/`, export
+   `ZWO_SDK_LIB_DIR` to it.
+4. `RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/lib/rusty-photon" cargo build
+   --release -p <all service crates>`; strip binaries.
+5. Per service: `cargo deb -p <crate> --no-build --no-strip` (`--no-build`
+   is essential — a rebuild would lose the staged env/RUSTFLAGS). With
+   `--rpm` on x86_64: `cargo generate-rpm -p services/<dir>`.
+6. Collect into `dist/<version>/` + `SHA256SUMS.txt`.
+7. Flags: `--services a,b,c` (subset), `--rpm`, `--skip-sdk-staging`
+   (offline rebuild from cache).
+
+## Verification
+
+- `lintian` on all debs (documented expected findings:
+  `custom-library-search-path` on zwo-camera); `rpmlint` on rpms.
+- `scripts/verify-packages.sh` in a podman `--systemd=always` `debian:trixie`
+  container (arm64 natively on the rig, x86_64 on the dev box), per service:
+  install → unit `active` → config self-created at
+  `/var/lib/rusty-photon/.config/rusty-photon/<svc>.json` with a minted
+  `unique_id` → port probe (`/management/apiversions` for Alpaca services;
+  service-specific endpoint otherwise) → remove (config survives) → purge
+  (config + state gone; user/home/symlink stay).
+- Cameras start with zero devices attached (qhy-camera contract C0:
+  warn-and-serve). zwo-camera: `ldd` resolves `libASICamera2.so` to
+  `/usr/lib/rusty-photon/` (RUNPATH proof).
+- `config.apply` write-back on dsd-fp2 under the unit sandbox.
+- Upgrade path: rebuild one service with `--deb-version 0.1.1-1`, install
+  over: live config untouched, no prompts, unit restarted
+  (`restart-after-upgrade`).
+- `systemd-analyze security` once per class; record scores here.
+- On-rig only: QHY firmware helper end-to-end with a real camera (download,
+  sha256, replug, enumeration under plugdev/0660); serial access via
+  dialout; Alpaca UDP discovery from another host.
+
+## Flagged unknowns (resolve during PR-2/PR-4)
+
+- [ ] Firmware directory the static libqhyccd expects at runtime
+      (`strings libqhyccd.a | grep -i firmware`); adjust the helper's
+      destination if not `/lib/firmware/qhy`.
+- [ ] Whether libqhyccd uploads firmware in-process via libusb (firmware
+      files + our udev rule suffice) or depends on the SDK's udev/fxload
+      rules for cold devices; whether the rig's camera cold-enumerates under
+      the Cypress VID `04b4` (add a second rule line if so).
+- [ ] sha256 pins for both SDK archives (capture on first download).
+- [ ] `cargo-generate-rpm` support for a package `name` override (if
+      missing: document and keep rpm crate-named until upstream supports it).
+- [ ] `dirs`-crate home resolution under systemd `User=` without `$HOME`
+      (units set `HOME` explicitly as belt-and-braces; confirm the fallback
+      works anyway).
+
+## Future considerations
+
+- PR-7: generalize `release.yml` to a service matrix (x86_64 deb/rpm),
+  rename tarballs/Homebrew formula (`Formula/rusty-photon-filemonitor.rb`,
+  class `RustyPhotonFilemonitor`); finish the tap setup carried over from
+  the superseded plan.
+- CI-built arm64 packages (Pi runner or cross with staged arm64 SDKs).
+- An apt repository (and/or dnf copr) instead of GitHub-release attachments.
+- `sky-survey-camera` and other simulators could later split into a
+  `-simulators` meta-package if rig installs want to exclude them.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -60,8 +60,11 @@ belong in any single service design doc.
 | [ADR-008](decisions/008-zwo-camera-native-sdk-ffi.md) | `zwo-camera` native ZWO SDK: author-maintained `zwo-rs`/`libzwo-sys` FFI + MIT-SDK public caching |
 | [ADR-009](decisions/009-vendor-qhyccd-rs.md) | Vendor `qhyccd-rs` + `libqhyccd-sys` into the workspace (dual-homed) |
 | [ADR-010](decisions/010-vendor-zwo-rs.md) | Vendor `zwo-rs` + `libzwo-sys` into the workspace (dual-homed) |
+| [ADR-011](decisions/011-error-reporting-layers.md) | Layered error reporting — `thiserror` everywhere, `color-eyre` only at the binary boundary |
+| [ADR-012](decisions/012-service-packaging-architecture.md) | System packaging architecture — native `.deb`/`.rpm` for all services (`rusty-photon-*` naming, XDG config, shared service user) |
+| [ADR-013](decisions/013-native-sdk-payload-policy.md) | Native SDK payload policy — redistribute ZWO (MIT), download QHY firmware on-target (proprietary) |
 | **Plans** (in-flight initiatives — see [docs/plans/](plans/)) | |
-| [filemonitor-packaging.md](plans/filemonitor-packaging.md) | Filemonitor OS packaging |
+| [service-packaging.md](plans/service-packaging.md) | `.deb`/`.rpm` packages for every service (14 daemons + phd2-guider CLI): shared `rusty-photon` user, hardened unit classes, QHY firmware downloader, ZWO blob bundling, on-rig arm64 builds. Behind [ADR-012](decisions/012-service-packaging-architecture.md)/[ADR-013](decisions/013-native-sdk-payload-policy.md) |
 | [i18n.md](plans/i18n.md) | Workspace internationalization: scope, tech-stack, and translation-sourcing options |
 | [workflow-dsl.md](plans/workflow-dsl.md) | Imaging workflow DSL: declarative JSON workflow documents executed by the generic `session-runner` orchestrator plugin (CEL-style bounded expressions, trigger overlay, re-derive resume); decision record + phases behind [`docs/services/session-runner.md`](services/session-runner.md) |
 | [ui-testing.md](plans/ui-testing.md) | ui-htmx UI-behavior testing strategy: BDD-embedded `scraper` DOM assertions + cross-OS `insta` snapshots + an advisory `thirtyfour` browser layer, with an anticipatory spike plan; Bazel-primary aware; Gherkin stays the source of truth |


### PR DESCRIPTION
## Summary

Kicks off `.deb`/`.rpm` packaging for the whole service family (14 daemons + the `phd2-guider` CLI), generalizing the pattern proven by filemonitor packaging (PR #33). Docs only — implementation follows in staged PRs per the plan.

- **`docs/plans/service-packaging.md`** — the plan: per-service `pkg/` assets kept convergent by a checker script, hardened systemd unit template with three service classes (serial / USB camera / network-only), maintainer-script design, on-device arm64 build script for the Orange Pi rig, verification matrix, PR phasing.
- **ADR-012 — System packaging architecture**: native packages over containers (USB/udev/firmware + Alpaca UDP discovery defeat containerization); `rusty-photon-*` prefix for packages, installed binaries, and units; **user-based XDG config owned by the services** (no conffiles — six services rewrite their config at runtime, so conffile semantics can't apply; packaged behavior = dev behavior); one shared `rusty-photon` system user with per-unit `SupplementaryGroups`; deb+rpm only for the family.
- **ADR-013 — Native SDK payload policy**: ZWO's MIT `.so` blobs are redistributed in-package (private libdir + RUNPATH); QHYCCD's proprietary firmware is never redistributed — a pinned, sha256-verified downloader helper installs it on the target. Resolves ADR-009's open redistribution question.
- Archive `filemonitor-packaging.md` as **SUPERSEDED** (its bare-name / conffile / per-service-user decisions are superseded; the unfinished Homebrew tap steps carry over to PR-7 of the new plan).
- `docs/workspace.md`: swap the plans row, add ADR-012/013 rows, and backfill the missing ADR-011 row.

## Test plan

Docs-only change (verified: no Rust/BUILD files touched). Pre-commit hook ran clippy / rustfmt / buildifier — all green. All relative links between the new/moved docs verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)