### PR TITLE
perf(bazel-cache): serve /cas/ reads from Cloudflare's edge cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ lcov.info
 # bazel-* are workspace symlinks at the repo root (bazel-bin, bazel-out, ...).
 # Anchored to root so it doesn't match e.g. docs/plans/archive/bazel-migration.md.
 /bazel-*
+# wrangler's local state (created by `wrangler deploy` in tools/bazel-cache-worker/).
+.wrangler/
 # user.bazelrc allows per-developer overrides without touching .bazelrc.
 user.bazelrc
 # MODULE.bazel.lock IS committed (like Cargo.lock) for reproducibility.

--- a/docs/skills/bazel-remote-cache.md
+++ b/docs/skills/bazel-remote-cache.md
@@ -15,8 +15,11 @@ Code, config, and deploy steps live in
 Retention is an R2 lifecycle rule (delete after 7 days) made into effective
 LRU by the Worker's **touch-on-read** (a GET of an object older than 2 days
 re-puts it, resetting its expiry clock) — see the Worker README's
-"Retention / eviction" for the full model. Worker changes only take effect
-after `wrangler deploy` (manual; no CI deploy step).
+"Retention / eviction" for the full model. `/cas/` GETs are additionally
+served from Cloudflare's per-PoP **edge cache** (1-day TTL; immutable
+content-addressed blobs, so no invalidation — the TTL is counted into the
+retention margin, see the README's "Edge cache"). Worker changes only take
+effect after `wrangler deploy` (manual; no CI deploy step).
 
 For **local builds**, point a gitignored `user.bazelrc` at a LAN `bazel-remote`
 (reads at LAN speed):

--- a/tools/bazel-cache-worker/README.md
+++ b/tools/bazel-cache-worker/README.md
@@ -75,7 +75,27 @@ Class A write per read object per 2 days (~$1–4/mo at this repo's scale).
 Residue: blobs a hit-heavy build never GETs (build-without-the-bytes skips
 most intermediate downloads) still age out; entries are regenerable and
 Bazel 9's default eviction retries rebuild through it. If the lifecycle
-window changes, keep `TOUCH_AFTER_MS` (src/cache.js) comfortably below it.
+window changes, keep `TOUCH_AFTER_MS + CAS_EDGE_TTL_S` (src/cache.js)
+comfortably below it — the edge cache (next section) adds its TTL to the
+worst-case gap between an object's R2 touches.
+
+### Edge cache (`/cas/` reads)
+
+CAS keys are content hashes — a key's bytes can never legitimately change —
+so the Worker serves `/cas/` GETs from Cloudflare's per-datacenter cache
+(`caches.default`, `max-age` 1 day) and only falls through to R2 on a miss
+(with one retry on transient R2 read errors). The common CI shape — the
+Linux/macOS/Windows build+test legs plus the coverage job pulling the same
+blobs within hours of each other — is served at edge latency, and an R2
+latency spike or transient error can't stall an edge-cached read. `/ac/`
+entries are mutable (a re-executed action re-uploads under the same key), so
+they always read R2 and are never edge-cached.
+
+Interplay with retention: an edge hit never reaches R2, so it cannot touch —
+a hot blob's R2 clock only advances on the origin reads between TTL
+expiries. The 1-day TTL bounds that: worst-case R2 age of a live object is
+2d (touch threshold) + 1d (edge TTL) + 1d (nightly read gap) ≈ 4d, inside
+the 7-day lifecycle window with margin.
 
 ## Verify
 

--- a/tools/bazel-cache-worker/src/cache.js
+++ b/tools/bazel-cache-worker/src/cache.js
@@ -2,7 +2,9 @@
 //
 // Implements the Bazel HTTP cache protocol (GET/HEAD/PUT on /ac/<hash> and
 // /cas/<hash>) over an R2 bucket, served from Cloudflare's edge, so cloud CI
-// reads it at edge speed (with R2's zero egress cost).
+// reads it at edge speed (with R2's zero egress cost). Hot /cas/ blobs are
+// served straight from the per-PoP edge cache with no R2 round trip at all
+// (see CAS_EDGE_TTL_S below).
 //
 // Security (public repo): reads are ANONYMOUS, so every PR including forks gets
 // a warm cache; writes require a Bearer token that only push-to-main / nightly
@@ -30,6 +32,30 @@ const KEY_RE = /^(ac|cas)\/[0-9a-fA-F]+$/;
 // a hit-heavy build never GETs (build-without-the-bytes skips most
 // intermediate downloads) are not touched and still age out.
 const TOUCH_AFTER_MS = 2 * 24 * 60 * 60 * 1000;
+
+// Edge-cache TTL for /cas/ reads. CAS keys are content hashes — a key's bytes
+// can never legitimately change — so serving them from Cloudflare's
+// per-datacenter cache needs no invalidation story (even a touch re-put
+// writes identical content). The constraint is retention interplay: an edge
+// hit never reaches R2, so it cannot touch — a hot blob's R2 clock only
+// advances on the origin reads between TTL expiries. Worst-case R2 age of a
+// live object is TOUCH_AFTER (2d) + this TTL (1d) + the nightly read gap
+// (1d) ≈ 4d, comfortably inside the 7-day lifecycle window; keep
+// TOUCH_AFTER_MS + CAS_EDGE_TTL_S well below that window if either changes.
+// A longer TTL would buy little anyway: CI reads are bursty (all legs of a
+// run land within hours), and the next origin read re-primes the PoP.
+const CAS_EDGE_TTL_S = 24 * 60 * 60;
+
+// One immediate retry on R2 read exceptions. Transient R2 errors exist, and
+// to Bazel a failed cache read becomes a rebuilt action — a second read is
+// far cheaper than that.
+async function r2Get(env, key) {
+  try {
+    return await env.CACHE.get(key);
+  } catch {
+    return env.CACHE.get(key);
+  }
+}
 
 async function touch(env, key, seenUploadedMs) {
   // Fresh get(): the client response consumes its own body stream. put()
@@ -60,12 +86,28 @@ export default {
 
     switch (request.method) {
       case "GET": {
-        const obj = await env.CACHE.get(key);
+        // /cas/ is immutable -> edge-cacheable: a hit never reaches R2, so an
+        // R2 latency spike or transient error can't stall the read. /ac/
+        // entries are mutable (a re-executed action re-uploads under the same
+        // key), so they always read R2.
+        const edgeable = key.startsWith("cas/");
+        if (edgeable) {
+          const hit = await caches.default.match(request);
+          if (hit) return hit;
+        }
+        const obj = await r2Get(env, key);
         if (!obj) return new Response(null, { status: 404 });
         if (Date.now() - obj.uploaded.getTime() > TOUCH_AFTER_MS) {
           ctx.waitUntil(touch(env, key, obj.uploaded.getTime()));
         }
-        return new Response(obj.body, { status: 200 });
+        // Content-Length gives Bazel a sized body instead of a chunked
+        // stream; Cache-Control is what makes cache.put store the response.
+        const headers = { "Content-Length": String(obj.size) };
+        if (edgeable) headers["Cache-Control"] = `public, max-age=${CAS_EDGE_TTL_S}`;
+        const res = new Response(obj.body, { status: 200, headers });
+        // clone() tees the body: one branch to the client, one to the edge.
+        if (edgeable) ctx.waitUntil(caches.default.put(request, res.clone()));
+        return res;
       }
       case "HEAD": {
         const obj = await env.CACHE.head(key);


### PR DESCRIPTION
## What

Adds a per-PoP edge-cache layer (`caches.default`) in front of R2 for `/cas/` GETs — the next resiliency step after #436 (remote_timeout) and #437 (touch-on-read).

- **`GET /cas/…`**: try the edge cache first; a hit returns immediately with no R2 round trip. On a miss, read R2, respond with `Cache-Control: public, max-age=86400` + `Content-Length`, and populate the edge via `ctx.waitUntil(cache.put(...))` off the response path.
- **`/ac/` stays uncached**: AC entries are mutable (a re-executed action re-uploads under the same key), so they always read R2. CAS keys are content hashes — immutable — so caching them needs no invalidation story (even a touch re-put writes identical bytes).
- **Origin-path hardening**: one immediate retry on transient R2 read errors; `Content-Length` from `obj.size` so Bazel sees a sized body instead of a chunked stream.
- Gitignore `.wrangler/` (local state from manual deploys).

## Why 1 day

An edge hit never reaches R2, so it can't touch-on-read — the TTL bounds how long a hot blob's R2 lifecycle clock can stall: worst case 2d (touch threshold) + 1d (edge TTL) + 1d (nightly read gap) ≈ 4d, inside the 7-day lifecycle window with margin. A longer TTL buys little: CI reads are bursty (Linux/macOS/Windows legs + coverage pull the same blobs within hours), and the next origin read re-primes the PoP. Constraint documented in `src/cache.js`, the Worker README, and `docs/skills/bazel-remote-cache.md`.

## What it buys

Edge-local first byte for repeated CAS reads across CI legs, zero R2 Class B ops on hits, and an R2 latency spike or transient error can't stall an edge-cached read. (Upload flakiness was #436's territory; this is read-path only.)

## Testing

- Ad-hoc Worker harness (fake R2 + fake `caches.default` + `ctx.waitUntil`), 15 checks, all green: edge hit serves without reading R2 and schedules nothing; cas miss primes the edge; `/ac/` never edge-cached, no `Cache-Control`; 404s not cached; touch-on-read still fires on origin reads with the burst-dedupe + conditional-write guards intact; R2 read retried exactly once; persistent R2 failure surfaces as an error, not a bogus 404.
- `bazel build //... && bazel test //...` (54/54), `cargo fmt`, `cargo clippy -D warnings` clean.

## Deploy

Not live on merge — needs a manual `cd tools/bazel-cache-worker && wrangler deploy`. Works because `cache.rustyphoton.space` is a custom domain (`cache.put` is a no-op on workers.dev). No `wrangler.toml` change; the Cache API needs no binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)