### PR TITLE
fix(ci): raise --remote_timeout 3s -> 15s for remote-cache resiliency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -177,17 +177,22 @@ test:ci --test_summary=terse
 
 # --remote_timeout is the per-RPC idle/inactivity timeout for remote-cache
 # operations, NOT a total transfer cap — healthy byte-flowing transfers survive
-# it; it only bites an RPC that has stalled with no bytes moving. Dropped from
-# the old 600s to 3s as the confirmed fix for the intermittent `//services/rp:bdd`
-# post-scenario park (PR #342 + the park experiment; see
+# it; it only bites an RPC that has stalled with no bytes moving. Originally
+# dropped from 600s to 3s as the confirmed fix for the intermittent
+# `//services/rp:bdd` post-scenario park (PR #342 + the park experiment; see
 # docs/plans/archive/bazel-migration.md): the park was a stale pooled keep-alive cache
 # RPC that blackholed and blocked until the timeout, so a tight idle bound
-# collapses it. On `build:ci`, so it applies to every CI invocation (build, fast
-# test, BDD, coverage) — the build/fast-test steps therefore also use 3s now; the
-# only risk there is a cold-object time-to-first-byte tripping a spurious retry,
-# which has not materialized in CI. Raise this if a slow cold cache starts
-# retrying healthy transfers.
-build:ci --remote_timeout=3
+# collapses it. Raised 3 -> 15 (2026-07-04): the spurious-retry risk the 3s
+# setting accepted DID materialize — CI showed `Download of '/ac/…' timed out.
+# Received 0 bytes` on PR reads and `Upload of '/cas/…' timed out. Sent 151
+# bytes` during main-push bulk uploads (disproportionately the Windows leg;
+# a 151-byte upload timing out is a slow first byte, not bandwidth). Failed
+# main-push uploads leave holes in the cache that later PR runs miss on. 15s
+# gives cold Worker+R2 round trips real headroom while still collapsing a
+# recurred park in seconds, not the old 600 — and the park's other, independent
+# fix (test:ci --spawn_strategy=local below) remains in place. On `build:ci`,
+# so it applies to every CI invocation (build, fast test, BDD, coverage).
+build:ci --remote_timeout=15
 
 # Bypass the sandbox for tests under CI. Required on macOS/Windows (darwin-sandbox
 # blocks the BDD-spawned ASCOM OmniSim from binding network ports) AND now on

--- a/.github/workflows/bazel-coverage.yml
+++ b/.github/workflows/bazel-coverage.yml
@@ -120,8 +120,8 @@ jobs:
           # build:ci's `toplevel` so the combined lcov and its per-test .dat inputs
           # are materialised locally. --test_output=all surfaces rp:bdd's BDD-TRACE
           # breadcrumbs (ENTER / reset-ok / EXIT, tagged +Ns) even on a passing run
-          # — parity with the BDD leg in bazel.yml. --spawn_strategy=local and
-          # --remote_timeout=3 (the confirmed rp:bdd post-scenario park fix) are
+          # — parity with the BDD leg in bazel.yml. --spawn_strategy=local (the
+          # confirmed rp:bdd post-scenario park fix) and --remote_timeout=15 are
           # inherited from `.bazelrc` test:ci/build:ci.
           #
           # `|| status=$?` keeps a non-zero exit from aborting the step and records
@@ -148,7 +148,7 @@ jobs:
           # here skips the no-`if:` Split step, which is the intended behaviour). The always()
           # test-log capture step still runs regardless, so a failure is fully triage-able.
           # The rp:bdd post-scenario park (which could cancel ~half of these runs at the
-          # 60-min wall) is fixed (3s --remote_timeout + --spawn_strategy=local in .bazelrc);
+          # 60-min wall) is fixed (bounded --remote_timeout + --spawn_strategy=local in .bazelrc);
           # this job is a required gate.
           if [[ $status -eq 124 || $status -eq 137 ]]; then
             echo "::error title=bazel coverage capped::Hit the 50-min observability cap (exit $status) — a test (almost certainly //services/rp:bdd) did not finish in time. Captured test logs are in the 'bazel-testlogs' artifact."

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -157,7 +157,7 @@ jobs:
         # --test_env discards Bazel's analysis cache; see .bazelrc for the why).
         # --spawn_strategy=local (bypasses the sandbox so the BDD-spawned OmniSim
         # can bind ports; also the confirmed fix for the rp:bdd post-scenario
-        # park) and --remote_timeout=3 both live in `.bazelrc`. --test_output=all
+        # park) and --remote_timeout=15 both live in `.bazelrc`. --test_output=all
         # surfaces rp:bdd's BDD-TRACE per-scenario breadcrumbs even on a passing run
         # (services/rp/tests/bdd.rs).
         run: |


### PR DESCRIPTION
## Problem

The remote cache (Cloudflare Worker + R2) has been flaky in CI. Recent run logs show every cache error is a timeout at the 3-second `--remote_timeout` bound, disproportionately on the Windows leg:

- **PR reads** (run 28717662760, windows): `Download of '/ac/…' timed out. Received 0 bytes` — cold time-to-first-byte exceeded 3s, so a healthy read was abandoned.
- **Main-push writes** (run 28716333132, windows): `Multiple errors during bulk transfer` with uploads timing out at `Sent 151 bytes` / `Sent 6237 bytes` — a 151-byte upload timing out is a slow first byte, not bandwidth.

The upload failures are the worse half: holes punched in the cache on push-to-main become misses for every subsequent PR run, which is exactly the observed "flaky cache" behavior.

## Fix

Raise `build:ci --remote_timeout` from 3 to 15.

The 3s value was one of two fixes for the `rp:bdd` post-scenario park (PR #342); its comment explicitly accepted the risk of "a cold-object time-to-first-byte tripping a spurious retry" and said to raise it if that materialized. It has. At 15s:

- Cold Worker+R2 round trips get real headroom (observed failures were all sub-second-payload requests starved of first-byte time).
- A recurred park is still bounded at seconds, not the old 600s.
- The park's other, independent fix (`test:ci --spawn_strategy=local`) is unchanged.

Also updates the two workflow comments that cited the old value.

## Testing

- `bazel build //... && bazel test //...` — green (52/52)
- `bazel build --nobuild --config=ci` analysis smoke — config parses
- `cargo fmt --check` clean; pre-commit hook ran full clippy + buildifier, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)