### PR TITLE
feat(packaging): on-device build + container verify tooling and operator guide (PR-6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lcov.info
 # committed (ADR-013).
 services/zwo-camera/pkg/lib/
 
+# Package build output of scripts/build-packages.sh (deb/rpm + SHA256SUMS).
+/dist/
+
 # Bazel
 # bazel-* are workspace symlinks at the repo root (bazel-bin, bazel-out, ...).
 # Anchored to root so it doesn't match e.g. docs/plans/archive/bazel-migration.md.

--- a/README.md
+++ b/README.md
@@ -145,10 +145,11 @@ cargo run -p sentinel -- -c services/sentinel/examples/config.json
 
 ### Deploying
 
-Every service ships as a `.deb` / `.rpm` package (`rusty-photon-<svc>`)
-with a hardened systemd unit, built natively on the target machine via
-`scripts/build-packages.sh`. See [docs/packaging.md](docs/packaging.md)
-for building, installing, configuring, and camera-SDK specifics.
+Every service ships as a `.deb` / `.rpm` package (`rusty-photon-<svc>`),
+built natively on the target machine via `scripts/build-packages.sh` —
+each daemon with a hardened systemd unit, `phd2-guider` as a plain CLI
+tool. See [docs/packaging.md](docs/packaging.md) for building,
+installing, configuring, and camera-SDK specifics.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ cargo run -p filemonitor -- --help
 cargo run -p sentinel -- -c services/sentinel/examples/config.json
 ```
 
+### Deploying
+
+Every service ships as a `.deb` / `.rpm` package (`rusty-photon-<svc>`)
+with a hardened systemd unit, built natively on the target machine via
+`scripts/build-packages.sh`. See [docs/packaging.md](docs/packaging.md)
+for building, installing, configuring, and camera-SDK specifics.
+
 ## Testing
 
 The project uses a layered test strategy. See [docs/skills/testing.md](docs/skills/testing.md) for the full testing guide.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -39,6 +39,10 @@ installed. `phd2-guider` is the one plain CLI package (no unit, no user).
 | plate-solver | 11131 | config-gated; needs ASTAP (below) |
 | calibrator-flats | 11170 | config-gated |
 
+Alpaca UDP discovery is deliberately not served: with this many Alpaca
+servers on one host they would collide on the discovery port. Point
+clients (N.I.N.A. etc.) at `host:port` directly using the table above.
+
 ## Building packages
 
 Packages are built natively on the target architecture — arm64 directly on

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,186 @@
+# Packaging & deployment guide
+
+How to build, install, and operate the rusty-photon `.deb` / `.rpm`
+packages on an observatory machine. Architecture decisions live in
+[ADR-012](decisions/012-service-packaging-architecture.md) (naming, config
+model, shared user, unit classes) and
+[ADR-013](decisions/013-native-sdk-payload-policy.md) (native camera-SDK
+payloads); the full design in
+[docs/plans/service-packaging.md](plans/service-packaging.md); the
+maintainer-script invariants in [packaging/README.md](../packaging/README.md).
+
+Deployment is native packages by explicit decision — the drivers' USB /
+udev / firmware needs and ASCOM Alpaca's UDP discovery defeat containers
+(ADR-012).
+
+## What gets installed
+
+Every package is named `rusty-photon-<svc>` and installs
+`/usr/bin/rusty-photon-<svc>` plus (for daemons) a hardened
+`rusty-photon-<svc>.service` unit that is enabled and started on install.
+All daemons run as the shared system user `rusty-photon` (home
+`/var/lib/rusty-photon`, no login shell), created by the first package
+installed. `phd2-guider` is the one plain CLI package (no unit, no user).
+
+| Service | Port | Notes |
+|---------|------|-------|
+| filemonitor | 11111 | Alpaca SafetyMonitor |
+| ppba-driver | 11112 | serial (dialout) |
+| qhy-focuser | 11113 | serial (dialout) |
+| sentinel | 11114 | dashboard: `/` |
+| rp | 11115 | orchestrator API |
+| sky-survey-camera | 11116 | config-gated (see below) |
+| star-adventurer-gti | 11117 | serial (dialout) |
+| pa-falcon-rotator | 11118 | serial (dialout) |
+| dsd-fp2 | 11119 | serial (dialout) |
+| ui-htmx | 11120 | web config UI |
+| qhy-camera | 11121 | USB camera; needs the firmware helper (below) |
+| zwo-camera | 11122 | USB camera; SDK blobs bundled |
+| plate-solver | 11131 | config-gated; needs ASTAP (below) |
+| calibrator-flats | 11170 | config-gated |
+
+## Building packages
+
+Packages are built natively on the target architecture — arm64 directly on
+the rig, x86_64 on a dev box (CI packaging for arm64 is deferred; see the
+plan). From a repo checkout on a Debian-family machine with Rust installed:
+
+```sh
+scripts/build-packages.sh                  # all services, .deb only
+scripts/build-packages.sh --rpm            # also .rpm (dev-box convenience)
+scripts/build-packages.sh --services qhy-camera,filemonitor
+scripts/build-packages.sh --skip-sdk-staging   # offline rebuild from cache
+```
+
+The script installs apt build prerequisites, stages the pinned native
+camera SDKs into `~/.cache/rusty-photon-pkg/` (QHYCCD static lib for the
+link; ZWO MIT blobs, which also become package payload per ADR-013), builds
+everything in one release pass with the RUNPATH the zwo-camera package
+needs, then runs `cargo deb` (and `cargo generate-rpm` with `--rpm`) per
+service. Artifacts land in `dist/<version>/` with a `SHA256SUMS.txt`.
+
+The QHY SDK version/sha256 pins and the ZWO blob ref are pinned in the
+script and cross-checked by `scripts/check-pkg-assets.sh` against the
+firmware helper and the CI SDK action, so shipped and CI-linked SDK bits
+cannot drift apart.
+
+## Installing
+
+```sh
+sudo apt-get install ./rusty-photon-<svc>_*.deb
+```
+
+`apt-get install ./<file>` (not `dpkg -i`) resolves the runtime
+dependencies. The unit is enabled and started immediately; on upgrade it is
+restarted. Verify with:
+
+```sh
+systemctl status rusty-photon-<svc>
+curl http://localhost:<port>/management/apiversions   # Alpaca services
+```
+
+**Config-gated services** (`sky-survey-camera`, `plate-solver`,
+`calibrator-flats`) have no sensible default config, so their units carry
+`ConditionPathExists=` on the config file: on a fresh install the unit
+stays inactive (not failed) until you write
+`/etc/rusty-photon/<svc>.json`, then `systemctl start rusty-photon-<svc>`.
+
+**Serial-device drivers** (`ppba-driver`, `qhy-focuser`,
+`pa-falcon-rotator`, `dsd-fp2`, `star-adventurer-gti`) validate their
+hardware eagerly at startup and exit if the device is missing — by design,
+so a broken device is never advertised on the network. Until the device is
+attached (and its path matches the config), the unit sits in a
+restart-every-5s loop; it comes up by itself once the hardware appears.
+The cameras and the network-only services serve with no hardware attached.
+
+## Configuration
+
+Packages ship no config files. Daemons self-create their config on first
+start at `/var/lib/rusty-photon/.config/rusty-photon/<svc>.json` (the
+shared user's XDG path), reachable via the `/etc/rusty-photon` symlink.
+Exceptions: the config-gated three (above) never write one, and the two
+cameras run on built-in defaults without writing a file until settings
+are saved (via ui-htmx `config.apply`) or one is created by hand at that
+path. To change settings:
+
+```sh
+sudo -e /etc/rusty-photon/<svc>.json
+sudo systemctl reload rusty-photon-<svc>    # reload-capable services
+sudo systemctl restart rusty-photon-<svc>   # the rest
+```
+
+Reload-capable (SIGHUP): filemonitor, ppba-driver, qhy-focuser,
+sky-survey-camera, pa-falcon-rotator, dsd-fp2, star-adventurer-gti,
+qhy-camera, zwo-camera. Note that services with `config.apply` support
+(via ui-htmx) rewrite these files at runtime — hand-edits and UI edits
+share the same file.
+
+## Camera specifics
+
+**qhy-camera** — QHYCCD's SDK is proprietary and never redistributed
+(ADR-013). After installing the package, run once, as root, with internet
+access:
+
+```sh
+sudo rusty-photon-qhy-firmware-install
+```
+
+It downloads the pinned SDK release from qhyccd.com, verifies a pinned
+sha256, and installs the camera firmware images, QHYCCD's udev
+firmware-upload rules, and their FX3-capable `fxload`. Then unplug/replug
+the camera — udev uploads firmware on plug-in. Offline installs work; the
+camera just stays unusable until the helper has run.
+
+**zwo-camera** — nothing to do: the MIT-licensed SDK blobs are bundled at
+`/usr/lib/rusty-photon/` (license in
+`/usr/share/doc/rusty-photon-zwo-camera/`). ZWO cameras keep firmware in
+onboard flash.
+
+Both camera packages install a udev rule granting the `plugdev` group
+access to their USB VID (the service user is in `plugdev` via the unit's
+`SupplementaryGroups=`).
+
+## plate-solver: ASTAP
+
+ASTAP is an external runtime dependency, deliberately not a package
+dependency: install it separately (arm64/amd64 `.deb` from the
+[ASTAP site](https://www.hnsky.org/astap.htm), plus a star database) and
+point `astap_binary_path` / `astap_db_directory` in
+`/etc/rusty-photon/plate-solver.json` at it.
+
+## Removing
+
+```sh
+sudo apt-get remove rusty-photon-<svc>   # keeps the service's config + state
+sudo apt-get purge rusty-photon-<svc>    # also deletes its config + state dir
+```
+
+The shared user, `/var/lib/rusty-photon`, and the `/etc/rusty-photon`
+symlink are never removed (shared across packages, Debian convention for
+system users). rpm has no purge lifecycle: erase behaves like `remove`;
+to fully clean up after an erase, delete
+`/var/lib/rusty-photon/.config/rusty-photon/<svc>.json` and
+`/var/lib/rusty-photon/<svc>/` by hand.
+
+## Verifying a build
+
+```sh
+scripts/verify-packages.sh            # all debs in dist/<version>/
+scripts/verify-packages.sh --services filemonitor,zwo-camera --keep
+```
+
+Runs a podman `--systemd=always` debian:trixie container and, per package:
+install → unit active → config self-created → HTTP probe → remove (config
+survives) → purge (config and state gone, shared pieces stay). Gated
+services verify enabled-but-inactive-and-not-failed instead; zwo-camera
+additionally proves via `ldd` that the bundled blobs resolve through the
+binary's RUNPATH. Rootless podman cannot apply the units' sandboxing, so
+the script resets the hardening inside the container — hardening is
+verified on real hosts with `systemd-analyze security
+rusty-photon-<svc>.service`.
+
+Expected `lintian` findings (accepted, not bugs):
+`custom-library-search-path` on zwo-camera (the RUNPATH is the design);
+`no-changelog` / `no-manual-page` / `copyright-without-copyright-notice`
+pre-1.0; `empty-field Depends` and `unstripped-binary` appear only on
+ad-hoc builds from non-Debian hosts.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -127,8 +127,9 @@ sudo rusty-photon-qhy-firmware-install
 
 It downloads the pinned SDK release from qhyccd.com, verifies a pinned
 sha256, and installs the camera firmware images, QHYCCD's udev
-firmware-upload rules, and their FX3-capable `fxload`. Then unplug/replug
-the camera — udev uploads firmware on plug-in. Offline installs work; the
+firmware-upload rules, and their FX3-capable `fxload`. An already-plugged
+cold camera is flashed immediately (the helper re-emits udev add events);
+otherwise firmware uploads on the next plug-in. Offline installs work; the
 camera just stays unusable until the helper has run.
 
 **zwo-camera** — nothing to do: the MIT-licensed SDK blobs are bundled at
@@ -180,7 +181,11 @@ verified on real hosts with `systemd-analyze security
 rusty-photon-<svc>.service`.
 
 Expected `lintian` findings (accepted, not bugs):
-`custom-library-search-path` on zwo-camera (the RUNPATH is the design);
-`no-changelog` / `no-manual-page` / `copyright-without-copyright-notice`
-pre-1.0; `empty-field Depends` and `unstripped-binary` appear only on
-ad-hoc builds from non-Debian hosts.
+`custom-library-search-path` on every package (the RUNPATH is injected
+uniformly; only zwo-camera uses it); `no-changelog` / `no-manual-page` /
+`copyright-without-copyright-notice` pre-1.0; `unstripped-binary-or-object`
+and `hardening-no-relro` on the two vendored ZWO blobs (shipped exactly as
+published); `embedded-library` on qhy-camera's statically linked SDK;
+`appstream-metadata-missing-modalias-provide` on the camera packages' udev
+rules; `empty-field Depends` and `unstripped-binary` on our own binaries
+only on ad-hoc builds from non-Debian hosts.

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -25,9 +25,9 @@ while keeping host-level setup anyway (see ADR-012 Context).
 | PR-1 | This plan + ADR-012 + ADR-013 + archive old plan | Merged | #435 |
 | PR-2 | Migrate filemonitor to the new pattern (template proof) + filemonitor/sentinel XDG fix + `check-pkg-assets.sh` | Merged | #438 |
 | PR-3 | 11 pure-Rust daemons + `phd2-guider` CLI package | Merged | #441 |
-| PR-4 | `qhy-camera` package + firmware downloader helper | In progress | `feature/qhy-camera-packaging` |
-| PR-5 | `zwo-camera` package with bundled MIT SDK blobs | In progress | `feature/zwo-camera-packaging` |
-| PR-6 | `build-packages.sh` + `verify-packages.sh` + `docs/packaging.md`; first on-rig install | Pending | |
+| PR-4 | `qhy-camera` package + firmware downloader helper | Merged | #444 |
+| PR-5 | `zwo-camera` package with bundled MIT SDK blobs | Merged | #446 |
+| PR-6 | `build-packages.sh` + `verify-packages.sh` + `docs/packaging.md`; first on-rig install | In progress | `feature/packaging-tooling` |
 | PR-7 | `release.yml` generalization (x86_64 matrix, Homebrew rename) | Deferred | |
 
 Carried over from the superseded plan (still open, now owned by PR-7):
@@ -369,13 +369,16 @@ guide (`docs/packaging.md`, a PR-6 deliverable).
 
 Runs on Debian arm64 (the rig) and x86_64 dev boxes:
 
-1. apt prereqs (idempotent): `build-essential pkg-config curl git libssl-dev
-   libcfitsio-dev libusb-1.0-0-dev libudev-dev clang libclang-dev dpkg-dev
-   ca-certificates`; `cargo install --locked cargo-deb` (3.6.x);
+1. apt prereqs (idempotent): `build-essential pkg-config curl git
+   libusb-1.0-0-dev libudev-dev clang libclang-dev dpkg-dev
+   ca-certificates` (`libssl-dev` and `libcfitsio-dev` from the original
+   sketch dropped — the workspace links neither: TLS is rustls, FITS is
+   pure-Rust `fitsrs`); `cargo install --locked cargo-deb`;
    `cargo-generate-rpm` only with `--rpm`.
 2. Stage QHY SDK into `~/.cache/rusty-photon-pkg/` (same pinned URL + sha256
-   as the firmware helper — the checker asserts the pins match), export
-   `QHYCCD_SDK_DIR=<extracted>/usr/local/lib`.
+   as the firmware helper — the checker asserts version **and both archive
+   sha256 pins** match), export `QHYCCD_SDK_DIR=<dir containing
+   libqhyccd.a>` (located with `find`, not a hardcoded archive layout).
 3. Stage ZWO blobs into `services/zwo-camera/pkg/lib/`, export
    `ZWO_SDK_LIB_DIR` to it.
 4. `RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/lib/rusty-photon" cargo build
@@ -410,6 +413,21 @@ Runs on Debian arm64 (the rig) and x86_64 dev boxes:
   `unique_id` → port probe (`/management/apiversions` for Alpaca services;
   service-specific endpoint otherwise) → remove (config survives) → purge
   (config + state gone; user/home/symlink stay).
+  **PR-6 findings:** (1) the stock Debian container image ships a
+  `policy-rc.d` that exits 101, silently blocking every maintainer-script
+  unit start — the verify image removes it. (2) "unit active" is the wrong
+  assertion for the five shared-transport serial drivers: their **eager
+  startup handshake** exits non-zero when the device is absent (deliberate —
+  never advertise a broken device), leaving the unit in a 5s restart loop
+  until hardware appears. For them the script instead asserts: handshake
+  attempted (journal), config self-created, and — only if a driver ever
+  gains warn-and-serve — the port probe. The active+probe class is the
+  cameras (qhy contract C0 warn-and-serve; zwo serves with zero cameras)
+  plus the network-only daemons. (3) The cameras do **not** self-create a
+  config (deliberate: no `materialize_identity` — UniqueIDs derive from
+  camera serials; they run on defaults until `config.apply` or an operator
+  writes a file), so the config-self-created assertion applies to the
+  network-only daemons and serial drivers only.
 - Cameras start with zero devices attached (qhy-camera contract C0:
   warn-and-serve). zwo-camera: `ldd` resolves `libASICamera2.so` to
   `/usr/lib/rusty-photon/` (RUNPATH proof).

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -440,6 +440,38 @@ Runs on Debian arm64 (the rig) and x86_64 dev boxes:
   sha256, replug, enumeration under plugdev/0660); serial access via
   dialout; Alpaca UDP discovery from another host.
 
+### On-rig results (first install — 2026-07-05, Debian 13 arm64 rig)
+
+- `build-packages.sh` from a fresh clone (only rustup + git pre-installed):
+  15 arm64 debs + SHA256SUMS; the AARCH64 QHY sha256 pin verified on first
+  use. On a Debian host `$auto` Depends resolve properly (qhy-camera:
+  `adduser, libc6, libstdc++6, libusb-1.0-0`).
+- All 15 installed in one apt transaction under the **real** hardening
+  (no drop-ins): the 6 network/camera services active with 200 on their
+  probes, the 5 serial drivers in the designed 5s retry loop, the 3 gated
+  units inactive-not-failed; the 9 expected configs self-created;
+  `/etc/rusty-photon` symlink in place; zwo blobs resolve via RUNPATH
+  (`ldd`). The sandbox does not break config write-back.
+- `systemd-analyze security`: network-only 6.2 MEDIUM (filemonitor),
+  serial 6.9 MEDIUM (dsd-fp2), camera 6.9 MEDIUM (qhy-camera).
+- QHY firmware helper end-to-end: download + sha256 + install OK; a cold
+  QHY5III715C (raw Cypress `1618:0715`) flashed and re-enumerated as
+  `1618:0716`, device node `plugdev`/`0660`, and the sandboxed service
+  discovered and serves it (`cameras=1`). **Helper fix from this test:**
+  a plain `udevadm trigger` emits change events, which do not fire the
+  SDK rules' `ACTION=="add"` fxload lines — an already-plugged cold
+  camera stayed raw; the helper now triggers
+  `--action=add --subsystem-match=usb`.
+- lintian (debian profile; filemonitor/qhy-camera/zwo-camera): only the
+  findings documented in `docs/packaging.md` — no surprises.
+- **Open finding (product, not packaging):** nothing binds UDP 32227.
+  Every service self-serves through rp-tls via `Server::into_service()`,
+  which bypasses ascom-alpaca's discovery responder, so the
+  `discovery_port` config field is dead and cross-host Alpaca UDP
+  discovery gets no answer (qhy-camera even sets `discovery_port = None`
+  explicitly). Needs a serving-path fix — spawn the discovery responder
+  alongside the HTTP listener — in its own PR.
+
 ## Flagged unknowns (resolve during PR-2/PR-4)
 
 - [x] Firmware directory: confirmed `/lib/firmware/qhy` (every fxload `RUN`

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -462,6 +462,12 @@ Runs on Debian arm64 (the rig) and x86_64 dev boxes:
   SDK rules' `ACTION=="add"` fxload lines — an already-plugged cold
   camera stayed raw; the helper now triggers
   `--action=add --subsystem-match=usb`.
+- ZWO end-to-end with real hardware (ASI120MC-S): hot-plug →
+  `90-rusty-photon-zwo.rules` applied `plugdev`/`0660` on the add event
+  (no trigger needed) → `systemctl reload` (SIGHUP, no restart)
+  re-enumerated → served on 11122 with a serial-derived UniqueID; the
+  bundled MIT blobs do the USB work via the RUNPATH. Zero manual steps
+  beyond the reload — the no-firmware-helper design confirmed.
 - lintian (debian profile; filemonitor/qhy-camera/zwo-camera): only the
   findings documented in `docs/packaging.md` — no surprises.
 - **Open finding (product, not packaging):** nothing binds UDP 32227.

--- a/docs/plans/service-packaging.md
+++ b/docs/plans/service-packaging.md
@@ -470,13 +470,16 @@ Runs on Debian arm64 (the rig) and x86_64 dev boxes:
   beyond the reload — the no-firmware-helper design confirmed.
 - lintian (debian profile; filemonitor/qhy-camera/zwo-camera): only the
   findings documented in `docs/packaging.md` — no surprises.
-- **Open finding (product, not packaging):** nothing binds UDP 32227.
-  Every service self-serves through rp-tls via `Server::into_service()`,
-  which bypasses ascom-alpaca's discovery responder, so the
-  `discovery_port` config field is dead and cross-host Alpaca UDP
-  discovery gets no answer (qhy-camera even sets `discovery_port = None`
-  explicitly). Needs a serving-path fix — spawn the discovery responder
-  alongside the HTTP listener — in its own PR.
+- **Discovery: off by default is the intended behavior** (confirmed by
+  Igor during this verification). Nothing binds UDP 32227: every service
+  self-serves through rp-tls via `Server::into_service()`, which bypasses
+  ascom-alpaca's discovery responder. That is correct for this family —
+  rusty-photon puts up to 14 Alpaca servers on one host, which would
+  collide on the discovery port (and a unicast query against a REUSEPORT
+  group is answered by an arbitrary one of them). Clients are configured
+  with explicit `host:port` instead. Possible later cleanup: the
+  `discovery_port` field the services persist in their configs is inert
+  and reads as if it did something.
 
 ## Flagged unknowns (resolve during PR-2/PR-4)
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -3,6 +3,8 @@
 Canonical shared files for the per-service `.deb`/`.rpm` packages described
 in [`docs/plans/service-packaging.md`](../docs/plans/service-packaging.md)
 and [ADR-012](../docs/decisions/012-service-packaging-architecture.md).
+Operator-facing docs (building, installing, configuring) live in
+[`docs/packaging.md`](../docs/packaging.md).
 
 ## Layout
 

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,235 @@
+#!/bin/sh
+# build-packages.sh — build the rusty-photon .deb (and optionally .rpm)
+# packages natively on the target machine: the Debian arm64 rig or an
+# x86_64 box. Operator guide: docs/packaging.md; design:
+# docs/plans/service-packaging.md + ADR-012/ADR-013.
+#
+# Steps:
+#   1. install build prerequisites (apt when available; cargo-deb always,
+#      cargo-generate-rpm only with --rpm),
+#   2. stage the native camera SDKs into ~/.cache/rusty-photon-pkg/:
+#      QHYCCD's static libqhyccd.a for the link (exported as
+#      QHYCCD_SDK_DIR), and the ZWO MIT blobs into the gitignored
+#      services/zwo-camera/pkg/lib/ — used both for the link
+#      (ZWO_SDK_LIB_DIR) and as package payload (ADR-013),
+#   3. one release build of every selected service with the RUNPATH the
+#      zwo-camera package needs (-Wl,-rpath,/usr/lib/rusty-photon;
+#      uniform across binaries, harmless where unused), then strip,
+#   4. per service: cargo deb --no-build --no-strip (a rebuild would lose
+#      the staged env/RUSTFLAGS); with --rpm also cargo generate-rpm,
+#   5. collect artifacts into dist/<version>/ + SHA256SUMS.txt.
+#
+# Usage: scripts/build-packages.sh [--services a,b,c] [--rpm] [--skip-sdk-staging]
+#   --services a,b,c    build only these services (default: every packaged one)
+#   --rpm               also build .rpm packages (x86_64 dev-box convenience)
+#   --skip-sdk-staging  offline rebuild: no downloads; requires the SDK
+#                       cache from a previous run
+
+set -eu
+
+die() { echo "build-packages: $*" >&2; exit 1; }
+
+# ---- pins -------------------------------------------------------------
+# The QHY pins must match services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
+# (scripts/check-pkg-assets.sh enforces it): the SDK linked at build time and
+# the firmware the helper installs on the target must be the same release.
+QHY_SDK_VERSION="26.06.04"
+QHY_SHA256_X86_64="cbfcec159809e6984c5013a587fed88c892afae9d834019e820213f64616a308"
+QHY_SHA256_AARCH64="d28795977311fba1cb7a4fdc48bbd6d5f994716674b2154d9a860d1fdf2f5e0e"
+# QHY's download layout for >= 26.06.04: the directory is the dotless version.
+QHY_URL_BASE="https://www.qhyccd.com/file/repository/publish/SDK/$(echo "$QHY_SDK_VERSION" | tr -d .)"
+
+# Must match the `ref` default in .github/actions/install-zwo-sdk/action.yml
+# (checker-enforced): the blobs shipped in the deb and the blobs CI links
+# against must come from the same indi-3rdparty commit. The immutable commit
+# SHA in the download URL is the integrity statement, same as in the action.
+ZWO_SDK_REF="b0802f28055b67aa6a99580d260c3bb4c27eba4b"
+
+usage() {
+    sed -n '/^# Usage:/,/^$/{s/^# \{0,1\}//p}' "$0"
+}
+
+RPM=0
+SKIP_STAGING=0
+ONLY_SERVICES=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --services)
+            shift
+            [ $# -gt 0 ] || die "--services needs a comma-separated list"
+            ONLY_SERVICES="$1"
+            ;;
+        --rpm) RPM=1 ;;
+        --skip-sdk-staging) SKIP_STAGING=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; die "unknown option: $1" ;;
+    esac
+    shift
+done
+
+[ "$(uname -s)" = Linux ] || die "deb/rpm packages are Linux-only (see release.yml for the other targets)"
+[ -f packaging/postinst.common ] || die "run from the repo root"
+
+# ---- service selection --------------------------------------------------
+# Packaged daemons are exactly the crates with a pkg/ dir (same discovery as
+# check-pkg-assets.sh); phd2-guider is the one CLI-only package (deb/rpm
+# metadata but no pkg/ dir).
+ALL_SERVICES=$(for d in services/*/pkg; do [ -d "$d" ] && basename "$(dirname "$d")"; done | tr '\n' ' ')
+ALL_SERVICES="$ALL_SERVICES phd2-guider"
+
+SERVICES=""
+if [ -n "$ONLY_SERVICES" ]; then
+    for s in $(echo "$ONLY_SERVICES" | tr ',' ' '); do
+        case " $ALL_SERVICES " in
+            *" $s "*) SERVICES="$SERVICES $s" ;;
+            *) die "unknown or unpackaged service: $s (packaged: $ALL_SERVICES)" ;;
+        esac
+    done
+else
+    SERVICES="$ALL_SERVICES"
+fi
+
+needs_qhy=0
+needs_zwo=0
+case " $SERVICES " in *" qhy-camera "*) needs_qhy=1 ;; esac
+case " $SERVICES " in *" zwo-camera "*) needs_zwo=1 ;; esac
+
+case "$(uname -m)" in
+    x86_64)
+        QHY_FILE="sdk_linux64_${QHY_SDK_VERSION}.tar.gz"
+        QHY_SHA256="$QHY_SHA256_X86_64"
+        ZWO_ARCH=x64
+        ;;
+    aarch64)
+        QHY_FILE="sdk_linux_arm64_${QHY_SDK_VERSION}.tar.gz"
+        QHY_SHA256="$QHY_SHA256_AARCH64"
+        ZWO_ARCH=armv8
+        ;;
+    *) die "unsupported architecture $(uname -m) (need x86_64 or aarch64)" ;;
+esac
+
+# ---- prerequisites ------------------------------------------------------
+SUDO=""
+[ "$(id -u)" = 0 ] || SUDO="sudo"
+
+# libusb-1.0-0-dev + libudev-dev: the camera SDK links (-lusb-1.0, -ludev);
+# clang/libclang-dev: bindgen in libzwo-sys; dpkg-dev: dpkg-shlibdeps for
+# cargo-deb's $auto dependency resolution.
+APT_PKGS="build-essential pkg-config curl git ca-certificates dpkg-dev libusb-1.0-0-dev libudev-dev clang libclang-dev"
+if command -v apt-get > /dev/null 2>&1; then
+    missing=""
+    for p in $APT_PKGS; do
+        dpkg -s "$p" > /dev/null 2>&1 || missing="$missing $p"
+    done
+    if [ -n "$missing" ]; then
+        echo "Installing build prerequisites:$missing"
+        $SUDO apt-get update -qq
+        # shellcheck disable=SC2086 # word-splitting the package list is intended
+        $SUDO apt-get install -y --no-install-recommends $missing
+    fi
+else
+    echo "build-packages: apt-get not found; make sure equivalents of these are installed: $APT_PKGS" >&2
+fi
+
+command -v cargo > /dev/null 2>&1 || die "cargo not found (install Rust via rustup)"
+command -v cargo-deb > /dev/null 2>&1 || cargo install --locked cargo-deb
+if [ "$RPM" = 1 ]; then
+    command -v cargo-generate-rpm > /dev/null 2>&1 || cargo install --locked cargo-generate-rpm
+fi
+
+# ---- SDK staging --------------------------------------------------------
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/rusty-photon-pkg"
+mkdir -p "$CACHE"
+
+# fetch URL DEST — atomic download (no half-written file poisoning the cache).
+fetch() {
+    echo "Downloading $1"
+    curl -fsSL -o "$2.part" "$1"
+    mv "$2.part" "$2"
+}
+
+if [ "$needs_qhy" = 1 ]; then
+    QHY_EXTRACT="$CACHE/qhy-sdk-$QHY_SDK_VERSION-$(uname -m)"
+    if [ ! -d "$QHY_EXTRACT" ]; then
+        [ "$SKIP_STAGING" = 0 ] || die "--skip-sdk-staging set but $QHY_EXTRACT is missing"
+        [ -f "$CACHE/$QHY_FILE" ] || fetch "$QHY_URL_BASE/$QHY_FILE" "$CACHE/$QHY_FILE"
+        echo "$QHY_SHA256  $CACHE/$QHY_FILE" | sha256sum -c --status - \
+            || die "sha256 mismatch for $QHY_FILE (expected $QHY_SHA256)"
+        tmp="$CACHE/extract.$$"
+        mkdir -p "$tmp"
+        tar -xzf "$CACHE/$QHY_FILE" -C "$tmp"
+        mv "$tmp/${QHY_FILE%.tar.gz}" "$QHY_EXTRACT"
+        rmdir "$tmp"
+    fi
+    # Locate the static lib rather than hardcoding the archive layout.
+    qhy_lib=$(find "$QHY_EXTRACT" -name libqhyccd.a | head -1)
+    [ -n "$qhy_lib" ] || die "libqhyccd.a not found under $QHY_EXTRACT"
+    QHYCCD_SDK_DIR=$(dirname "$qhy_lib")
+    export QHYCCD_SDK_DIR
+    echo "QHYCCD SDK $QHY_SDK_VERSION staged: QHYCCD_SDK_DIR=$QHYCCD_SDK_DIR"
+fi
+
+if [ "$needs_zwo" = 1 ]; then
+    ZWO_CACHE="$CACHE/zwo-$ZWO_SDK_REF-$ZWO_ARCH"
+    mkdir -p "$ZWO_CACHE"
+    ZWO_BASE="https://github.com/indilib/indi-3rdparty/raw/$ZWO_SDK_REF/libasi"
+    for blob in libASICamera2 libEFWFilter; do
+        if [ ! -f "$ZWO_CACHE/$blob.so" ]; then
+            [ "$SKIP_STAGING" = 0 ] || die "--skip-sdk-staging set but $ZWO_CACHE/$blob.so is missing"
+            fetch "$ZWO_BASE/$ZWO_ARCH/$blob.bin" "$ZWO_CACHE/$blob.so"
+        fi
+    done
+    # Both the link search dir and the cargo-deb/generate-rpm asset source.
+    mkdir -p services/zwo-camera/pkg/lib
+    cp "$ZWO_CACHE/libASICamera2.so" "$ZWO_CACHE/libEFWFilter.so" services/zwo-camera/pkg/lib/
+    ZWO_SDK_LIB_DIR="$(pwd)/services/zwo-camera/pkg/lib"
+    export ZWO_SDK_LIB_DIR
+    echo "ZWO SDK blobs (indi-3rdparty $ZWO_SDK_REF) staged: ZWO_SDK_LIB_DIR=$ZWO_SDK_LIB_DIR"
+fi
+
+# ---- build ----------------------------------------------------------------
+# The RUNPATH lets the SONAME-less bundled ZWO blobs resolve from
+# /usr/lib/rusty-photon at runtime. Deliberately set here, not in a build.rs
+# (which would ripple into Bazel/repin). Overrides any ambient RUSTFLAGS so
+# the produced binaries do not depend on the invoking shell's environment.
+RUSTFLAGS="-C link-arg=-Wl,-rpath,/usr/lib/rusty-photon"
+export RUSTFLAGS
+
+build_args=""
+for s in $SERVICES; do
+    build_args="$build_args -p $s"
+done
+echo "Building release binaries:$build_args"
+# shellcheck disable=SC2086 # word-splitting the -p list is intended
+cargo build --release $build_args
+
+for s in $SERVICES; do
+    strip "target/release/$s"
+done
+
+# ---- package -----------------------------------------------------------
+VERSION=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+[ -n "$VERSION" ] || die "could not read the workspace version from Cargo.toml"
+DIST="dist/$VERSION"
+mkdir -p "$DIST"
+
+for s in $SERVICES; do
+    echo "Packaging $s"
+    # --no-build: reusing the staged-env build above is essential; a rebuild
+    # here would drop QHYCCD_SDK_DIR/ZWO_SDK_LIB_DIR/RUSTFLAGS.
+    cargo deb -p "$s" --no-build --no-strip --output "$DIST/"
+    if [ "$RPM" = 1 ]; then
+        cargo generate-rpm -p "services/$s" -o "$DIST/"
+    fi
+done
+
+(
+    cd "$DIST"
+    rm -f SHA256SUMS.txt
+    # shellcheck disable=SC2035
+    sha256sum *.deb *.rpm > SHA256SUMS.txt 2>/dev/null || sha256sum *.deb > SHA256SUMS.txt
+)
+
+echo ""
+echo "Packages in $DIST/:"
+ls -1 "$DIST"

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -162,7 +162,9 @@ if [ "$needs_qhy" = 1 ]; then
         mkdir -p "$tmp"
         tar -xzf "$CACHE/$QHY_FILE" -C "$tmp"
         mv "$tmp/${QHY_FILE%.tar.gz}" "$QHY_EXTRACT"
-        rmdir "$tmp"
+        # rm -rf, not rmdir: any extra top-level entry in a future archive
+        # layout would make rmdir abort the build under set -e.
+        rm -rf "$tmp"
     fi
     # Locate the static lib rather than hardcoding the archive layout.
     qhy_lib=$(find "$QHY_EXTRACT" -name libqhyccd.a | head -1)

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -143,6 +143,9 @@ mkdir -p "$CACHE"
 
 # fetch URL DEST — atomic download (no half-written file poisoning the cache).
 fetch() {
+    # Explicit check: on non-apt hosts nothing above installed curl, and a
+    # bare `curl: not found` under set -e would be low-signal.
+    command -v curl > /dev/null 2>&1 || die "curl not found (needed to download the SDKs)"
     echo "Downloading $1"
     curl -fsSL -o "$2.part" "$1"
     mv "$2.part" "$2"
@@ -203,6 +206,9 @@ echo "Building release binaries:$build_args"
 # shellcheck disable=SC2086 # word-splitting the -p list is intended
 cargo build --release $build_args
 
+# Same reasoning as the curl check in fetch(): make a missing binutils on a
+# non-apt host fail with an actionable message, not a bare `strip: not found`.
+command -v strip > /dev/null 2>&1 || die "strip not found (install binutils)"
 for s in $SERVICES; do
     strip "target/release/$s"
 done

--- a/scripts/check-pkg-assets.sh
+++ b/scripts/check-pkg-assets.sh
@@ -93,7 +93,8 @@ for pkgdir in services/*/pkg; do
         || err "$svc: [package.metadata.generate-rpm] name must be \"$name\""
 done
 
-# The QHY SDK version is pinned in two shipped places (ADR-013); they must match.
+# The QHY SDK pins (version + archive sha256s) live in two shipped places
+# (ADR-013); they must match.
 bp=scripts/build-packages.sh
 fw=services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
 if [ -f "$bp" ] && [ -f "$fw" ]; then
@@ -102,6 +103,13 @@ if [ -f "$bp" ] && [ -f "$fw" ]; then
     if [ -z "$v1" ] || [ "$v1" != "$v2" ]; then
         err "QHY SDK version pin mismatch: build-packages.sh='$v1' vs firmware-install='$v2'"
     fi
+    for arch in X86_64 AARCH64; do
+        s1=$(sed -n "s/^QHY_SHA256_$arch=\"\(.*\)\"\$/\1/p" "$bp" | head -1)
+        s2=$(sed -n "s/^SHA256_$arch=\"\(.*\)\"\$/\1/p" "$fw" | head -1)
+        if [ -z "$s1" ] || [ "$s1" != "$s2" ]; then
+            err "QHY SDK sha256 pin mismatch ($arch): build-packages.sh='$s1' vs firmware-install='$s2'"
+        fi
+    done
 fi
 
 # The packaged ZWO SDK license must match the copy vendored with the SDK

--- a/scripts/verify-packages.sh
+++ b/scripts/verify-packages.sh
@@ -1,0 +1,362 @@
+#!/bin/sh
+# verify-packages.sh — lifecycle-verify the built .deb packages in a podman
+# systemd container (debian:trixie). Per service: install → unit active →
+# config self-created at /var/lib/rusty-photon/.config/rusty-photon/<svc>.json
+# → HTTP probe → remove (config survives) → purge (config + state gone;
+# shared user/home//etc symlink stay). ConditionPathExists-gated services
+# (sky-survey-camera, plate-solver, calibrator-flats) instead verify
+# enabled-but-not-started-and-not-failed. Runs natively on arm64 (the rig)
+# and x86_64 (dev box).
+#
+# Rootless-container caveat (docs/plans/service-packaging.md): rootless
+# podman cannot apply the units' sandboxing across the User= switch
+# (217/USER, 226/NAMESPACE), so this script pre-installs a drop-in that
+# resets the whole hardening block inside the container. Containers verify
+# the packaging lifecycle; the hardening is verified on real hosts
+# (systemd-analyze security + an active unit on the rig).
+#
+# Usage: scripts/verify-packages.sh [--services a,b,c] [--dist DIR] [--keep]
+#   --services a,b,c  verify only these (default: every rusty-photon-*.deb in DIST)
+#   --dist DIR        package directory (default: dist/<workspace version>)
+#   --keep            keep the container on exit (debugging)
+
+set -eu
+
+die() { echo "verify-packages: $*" >&2; exit 1; }
+
+usage() {
+    sed -n '/^# Usage:/,/^$/{s/^# \{0,1\}//p}' "$0"
+}
+
+KEEP=0
+DIST=""
+ONLY_SERVICES=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --services)
+            shift
+            [ $# -gt 0 ] || die "--services needs a comma-separated list"
+            ONLY_SERVICES="$1"
+            ;;
+        --dist)
+            shift
+            [ $# -gt 0 ] || die "--dist needs a directory"
+            DIST="$1"
+            ;;
+        --keep) KEEP=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; die "unknown option: $1" ;;
+    esac
+    shift
+done
+
+[ -f packaging/postinst.common ] || die "run from the repo root"
+command -v podman > /dev/null 2>&1 || die "podman not found"
+
+if [ -z "$DIST" ]; then
+    version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+    DIST="dist/$version"
+fi
+[ -d "$DIST" ] || die "$DIST not found — run scripts/build-packages.sh first"
+DIST_ABS=$(cd "$DIST" && pwd)
+
+# Service list: from the debs actually present, or --services.
+if [ -n "$ONLY_SERVICES" ]; then
+    SERVICES=$(echo "$ONLY_SERVICES" | tr ',' ' ')
+else
+    SERVICES=$(for f in "$DIST_ABS"/rusty-photon-*.deb; do
+        [ -e "$f" ] || continue
+        b=$(basename "$f")
+        b=${b#rusty-photon-}
+        echo "${b%%_*}"
+    done | sort -u | tr '\n' ' ')
+fi
+[ -n "$SERVICES" ] || die "no rusty-photon-*.deb packages in $DIST_ABS"
+for s in $SERVICES; do
+    ls "$DIST_ABS/rusty-photon-${s}_"*.deb > /dev/null 2>&1 \
+        || die "no rusty-photon-${s}_*.deb in $DIST_ABS"
+done
+echo "Verifying: $SERVICES"
+
+port_of() {
+    case "$1" in
+        filemonitor) echo 11111 ;;
+        ppba-driver) echo 11112 ;;
+        qhy-focuser) echo 11113 ;;
+        sentinel) echo 11114 ;;
+        rp) echo 11115 ;;
+        sky-survey-camera) echo 11116 ;;
+        star-adventurer-gti) echo 11117 ;;
+        pa-falcon-rotator) echo 11118 ;;
+        dsd-fp2) echo 11119 ;;
+        ui-htmx) echo 11120 ;;
+        qhy-camera) echo 11121 ;;
+        zwo-camera) echo 11122 ;;
+        plate-solver) echo 11131 ;;
+        calibrator-flats) echo 11170 ;;
+        *) echo "" ;;
+    esac
+}
+
+probe_path() {
+    # Alpaca services answer the management API; the plain-HTTP services
+    # (sentinel dashboard, rp orchestrator, ui-htmx BFF) expose /health.
+    case "$1" in
+        sentinel|rp|ui-htmx) echo /health ;;
+        *) echo /management/apiversions ;;
+    esac
+}
+
+is_gated() {
+    # No defaultable config → unit gated on ConditionPathExists (see plan).
+    case "$1" in
+        sky-survey-camera|plate-solver|calibrator-flats) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_serial() {
+    # Serial-device drivers validate hardware eagerly at startup and exit
+    # when their device is absent (deliberate: fail startup instead of
+    # advertising a broken device on the network); systemd then retries
+    # every 5s until the device appears. The container has no serial
+    # devices, so "active" is not the contract to verify for these.
+    case "$1" in
+        ppba-driver|qhy-focuser|pa-falcon-rotator|dsd-fp2|star-adventurer-gti) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_cli() {
+    case "$1" in
+        phd2-guider) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+self_creates_config() {
+    # The cameras deliberately do NOT materialize a config on start (no
+    # materialize_identity — ASCOM UniqueIDs derive from camera serials;
+    # they run on defaults until config.apply / an operator writes a file).
+    # Gated services never start without one.
+    if is_gated "$1"; then return 1; fi
+    case "$1" in
+        qhy-camera|zwo-camera) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# ---- container ----------------------------------------------------------
+IMG=localhost/rusty-photon-pkg-verify
+CNAME="rusty-photon-verify-$$"
+
+echo "Building the verification image ($IMG)..."
+podman build -q -t "$IMG" - <<'EOF' > /dev/null
+FROM debian:trixie
+# The stock Debian image ships a policy-rc.d that exits 101, silently
+# blocking every unit start from maintainer scripts — exactly what this
+# script exists to verify. Remove it; we run a real systemd via /sbin/init.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    systemd systemd-sysv udev ca-certificates curl \
+    && rm -f /usr/sbin/policy-rc.d
+CMD ["/sbin/init"]
+EOF
+
+cleanup() {
+    if [ "$KEEP" = 1 ]; then
+        echo "Container kept: podman exec -it $CNAME bash (remove: podman rm -f $CNAME)"
+    else
+        podman rm -f "$CNAME" > /dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+podman run -d --name "$CNAME" --systemd=always \
+    -v "$DIST_ABS:/dist:ro,Z" "$IMG" > /dev/null
+
+cx() { podman exec "$CNAME" "$@"; }
+
+fail() {
+    svc="$1"
+    shift
+    echo "verify-packages: FAIL [$svc]: $*" >&2
+    cx journalctl -u "rusty-photon-$svc" --no-pager -n 40 >&2 || true
+    exit 1
+}
+
+echo "Waiting for systemd in the container..."
+i=0
+while :; do
+    state=$(cx systemctl is-system-running 2> /dev/null || true)
+    case "$state" in running | degraded) break ;; esac
+    i=$((i + 1))
+    [ "$i" -lt 60 ] || die "systemd did not come up in the container (state: $state)"
+    sleep 1
+done
+
+# Hardening-reset drop-ins must exist BEFORE the debs install (postinst
+# starts the units immediately).
+for s in $SERVICES; do
+    is_cli "$s" && continue
+    cx mkdir -p "/etc/systemd/system/rusty-photon-$s.service.d"
+    podman exec -i "$CNAME" sh -c \
+        "cat > /etc/systemd/system/rusty-photon-$s.service.d/99-container-verify.conf" <<'EOF'
+# Rootless podman cannot set up the sandbox across the User= switch.
+# Containers verify packaging lifecycle only; hardening is verified on hosts.
+[Service]
+NoNewPrivileges=no
+ProtectSystem=off
+ReadWritePaths=
+ProtectHome=no
+PrivateTmp=no
+ProtectKernelTunables=no
+ProtectKernelModules=no
+ProtectControlGroups=no
+RestrictSUIDSGID=no
+LockPersonality=no
+RestrictRealtime=no
+RestrictAddressFamilies=
+PrivateDevices=no
+MemoryDenyWriteExecute=no
+UMask=0022
+EOF
+done
+
+echo "Refreshing apt package lists in the container..."
+cx sh -c "apt-get update -qq"
+
+# Debs built on a non-Debian host carry an empty `$auto` Depends
+# (dpkg-shlibdeps needs Debian's shlibs database; cargo-deb warns and moves
+# on). Preinstall the known runtime libs so lifecycle verification still
+# works there; on Debian-host (rig) builds Depends is populated and apt
+# resolves it strictly, so this branch stays cold.
+compensate=0
+for s in $SERVICES; do
+    dep=$(cx sh -c "dpkg-deb -f /dist/rusty-photon-${s}_*.deb Depends" 2> /dev/null || true)
+    [ -n "$dep" ] || compensate=1
+done
+if [ "$compensate" = 1 ]; then
+    echo "verify-packages: WARNING: deb(s) with empty Depends (non-Debian-host build); preinstalling runtime libs"
+    cx sh -c "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libusb-1.0-0 libudev1 libstdc++6" > /dev/null
+fi
+
+# ---- install + per-service checks ----------------------------------------
+for s in $SERVICES; do
+    echo "== $s: install"
+    cx sh -c "DEBIAN_FRONTEND=noninteractive apt-get install -y /dist/rusty-photon-${s}_*.deb" \
+        > /dev/null || fail "$s" "apt-get install failed"
+
+    if is_cli "$s"; then
+        cx test -x "/usr/bin/rusty-photon-$s" || fail "$s" "binary missing"
+        cx "/usr/bin/rusty-photon-$s" --help > /dev/null || fail "$s" "--help failed"
+        echo "== $s: OK (CLI)"
+        continue
+    fi
+
+    # Shared layout, created by the first daemon postinst and stable after.
+    cx test -L /etc/rusty-photon || fail "$s" "/etc/rusty-photon symlink missing"
+    cx sh -c "getent passwd rusty-photon > /dev/null" || fail "$s" "rusty-photon user missing"
+
+    cfg="/var/lib/rusty-photon/.config/rusty-photon/$s.json"
+    if is_gated "$s"; then
+        # No config → unit must be enabled but neither active nor failed.
+        cx systemctl is-enabled --quiet "rusty-photon-$s" || fail "$s" "unit not enabled"
+        if cx systemctl is-active --quiet "rusty-photon-$s"; then
+            fail "$s" "gated unit is active without a config"
+        fi
+        if cx systemctl is-failed --quiet "rusty-photon-$s"; then
+            fail "$s" "gated unit failed instead of waiting on ConditionPathExists"
+        fi
+        cx test ! -e "$cfg" || fail "$s" "config exists on a fresh install of a gated service"
+        echo "== $s: OK (gated on config)"
+        continue
+    fi
+
+    if is_serial "$s"; then
+        # Verifiable without hardware: the binary starts, self-creates its
+        # config, and fails on the absent device — not earlier (loader,
+        # user, or config problems would die before the handshake).
+        i=0
+        until cx sh -c "journalctl -u rusty-photon-$s --no-pager 2>/dev/null | grep -q 'eager startup handshake'"; do
+            i=$((i + 1))
+            [ "$i" -lt 30 ] || fail "$s" "no eager-handshake attempt in the journal"
+            sleep 1
+        done
+        i=0
+        until cx sh -c "test -s $cfg"; do
+            i=$((i + 1))
+            [ "$i" -lt 15 ] || fail "$s" "config not self-created at $cfg"
+            sleep 1
+        done
+        if cx systemctl is-active --quiet "rusty-photon-$s"; then
+            # In case a serial driver ever gains warn-and-serve, hold it to
+            # the full contract.
+            port=$(port_of "$s")
+            path=$(probe_path "$s")
+            cx curl -fsS -o /dev/null "http://127.0.0.1:$port$path" 2> /dev/null \
+                || fail "$s" "active but no HTTP response on port $port ($path)"
+            echo "== $s: OK (active, config, port $port)"
+        else
+            echo "== $s: OK (config self-created; retrying on absent serial device)"
+        fi
+        continue
+    fi
+
+    i=0
+    until cx systemctl is-active --quiet "rusty-photon-$s"; do
+        i=$((i + 1))
+        [ "$i" -lt 30 ] || fail "$s" "unit not active after 30s"
+        sleep 1
+    done
+
+    if self_creates_config "$s"; then
+        i=0
+        until cx sh -c "test -s $cfg"; do
+            i=$((i + 1))
+            [ "$i" -lt 15 ] || fail "$s" "config not self-created at $cfg"
+            sleep 1
+        done
+    fi
+
+    port=$(port_of "$s")
+    path=$(probe_path "$s")
+    i=0
+    until cx curl -fsS -o /dev/null "http://127.0.0.1:$port$path" 2> /dev/null; do
+        i=$((i + 1))
+        [ "$i" -lt 30 ] || fail "$s" "no HTTP response on port $port ($path)"
+        sleep 1
+    done
+
+    if [ "$s" = zwo-camera ]; then
+        # RUNPATH proof: the SONAME-less bundled blobs resolve from the
+        # package's private lib dir, not from a global path.
+        cx sh -c "ldd /usr/bin/rusty-photon-zwo-camera | grep -q /usr/lib/rusty-photon/libASICamera2.so" \
+            || fail "$s" "libASICamera2.so does not resolve to /usr/lib/rusty-photon (RUNPATH)"
+    fi
+    echo "== $s: OK (active, config, port $port)"
+done
+
+# ---- remove / purge lifecycle ---------------------------------------------
+for s in $SERVICES; do
+    echo "== $s: remove + purge"
+    cx sh -c "DEBIAN_FRONTEND=noninteractive apt-get remove -y rusty-photon-$s" > /dev/null \
+        || fail "$s" "apt-get remove failed"
+    if is_cli "$s"; then
+        continue
+    fi
+    cfg="/var/lib/rusty-photon/.config/rusty-photon/$s.json"
+    if self_creates_config "$s"; then
+        cx test -f "$cfg" || fail "$s" "config did not survive remove (must only go on purge)"
+    fi
+    cx dpkg --purge "rusty-photon-$s" > /dev/null || fail "$s" "dpkg --purge failed"
+    cx test ! -e "$cfg" || fail "$s" "config survived purge"
+    cx test ! -e "/var/lib/rusty-photon/$s" || fail "$s" "state dir survived purge"
+done
+
+# The shared pieces are never removed (Debian convention; shared across pkgs).
+cx sh -c "getent passwd rusty-photon > /dev/null" || die "shared user removed by purge"
+cx test -d /var/lib/rusty-photon || die "shared home removed by purge"
+cx test -L /etc/rusty-photon || die "/etc/rusty-photon symlink removed by purge"
+
+echo ""
+echo "verify-packages: OK ($(echo "$SERVICES" | wc -w | tr -d ' ') packages)"

--- a/scripts/verify-packages.sh
+++ b/scripts/verify-packages.sh
@@ -294,6 +294,7 @@ for s in $SERVICES; do
             # In case a serial driver ever gains warn-and-serve, hold it to
             # the full contract.
             port=$(port_of "$s")
+            [ -n "$port" ] || fail "$s" "no port mapping — add $s to port_of()"
             path=$(probe_path "$s")
             cx curl -fsS -o /dev/null "http://127.0.0.1:$port$path" 2> /dev/null \
                 || fail "$s" "active but no HTTP response on port $port ($path)"
@@ -321,6 +322,7 @@ for s in $SERVICES; do
     fi
 
     port=$(port_of "$s")
+    [ -n "$port" ] || fail "$s" "no port mapping — add $s to port_of()"
     path=$(probe_path "$s")
     i=0
     until cx curl -fsS -o /dev/null "http://127.0.0.1:$port$path" 2> /dev/null; do

--- a/scripts/verify-packages.sh
+++ b/scripts/verify-packages.sh
@@ -2,11 +2,13 @@
 # verify-packages.sh — lifecycle-verify the built .deb packages in a podman
 # systemd container (debian:trixie). Per service: install → unit active →
 # config self-created at /var/lib/rusty-photon/.config/rusty-photon/<svc>.json
-# → HTTP probe → remove (config survives) → purge (config + state gone;
-# shared user/home//etc symlink stay). ConditionPathExists-gated services
-# (sky-survey-camera, plate-solver, calibrator-flats) instead verify
-# enabled-but-not-started-and-not-failed. Runs natively on arm64 (the rig)
-# and x86_64 (dev box).
+# → HTTP probe → remove (config survives) → purge (config + state gone; the
+# shared user, home dir, and /etc/rusty-photon symlink stay). Class
+# exceptions: ConditionPathExists-gated services (sky-survey-camera,
+# plate-solver, calibrator-flats) verify enabled-but-inactive-and-not-failed;
+# serial drivers verify config + handshake-attempted instead of active (see
+# is_serial); the cameras never self-create a config (see
+# self_creates_config). Runs natively on arm64 (the rig) and x86_64 (dev box).
 #
 # Rootless-container caveat (docs/plans/service-packaging.md): rootless
 # podman cannot apply the units' sandboxing across the User= switch

--- a/scripts/verify-packages.sh
+++ b/scripts/verify-packages.sh
@@ -75,8 +75,12 @@ else
 fi
 [ -n "$SERVICES" ] || die "no rusty-photon-*.deb packages in $DIST_ABS"
 for s in $SERVICES; do
-    ls "$DIST_ABS/rusty-photon-${s}_"*.deb > /dev/null 2>&1 \
-        || die "no rusty-photon-${s}_*.deb in $DIST_ABS"
+    # Exactly one deb per service: a multi-match glob (e.g. two revisions
+    # left over from an upgrade test) would make the in-container
+    # dpkg-deb/apt-get invocations below misbehave in confusing ways.
+    set -- "$DIST_ABS/rusty-photon-${s}_"*.deb
+    [ -e "$1" ] || die "no rusty-photon-${s}_*.deb in $DIST_ABS"
+    [ $# -eq 1 ] || die "multiple rusty-photon-${s}_*.deb in $DIST_ABS — remove stale builds first"
 done
 echo "Verifying: $SERVICES"
 

--- a/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
+++ b/services/qhy-camera/pkg/rusty-photon-qhy-firmware-install
@@ -121,8 +121,11 @@ install -m 0644 "$TMP/85-qhyccd.rules" "$ROOT/etc/udev/rules.d/85-qhyccd.rules"
 
 if [ -z "$ROOT" ] && command -v udevadm > /dev/null 2>&1; then
     udevadm control --reload-rules || true
-    udevadm trigger || true
+    # Re-emit *add* events: the SDK rules' fxload lines match ACTION=="add",
+    # so a plain trigger (change events) leaves an already-plugged cold
+    # camera raw. Verified on-rig: a 1618:0715 flashed only on an add event.
+    udevadm trigger --action=add --subsystem-match=usb || true
 fi
 
-echo "QHYCCD firmware $VERSION installed. Unplug and replug the camera:"
-echo "udev uploads firmware to cold cameras on the next plug-in."
+echo "QHYCCD firmware $VERSION installed. An already-plugged cold camera is"
+echo "flashed immediately; otherwise udev uploads firmware on the next plug-in."


### PR DESCRIPTION
Part 6 of [docs/plans/service-packaging.md](../blob/main/docs/plans/service-packaging.md) (ADR-012 / ADR-013). Adds the tooling that turns the per-service packaging metadata from PR-2..5 into installable artifacts, plus the operator guide.

## What's here

- **`scripts/build-packages.sh`** — native package build on the target machine (rig arm64 / dev-box x86_64): apt prereqs, sha256-pinned QHYCCD SDK staging (`QHYCCD_SDK_DIR`), ZWO blob staging into the gitignored `pkg/lib/` (`ZWO_SDK_LIB_DIR` + package payload per ADR-013), one release build with the `/usr/lib/rusty-photon` RUNPATH, then per-service `cargo deb --no-build` (+ `cargo generate-rpm` with `--rpm`) into `dist/<version>/` with `SHA256SUMS.txt`. Flags: `--services`, `--rpm`, `--skip-sdk-staging`.
- **`scripts/verify-packages.sh`** — podman `--systemd=always` debian:trixie lifecycle verification: install → unit active → config self-created → HTTP probe → remove keeps config → purge deletes config+state while the shared user/home/`/etc/rusty-photon` symlink survive. Pre-installs the PR-2 hardening-reset drop-in (rootless podman) and compensates for the empty-`$auto`-Depends debs non-Debian hosts produce.
- **`docs/packaging.md`** — operator guide (build, install, configure, QHY firmware helper, ZWO bundled blobs, ASTAP for plate-solver, remove-vs-purge, rpm caveats, expected lintian findings) + README "Deploying" pointer.
- **Checker**: both pin-sync rules are now active (`QHY_SDK_VERSION`, `ZWO_SDK_REF`), and the QHY rule now also compares the two archive **sha256** pins, as the plan promised.
- Deviation from the plan's apt sketch: `libssl-dev`/`libcfitsio-dev` dropped — the workspace links neither (rustls TLS; pure-Rust `fitsrs`). Recorded in the plan doc.

## Findings (baked into the script + docs)

1. The stock Debian container image ships a `policy-rc.d` that exits 101, **silently blocking every maintainer-script unit start** — the verify image removes it (the first full run passed vacuously without this).
2. The five shared-transport serial drivers **eagerly validate hardware and exit** when their device is absent (deliberate: never advertise a broken device). On a hardware-less install they sit in a 5s restart loop, so the script verifies config-created + handshake-attempted instead of "active".
3. The cameras deliberately **never self-create a config** (no `materialize_identity` — UniqueIDs derive from camera serials), so the config assertion applies only to the network-only daemons and serial drivers.

## Verification (x86_64 dev box)

- `scripts/build-packages.sh --rpm`: 15 debs + 15 rpms + SHA256SUMS in `dist/0.1.0/`; `readelf -d` shows `RUNPATH [/usr/lib/rusty-photon]` on zwo-camera.
- `scripts/verify-packages.sh`: **OK (15 packages)** — full install/active/config/probe/remove/purge cycle; zwo-camera `ldd` resolves `libASICamera2.so` from `/usr/lib/rusty-photon` inside the container.
- Gate: `bazel build //... && bazel test //...` (54 pass), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `check-pkg-assets: OK`.

## Still on the PR-6 list (needs the rig)

First on-rig arm64 build + install, `systemd-analyze security` scores per class, QHY firmware helper end-to-end with a real camera, Alpaca UDP discovery from another host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)