### PR TITLE
feat(zwo-camera): package as rusty-photon-zwo-camera with bundled MIT SDK blobs (PR-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ lcov.info
 .vscode
 .env
 
+# ZWO MIT SDK blobs staged there by scripts/build-packages.sh right before
+# `cargo deb` runs; downloaded from the pinned indi-3rdparty ref, never
+# committed (ADR-013).
+services/zwo-camera/pkg/lib/
+
 # Bazel
 # bazel-* are workspace symlinks at the repo root (bazel-bin, bazel-out, ...).
 # Anchored to root so it doesn't match e.g. docs/plans/archive/bazel-migration.md.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -531,7 +531,7 @@
           "FILE:@@//services/sky-survey-camera/Cargo.toml bc9d2161ff86be9a331ab3a87b2732930faedb8e60b4155aa4943829e8a3ae46",
           "FILE:@@//services/star-adventurer-gti/Cargo.toml c2aab0c72d29c451a7dd1cc0258d275728015fdd6b4060de1087ddc127ff8d92",
           "FILE:@@//services/ui-htmx/Cargo.toml 6816163a63844190ac338a0c475ae5ff1788135ff17dad5f704a8ac19db53909",
-          "FILE:@@//services/zwo-camera/Cargo.toml 3ecf41bdfd58574b03b72c4e25e21d079d7bd910a48fdbc119875c7fc42704fd",
+          "FILE:@@//services/zwo-camera/Cargo.toml 3b45cf5a51d59f150c803f62c57cfd97b5ac9d25dfa5be207bbe484f4013e15c",
           "FILE:@@//crates/zwo-rs/Cargo.toml a4f99ac35a86cdaba4bba12510f9b4af888c8a7d9121217783da4473136ba8da",
           "FILE:@@//crates/zwo-rs/libzwo-sys/Cargo.toml d68308c71d4e93213fec5789007950c150c5e2946d2939ef9f510cb76305346f",
           "FILE:@@//tests/operation-watchdog-e2e/Cargo.toml a59e56c17d83db43704bb3cdd2c6b685b2ef18f5cea3e317ffa31bdf78f769ce"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -531,7 +531,7 @@
           "FILE:@@//services/sky-survey-camera/Cargo.toml bc9d2161ff86be9a331ab3a87b2732930faedb8e60b4155aa4943829e8a3ae46",
           "FILE:@@//services/star-adventurer-gti/Cargo.toml c2aab0c72d29c451a7dd1cc0258d275728015fdd6b4060de1087ddc127ff8d92",
           "FILE:@@//services/ui-htmx/Cargo.toml 6816163a63844190ac338a0c475ae5ff1788135ff17dad5f704a8ac19db53909",
-          "FILE:@@//services/zwo-camera/Cargo.toml 3b45cf5a51d59f150c803f62c57cfd97b5ac9d25dfa5be207bbe484f4013e15c",
+          "FILE:@@//services/zwo-camera/Cargo.toml 9369c54cb0458ee89f155dd8a9f3435f530c499610588d912070c585ff1082d1",
           "FILE:@@//crates/zwo-rs/Cargo.toml a4f99ac35a86cdaba4bba12510f9b4af888c8a7d9121217783da4473136ba8da",
           "FILE:@@//crates/zwo-rs/libzwo-sys/Cargo.toml d68308c71d4e93213fec5789007950c150c5e2946d2939ef9f510cb76305346f",
           "FILE:@@//tests/operation-watchdog-e2e/Cargo.toml a59e56c17d83db43704bb3cdd2c6b685b2ef18f5cea3e317ffa31bdf78f769ce"

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -26,7 +26,7 @@ while keeping host-level setup anyway (see ADR-012 Context).
 | PR-2 | Migrate filemonitor to the new pattern (template proof) + filemonitor/sentinel XDG fix + `check-pkg-assets.sh` | Merged | #438 |
 | PR-3 | 11 pure-Rust daemons + `phd2-guider` CLI package | Merged | #441 |
 | PR-4 | `qhy-camera` package + firmware downloader helper | In progress | `feature/qhy-camera-packaging` |
-| PR-5 | `zwo-camera` package with bundled MIT SDK blobs | Pending | |
+| PR-5 | `zwo-camera` package with bundled MIT SDK blobs | In progress | `feature/zwo-camera-packaging` |
 | PR-6 | `build-packages.sh` + `verify-packages.sh` + `docs/packaging.md`; first on-rig install | Pending | |
 | PR-7 | `release.yml` generalization (x86_64 matrix, Homebrew rename) | Deferred | |
 
@@ -97,8 +97,11 @@ services/<svc>/pkg/
 
 Extras: `services/qhy-camera/pkg/` adds `90-rusty-photon-qhy.rules` +
 `rusty-photon-qhy-firmware-install`; `services/zwo-camera/pkg/` adds
-`70-rusty-photon-zwo.rules` + a gitignored `lib/` dir into which the build
-script stages the ZWO blobs + license before `cargo deb` runs.
+`90-rusty-photon-zwo.rules` (named 90- for family consistency; unlike QHY
+there are no vendor rules to sort against), a committed
+`ZWO-SDK-LICENSE.txt` (checker-verified copy of the license vendored with
+the libzwo-sys headers), and a gitignored `lib/` dir into which the build
+script stages the ZWO blobs before `cargo deb` runs.
 
 `check-pkg-assets.sh` asserts, per daemon crate: unit file named
 `rusty-photon-<dir>.service` with `ExecStart=/usr/bin/rusty-photon-<dir>`
@@ -321,7 +324,10 @@ startup error — and their units are `ConditionPathExists`-gated, as is
 - MIT blobs `libASICamera2.so` + `libEFWFilter.so` (from the same pinned
   indi-3rdparty commit `.github/actions/install-zwo-sdk` uses) are packaged
   at `/usr/lib/rusty-photon/`, license at
-  `/usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt`.
+  `/usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt`. The license
+  asset is a **committed copy** in `pkg/` (cargo-deb assets stay inside the
+  crate dir); the checker `cmp`s it against the canonical
+  `crates/zwo-rs/libzwo-sys/sdk/include/license.txt` so it cannot drift.
 - The blobs carry **no SONAME** → loader resolution via **RUNPATH**:
   `build-packages.sh` exports
   `RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/lib/rusty-photon"` for the release
@@ -329,11 +335,23 @@ startup error — and their units are `ConditionPathExists`-gated, as is
   `build.rs` change, which would ripple into Bazel/repin). Expected lintian
   finding `custom-library-search-path` is documented, not fixed.
 - deb `depends` are **explicit** (`libc6, libgcc-s1, libstdc++6,
-  libusb-1.0-0, libudev1`) — dpkg-shlibdeps cannot map SONAME-less private
-  blobs and `$auto` would fail.
+  libusb-1.0-0, libudev1, adduser`) — dpkg-shlibdeps cannot map SONAME-less
+  private blobs and `$auto` would fail.
+- rpm mirrors that with `auto-req = "disabled"`: rpm's dependency generator
+  would emit requires on the bundled SONAME-less blobs that no package
+  provides, making the rpm uninstallable. The deb `depends` list stays the
+  canonical statement of runtime needs (rpm is an x86_64 dev-box
+  convenience pre-1.0).
 - Build staging: blobs downloaded into gitignored
   `services/zwo-camera/pkg/lib/`; `ZWO_SDK_LIB_DIR` points there for the
-  link; `cargo deb` picks them up as plain assets.
+  link; `cargo deb` picks them up as plain assets. The checker asserts (once
+  `build-packages.sh` exists) that its `ZWO_SDK_REF` pin equals the
+  `install-zwo-sdk` action's default ref — shipped blobs and CI-linked blobs
+  must come from the same commit.
+- Own udev rule `90-rusty-photon-zwo.rules` (VID `03c3` → `plugdev`/`0660`
+  + the usbfs memory bump). ZWO cameras keep firmware in onboard flash — no
+  upload step, no vendor udev rules, no firmware helper; the postinst
+  stanza's firmware-pointer branch is a deliberate no-op here.
 
 ### phd2-guider (PR-3)
 

--- a/docs/services/zwo-camera.md
+++ b/docs/services/zwo-camera.md
@@ -793,6 +793,30 @@ driver itself). The FFI crate is the long pole (~40–50% of effort); once
 - Per-serial connect-time tuning; `FullWellCapacity`; TLS / Basic Auth via
   `rp-tls` / `rp-auth`.
 
+## Packaging
+
+Packaged as `rusty-photon-zwo-camera` (`.deb`/`.rpm`) per
+[ADR-012](../decisions/012-service-packaging-architecture.md) /
+[ADR-013](../decisions/013-native-sdk-payload-policy.md) and
+[`docs/plans/service-packaging.md`](../plans/service-packaging.md):
+binary at `/usr/bin/rusty-photon-zwo-camera`, hardened
+`rusty-photon-zwo-camera.service` (camera class: `plugdev` +
+`AF_NETLINK`, no `PrivateDevices`/`MemoryDenyWriteExecute`), and a udev
+rule `90-rusty-photon-zwo.rules` granting `plugdev` members access to
+enumerated ZWO devices (VID `03c3`) plus the usbfs memory bump.
+
+Unlike qhy-camera, the native SDK ships **inside the package**: ZWO's
+blobs are MIT-licensed, so `libASICamera2.so` + `libEFWFilter.so`
+(downloaded at package-build time by `scripts/build-packages.sh` from the
+same pinned indi-3rdparty commit `.github/actions/install-zwo-sdk` uses)
+are installed at `/usr/lib/rusty-photon/`, with the SDK license at
+`/usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt`. The blobs
+carry no SONAME, so the packaged binary locates them via a RUNPATH
+(`-Wl,-rpath,/usr/lib/rusty-photon`) injected by the build script — no
+`ldconfig`, no `/usr/local` spill, no external SDK install step for the
+operator. ZWO cameras keep their firmware in onboard flash, so there is
+no firmware-install helper and no cold-plug upload path.
+
 ## References
 
 - Decision record: [`docs/plans/zwo-driver.md`](../plans/zwo-driver.md) ·

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -25,8 +25,12 @@ construction, byte for byte. The stanza also prints a pointer to
 (qhy-camera does — proprietary firmware is downloaded by the operator, never
 packaged, per ADR-013; zwo-camera bundles its MIT blobs instead, so the
 pointer is a no-op there). Camera `pkg/` dirs additionally hold the udev
-rule file and, for qhy-camera, the firmware helper — both listed as plain
-`assets` in the metadata blocks.
+rule file and the per-camera native-SDK payload pieces, all listed as plain
+`assets` in the metadata blocks: qhy-camera the firmware helper; zwo-camera
+the committed `ZWO-SDK-LICENSE.txt` (checker-`cmp`'d against the copy
+vendored with the libzwo-sys headers) plus a gitignored `lib/` dir into
+which `scripts/build-packages.sh` stages the MIT SDK blobs right before
+`cargo deb` runs.
 
 `scripts/check-pkg-assets.sh` enforces all of this — run it after touching
 anything under `packaging/` or a service's `pkg/` directory. It discovers

--- a/scripts/check-pkg-assets.sh
+++ b/scripts/check-pkg-assets.sh
@@ -79,6 +79,10 @@ for pkgdir in services/*/pkg; do
             [ -f "$pkgdir/90-rusty-photon-qhy.rules" ] \
                 || err "$svc: missing pkg/90-rusty-photon-qhy.rules"
             ;;
+        zwo-camera)
+            [ -f "$pkgdir/90-rusty-photon-zwo.rules" ] \
+                || err "$svc: missing pkg/90-rusty-photon-zwo.rules"
+            ;;
     esac
 
     toml_section "$toml" "package.metadata.deb" | grep -q "^name = \"$name\"" \
@@ -97,6 +101,27 @@ if [ -f "$bp" ] && [ -f "$fw" ]; then
     v2=$(sed -n 's/^VERSION="\(.*\)"$/\1/p' "$fw" | head -1)
     if [ -z "$v1" ] || [ "$v1" != "$v2" ]; then
         err "QHY SDK version pin mismatch: build-packages.sh='$v1' vs firmware-install='$v2'"
+    fi
+fi
+
+# The packaged ZWO SDK license must match the copy vendored with the SDK
+# headers (single upstream source; the pkg/ copy exists only because cargo-deb
+# assets should stay inside the crate directory).
+zl=services/zwo-camera/pkg/ZWO-SDK-LICENSE.txt
+zv=crates/zwo-rs/libzwo-sys/sdk/include/license.txt
+cmp -s "$zv" "$zl" \
+    || err "zwo-camera: pkg/ZWO-SDK-LICENSE.txt differs from $zv"
+
+# The ZWO blob ref is pinned in two places once the build script exists:
+# build-packages.sh (stages pkg/lib/ for the deb) and the CI action's default
+# ref (provisions the link-time SDK) — the shipped blobs and the CI-linked
+# blobs must come from the same indi-3rdparty commit.
+act=.github/actions/install-zwo-sdk/action.yml
+if [ -f "$bp" ] && [ -f "$act" ]; then
+    z1=$(sed -n 's/^ZWO_SDK_REF="\(.*\)"$/\1/p' "$bp" | head -1)
+    z2=$(awk '$1 == "ref:" { in_ref = 1 } in_ref && $1 == "default:" { print $2; exit }' "$act")
+    if [ -z "$z1" ] || [ "$z1" != "$z2" ]; then
+        err "ZWO SDK ref pin mismatch: build-packages.sh='$z1' vs install-zwo-sdk default='$z2'"
     fi
 fi
 

--- a/services/zwo-camera/Cargo.toml
+++ b/services/zwo-camera/Cargo.toml
@@ -49,6 +49,77 @@ parking_lot = { workspace = true }
 [package.metadata.conformu]
 command = "cargo test -p zwo-camera --features conformu --test conformu_integration -- --nocapture"
 
+[package.metadata.deb]
+name = "rusty-photon-zwo-camera"
+maintainer = "Igor von Nyssen <igor@vonnyssen.com>"
+extended-description = "ASCOM Alpaca Camera driver for ZWO ASI cameras. Bundles ZWO's MIT-licensed SDK libraries (libASICamera2, libEFWFilter) under /usr/lib/rusty-photon; no separate SDK install is needed."
+section = "science"
+priority = "optional"
+# Explicit list, NOT "$auto": the bundled SDK blobs carry no SONAME, so
+# dpkg-shlibdeps cannot map the binary's bare libASICamera2.so/libEFWFilter.so
+# NEEDED entries to any package and would fail. These are the direct runtime
+# needs (glibc, libgcc, C++ runtime for libASICamera2, libusb, libudev for
+# libEFWFilter); adduser is used by postinst.
+depends = "libc6, libgcc-s1, libstdc++6, libusb-1.0-0, libudev1, adduser"
+assets = [
+    ["target/release/zwo-camera", "usr/bin/rusty-photon-zwo-camera", "755"],
+    ["pkg/90-rusty-photon-zwo.rules", "usr/lib/udev/rules.d/90-rusty-photon-zwo.rules", "644"],
+    # MIT SDK blobs: staged into gitignored pkg/lib/ by scripts/build-packages.sh
+    # from the pinned indi-3rdparty ref (same pin as .github/actions/install-zwo-sdk),
+    # never committed (ADR-013). The blobs have no SONAME, so the binary finds them
+    # via the RUNPATH build-packages.sh injects (-Wl,-rpath,/usr/lib/rusty-photon).
+    ["pkg/lib/libASICamera2.so", "usr/lib/rusty-photon/libASICamera2.so", "644"],
+    ["pkg/lib/libEFWFilter.so", "usr/lib/rusty-photon/libEFWFilter.so", "644"],
+    # The license must travel with the redistributed blobs (checker asserts this
+    # copy matches the one vendored with the SDK headers in libzwo-sys).
+    ["pkg/ZWO-SDK-LICENSE.txt", "usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt", "644"],
+]
+maintainer-scripts = "pkg/"
+
+[package.metadata.deb.systemd-units]
+unit-name = "rusty-photon-zwo-camera"
+unit-scripts = "pkg/"
+enable = true
+start = true
+restart-after-upgrade = true
+
+[package.metadata.generate-rpm]
+name = "rusty-photon-zwo-camera"
+summary = "ASCOM Alpaca Camera driver for ZWO ASI cameras"
+license = "MIT OR Apache-2.0"
+assets = [
+    { source = "target/release/zwo-camera", dest = "/usr/bin/rusty-photon-zwo-camera", mode = "755" },
+    { source = "pkg/rusty-photon-zwo-camera.service", dest = "/usr/lib/systemd/system/rusty-photon-zwo-camera.service", mode = "644" },
+    { source = "pkg/90-rusty-photon-zwo.rules", dest = "/usr/lib/udev/rules.d/90-rusty-photon-zwo.rules", mode = "644" },
+    { source = "pkg/lib/libASICamera2.so", dest = "/usr/lib/rusty-photon/libASICamera2.so", mode = "644" },
+    { source = "pkg/lib/libEFWFilter.so", dest = "/usr/lib/rusty-photon/libEFWFilter.so", mode = "644" },
+    { source = "pkg/ZWO-SDK-LICENSE.txt", dest = "/usr/share/doc/rusty-photon-zwo-camera/ZWO-SDK-LICENSE.txt", mode = "644" },
+]
+# rpm's dependency generator would emit requires on the SONAME-less bundled
+# blobs (libASICamera2.so, libEFWFilter.so) that no package provides, making
+# the rpm uninstallable. Disable it; the deb `depends` list above is the
+# canonical statement of runtime needs (rpm builds are an x86_64 dev-box
+# convenience pre-1.0, per the plan).
+auto-req = "disabled"
+post_install_script = """
+getent passwd rusty-photon > /dev/null || useradd -r -d /var/lib/rusty-photon -s /sbin/nologin rusty-photon
+getent group plugdev > /dev/null || groupadd -r plugdev
+install -d -m 0750 -o rusty-photon -g rusty-photon /var/lib/rusty-photon /var/lib/rusty-photon/.config /var/lib/rusty-photon/.config/rusty-photon
+[ -e /etc/rusty-photon ] || ln -s /var/lib/rusty-photon/.config/rusty-photon /etc/rusty-photon
+systemctl daemon-reload
+systemctl enable rusty-photon-zwo-camera.service
+udevadm control --reload-rules || true
+udevadm trigger || true
+"""
+pre_uninstall_script = """
+systemctl stop rusty-photon-zwo-camera.service || true
+systemctl disable rusty-photon-zwo-camera.service || true
+"""
+# rpm has no purge lifecycle: erase preserves the runtime-created config and
+# state (removal is a documented manual step), matching dpkg remove-vs-purge.
+post_uninstall_script = "systemctl daemon-reload"
+require-sh = true
+
 [dev-dependencies]
 # zwo-rs is now a first-party member with explicit Bazel real
 # (`//crates/zwo-rs:zwo-rs`) and simulation (`:zwo-rs_sim`) variants, so this

--- a/services/zwo-camera/Cargo.toml
+++ b/services/zwo-camera/Cargo.toml
@@ -86,7 +86,9 @@ restart-after-upgrade = true
 [package.metadata.generate-rpm]
 name = "rusty-photon-zwo-camera"
 summary = "ASCOM Alpaca Camera driver for ZWO ASI cameras"
-license = "MIT OR Apache-2.0"
+# Aggregate expression: our dual-licensed code AND the bundled MIT-only ZWO
+# SDK blobs — Apache-2.0 alone does not cover the whole package contents.
+license = "(MIT OR Apache-2.0) AND MIT"
 assets = [
     { source = "target/release/zwo-camera", dest = "/usr/bin/rusty-photon-zwo-camera", mode = "755" },
     { source = "pkg/rusty-photon-zwo-camera.service", dest = "/usr/lib/systemd/system/rusty-photon-zwo-camera.service", mode = "644" },

--- a/services/zwo-camera/pkg/90-rusty-photon-zwo.rules
+++ b/services/zwo-camera/pkg/90-rusty-photon-zwo.rules
@@ -1,0 +1,12 @@
+# Rusty Photon ZWO camera access (installed by rusty-photon-zwo-camera).
+#
+# ZWO ASI cameras and EFW filter wheels (VID 03c3) ship their firmware in
+# onboard flash — no upload step, no vendor udev rules required — so this
+# is the only rule file the package needs: make the devices
+# group-accessible to plugdev instead of relying on ZWO's world-writable
+# MODE="0666" rules. Named 90- for family consistency with
+# 90-rusty-photon-qhy.rules.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03c3", GROUP="plugdev", MODE="0660"
+# High-resolution sensors need more than the usbfs default (16 MB) for
+# bulk transfers; ZWO's own asi.rules applies the same 200 MB bump.
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="03c3", RUN+="/bin/sh -c 'echo 200 > /sys/module/usbcore/parameters/usbfs_memory_mb || true'"

--- a/services/zwo-camera/pkg/ZWO-SDK-LICENSE.txt
+++ b/services/zwo-camera/pkg/ZWO-SDK-LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2015, ZWO Company
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/services/zwo-camera/pkg/postinst
+++ b/services/zwo-camera/pkg/postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+if ! getent passwd rusty-photon > /dev/null; then
+    adduser --system --group --home /var/lib/rusty-photon --quiet rusty-photon
+fi
+# Create the config directory chain too: /etc/rusty-photon points at it,
+# and ConditionPathExists-gated services never start on a fresh install,
+# so nothing else would create it before the operator writes a config.
+install -d -m 0750 -o rusty-photon -g rusty-photon \
+    /var/lib/rusty-photon \
+    /var/lib/rusty-photon/.config \
+    /var/lib/rusty-photon/.config/rusty-photon
+if [ ! -e /etc/rusty-photon ]; then
+    ln -s /var/lib/rusty-photon/.config/rusty-photon /etc/rusty-photon
+fi
+# Camera packages ship a udev rule; make it effective without a reboot.
+udevadm control --reload-rules || true
+udevadm trigger || true
+# Proprietary camera firmware is never packaged (ADR-013). When the
+# package ships a firmware-install helper, point the operator at it.
+fw_helper="/usr/sbin/${DPKG_MAINTSCRIPT_PACKAGE%-camera}-firmware-install"
+if [ -x "$fw_helper" ]; then
+    echo "$DPKG_MAINTSCRIPT_PACKAGE: camera firmware is not bundled."
+    echo "Run '$fw_helper' once as root before first use."
+fi
+#DEBHELPER#

--- a/services/zwo-camera/pkg/postrm
+++ b/services/zwo-camera/pkg/postrm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+SVC="${DPKG_MAINTSCRIPT_PACKAGE#rusty-photon-}"
+if [ "$1" = "purge" ]; then
+    rm -f "/var/lib/rusty-photon/.config/rusty-photon/$SVC.json"
+    rm -rf "/var/lib/rusty-photon/$SVC"
+fi
+#DEBHELPER#

--- a/services/zwo-camera/pkg/rusty-photon-zwo-camera.service
+++ b/services/zwo-camera/pkg/rusty-photon-zwo-camera.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Rusty Photon zwo-camera - ASCOM Alpaca Camera for ZWO ASI cameras (port 11122)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/rusty-photon-zwo-camera
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=rusty-photon
+Group=rusty-photon
+SupplementaryGroups=plugdev
+Environment=RUST_LOG=info
+Environment=HOME=/var/lib/rusty-photon
+WorkingDirectory=/var/lib/rusty-photon
+StateDirectory=rusty-photon/zwo-camera
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/rusty-photon
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Fifth phase of `docs/plans/service-packaging.md`: the zwo-camera package — the second camera package and the first that **redistributes its native SDK inside the package** (ZWO's blobs are MIT-licensed, per ADR-013; contrast qhy-camera's operator-invoked, sha256-pinned firmware downloader).

### Package layout

- **Unit** `rusty-photon-zwo-camera.service`: camera class (`SupplementaryGroups=plugdev`, `AF_NETLINK` for libusb hotplug, no `PrivateDevices`/`MemoryDenyWriteExecute`), `ExecReload` (reload-capable via `run_with_reload`), port 11122.
- **udev rule** `90-rusty-photon-zwo.rules`: VID `03c3` → `plugdev`/`0660` + the usbfs 200 MB bump ZWO's own `asi.rules` applies. Named 90- for family consistency with the QHY rule; unlike QHY there are no vendor rules to sort against — ZWO firmware lives in onboard flash, so there is no upload path, no vendor rules, and no firmware helper (the postinst stanza's firmware-pointer branch is a deliberate no-op).
- **SDK blobs** `libASICamera2.so` + `libEFWFilter.so` → `/usr/lib/rusty-photon/`, staged at package-build time into gitignored `pkg/lib/` by `scripts/build-packages.sh` (PR-6) from the **same pinned indi-3rdparty ref** `.github/actions/install-zwo-sdk` uses. The blobs carry no SONAME, so the binary resolves them via the RUNPATH the build script injects (`-Wl,-rpath,/usr/lib/rusty-photon`).
- **License**: `ZWO-SDK-LICENSE.txt` committed in `pkg/` (must travel with the redistributed blobs) → `/usr/share/doc/rusty-photon-zwo-camera/`.

### Dependency metadata

- deb `depends` is **explicit** (`libc6, libgcc-s1, libstdc++6, libusb-1.0-0, libudev1, adduser`): dpkg-shlibdeps cannot map the SONAME-less private blobs, so `$auto` would fail.
- rpm sets `auto-req = "disabled"`: rpm's generator would emit requires on the bundled blobs that no package provides, making the rpm uninstallable. The deb list stays the canonical statement of runtime needs.

### Checker extensions (`scripts/check-pkg-assets.sh`)

- zwo-camera must ship `pkg/90-rusty-photon-zwo.rules`.
- `pkg/ZWO-SDK-LICENSE.txt` must be byte-identical to the copy vendored with the libzwo-sys headers (`crates/zwo-rs/libzwo-sys/sdk/include/license.txt`) — single upstream source, no drift.
- Guarded pin-sync (activates in PR-6): `build-packages.sh`'s `ZWO_SDK_REF` must equal the `install-zwo-sdk` action's default ref, so shipped blobs and CI-linked blobs come from the same commit. The awk parse is verified against the current action.yml.

### Docs

`docs/services/zwo-camera.md` gains a Packaging section; `packaging/README.md` camera paragraph extended; plan updated (status row, `70-` → `90-` rule rename, license + auto-req decisions recorded in the PR-5 section).

## Test plan

- [x] `bazel build //... && bazel test //...` (54 tests green)
- [x] `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `scripts/check-pkg-assets.sh` OK (postinst byte-exact camera variant, license cmp, rule presence)
- [x] `CARGO_BAZEL_REPIN=1 bazel mod tidy && bazel mod tidy`
- [ ] `cargo deb`/`cargo generate-rpm` end-to-end happens in PR-6 (`build-packages.sh` stages `pkg/lib/` + injects the RUNPATH; container + on-rig verification per the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)