### PR TITLE
feat(qhy-camera): package as rusty-photon-qhy-camera with firmware-install helper (PR-4)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -520,7 +520,7 @@
           "FILE:@@//services/pa-falcon-rotator/Cargo.toml f7fad4b100f0fa4e2eb4a76acc06f5f15c07c9ae54d8fae6695d89e7649a17a0",
           "FILE:@@//services/phd2-guider/Cargo.toml f4b1dc0b503c58cebab7b379f4984bd9ca2659a037d7861c725d74eb56f0bc3f",
           "FILE:@@//services/ppba-driver/Cargo.toml 8ab098e9dd9f1ca1295e25242d1dce13ffdfd959a96a1f4d94ef0e3a37c81958",
-          "FILE:@@//services/qhy-camera/Cargo.toml 01c6581a16d8e4770e3eaf922441c066db5b095089cbb7bb01c1dc50f2b09c71",
+          "FILE:@@//services/qhy-camera/Cargo.toml 673f077dc03356c5efbb6d916958454ecadcf8a3ae4c897a4b3ef5bcd6e5f111",
           "FILE:@@//services/qhy-focuser/Cargo.toml aa7bfea0140f581f61318acc2f14b22b90afbf0ed43e8fd7c8b7b0ee008cd0a0",
           "FILE:@@//services/calibrator-flats/Cargo.toml 66296d3389d9f2a6fc0a1f94059e82a822b871c8509c2abf72d6f0b387cdff74",
           "FILE:@@//services/dsd-fp2/Cargo.toml b987ddce744ec9aac54301c035b46bf5b05f00336782281f88d17b84d235464c",

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -285,7 +285,7 @@ startup error — and their units are `ConditionPathExists`-gated, as is
 
   ```
   SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", GROUP="plugdev", MODE="0660"
-  ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb'"
+  ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb || true'"
   ```
 
 - `/usr/sbin/rusty-photon-qhy-firmware-install` (root-only, run manually;

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -25,7 +25,7 @@ while keeping host-level setup anyway (see ADR-012 Context).
 | PR-1 | This plan + ADR-012 + ADR-013 + archive old plan | Merged | #435 |
 | PR-2 | Migrate filemonitor to the new pattern (template proof) + filemonitor/sentinel XDG fix + `check-pkg-assets.sh` | Merged | #438 |
 | PR-3 | 11 pure-Rust daemons + `phd2-guider` CLI package | Merged | #441 |
-| PR-4 | `qhy-camera` package + firmware downloader helper | Pending | |
+| PR-4 | `qhy-camera` package + firmware downloader helper | In progress | `feature/qhy-camera-packaging` |
 | PR-5 | `zwo-camera` package with bundled MIT SDK blobs | Pending | |
 | PR-6 | `build-packages.sh` + `verify-packages.sh` + `docs/packaging.md`; first on-rig install | Pending | |
 | PR-7 | `release.yml` generalization (x86_64 matrix, Homebrew rename) | Deferred | |
@@ -95,7 +95,7 @@ services/<svc>/pkg/
   postrm                 # copy of packaging/postrm.common
 ```
 
-Extras: `services/qhy-camera/pkg/` adds `70-rusty-photon-qhy.rules` +
+Extras: `services/qhy-camera/pkg/` adds `90-rusty-photon-qhy.rules` +
 `rusty-photon-qhy-firmware-install`; `services/zwo-camera/pkg/` adds
 `70-rusty-photon-zwo.rules` + a gitignored `lib/` dir into which the build
 script stages the ZWO blobs + license before `cargo deb` runs.
@@ -277,8 +277,11 @@ startup error — and their units are `ConditionPathExists`-gated, as is
 - `libqhyccd.a` is linked **statically** → runtime NEEDED is only
   `libusb-1.0.so.0` + `libstdc++.so.6`; deb `depends = "$auto"` resolves them
   via dpkg-shlibdeps.
-- Own-authored udev rule `70-rusty-photon-qhy.rules` →
-  `/usr/lib/udev/rules.d/` (never `/etc/udev/rules.d` from a package):
+- Own-authored udev rule `90-rusty-photon-qhy.rules` →
+  `/usr/lib/udev/rules.d/` (never `/etc/udev/rules.d` from a package). It
+  deliberately sorts **after** the SDK's `85-qhyccd.rules` so its
+  `GROUP="plugdev", MODE="0660"` tightens the SDK rules' trailing blanket
+  `MODE="0666"`:
 
   ```
   SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", GROUP="plugdev", MODE="0660"
@@ -290,10 +293,28 @@ startup error — and their units are `ConditionPathExists`-gated, as is
   fail): downloads the QHYCCD SDK pinned at **26.06.04** from
   `https://www.qhyccd.com/file/repository/publish/SDK/260604/` —
   `sdk_linux_arm64_26.06.04.tar.gz` (aarch64) or
-  `sdk_linux64_26.06.04.tar.gz` (x86_64) — verifies a pinned sha256, and
-  installs **only the firmware files** to `/lib/firmware/qhy`. It installs
-  neither `libqhyccd.so` (we link statically) nor the SDK's udev rules (we
-  ship our own). `--force` re-installs.
+  `sdk_linux64_26.06.04.tar.gz` (x86_64) — verifies the pinned sha256
+  (pins live in the helper; the URL-dir scheme for >= 26.06.04 is the
+  dotless YYMMDD form, matching `qhyccd-sdk-install@v4`), and installs the
+  pieces a camera needs at runtime: firmware images → `/lib/firmware/qhy`,
+  the SDK's `85-qhyccd.rules` → `/etc/udev/rules.d/` with its `RUN` paths
+  rewritten, and QHYCCD's FX2/FX3-capable `fxload` → `/usr/local/sbin/fxload`
+  (never `/usr/sbin/fxload`, which Debian's FX2-only `fxload` package may
+  own). It installs neither `libqhyccd.so` (we link statically) nor
+  headers/samples. `--force` re-installs; `--root DIR` supports container
+  testing.
+
+  **PR-4 finding — the helper installs the SDK udev rules + fxload after
+  all** (this plan originally said firmware files only): on Linux the SDK
+  performs **no in-process firmware upload** — its only firmware-path entry
+  points (`OSXInitQHYCCDFirmware*`) are macOS/Android, and `libqhyccd.a`
+  embeds firmware *basenames* but no search directory. A cold-plugged
+  camera enumerates as a raw Cypress controller (VID `1618` with a raw
+  per-model PID; the legacy Cypress VID `04b4` appears only in the bare
+  FX2 dev-board rule) and receives firmware solely via the SDK's udev
+  `RUN` rules exec'ing fxload as root out of `/lib/firmware/qhy`. Without
+  those rules and QHYCCD's own fxload build (stock Debian fxload cannot
+  program FX3), a factory-fresh camera never becomes usable.
 
 ### zwo-camera (PR-5)
 
@@ -385,14 +406,19 @@ Runs on Debian arm64 (the rig) and x86_64 dev boxes:
 
 ## Flagged unknowns (resolve during PR-2/PR-4)
 
-- [ ] Firmware directory the static libqhyccd expects at runtime
-      (`strings libqhyccd.a | grep -i firmware`); adjust the helper's
-      destination if not `/lib/firmware/qhy`.
-- [ ] Whether libqhyccd uploads firmware in-process via libusb (firmware
-      files + our udev rule suffice) or depends on the SDK's udev/fxload
-      rules for cold devices; whether the rig's camera cold-enumerates under
-      the Cypress VID `04b4` (add a second rule line if so).
-- [ ] sha256 pins for both SDK archives (capture on first download).
+- [x] Firmware directory: confirmed `/lib/firmware/qhy` (every fxload `RUN`
+      line in the SDK's udev rules hardcodes it, and the 26.06.04 archive
+      ships `lib/firmware/qhy/**`; `libqhyccd.a` itself embeds only
+      basenames).
+- [x] In-process vs fxload: on Linux, firmware upload is **udev + fxload
+      only** (the SDK's in-process entry points are macOS/Android-only), so
+      the helper also installs the SDK's `85-qhyccd.rules` (RUN paths
+      rewritten) and QHYCCD's fxload — see the PR-4 finding above. Cold
+      cameras enumerate at VID `1618` with raw per-model PIDs; `04b4` is
+      only the bare FX2 dev board, already covered by the SDK rules. The
+      end-to-end cold-plug check stays an on-rig item (PR-6).
+- [x] sha256 pins for both 26.06.04 archives captured in
+      `rusty-photon-qhy-firmware-install` (single source of truth).
 - [ ] `cargo-generate-rpm` support for a package `name` override (if
       missing: document and keep rpm crate-named until upstream supports it).
 - [ ] `dirs`-crate home resolution under systemd `User=` without `$HOME`

--- a/docs/services/qhy-camera.md
+++ b/docs/services/qhy-camera.md
@@ -692,6 +692,27 @@ the "how" decisions made while building.
 - **`ElectronsPerADU` / `FullWellCapacity`** real values if a signal model is
   added.
 
+## Packaging
+
+Packaged as `rusty-photon-qhy-camera` (`.deb`/`.rpm`) per
+[ADR-012](../decisions/012-service-packaging-architecture.md) /
+[ADR-013](../decisions/013-native-sdk-payload-policy.md) and
+[`docs/plans/service-packaging.md`](../plans/service-packaging.md):
+binary at `/usr/bin/rusty-photon-qhy-camera`, hardened
+`rusty-photon-qhy-camera.service` (camera class: `plugdev` +
+`AF_NETLINK`, no `PrivateDevices`/`MemoryDenyWriteExecute`), and a udev
+rule `90-rusty-photon-qhy.rules` granting `plugdev` members access to
+enumerated QHY cameras (VID `1618`).
+
+QHYCCD's proprietary firmware is **never** bundled. After installing the
+package, run `/usr/sbin/rusty-photon-qhy-firmware-install` once as root:
+it downloads the sha256-pinned SDK archive from qhyccd.com and installs
+the camera firmware (`/lib/firmware/qhy`), the SDK's firmware-upload udev
+rules, and QHYCCD's FX2/FX3-capable `fxload` (`/usr/local/sbin`) — on
+Linux a cold-plugged camera receives firmware via udev + fxload as root,
+not in-process, so all three pieces are required for a factory-fresh
+camera to enumerate.
+
 ## References
 
 - [`qhyccd-sdk-manual.md`](../references/qhyccd-sdk-manual.md) — full English translation of the

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -20,7 +20,13 @@ The camera packages (`qhy-camera`, `zwo-camera`) are the one sanctioned
 variant: their `postinst` must be exactly `postinst.common` with
 [`postinst.udev-stanza`](postinst.udev-stanza) inserted before the
 `#DEBHELPER#` line (they ship udev rules). The checker verifies that exact
-construction, byte for byte.
+construction, byte for byte. The stanza also prints a pointer to
+`/usr/sbin/<pkg-minus-camera>-firmware-install` when the package ships one
+(qhy-camera does — proprietary firmware is downloaded by the operator, never
+packaged, per ADR-013; zwo-camera bundles its MIT blobs instead, so the
+pointer is a no-op there). Camera `pkg/` dirs additionally hold the udev
+rule file and, for qhy-camera, the firmware helper — both listed as plain
+`assets` in the metadata blocks.
 
 `scripts/check-pkg-assets.sh` enforces all of this — run it after touching
 anything under `packaging/` or a service's `pkg/` directory. It discovers

--- a/packaging/postinst.udev-stanza
+++ b/packaging/postinst.udev-stanza
@@ -1,3 +1,10 @@
 # Camera packages ship a udev rule; make it effective without a reboot.
 udevadm control --reload-rules || true
 udevadm trigger || true
+# Proprietary camera firmware is never packaged (ADR-013). When the
+# package ships a firmware-install helper, point the operator at it.
+fw_helper="/usr/sbin/${DPKG_MAINTSCRIPT_PACKAGE%-camera}-firmware-install"
+if [ -x "$fw_helper" ]; then
+    echo "$DPKG_MAINTSCRIPT_PACKAGE: camera firmware is not bundled."
+    echo "Run '$fw_helper' once as root before first use."
+fi

--- a/scripts/check-pkg-assets.sh
+++ b/scripts/check-pkg-assets.sh
@@ -72,6 +72,15 @@ for pkgdir in services/*/pkg; do
             ;;
     esac
 
+    # Camera packages ship their own udev rule (the postinst udev stanza
+    # reloads rules on install, so the rule file must actually be there).
+    case "$svc" in
+        qhy-camera)
+            [ -f "$pkgdir/90-rusty-photon-qhy.rules" ] \
+                || err "$svc: missing pkg/90-rusty-photon-qhy.rules"
+            ;;
+    esac
+
     toml_section "$toml" "package.metadata.deb" | grep -q "^name = \"$name\"" \
         || err "$svc: [package.metadata.deb] name must be \"$name\""
     toml_section "$toml" "package.metadata.deb.systemd-units" | grep -q "^unit-name = \"$name\"" \

--- a/services/qhy-camera/Cargo.toml
+++ b/services/qhy-camera/Cargo.toml
@@ -50,6 +50,59 @@ parking_lot = { workspace = true }
 [package.metadata.conformu]
 command = "cargo test -p qhy-camera --features conformu --test conformu_integration -- --nocapture"
 
+[package.metadata.deb]
+name = "rusty-photon-qhy-camera"
+maintainer = "Igor von Nyssen <igor@vonnyssen.com>"
+extended-description = "ASCOM Alpaca Camera and FilterWheel driver for QHYCCD cameras. QHYCCD's proprietary firmware is not bundled: run rusty-photon-qhy-firmware-install once as root after installation."
+section = "science"
+priority = "optional"
+# $auto = dpkg-shlibdeps (needs a Debian build host); adduser is used by postinst.
+depends = "$auto, adduser"
+assets = [
+    ["target/release/qhy-camera", "usr/bin/rusty-photon-qhy-camera", "755"],
+    ["pkg/90-rusty-photon-qhy.rules", "usr/lib/udev/rules.d/90-rusty-photon-qhy.rules", "644"],
+    ["pkg/rusty-photon-qhy-firmware-install", "usr/sbin/rusty-photon-qhy-firmware-install", "755"],
+]
+maintainer-scripts = "pkg/"
+
+[package.metadata.deb.systemd-units]
+unit-name = "rusty-photon-qhy-camera"
+unit-scripts = "pkg/"
+enable = true
+start = true
+restart-after-upgrade = true
+
+[package.metadata.generate-rpm]
+name = "rusty-photon-qhy-camera"
+summary = "ASCOM Alpaca Camera and FilterWheel driver for QHYCCD cameras"
+license = "MIT OR Apache-2.0"
+assets = [
+    { source = "target/release/qhy-camera", dest = "/usr/bin/rusty-photon-qhy-camera", mode = "755" },
+    { source = "pkg/rusty-photon-qhy-camera.service", dest = "/usr/lib/systemd/system/rusty-photon-qhy-camera.service", mode = "644" },
+    { source = "pkg/90-rusty-photon-qhy.rules", dest = "/usr/lib/udev/rules.d/90-rusty-photon-qhy.rules", mode = "644" },
+    { source = "pkg/rusty-photon-qhy-firmware-install", dest = "/usr/sbin/rusty-photon-qhy-firmware-install", mode = "755" },
+]
+post_install_script = """
+getent passwd rusty-photon > /dev/null || useradd -r -d /var/lib/rusty-photon -s /sbin/nologin rusty-photon
+getent group plugdev > /dev/null || groupadd -r plugdev
+install -d -m 0750 -o rusty-photon -g rusty-photon /var/lib/rusty-photon /var/lib/rusty-photon/.config /var/lib/rusty-photon/.config/rusty-photon
+[ -e /etc/rusty-photon ] || ln -s /var/lib/rusty-photon/.config/rusty-photon /etc/rusty-photon
+systemctl daemon-reload
+systemctl enable rusty-photon-qhy-camera.service
+udevadm control --reload-rules || true
+udevadm trigger || true
+echo "rusty-photon-qhy-camera: camera firmware is not bundled."
+echo "Run '/usr/sbin/rusty-photon-qhy-firmware-install' once as root before first use."
+"""
+pre_uninstall_script = """
+systemctl stop rusty-photon-qhy-camera.service || true
+systemctl disable rusty-photon-qhy-camera.service || true
+"""
+# rpm has no purge lifecycle: erase preserves the runtime-created config and
+# state (removal is a documented manual step), matching dpkg remove-vs-purge.
+post_uninstall_script = "systemctl daemon-reload"
+require-sh = true
+
 [dev-dependencies]
 # ascom-alpaca's `client` feature is used only by the BDD harness
 # (tests/bdd/world.rs), so keep it out of the production server binary — it

--- a/services/qhy-camera/pkg/90-rusty-photon-qhy.rules
+++ b/services/qhy-camera/pkg/90-rusty-photon-qhy.rules
@@ -1,0 +1,10 @@
+# Rusty Photon QHYCCD camera access (installed by rusty-photon-qhy-camera).
+#
+# Enumerated QHY cameras (VID 1618) become group-accessible to plugdev
+# instead of world-writable. This file deliberately sorts after the SDK's
+# 85-qhyccd.rules (installed by rusty-photon-qhy-firmware-install) so it
+# tightens that file's blanket MODE="0666" to 0660 + plugdev.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", GROUP="plugdev", MODE="0660"
+# High-resolution sensors need more than the usbfs default (16 MB) for
+# bulk transfers; QHYCCD recommends 200 MB.
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb'"

--- a/services/qhy-camera/pkg/90-rusty-photon-qhy.rules
+++ b/services/qhy-camera/pkg/90-rusty-photon-qhy.rules
@@ -7,4 +7,4 @@
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", GROUP="plugdev", MODE="0660"
 # High-resolution sensors need more than the usbfs default (16 MB) for
 # bulk transfers; QHYCCD recommends 200 MB.
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb'"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1618", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb || true'"

--- a/services/qhy-camera/pkg/postinst
+++ b/services/qhy-camera/pkg/postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+if ! getent passwd rusty-photon > /dev/null; then
+    adduser --system --group --home /var/lib/rusty-photon --quiet rusty-photon
+fi
+# Create the config directory chain too: /etc/rusty-photon points at it,
+# and ConditionPathExists-gated services never start on a fresh install,
+# so nothing else would create it before the operator writes a config.
+install -d -m 0750 -o rusty-photon -g rusty-photon \
+    /var/lib/rusty-photon \
+    /var/lib/rusty-photon/.config \
+    /var/lib/rusty-photon/.config/rusty-photon
+if [ ! -e /etc/rusty-photon ]; then
+    ln -s /var/lib/rusty-photon/.config/rusty-photon /etc/rusty-photon
+fi
+# Camera packages ship a udev rule; make it effective without a reboot.
+udevadm control --reload-rules || true
+udevadm trigger || true
+# Proprietary camera firmware is never packaged (ADR-013). When the
+# package ships a firmware-install helper, point the operator at it.
+fw_helper="/usr/sbin/${DPKG_MAINTSCRIPT_PACKAGE%-camera}-firmware-install"
+if [ -x "$fw_helper" ]; then
+    echo "$DPKG_MAINTSCRIPT_PACKAGE: camera firmware is not bundled."
+    echo "Run '$fw_helper' once as root before first use."
+fi
+#DEBHELPER#

--- a/services/qhy-camera/pkg/postrm
+++ b/services/qhy-camera/pkg/postrm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+SVC="${DPKG_MAINTSCRIPT_PACKAGE#rusty-photon-}"
+if [ "$1" = "purge" ]; then
+    rm -f "/var/lib/rusty-photon/.config/rusty-photon/$SVC.json"
+    rm -rf "/var/lib/rusty-photon/$SVC"
+fi
+#DEBHELPER#

--- a/services/qhy-camera/pkg/rusty-photon-qhy-camera.service
+++ b/services/qhy-camera/pkg/rusty-photon-qhy-camera.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Rusty Photon qhy-camera - ASCOM Alpaca Camera and FilterWheel for QHYCCD cameras (port 11121)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/rusty-photon-qhy-camera
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=rusty-photon
+Group=rusty-photon
+SupplementaryGroups=plugdev
+Environment=RUST_LOG=info
+Environment=HOME=/var/lib/rusty-photon
+WorkingDirectory=/var/lib/rusty-photon
+StateDirectory=rusty-photon/qhy-camera
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/rusty-photon
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
+++ b/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
@@ -22,9 +22,10 @@
 # driver links libqhyccd statically.
 #
 # Usage: rusty-photon-qhy-firmware-install [--force] [--root DIR]
-#   --force      reinstall over an existing /lib/firmware/qhy
+#   --force      reinstall even if everything is already installed
 #   --root DIR   install under DIR instead of / (container testing;
-#                skips the root requirement and the udev reload)
+#                skips the root requirement and the udev reload).
+#                `--root /` is normalized to a plain root install.
 
 set -eu
 
@@ -55,6 +56,9 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+# `--root /` is a real-root install: keep the root check and udev reload.
+[ "$ROOT" = "/" ] && ROOT=""
+
 if [ -z "$ROOT" ] && [ "$(id -u)" != 0 ]; then
     echo "rusty-photon-qhy-firmware-install: must run as root (or use --root)" >&2
     exit 1
@@ -69,8 +73,14 @@ case "$(uname -m)" in
         ;;
 esac
 
-if [ -d "$ROOT/lib/firmware/qhy" ] && [ "$FORCE" != 1 ]; then
-    echo "$ROOT/lib/firmware/qhy already exists; use --force to reinstall"
+# Complete only when all three artifacts are present — a partial state
+# (e.g. firmware left behind by QHYCCD's own install.sh, or an
+# interrupted run) must proceed and converge on the full layout.
+if [ "$FORCE" != 1 ] \
+    && [ -d "$ROOT/lib/firmware/qhy" ] \
+    && [ -x "$ROOT/usr/local/sbin/fxload" ] \
+    && [ -f "$ROOT/etc/udev/rules.d/85-qhyccd.rules" ]; then
+    echo "firmware, fxload, and udev rules already installed; use --force to reinstall"
     exit 0
 fi
 

--- a/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
+++ b/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
@@ -87,7 +87,12 @@ else
     exit 1
 fi
 
-echo "$SHA256  $TMP/$FILE" | sha256sum -c - > /dev/null
+if ! echo "$SHA256  $TMP/$FILE" | sha256sum -c --status -; then
+    echo "rusty-photon-qhy-firmware-install: sha256 mismatch for $FILE" >&2
+    echo "  expected: $SHA256" >&2
+    echo "  actual:   $(sha256sum "$TMP/$FILE" | cut -d' ' -f1)" >&2
+    exit 1
+fi
 echo "sha256 verified."
 
 tar -xzf "$TMP/$FILE" -C "$TMP"

--- a/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
+++ b/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
@@ -1,0 +1,113 @@
+#!/bin/sh
+# rusty-photon-qhy-firmware-install — fetch the pinned QHYCCD SDK and
+# install the pieces a QHY camera needs at runtime. Per ADR-013 the SDK
+# is proprietary and never bundled in a package; this helper downloads
+# it from qhyccd.com at the operator's explicit request, verifies a
+# pinned sha256, and installs:
+#
+#   /lib/firmware/qhy/                  camera firmware images
+#   /etc/udev/rules.d/85-qhyccd.rules   QHYCCD's firmware-upload rules,
+#                                       RUN paths rewritten to the
+#                                       fxload installed below
+#   /usr/local/sbin/fxload              QHYCCD's FX2/FX3-capable fxload
+#
+# A cold-plugged QHY camera enumerates as a raw Cypress controller and
+# only becomes a camera after root uploads firmware into it; on Linux
+# the SDK delegates that to udev + fxload (its in-process upload entry
+# points are macOS/Android-only). Stock Debian fxload cannot program
+# FX3, so QHYCCD's build goes to /usr/local/sbin — never
+# /usr/sbin/fxload, which the Debian fxload package may own.
+#
+# The SDK's shared library, headers, and samples are NOT installed; the
+# driver links libqhyccd statically.
+#
+# Usage: rusty-photon-qhy-firmware-install [--force] [--root DIR]
+#   --force      reinstall over an existing /lib/firmware/qhy
+#   --root DIR   install under DIR instead of / (container testing;
+#                skips the root requirement and the udev reload)
+
+set -eu
+
+VERSION="26.06.04"
+# QHY's download layout for >= 26.06.04: the directory is the version
+# with the dots dropped (YYMMDD).
+URL_BASE="https://www.qhyccd.com/file/repository/publish/SDK/260604"
+SHA256_X86_64="cbfcec159809e6984c5013a587fed88c892afae9d834019e820213f64616a308"
+SHA256_AARCH64="d28795977311fba1cb7a4fdc48bbd6d5f994716674b2154d9a860d1fdf2f5e0e"
+
+usage() {
+    echo "usage: rusty-photon-qhy-firmware-install [--force] [--root DIR]"
+}
+
+FORCE=0
+ROOT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force) FORCE=1 ;;
+        --root)
+            shift
+            [ $# -gt 0 ] || { echo "--root needs a directory" >&2; exit 2; }
+            ROOT="$1"
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$ROOT" ] && [ "$(id -u)" != 0 ]; then
+    echo "rusty-photon-qhy-firmware-install: must run as root (or use --root)" >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64) FILE="sdk_linux64_${VERSION}.tar.gz" SHA256="$SHA256_X86_64" ;;
+    aarch64) FILE="sdk_linux_arm64_${VERSION}.tar.gz" SHA256="$SHA256_AARCH64" ;;
+    *)
+        echo "unsupported architecture $(uname -m) (QHYCCD publishes x86_64 and aarch64)" >&2
+        exit 1
+        ;;
+esac
+
+if [ -d "$ROOT/lib/firmware/qhy" ] && [ "$FORCE" != 1 ]; then
+    echo "$ROOT/lib/firmware/qhy already exists; use --force to reinstall"
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+echo "Downloading QHYCCD SDK $VERSION ($FILE)..."
+if command -v curl > /dev/null 2>&1; then
+    curl -fsSL -o "$TMP/$FILE" "$URL_BASE/$FILE"
+elif command -v wget > /dev/null 2>&1; then
+    wget -q -O "$TMP/$FILE" "$URL_BASE/$FILE"
+else
+    echo "rusty-photon-qhy-firmware-install: needs curl or wget" >&2
+    exit 1
+fi
+
+echo "$SHA256  $TMP/$FILE" | sha256sum -c - > /dev/null
+echo "sha256 verified."
+
+tar -xzf "$TMP/$FILE" -C "$TMP"
+SRC="$TMP/${FILE%.tar.gz}"
+
+install -d -m 0755 "$ROOT/lib/firmware/qhy"
+install -m 0644 "$SRC"/lib/firmware/qhy/* "$ROOT/lib/firmware/qhy/"
+
+install -d -m 0755 "$ROOT/usr/local/sbin"
+install -m 0755 "$SRC/sbin/fxload" "$ROOT/usr/local/sbin/fxload"
+
+install -d -m 0755 "$ROOT/etc/udev/rules.d"
+sed 's|/sbin/fxload |/usr/local/sbin/fxload |g' \
+    "$SRC/etc/udev/rules.d/85-qhyccd.rules" > "$TMP/85-qhyccd.rules"
+install -m 0644 "$TMP/85-qhyccd.rules" "$ROOT/etc/udev/rules.d/85-qhyccd.rules"
+
+if [ -z "$ROOT" ] && command -v udevadm > /dev/null 2>&1; then
+    udevadm control --reload-rules || true
+    udevadm trigger || true
+fi
+
+echo "QHYCCD firmware $VERSION installed. Unplug and replug the camera:"
+echo "udev uploads firmware to cold cameras on the next plug-in."


### PR DESCRIPTION
## Summary

PR-4 of [`docs/plans/service-packaging.md`](docs/plans/service-packaging.md): the `rusty-photon-qhy-camera` `.deb`/`.rpm` package.

- **`services/qhy-camera/pkg/`** — camera-class hardened unit (`SupplementaryGroups=plugdev`, `AF_NETLINK` for libusb hotplug, no `PrivateDevices`/`MemoryDenyWriteExecute`, `ExecReload` since the service is reload-capable), canonical `postinst` (with the udev stanza) / `postrm`, the udev rule, and the firmware helper.
- **`90-rusty-photon-qhy.rules`** (renamed from the planned `70-…`): grants `plugdev` members 0660 access to enumerated QHY cameras (VID `1618`) and raises `usbfs_memory_mb` to 200. It deliberately sorts **after** the SDK's `85-qhyccd.rules` so it tightens that file's trailing blanket `MODE="0666"`.
- **`rusty-photon-qhy-firmware-install`** — downloads the QHYCCD SDK pinned at **26.06.04** (sha256-pinned per arch, x86_64 + aarch64), and installs firmware → `/lib/firmware/qhy`, the SDK's udev rules → `/etc/udev/rules.d/` (RUN paths rewritten), and QHYCCD's FX2/FX3-capable `fxload` → `/usr/local/sbin/fxload`. `--force` reinstalls, `--root DIR` for container testing. Nothing proprietary ships in the package (ADR-013); postinst prints a pointer, never downloads.

## Plan amendment — why the helper installs more than firmware

The plan said "installs **only** the firmware files… not the SDK's udev rules". Investigation (documented in the plan's PR-4 section + resolved unknowns) showed that's not viable:

- `libqhyccd.a` embeds firmware **basenames** but no search directory, and its only firmware-path entry points are `OSXInitQHYCCDFirmware*` (macOS/Android). **On Linux there is no in-process upload.**
- A cold-plugged QHY camera enumerates as a raw Cypress controller (VID `1618`, raw per-model PID — `04b4` is only the bare FX2 dev board) and receives firmware **exclusively** via the SDK's udev `RUN` rules exec'ing fxload as root from `/lib/firmware/qhy`.
- Stock Debian `fxload` cannot program FX3, so QHYCCD's own build is required; it goes to `/usr/local/sbin` — never `/usr/sbin/fxload`, which the Debian `fxload` package may own.

Without those two pieces a factory-fresh camera never becomes usable, so the helper (operator-run, root, pinned + checksummed) installs all three.

Also resolved: QHY's ≥ 26.06.04 download scheme (URL dir = dotless `260604`, `.tar.gz` archives, `sdk_linux_arm64_*` naming) — matches `qhyccd-sdk-install@v4`.

## Supporting changes

- `packaging/postinst.udev-stanza`: prints a pointer to `/usr/sbin/<pkg-minus-camera>-firmware-install` when the package ships one (no-op for zwo-camera, which will bundle its MIT blobs).
- `scripts/check-pkg-assets.sh`: cameras must ship their udev rule file. The existing QHY version pin-sync check picks up the helper's `VERSION=` automatically once `build-packages.sh` lands (PR-6).
- rpm scriptlet: `groupadd -r plugdev` fallback (not a stock group on RPM distros) + udevadm reload + firmware pointer.
- Docs: plan status/PR-4 section/unknowns; `docs/services/qhy-camera.md` Packaging section; `packaging/README.md` camera extras.

## Test plan

- [x] `bazel build //... && bazel test //...` (54/54)
- [x] `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `scripts/check-pkg-assets.sh` (camera postinst variant, ExecReload, udev rule, metadata names)
- [x] Firmware helper end-to-end with `--root`: real download, sha256 verified, 108 firmware files installed, all 115 fxload RUN paths rewritten (0 leftovers), idempotent re-run exits 0
- [x] `CARGO_BAZEL_REPIN=1 bazel mod tidy && bazel mod tidy`
- [ ] `cargo deb` / install / cold-plug verification on the Orange Pi — PR-6 (`verify-packages.sh` + on-rig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)