### PR TITLE
feat(bazel-cache): touch-on-read so R2 age expiry behaves as LRU

### DIFF
--- a/docs/skills/bazel-remote-cache.md
+++ b/docs/skills/bazel-remote-cache.md
@@ -12,6 +12,11 @@ Cloud CI (`.github/workflows/bazel.yml`) uses a Bazel HTTP remote cache served
 by a **Cloudflare Worker backed by R2**, at `https://cache.rustyphoton.space`.
 Code, config, and deploy steps live in
 [`tools/bazel-cache-worker/`](../../tools/bazel-cache-worker/README.md).
+Retention is an R2 lifecycle rule (delete after 7 days) made into effective
+LRU by the Worker's **touch-on-read** (a GET of an object older than 2 days
+re-puts it, resetting its expiry clock) — see the Worker README's
+"Retention / eviction" for the full model. Worker changes only take effect
+after `wrangler deploy` (manual; no CI deploy step).
 
 For **local builds**, point a gitignored `user.bazelrc` at a LAN `bazel-remote`
 (reads at LAN speed):

--- a/tools/bazel-cache-worker/README.md
+++ b/tools/bazel-cache-worker/README.md
@@ -56,10 +56,26 @@ wrangler deploy
 
 ### Retention / eviction
 
-R2 has no built-in LRU, so set a **lifecycle rule** to bound growth: Cloudflare
-dashboard → R2 → `rusty-photon-bazel-cache` → Settings → Object lifecycle →
-**delete objects older than 30 days**. Cache entries are regenerable, so
-age-based eviction is safe and keeps storage in the free tier.
+R2 has no built-in LRU. Growth is bounded by an **object lifecycle rule**
+(Cloudflare dashboard → R2 → `rusty-photon-bazel-cache` → Settings → Object
+lifecycle), currently **delete objects older than 7 days**. On its own that
+rule would be an age bomb, not an LRU: R2 expires by *upload* time, and Bazel
+never re-uploads an entry that keeps getting cache hits, so every object would
+die a fixed time after it was last *built* — the stable core of the graph
+expiring en masse once per window, followed by a cold rebuild. (The nightly
+main build does not help here: an all-hit build uploads nothing.)
+
+The Worker therefore **touches on read**: a GET of an object older than 2 days
+re-puts it under the same key (in `ctx.waitUntil`, off the response path),
+resetting its lifecycle clock. Net effect: age expiry becomes effective LRU —
+anything read within the window survives, genuinely unused entries age out.
+The nightly full build reads the complete action-cache set daily, so live
+entries are touched well before the 7-day deadline. Cost bound: at most one
+Class A write per read object per 2 days (~$1–4/mo at this repo's scale).
+Residue: blobs a hit-heavy build never GETs (build-without-the-bytes skips
+most intermediate downloads) still age out; entries are regenerable and
+Bazel 9's default eviction retries rebuild through it. If the lifecycle
+window changes, keep `TOUCH_AFTER_MS` (src/cache.js) comfortably below it.
 
 ## Verify
 

--- a/tools/bazel-cache-worker/src/cache.js
+++ b/tools/bazel-cache-worker/src/cache.js
@@ -13,8 +13,35 @@
 
 const KEY_RE = /^(ac|cas)\/[0-9a-fA-F]+$/;
 
+// Touch-on-read. The bucket's lifecycle rule deletes objects by UPLOAD age,
+// but Bazel never re-uploads an entry that keeps getting cache hits, so
+// without a touch every object dies a fixed time after it was last BUILT, not
+// last USED — the whole stable core of the action graph expires en masse once
+// per lifecycle window and the next builds run cold. Re-putting a read object
+// resets its lifecycle clock, turning age-based expiry into effective LRU:
+// anything read within the window survives.
+//
+// Only objects older than TOUCH_AFTER_MS are re-put, bounding the Class A
+// (write) cost to at most one write per read object per 2 days. The safety
+// constraint is TOUCH_AFTER + the longest read gap of a live object < the
+// lifecycle window (7 days); the nightly full build of main reads the entire
+// //... action-cache set daily, so 2 days leaves wide margin. Known residue,
+// both backstopped by Bazel 9's default eviction retries (rewind + rebuild):
+//  - blobs a hit-heavy build never GETs (build-without-the-bytes skips most
+//    intermediate downloads) are not touched and still age out;
+//  - a touch can race a concurrent push-to-main PUT of the same /ac key and
+//    resurrect the just-replaced entry (both are valid results; harmless).
+const TOUCH_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
+
+async function touch(env, key) {
+  // Fresh get(): the client response consumes its own body stream. put()
+  // accepts the R2ObjectBody stream directly (its length is known).
+  const obj = await env.CACHE.get(key);
+  if (obj) await env.CACHE.put(key, obj.body);
+}
+
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const key = new URL(request.url).pathname.replace(/^\/+/, "");
 
     // Health check for humans; Bazel never hits this.
@@ -28,7 +55,11 @@ export default {
     switch (request.method) {
       case "GET": {
         const obj = await env.CACHE.get(key);
-        return obj ? new Response(obj.body, { status: 200 }) : new Response(null, { status: 404 });
+        if (!obj) return new Response(null, { status: 404 });
+        if (Date.now() - obj.uploaded.getTime() > TOUCH_AFTER_MS) {
+          ctx.waitUntil(touch(env, key));
+        }
+        return new Response(obj.body, { status: 200 });
       }
       case "HEAD": {
         const obj = await env.CACHE.head(key);

--- a/tools/bazel-cache-worker/src/cache.js
+++ b/tools/bazel-cache-worker/src/cache.js
@@ -26,18 +26,24 @@ const KEY_RE = /^(ac|cas)\/[0-9a-fA-F]+$/;
 // constraint is TOUCH_AFTER + the longest read gap of a live object < the
 // lifecycle window (7 days); the nightly full build of main reads the entire
 // //... action-cache set daily, so 2 days leaves wide margin. Known residue,
-// both backstopped by Bazel 9's default eviction retries (rewind + rebuild):
-//  - blobs a hit-heavy build never GETs (build-without-the-bytes skips most
-//    intermediate downloads) are not touched and still age out;
-//  - a touch can race a concurrent push-to-main PUT of the same /ac key and
-//    resurrect the just-replaced entry (both are valid results; harmless).
+// backstopped by Bazel 9's default eviction retries (rewind + rebuild): blobs
+// a hit-heavy build never GETs (build-without-the-bytes skips most
+// intermediate downloads) are not touched and still age out.
 const TOUCH_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
 
-async function touch(env, key) {
+async function touch(env, key, seenUploadedMs) {
   // Fresh get(): the client response consumes its own body stream. put()
   // accepts the R2ObjectBody stream directly (its length is known).
   const obj = await env.CACHE.get(key);
-  if (obj) await env.CACHE.put(key, obj.body);
+  // Gone, or already refreshed/replaced since the GET that scheduled this
+  // touch (a sibling touch from a GET burst on the same stale key, or a real
+  // push-to-main PUT) -> nothing to do. Collapses duplicate touches to one
+  // Class A write and keeps a touch from resurrecting a replaced entry.
+  if (!obj || obj.uploaded.getTime() !== seenUploadedMs) return;
+  // The conditional write closes the remaining get->put window: if anything
+  // replaced the object in between, the etag no longer matches and R2 drops
+  // the touch (put resolves null; fine — the object is fresh either way).
+  await env.CACHE.put(key, obj.body, { onlyIf: { etagMatches: obj.etag } });
 }
 
 export default {
@@ -57,7 +63,7 @@ export default {
         const obj = await env.CACHE.get(key);
         if (!obj) return new Response(null, { status: 404 });
         if (Date.now() - obj.uploaded.getTime() > TOUCH_AFTER_MS) {
-          ctx.waitUntil(touch(env, key));
+          ctx.waitUntil(touch(env, key, obj.uploaded.getTime()));
         }
         return new Response(obj.body, { status: 200 });
       }


### PR DESCRIPTION
## Problem

The bucket's lifecycle rule (now **7 days**) deletes objects by **upload age**, but Bazel never re-uploads an entry that keeps getting cache hits — and the nightly all-hit build of main uploads nothing. So every object dies a fixed time after it was last *built*, not last *used*: the stable core of the action graph expires en masse once per window, and PR builds run cold until the next nightly re-executes and re-uploads everything. With a 7-day window that's a weekly scheduled cache wipe.

## Fix

The Worker now **touches on read**: a GET of an object older than 2 days re-puts it under the same key inside `ctx.waitUntil()` (off the response path), resetting its lifecycle clock. Age-based expiry becomes effective LRU — anything read within the window survives; genuinely unused entries still age out.

Why 2 days: the safety constraint is `TOUCH_AFTER + longest read gap of a live object < lifecycle window`. The nightly reads the entire `//...` action-cache set daily, so 2 days leaves wide margin against the 7-day deadline while bounding cost to at most one Class A write per read object per 2 days (~$1–4/mo at this repo's scale).

Known residue (documented in code + README, both backstopped by Bazel 9's default eviction retries):
- Blobs a hit-heavy build never GETs (BwoB skips most intermediate downloads) are not touched and still age out.
- A touch can race a concurrent push-to-main PUT of the same `/ac` key and resurrect the just-replaced entry — both are valid results.

Also updates the Worker README's retention section (was still describing the old 30-day guidance) and adds the retention model to `docs/skills/bazel-remote-cache.md`.

## Testing

Ad-hoc node harness driving the fetch handler against a fake R2 binding + `ctx.waitUntil` (9 checks, all green):
- fresh GET (1 day old): 200, body served, **no** touch
- stale GET (3 days old): 200, exactly one touch scheduled; content preserved, upload clock reset
- touch of a key deleted between response and waitUntil: no-op, no rejection
- HEAD never touches (GET-only by design); 404 / 400 / 405 / PUT token-gating unchanged
- `bazel build //... && bazel test //...` green (54/54); pre-commit hook ran clippy + fmt + buildifier

## Deploy

⚠️ Takes effect only after a manual deploy — there is no CI deploy step:

```bash
cd tools/bazel-cache-worker && wrangler deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)