### PR TITLE
feat(session-runner): SSE event client + wait.until_event (workflow DSL Phase D1)

### DIFF
--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -330,8 +330,23 @@ committable on its own.
 
 ### Phase D — Triggers, events, resume
 
-- [ ] SSE event client (`/api/events/subscribe`, `Last-Event-ID` = the
+- [x] SSE event client (`/api/events/subscribe`, `Last-Event-ID` = the
       envelope's `event_seq`).
+
+      **Done (2026-07-05):** `services/session-runner/src/events.rs` — the
+      workspace's house SSE-client pattern (chunked `reqwest` + hand
+      parser, as in sentinel's watchdog and bdd-infra), reconnecting every
+      1 s with the cursor, `stream_gap` logged-and-continued. The intake
+      opens per session run before the first instruction and closes with
+      it; the engine gained the `EventIntake`/`EngineEvent` seam and a
+      monotonic `Clock` reading, and `wait.until_event` is implemented
+      against it (buffered-since-run-start matching, final check at
+      expiry, sleep-measured budget — pins recorded in the design doc's
+      § `wait` / § Event Subscription). BDD: `events.feature` runs
+      purpose-built fixture documents (`tests/fixtures/workflows/`,
+      merged into the spawned service's `workflows_dir`) proving the
+      buffered-event wait and the timeout-ends-the-session path
+      end-to-end.
 - [ ] Trigger engine: `event`, `poll`, and the synthetic
       `correction_requested` sources; `when` gating and `while`
       phase-gates; safe-point interleaving; `once` / `cooldown`.

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -286,6 +286,20 @@ rendered as compact JSON (an error message is terminal output, not data).
   wall-clock adjustment (NTP step) can neither fire a timeout early nor
   extend a wait; the wall clock feeds only `seconds_until()`, where
   calendar time is the point.
+- An `until_event` wait matches against every event received since the
+  **run** started, not just those arriving after the wait began: the
+  engine's event intake opens before the first instruction and buffers
+  while instructions run, so an event emitted during an earlier
+  instruction (say, the `exposure_complete` of a capture the document
+  just made) still satisfies a later wait. Buffered events are checked
+  once more exactly when the timeout expires — only then does expiry
+  raise (the same final-evaluation rule as `until`). Its budget is
+  measured like `until`'s: monotonic time spent waiting, so trigger
+  actions running during the wait do not count against it. Non-matching
+  events are consumed and (Phase D2) feed trigger evaluation; the wait
+  neither extends nor aborts for them. If the event stream is down, the
+  wait simply runs to its timeout — a missing stream is never an
+  instruction error ([Event Subscription](#event-subscription)).
 
 #### `log` — operator-visible message
 
@@ -621,7 +635,8 @@ smell the authoring docs will warn about.
 ## Event Subscription
 
 The engine consumes `rp`'s SSE stream (`/api/events/subscribe`) for trigger
-sources. The SSE `id` is the envelope's `event_seq`; on reconnect the engine
+sources and `until_event` waits. The SSE `id` is the envelope's `event_seq`;
+on reconnect the engine
 sends `Last-Event-ID`, and replay is exact within `rp`'s retention window
 (the most recent 512 envelopes — `rp.md` § Real-Time Stream). If the engine
 was gone long enough that its cursor was evicted, the stream leads with a
@@ -632,6 +647,27 @@ outage. Events that arrive while no trigger matches
 are discarded — the engine keeps no event history. The stream URL is derived
 from the invocation's `mcp_server_url` origin unless overridden in
 configuration.
+
+Implementation pins (`src/events.rs`, Phase D):
+
+- The subscription is **per session run**: it opens before the first
+  instruction executes (so nothing emitted mid-session is missed — the
+  `until_event` buffering above depends on this) and closes when the run
+  ends. Reconnects after a dropped stream or refused connect retry every
+  1 s, indefinitely, carrying the cursor; a session with a dead stream
+  keeps running — tool calls, not events, decide whether `rp` is alive
+  (§ Safety Behavior).
+- What the engine sees of an envelope is its event-type name plus its
+  `payload` (the `event.*` value). Stream-control frames (`stream_gap`,
+  `stream_error`) and malformed frames never reach the engine.
+- The intake buffers up to 256 events (matching `rp`'s own broadcast
+  buffer) while an instruction runs; if the engine falls further behind,
+  backpressure reaches the socket and `rp`'s slow-consumer cutoff +
+  reconnect replay take over — the designed loss path, ending in a
+  logged `stream_gap` at worst.
+- The transport is the workspace's house SSE-client pattern (`sentinel`'s
+  watchdog, `bdd-infra`'s harness client): a chunked `reqwest` `GET` and
+  a hand-rolled `id:`/`event:`/`data:` parser.
 
 Webhook delivery is not used: `session-runner` registers no
 `subscribes_to`/`barrier_gates` and never blocks `rp`'s tool pipeline. It is
@@ -1016,9 +1052,16 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 |----------------|--------------|--------------------------|
 | Invocation + validation | `invocation.feature` | invalid document rejected at `/invoke`; unknown tool named in error; parameter type mismatch |
 | Flats port equivalence | `flat_calibration.feature` | the scenarios from `calibrator-flats`' suite, run against the document — same events, frame counts, cleanup-on-failure |
+| Event subscription | `events.feature` | an `until_event` wait satisfied by an event emitted during an earlier instruction (pins subscription-from-run-start); a wait whose event never arrives fails the session at its timeout rather than hanging |
 | Triggers | `triggers.feature` | refocus fires between exposures, not during; cooldown respected; poll trigger fires flip action |
 | Resume | `recovery.feature` | kill mid-capture-loop → re-invoke with recovery → progress continues without repeated frames; `once` marker not re-run |
 | Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes |
+
+Scenarios that need a document the shipped set doesn't provide (a
+targeted `until_event` wait, resume fixtures) execute purpose-built
+documents from `tests/fixtures/workflows/`; the spawned service's
+`workflows_dir` is a per-scenario merge of `workflows/` and that fixtures
+directory.
 
 ### Golden documents
 

--- a/services/session-runner/BUILD.bazel
+++ b/services/session-runner/BUILD.bazel
@@ -87,6 +87,7 @@ rust_test(
         "//services/rp",
     ] + glob([
         "tests/features/**",
+        "tests/fixtures/**",
         "workflows/*.json",
     ]),
     edition = "2021",

--- a/services/session-runner/src/engine/exec.rs
+++ b/services/session-runner/src/engine/exec.rs
@@ -21,7 +21,7 @@ use crate::document::{
 };
 use crate::expr::{EvalContext, Expression};
 
-use super::{Clock, ToolCallError, ToolClient, WorkflowError};
+use super::{Clock, EventIntake, ToolCallError, ToolClient, WorkflowError};
 
 /// Why execution stopped early.
 #[derive(Debug)]
@@ -42,6 +42,8 @@ pub(super) struct Exec<'a, T, C> {
     blackboard: &'a mut Blackboard,
     tools: &'a T,
     clock: &'a C,
+    /// The session's event intake, live from before the first instruction.
+    events: EventIntake,
     /// The `result` namespace: the structured result of the most recent
     /// result-producing instruction on the current path (`null` at
     /// session start).
@@ -61,12 +63,14 @@ where
         blackboard: &'a mut Blackboard,
         tools: &'a T,
         clock: &'a C,
+        events: EventIntake,
     ) -> Self {
         Self {
             params,
             blackboard,
             tools,
             clock,
+            events,
             result: Value::Null,
             error: None,
         }
@@ -448,13 +452,63 @@ where
                 self.clock.sleep(*duration).await;
                 Ok(())
             }
-            Wait::UntilEvent { event, timeout: _ } => Err(self.error_here(
-                ins,
-                format!(
-                    "`wait` `until_event` (`{event}`) is not implemented yet — event \
-                     subscriptions land with the trigger engine (workflow-dsl plan, Phase D)"
-                ),
-            )),
+            Wait::UntilEvent { event, timeout } => {
+                debug!(
+                    event = %event,
+                    timeout = %humantime::format_duration(*timeout),
+                    "waiting for event"
+                );
+                // The intake runs from before the first instruction, so an
+                // event emitted while an earlier instruction ran is still
+                // buffered here — a wait can be satisfied by an event that
+                // technically preceded it (design § Event Subscription).
+                //
+                // The timeout budget is the time spent *waiting* (measured
+                // on the monotonic clock, so an NTP step can neither fire
+                // the timeout early nor extend the wait); Phase D2's
+                // trigger actions, which run during a wait, will not count
+                // against it.
+                let mut elapsed = std::time::Duration::ZERO;
+                loop {
+                    // Drain the buffer first — and once more when the
+                    // budget expires, so an event that arrived exactly at
+                    // expiry still satisfies the wait (mirroring `until`'s
+                    // final evaluation at timeout).
+                    while let Some(received) = self.events.try_next() {
+                        if received.event == *event {
+                            return Ok(());
+                        }
+                        debug!(received = %received.event, awaiting = %event,
+                               "ignoring non-matching event during `until_event` wait");
+                    }
+                    if elapsed >= *timeout {
+                        return Err(self.error_here(
+                            ins,
+                            format!(
+                                "`wait` `until_event` `{event}` did not arrive within {}",
+                                humantime::format_duration(*timeout)
+                            ),
+                        ));
+                    }
+                    let remaining = *timeout - elapsed;
+                    let waited_from = self.clock.monotonic();
+                    tokio::select! {
+                        // Biased so a just-arrived event beats an
+                        // already-expired sleep (the mock clock's sleeps
+                        // resolve instantly).
+                        biased;
+                        received = self.events.next() => {
+                            if received.event == *event {
+                                return Ok(());
+                            }
+                            debug!(received = %received.event, awaiting = %event,
+                                   "ignoring non-matching event during `until_event` wait");
+                        }
+                        () = self.clock.sleep(remaining) => {}
+                    }
+                    elapsed += self.clock.monotonic().saturating_sub(waited_from);
+                }
+            }
             Wait::Until {
                 condition,
                 poll_interval,

--- a/services/session-runner/src/engine/exec_tests.rs
+++ b/services/session-runner/src/engine/exec_tests.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use chrono::{DateTime, TimeZone, Utc};
 use serde_json::{json, Map, Value};
 
-use super::{run, Clock, RunOutcome, ToolCallError, ToolClient};
+use super::{run, Clock, EngineEvent, EventIntake, RunOutcome, ToolCallError, ToolClient};
 use crate::blackboard::Blackboard;
 use crate::document::{bind_parameters, Document};
 
@@ -115,6 +115,11 @@ impl Clock for MockClock {
         }
         self.sleeps.lock().unwrap().push(duration);
     }
+
+    fn monotonic(&self) -> Duration {
+        // Mock time passes only while sleeping.
+        self.sleeps.lock().unwrap().iter().sum()
+    }
 }
 
 // --- harness --------------------------------------------------------------
@@ -130,7 +135,7 @@ fn doc_with_root(root: Value) -> Document {
 
 /// Run `doc` against a blackboard file in `dir` (loaded, so repeated runs
 /// share persisted state) and return the outcome plus the final session
-/// value.
+/// value. No event stream — see [`run_with_events`] for that.
 async fn run_in(
     dir: &tempfile::TempDir,
     doc: &Document,
@@ -141,9 +146,35 @@ async fn run_in(
     let mut blackboard = Blackboard::load(dir.path().join("session.json"))
         .await
         .unwrap();
-    let outcome = run(doc, params, &mut blackboard, tools, clock).await;
+    let outcome = run(
+        doc,
+        params,
+        &mut blackboard,
+        tools,
+        clock,
+        EventIntake::disconnected(),
+    )
+    .await;
     let session = blackboard.value().clone();
     (outcome, session)
+}
+
+/// One-shot run of a parameterless document with a live event intake fed
+/// by the returned sender's prior sends (buffer the events, then run —
+/// the intake is live from run start, so pre-buffered events model events
+/// emitted while earlier instructions ran).
+async fn run_with_events(
+    root: Value,
+    tools: &MockTools,
+    clock: &(impl Clock + Sync),
+    events: EventIntake,
+) -> RunOutcome {
+    let dir = tempfile::tempdir().unwrap();
+    let doc = doc_with_root(root);
+    let mut blackboard = Blackboard::load(dir.path().join("session.json"))
+        .await
+        .unwrap();
+    run(&doc, &json!({}), &mut blackboard, tools, clock, events).await
 }
 
 /// One-shot run of a parameterless document.
@@ -856,6 +887,12 @@ impl Clock for SteppingClock {
         }
         self.sleeps.lock().unwrap().push(duration);
     }
+
+    fn monotonic(&self) -> Duration {
+        // The wall clock steps; the monotonic reading, by contract,
+        // advances only by the time actually slept.
+        self.sleeps.lock().unwrap().iter().sum()
+    }
 }
 
 #[tokio::test]
@@ -884,16 +921,85 @@ async fn test_wait_until_timeout_is_immune_to_wall_clock_steps() {
     );
 }
 
+// --- wait: until_event ------------------------------------------------------
+
+/// An intake pre-loaded with `events` (name, payload) — models events that
+/// arrived (and were buffered) while earlier instructions ran.
+fn buffered_events(events: &[(&str, Value)]) -> EventIntake {
+    let (tx, rx) = tokio::sync::mpsc::channel(events.len().max(1));
+    for (event, payload) in events {
+        tx.try_send(EngineEvent {
+            event: (*event).to_owned(),
+            payload: payload.clone(),
+        })
+        .unwrap();
+    }
+    // The sender drops here: the stream ends after the buffered events,
+    // exactly like an rp that emitted these and then went quiet.
+    EventIntake::new(rx)
+}
+
 #[tokio::test]
-async fn test_wait_until_event_is_a_phase_d_gap_for_now() {
+async fn test_wait_until_event_is_satisfied_by_a_buffered_event() {
+    // The intake runs from before the first instruction, so an event that
+    // arrived during an earlier instruction still satisfies the wait — no
+    // sleeping needed.
     let tools = MockTools::none();
+    let clock = MockClock::new();
     let root = json!({ "wait": { "until_event": "guide_settled", "timeout": "5m" } });
-    let (outcome, _) = run_root(root, &tools).await;
+    let events = buffered_events(&[("guide_settled", json!({ "rms": 0.4 }))]);
+    let outcome = run_with_events(root, &tools, &clock, events).await;
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(clock.sleeps(), Vec::<Duration>::new());
+}
+
+#[tokio::test]
+async fn test_wait_until_event_drains_past_non_matching_events() {
+    let tools = MockTools::none();
+    let clock = MockClock::new();
+    let root = json!({ "wait": { "until_event": "guide_settled", "timeout": "5m" } });
+    let events = buffered_events(&[
+        ("exposure_complete", json!({ "document_id": "doc-1" })),
+        ("filter_switch", json!({ "filter_name": "Ha" })),
+        ("guide_settled", Value::Null),
+    ]);
+    let outcome = run_with_events(root, &tools, &clock, events).await;
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(clock.sleeps(), Vec::<Duration>::new());
+}
+
+#[tokio::test]
+async fn test_wait_until_event_times_out_when_the_event_never_arrives() {
+    // A closed, empty intake: the select's event arm pends forever, so
+    // the full remaining budget is slept away and expiry raises.
+    let tools = MockTools::none();
+    let clock = MockClock::new();
+    let root = json!({ "id": "settle",
+                       "wait": { "until_event": "guide_settled", "timeout": "5m" } });
+    let outcome = run_with_events(root, &tools, &clock, EventIntake::disconnected()).await;
+    let error = failure(outcome);
+    assert_eq!(
+        error.message,
+        "`wait` `until_event` `guide_settled` did not arrive within 5m"
+    );
+    assert_eq!(error.instruction_id.as_deref(), Some("settle"));
+    assert_eq!(clock.sleeps(), vec![Duration::from_secs(300)]);
+}
+
+#[tokio::test]
+async fn test_wait_until_event_times_out_past_non_matching_events() {
+    // Non-matching buffered events are consumed but must not satisfy —
+    // or extend — the wait.
+    let tools = MockTools::none();
+    let clock = MockClock::new();
+    let root = json!({ "wait": { "until_event": "guide_settled", "timeout": "1m" } });
+    let events = buffered_events(&[("exposure_complete", Value::Null)]);
+    let outcome = run_with_events(root, &tools, &clock, events).await;
     assert_eq!(
         failure(outcome).message,
-        "`wait` `until_event` (`guide_settled`) is not implemented yet — event \
-         subscriptions land with the trigger engine (workflow-dsl plan, Phase D)"
+        "`wait` `until_event` `guide_settled` did not arrive within 1m"
     );
+    assert_eq!(clock.sleeps(), vec![Duration::from_secs(60)]);
 }
 
 // --- fail, if, log -------------------------------------------------------------

--- a/services/session-runner/src/engine/io.rs
+++ b/services/session-runner/src/engine/io.rs
@@ -1,16 +1,20 @@
-//! The engine's outward-facing seams: the tool-call client and the clock.
+//! The engine's outward-facing seams: the tool-call client, the clock, and
+//! the event intake.
 //!
-//! Both are traits so the interpreter is testable without `rp`: unit tests
-//! drive the tree with a scripted [`ToolClient`] and a mock [`Clock`]
-//! (design: `docs/services/session-runner.md` § Testing Strategy). The real
-//! implementations are the `rmcp`-based MCP client (Phase C service wiring)
-//! and [`SystemClock`].
+//! All three are injectable so the interpreter is testable without `rp`:
+//! unit tests drive the tree with a scripted [`ToolClient`], a mock
+//! [`Clock`], and a hand-fed [`EventIntake`] (design:
+//! `docs/services/session-runner.md` § Testing Strategy). The real
+//! implementations are the `rmcp`-based MCP client, [`SystemClock`], and
+//! the SSE client in `crate::events`.
 
 use std::future::Future;
-use std::time::Duration;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
+use tokio::sync::mpsc;
 
 /// A failed tool call, as the engine distinguishes them.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
@@ -38,16 +42,23 @@ pub trait ToolClient {
     ) -> impl Future<Output = Result<Value, ToolCallError>> + Send;
 }
 
-/// The engine clock: one seam for both "what time is it" (the expression
-/// context's `now`, read by `seconds_until()`) and "pause" (`wait`
-/// durations, poll intervals, retry backoff), so engine tests are
-/// deterministic and instant.
+/// The engine clock: one seam for "what time is it" (the expression
+/// context's `now`, read by `seconds_until()`), "pause" (`wait`
+/// durations, poll intervals, retry backoff), and "how long did that
+/// take" (the monotonic reading that measures `wait` timeout budgets), so
+/// engine tests are deterministic and instant.
 pub trait Clock {
     fn now(&self) -> DateTime<Utc>;
     fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send;
+    /// A monotonic reading for measuring elapsed waits. Only differences
+    /// are meaningful; the reference point is arbitrary but fixed for the
+    /// clock's lifetime. Monotonic by contract: a wall-clock adjustment
+    /// (NTP step) must not move it (design § `wait`).
+    fn monotonic(&self) -> Duration;
 }
 
-/// The production clock: `chrono::Utc::now` + `tokio::time::sleep`.
+/// The production clock: `chrono::Utc::now` + `tokio::time::sleep` +
+/// `std::time::Instant` against a process-lifetime epoch.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SystemClock;
 
@@ -58,5 +69,73 @@ impl Clock for SystemClock {
 
     async fn sleep(&self, duration: Duration) {
         tokio::time::sleep(duration).await;
+    }
+
+    fn monotonic(&self) -> Duration {
+        static EPOCH: OnceLock<Instant> = OnceLock::new();
+        EPOCH.get_or_init(Instant::now).elapsed()
+    }
+}
+
+/// One event as the engine consumes it: the envelope's event-type name
+/// plus its `payload` (which becomes the `event.*` namespace in trigger
+/// scopes). Produced by the SSE client (`crate::events`) and, for the
+/// synthetic `correction_requested` source, by the engine itself.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EngineEvent {
+    pub event: String,
+    pub payload: Value,
+}
+
+/// The engine's intake of `rp` events, running from before the first
+/// instruction so nothing emitted mid-session is missed: events received
+/// while an instruction runs stay buffered until the engine next looks.
+///
+/// A closed or absent stream is not an error — [`EventIntake::next`]
+/// simply never resolves, so an `until_event` wait runs to its timeout
+/// and (Phase D2) triggers never fire, matching the design's stance that
+/// events can always be missed across an outage.
+#[derive(Debug)]
+pub struct EventIntake {
+    /// `None` once the sending side is gone (or for
+    /// [`EventIntake::disconnected`]) — nothing will ever arrive.
+    rx: Option<mpsc::Receiver<EngineEvent>>,
+}
+
+impl EventIntake {
+    pub fn new(rx: mpsc::Receiver<EngineEvent>) -> Self {
+        Self { rx: Some(rx) }
+    }
+
+    /// An intake with no stream behind it: nothing ever arrives.
+    pub fn disconnected() -> Self {
+        Self { rx: None }
+    }
+
+    /// The next buffered event, without waiting; `None` when the buffer
+    /// is empty (or the stream is gone).
+    pub(crate) fn try_next(&mut self) -> Option<EngineEvent> {
+        use tokio::sync::mpsc::error::TryRecvError;
+        match self.rx.as_mut()?.try_recv() {
+            Ok(event) => Some(event),
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => {
+                self.rx = None;
+                None
+            }
+        }
+    }
+
+    /// Wait for the next event. Resolves **only** when an event arrives:
+    /// on a closed stream it pends forever, so callers select this
+    /// against a sleep without needing a closed-stream branch.
+    pub(crate) async fn next(&mut self) -> EngineEvent {
+        if let Some(rx) = self.rx.as_mut() {
+            if let Some(event) = rx.recv().await {
+                return event;
+            }
+            self.rx = None;
+        }
+        std::future::pending().await
     }
 }

--- a/services/session-runner/src/engine/mod.rs
+++ b/services/session-runner/src/engine/mod.rs
@@ -8,11 +8,11 @@
 //! two seams so unit tests need no `rp`: a [`ToolClient`] (the real MCP
 //! client arrives with the Phase C service wiring) and a [`Clock`].
 //!
-//! Phase boundary (`docs/plans/workflow-dsl.md`): this is the Phase C
-//! engine core. Trigger evaluation — including `wait` `until_event` and
-//! the `event.*` namespace — lands in Phase D; until then a document's
-//! declared triggers do not fire (warned at run start) and an
-//! `until_event` wait raises a workflow error.
+//! Phase boundary (`docs/plans/workflow-dsl.md`): the Phase C engine core
+//! plus the Phase D event intake (`wait` `until_event` against the SSE
+//! stream). Trigger evaluation — including the `event.*` namespace — is
+//! the remaining Phase D work; until it lands a document's declared
+//! triggers do not fire (warned at run start).
 
 mod exec;
 mod io;
@@ -25,7 +25,7 @@ mod exec_tests;
 use serde_json::{json, Value};
 use tracing::{debug, info, warn};
 
-pub use io::{Clock, SystemClock, ToolCallError, ToolClient};
+pub use io::{Clock, EngineEvent, EventIntake, SystemClock, ToolCallError, ToolClient};
 
 use crate::blackboard::Blackboard;
 use crate::document::Document;
@@ -77,13 +77,16 @@ pub enum RunOutcome {
 /// [`crate::document::bind_parameters`]; `blackboard` is empty for a fresh
 /// session or reloaded for a recovery invocation — re-execution from the
 /// root against the persisted blackboard *is* the resume model (design
-/// § Re-entrancy Contract).
+/// § Re-entrancy Contract). `events` is the session's event intake
+/// (subscribed before the first instruction, so an event emitted while an
+/// earlier instruction ran still satisfies a later `until_event` wait).
 pub async fn run<T, C>(
     doc: &Document,
     params: &Value,
     blackboard: &mut Blackboard,
     tools: &T,
     clock: &C,
+    events: EventIntake,
 ) -> RunOutcome
 where
     T: ToolClient + Sync,
@@ -97,7 +100,7 @@ where
              (workflow-dsl plan, Phase D) — they will not fire"
         );
     }
-    let mut exec = exec::Exec::new(params, blackboard, tools, clock);
+    let mut exec = exec::Exec::new(params, blackboard, tools, clock, events);
     match exec.exec_block(std::slice::from_ref(&doc.root)).await {
         Ok(()) => {
             debug!(document = %doc.name, "workflow completed");

--- a/services/session-runner/src/events.rs
+++ b/services/session-runner/src/events.rs
@@ -1,0 +1,482 @@
+//! SSE client for `rp`'s `/api/events/subscribe` stream (design § Event
+//! Subscription): connects when a session starts, tails the stream,
+//! reconnects with `Last-Event-ID`, and forwards each envelope's
+//! event-type name + `payload` to the engine's [`EventIntake`].
+//!
+//! Loss handling follows the design's stance that events can always be
+//! missed across an outage: a reconnect replays exactly within `rp`'s
+//! 512-envelope retention; a `stream_gap` (cursor evicted, or this
+//! consumer lagged) is logged at `info!` and the stream simply continues.
+//! The client task ends when the engine drops the intake — a session's
+//! subscription lives exactly as long as its run.
+//!
+//! The transport is the workspace house pattern for SSE consumption
+//! (`sentinel`'s watchdog, `bdd-infra`'s harness client): a long-lived
+//! `GET` read chunk by chunk with [`reqwest::Response::chunk`] — no
+//! `stream` cargo feature — and a hand-rolled parser for the
+//! `id:`/`event:`/`data:` line protocol.
+
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tracing::{debug, info};
+
+use crate::engine::{EngineEvent, EventIntake};
+
+/// Pause between reconnect attempts after a dropped stream or a failed
+/// connect. Short enough that a restarting `rp` is picked up well inside
+/// its 512-envelope retention; long enough not to hammer a dead endpoint.
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Intake buffer depth, matching `rp`'s own broadcast buffer. When the
+/// engine is mid-instruction the buffer absorbs the stream; if it fills,
+/// backpressure propagates to the socket and `rp` eventually cuts this
+/// consumer loose with a `stream_gap` — the designed slow-consumer path.
+const EVENT_BUFFER: usize = 256;
+
+/// Subscribe to the SSE stream at `events_url` and return the engine's
+/// intake. The connection (and every reconnect) happens on a background
+/// task that exits when the returned intake is dropped.
+pub fn subscribe(events_url: String) -> EventIntake {
+    let (tx, rx) = mpsc::channel(EVENT_BUFFER);
+    tokio::spawn(client_loop(events_url, tx));
+    EventIntake::new(rx)
+}
+
+async fn client_loop(url: String, tx: mpsc::Sender<EngineEvent>) {
+    let client = reqwest::Client::new();
+    let mut last_seq: Option<u64> = None;
+    loop {
+        let mut request = client.get(&url).header("accept", "text/event-stream");
+        if let Some(id) = last_seq {
+            request = request.header("last-event-id", id.to_string());
+        }
+        let response = tokio::select! {
+            _ = tx.closed() => return,
+            sent = request.send() => sent,
+        };
+        match response {
+            Ok(response) if response.status().is_success() => {
+                debug!(%url, cursor = ?last_seq, "event stream connected");
+                read_stream(response, &tx, &mut last_seq).await;
+            }
+            Ok(response) => {
+                debug!(%url, status = %response.status(), "event stream subscribe rejected");
+            }
+            Err(e) => {
+                debug!(%url, error = %e, "event stream connect failed");
+            }
+        }
+        tokio::select! {
+            _ = tx.closed() => return,
+            () = tokio::time::sleep(RECONNECT_BACKOFF) => {}
+        }
+    }
+}
+
+/// Tail one connection: parse frames, track the replay cursor, forward
+/// envelopes. Returns when the stream ends (reconnect) or the intake is
+/// dropped (checked by the caller via `tx.closed()`).
+async fn read_stream(
+    mut response: reqwest::Response,
+    tx: &mpsc::Sender<EngineEvent>,
+    last_seq: &mut Option<u64>,
+) {
+    let mut buffer = String::new();
+    loop {
+        let chunk = tokio::select! {
+            // Intake dropped (the run ended): stop immediately and drop the
+            // response so the HTTP connection closes — otherwise this task
+            // could block on `chunk()` forever on a quiet stream, leaking
+            // the task + connection.
+            _ = tx.closed() => return,
+            chunk = response.chunk() => chunk,
+        };
+        match chunk {
+            Ok(Some(chunk)) => {
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
+                for frame in drain_frames(&mut buffer) {
+                    if let Some(id) = frame.id {
+                        *last_seq = Some(id);
+                    }
+                    let Some(event) = engine_event(frame) else {
+                        continue;
+                    };
+                    if tx.send(event).await.is_err() {
+                        return;
+                    }
+                }
+            }
+            // Stream ended or transport error: back to the caller for a
+            // reconnect with the cursor.
+            Ok(None) => {
+                debug!("event stream ended");
+                return;
+            }
+            Err(e) => {
+                debug!(error = %e, "event stream read failed");
+                return;
+            }
+        }
+    }
+}
+
+/// One parsed SSE frame.
+struct SseFrame {
+    /// The `id:` line — the envelope's `event_seq`, the replay cursor.
+    id: Option<u64>,
+    /// The `event:` line — the envelope's event-type name.
+    event: Option<String>,
+    data: String,
+}
+
+/// An engine event from a frame, or `None` for the frames the engine
+/// never sees: stream-control frames (`stream_gap` logged at `info!` per
+/// the design, `stream_error` at `debug!`) and anything malformed.
+fn engine_event(frame: SseFrame) -> Option<EngineEvent> {
+    match frame.event.as_deref() {
+        Some("stream_gap") => {
+            // Evicted cursor or lagged consumer: events were missed. The
+            // engine just continues — poll triggers re-observe current
+            // state on their next cycle, and the re-entrancy contract
+            // already assumes events can be missed across an outage.
+            info!(detail = %frame.data, "event stream gap: some events were missed");
+            None
+        }
+        Some("stream_error") => {
+            debug!(detail = %frame.data, "event stream control frame reported an error");
+            None
+        }
+        Some(event) => {
+            let Ok(envelope) = serde_json::from_str::<Value>(&frame.data) else {
+                debug!(event = %event, "discarding event frame with non-JSON data");
+                return None;
+            };
+            let payload = envelope.get("payload").cloned().unwrap_or(Value::Null);
+            Some(EngineEvent {
+                event: event.to_owned(),
+                payload,
+            })
+        }
+        None => None,
+    }
+}
+
+/// Extract every complete SSE frame (`\n\n`-delimited) from `buffer`,
+/// leaving any trailing partial frame for the next chunk.
+fn drain_frames(buffer: &mut String) -> Vec<SseFrame> {
+    let mut out = Vec::new();
+    while let Some(idx) = buffer.find("\n\n") {
+        let block: String = buffer.drain(..idx + 2).collect();
+        if let Some(frame) = parse_frame(&block) {
+            out.push(frame);
+        }
+    }
+    out
+}
+
+/// Parse one `\n\n`-delimited SSE block. Comment lines (`:`-prefixed
+/// keep-alives) are skipped; a block with no `event` and no `data` yields
+/// `None`.
+fn parse_frame(block: &str) -> Option<SseFrame> {
+    let mut id = None;
+    let mut event = None;
+    let mut data_lines: Vec<String> = Vec::new();
+    for line in block.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+        let (field, value) = match line.split_once(':') {
+            Some((f, v)) => (f, v.strip_prefix(' ').unwrap_or(v)),
+            None => (line, ""),
+        };
+        match field {
+            "id" => id = value.trim().parse::<u64>().ok(),
+            "event" => event = Some(value.to_string()),
+            "data" => data_lines.push(value.to_string()),
+            _ => {}
+        }
+    }
+    if event.is_none() && data_lines.is_empty() {
+        return None;
+    }
+    Some(SseFrame {
+        id,
+        event,
+        data: data_lines.join("\n"),
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    // --- scripted SSE server -------------------------------------------------
+    //
+    // A raw TCP stand-in for rp's `/api/events/subscribe`: each accepted
+    // connection captures the request head (for `last-event-id`
+    // assertions), plays one scripted response, and either closes or
+    // holds the stream open until the client hangs up.
+
+    struct Connection {
+        status: &'static str,
+        body: &'static str,
+        /// Hold the stream open after `body` until the client closes.
+        hold: bool,
+    }
+
+    async fn spawn_sse_server(
+        script: Vec<Connection>,
+    ) -> (String, mpsc::UnboundedReceiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (heads_tx, heads_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            for connection in script {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut head = Vec::new();
+                let mut byte = [0u8; 1];
+                while !head.ends_with(b"\r\n\r\n") {
+                    match socket.read(&mut byte).await {
+                        Ok(1..) => head.push(byte[0]),
+                        _ => break,
+                    }
+                }
+                let _ = heads_tx.send(String::from_utf8_lossy(&head).into_owned());
+                let response = format!(
+                    "HTTP/1.1 {}\r\ncontent-type: text/event-stream\r\n\
+                     connection: close\r\n\r\n{}",
+                    connection.status, connection.body
+                );
+                if socket.write_all(response.as_bytes()).await.is_err() {
+                    continue;
+                }
+                if connection.hold {
+                    let mut sink = [0u8; 64];
+                    loop {
+                        match socket.read(&mut sink).await {
+                            Ok(0) | Err(_) => break,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        });
+        (format!("http://{addr}/api/events/subscribe"), heads_rx)
+    }
+
+    async fn next_event(intake: &mut EventIntake) -> EngineEvent {
+        timeout(Duration::from_secs(5), intake.next())
+            .await
+            .expect("expected an event within 5s")
+    }
+
+    // --- client behavior -------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_envelopes_are_forwarded_in_order_and_control_frames_are_not() {
+        let body = ": keep-alive\n\n\
+                    id: 7\nevent: exposure_started\ndata: {\"event\":\"exposure_started\",\
+                    \"event_seq\":7,\"payload\":{\"camera_id\":\"main-cam\"}}\n\n\
+                    event: stream_gap\ndata: {\"event\":\"stream_gap\",\"lagged\":3}\n\n\
+                    id: 8\nevent: exposure_complete\ndata: {\"event\":\"exposure_complete\",\
+                    \"event_seq\":8,\"payload\":{\"document_id\":\"doc-1\"}}\n\n\
+                    event: stream_error\ndata: {\"error\":\"serialization\"}\n\n";
+        let (url, _heads) = spawn_sse_server(vec![Connection {
+            status: "200 OK",
+            body,
+            hold: true,
+        }])
+        .await;
+
+        let mut intake = subscribe(url);
+        assert_eq!(
+            next_event(&mut intake).await,
+            EngineEvent {
+                event: "exposure_started".to_owned(),
+                payload: json!({ "camera_id": "main-cam" }),
+            }
+        );
+        assert_eq!(
+            next_event(&mut intake).await,
+            EngineEvent {
+                event: "exposure_complete".to_owned(),
+                payload: json!({ "document_id": "doc-1" }),
+            }
+        );
+        // The control frames were consumed, not forwarded.
+        assert!(intake.try_next().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_resumes_from_the_last_seen_event_seq() {
+        let first = "id: 41\nevent: tick\ndata: {\"payload\":{\"n\":1}}\n\n\
+                     id: 42\nevent: tick\ndata: {\"payload\":{\"n\":2}}\n\n";
+        let second = "id: 43\nevent: tick\ndata: {\"payload\":{\"n\":3}}\n\n";
+        let (url, mut heads) = spawn_sse_server(vec![
+            Connection {
+                status: "200 OK",
+                body: first,
+                hold: false,
+            },
+            Connection {
+                status: "200 OK",
+                body: second,
+                hold: true,
+            },
+        ])
+        .await;
+
+        let mut intake = subscribe(url);
+        for n in 1..=3 {
+            assert_eq!(next_event(&mut intake).await.payload, json!({ "n": n }));
+        }
+        let first_head = heads.recv().await.unwrap().to_lowercase();
+        assert!(
+            !first_head.contains("last-event-id"),
+            "the initial connect must not carry a cursor: {first_head}"
+        );
+        let second_head = heads.recv().await.unwrap().to_lowercase();
+        assert!(
+            second_head.contains("last-event-id: 42"),
+            "the reconnect must resume after the last seen event_seq: {second_head}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_rejected_subscribe_is_retried() {
+        let (url, _heads) = spawn_sse_server(vec![
+            Connection {
+                status: "503 Service Unavailable",
+                body: "",
+                hold: false,
+            },
+            Connection {
+                status: "200 OK",
+                body: "id: 1\nevent: tick\ndata: {\"payload\":null}\n\n",
+                hold: true,
+            },
+        ])
+        .await;
+
+        let mut intake = subscribe(url);
+        assert_eq!(next_event(&mut intake).await.event, "tick");
+    }
+
+    #[tokio::test]
+    async fn test_dropping_the_intake_ends_the_client() {
+        let (url, mut heads) = spawn_sse_server(vec![
+            Connection {
+                status: "200 OK",
+                body: "",
+                hold: true,
+            },
+            // A second scripted connection that must never be used.
+            Connection {
+                status: "200 OK",
+                body: "",
+                hold: true,
+            },
+        ])
+        .await;
+
+        let intake = subscribe(url);
+        // First connection established…
+        heads.recv().await.unwrap();
+        drop(intake);
+        // …and no reconnect after the intake is gone (well past the
+        // reconnect backoff).
+        tokio::time::sleep(RECONNECT_BACKOFF + Duration::from_millis(500)).await;
+        assert!(
+            heads.try_recv().is_err(),
+            "the client must stop once the intake is dropped"
+        );
+    }
+
+    // --- frame parsing ---------------------------------------------------------
+
+    #[test]
+    fn test_parse_frame_reads_id_event_and_data() {
+        let frame = parse_frame("id: 12\nevent: slew_started\ndata: {\"a\":1}\n\n").unwrap();
+        assert_eq!(frame.id, Some(12));
+        assert_eq!(frame.event.as_deref(), Some("slew_started"));
+        assert_eq!(frame.data, "{\"a\":1}");
+    }
+
+    #[test]
+    fn test_parse_frame_handles_crlf_and_missing_space_after_colon() {
+        let frame = parse_frame("id:3\r\nevent:tick\r\ndata:{}\r\n\r\n").unwrap();
+        assert_eq!(frame.id, Some(3));
+        assert_eq!(frame.event.as_deref(), Some("tick"));
+        assert_eq!(frame.data, "{}");
+    }
+
+    #[test]
+    fn test_parse_frame_joins_multiple_data_lines() {
+        let frame = parse_frame("data: line1\ndata: line2\n\n").unwrap();
+        assert_eq!(frame.data, "line1\nline2");
+    }
+
+    #[test]
+    fn test_parse_frame_skips_comment_only_blocks() {
+        assert!(parse_frame(": keep-alive\n\n").is_none());
+    }
+
+    #[test]
+    fn test_drain_frames_leaves_a_trailing_partial_frame() {
+        let mut buffer = "event: a\ndata: {}\n\nevent: b\nda".to_owned();
+        let frames = drain_frames(&mut buffer);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].event.as_deref(), Some("a"));
+        assert_eq!(buffer, "event: b\nda");
+    }
+
+    // --- envelope classification -------------------------------------------------
+
+    fn frame(event: Option<&str>, data: &str) -> SseFrame {
+        SseFrame {
+            id: None,
+            event: event.map(str::to_owned),
+            data: data.to_owned(),
+        }
+    }
+
+    #[test]
+    fn test_engine_event_extracts_the_payload() {
+        let event = engine_event(frame(
+            Some("exposure_complete"),
+            "{\"event\":\"exposure_complete\",\"payload\":{\"document_id\":\"d\"}}",
+        ))
+        .unwrap();
+        assert_eq!(event.event, "exposure_complete");
+        assert_eq!(event.payload, json!({ "document_id": "d" }));
+    }
+
+    #[test]
+    fn test_engine_event_defaults_a_missing_payload_to_null() {
+        let event = engine_event(frame(Some("session_started"), "{\"event_seq\":1}")).unwrap();
+        assert_eq!(event.payload, Value::Null);
+    }
+
+    #[test]
+    fn test_engine_event_drops_control_and_malformed_frames() {
+        assert!(engine_event(frame(Some("stream_gap"), "{\"lagged\":9}")).is_none());
+        assert!(engine_event(frame(Some("stream_error"), "{}")).is_none());
+        assert!(engine_event(frame(Some("tick"), "not json")).is_none());
+        assert!(engine_event(frame(None, "{\"payload\":1}")).is_none());
+    }
+}

--- a/services/session-runner/src/lib.rs
+++ b/services/session-runner/src/lib.rs
@@ -5,16 +5,17 @@
 //! Design: `docs/services/session-runner.md`; delivery plan:
 //! `docs/plans/workflow-dsl.md`. This crate ships the expression layer
 //! ([`expr`]), the document layer ([`document`]: model, validation layers
-//! 1–2, parameter binding), the engine ([`engine`] + [`blackboard`]), and
-//! the service wiring ([`mcp_client`], [`routes`], [`config`]) behind the
-//! two-phase [`ServerBuilder`]. Still ahead in the plan: the trigger
-//! engine, SSE events, and resume BDD (Phase D).
+//! 1–2, parameter binding), the engine ([`engine`] + [`blackboard`]), the
+//! SSE event client ([`events`]), and the service wiring ([`mcp_client`],
+//! [`routes`], [`config`]) behind the two-phase [`ServerBuilder`]. Still
+//! ahead in the plan: the trigger engine and resume BDD (Phase D).
 
 pub mod blackboard;
 pub mod config;
 pub mod document;
 pub mod engine;
 pub mod error;
+pub mod events;
 pub mod expr;
 pub mod mcp_client;
 pub mod routes;

--- a/services/session-runner/src/routes.rs
+++ b/services/session-runner/src/routes.rs
@@ -32,7 +32,8 @@ use crate::document::{
     bind_parameters, resolve_workflow_path, validate_against_catalog, Document, ToolSpec,
     ValidationIssue,
 };
-use crate::engine::{run, RunOutcome, SystemClock, ToolClient};
+use crate::engine::{run, EventIntake, RunOutcome, SystemClock, ToolClient};
+use crate::events;
 use crate::mcp_client::McpClient;
 
 /// Engine defaults for the acknowledgment durations when the document
@@ -307,16 +308,35 @@ async fn invoke(
         "max_duration": humantime::format_duration(max).to_string(),
     });
 
+    // Subscribe to rp's SSE stream before the first instruction runs, so
+    // an event emitted during an early instruction still satisfies a later
+    // `until_event` wait (and, Phase D2, feeds triggers). The client task
+    // lives exactly as long as the run: it exits when the intake drops.
+    let events_url = config.events_url.clone().unwrap_or_else(|| {
+        format!(
+            "{}/api/events/subscribe",
+            rp_base_url(&request.mcp_server_url)
+        )
+    });
+    let intake = events::subscribe(events_url);
+
     tokio::spawn(run_session(
         document,
         params,
         blackboard,
         mcp,
+        intake,
         request.workflow_id,
         request.mcp_server_url,
     ));
 
     (StatusCode::OK, Json(ack))
+}
+
+/// `rp`'s HTTP origin, derived from the invocation's MCP endpoint — the
+/// base for the completion POST and the default SSE stream URL.
+fn rp_base_url(mcp_server_url: &str) -> &str {
+    mcp_server_url.trim_end_matches("/mcp")
 }
 
 /// Run the engine to completion and honor the completion contract:
@@ -328,10 +348,19 @@ async fn run_session<T: ToolClient + Sync>(
     params: Value,
     mut blackboard: Blackboard,
     tools: T,
+    events: EventIntake,
     workflow_id: String,
     mcp_server_url: String,
 ) {
-    let outcome = run(&document, &params, &mut blackboard, &tools, &SystemClock).await;
+    let outcome = run(
+        &document,
+        &params,
+        &mut blackboard,
+        &tools,
+        &SystemClock,
+        events,
+    )
+    .await;
     let (status, result) = match &outcome {
         RunOutcome::Terminated => return,
         RunOutcome::Completed => (
@@ -392,8 +421,10 @@ async fn post_completion(
     status: &str,
     result: Value,
 ) -> bool {
-    let base_url = mcp_server_url.trim_end_matches("/mcp");
-    let url = format!("{base_url}/api/plugins/{workflow_id}/complete");
+    let url = format!(
+        "{}/api/plugins/{workflow_id}/complete",
+        rp_base_url(mcp_server_url)
+    );
     let body = json!({ "status": status, "result": result });
     debug!(%url, %status, "posting completion");
     let client = match reqwest::Client::builder()
@@ -774,6 +805,7 @@ mod tests {
             json!({}),
             blackboard,
             tools,
+            EventIntake::disconnected(),
             "wf-1".to_owned(),
             mcp_url,
         )

--- a/services/session-runner/src/routes.rs
+++ b/services/session-runner/src/routes.rs
@@ -334,9 +334,12 @@ async fn invoke(
 }
 
 /// `rp`'s HTTP origin, derived from the invocation's MCP endpoint — the
-/// base for the completion POST and the default SSE stream URL.
+/// base for the completion POST and the default SSE stream URL. Tolerates
+/// a trailing slash on the endpoint (`…/mcp/`), which would otherwise
+/// survive the suffix strip and double the slash in derived URLs.
 fn rp_base_url(mcp_server_url: &str) -> &str {
-    mcp_server_url.trim_end_matches("/mcp")
+    let trimmed = mcp_server_url.trim_end_matches('/');
+    trimmed.strip_suffix("/mcp").unwrap_or(trimmed)
 }
 
 /// Run the engine to completion and honor the completion contract:
@@ -640,6 +643,17 @@ mod tests {
         );
         let message = response["errors"][0]["message"].as_str().unwrap();
         assert!(message.contains("missing"), "{message}");
+    }
+
+    // --- rp URL derivation -----------------------------------------------------
+
+    #[test]
+    fn test_rp_base_url_strips_the_mcp_suffix_with_or_without_a_trailing_slash() {
+        for url in ["http://host:11115/mcp", "http://host:11115/mcp/"] {
+            assert_eq!(rp_base_url(url), "http://host:11115", "{url}");
+        }
+        // No /mcp suffix: only trailing slashes are dropped.
+        assert_eq!(rp_base_url("http://host:11115/"), "http://host:11115");
     }
 
     // --- /invoke error paths -------------------------------------------------

--- a/services/session-runner/tests/bdd/steps/event_steps.rs
+++ b/services/session-runner/tests/bdd/steps/event_steps.rs
@@ -1,0 +1,38 @@
+//! BDD step definitions for the event-subscription contract: the engine's
+//! SSE intake and the `wait.until_event` instruction, exercised through
+//! purpose-built fixture documents (`tests/fixtures/workflows/`).
+
+use std::time::Duration;
+
+use cucumber::{given, then};
+
+use crate::steps::infrastructure::{
+    configure_default_equipment, register_orchestrator, start_rp_service,
+    start_session_runner_service,
+};
+use crate::world::SessionRunnerWorld;
+
+#[given(
+    expr = "rp is running with a camera and the session-runner orchestrator running the {string} workflow"
+)]
+async fn rp_running_with_fixture_workflow(world: &mut SessionRunnerWorld, workflow: String) {
+    configure_default_equipment(world).await;
+    start_session_runner_service(world).await;
+    let parameters = match workflow.as_str() {
+        "wait_for_exposure_event" => Some(serde_json::json!({ "camera_id": "main-cam" })),
+        "wait_for_missing_event" => None,
+        other => panic!("no registration parameters defined for fixture workflow `{other}`"),
+    };
+    register_orchestrator(world, &workflow, parameters);
+    start_rp_service(world).await;
+}
+
+#[then(expr = "the session ends within {int} seconds")]
+async fn session_ends_within(world: &mut SessionRunnerWorld, seconds: u64) {
+    assert!(
+        world
+            .wait_for_session_idle(Duration::from_secs(seconds))
+            .await,
+        "expected the session to return to idle within {seconds}s"
+    );
+}

--- a/services/session-runner/tests/bdd/steps/flat_calibration_steps.rs
+++ b/services/session-runner/tests/bdd/steps/flat_calibration_steps.rs
@@ -2,16 +2,18 @@
 //!
 //! The scenarios spawn three processes: OmniSim (Alpaca simulator), rp
 //! (equipment gateway + session orchestrator), and session-runner (the
-//! generic document engine under test). All three are coordinated via
-//! `bdd_infra::rp_harness` helpers; this file holds only the Gherkin step
-//! wiring and the session-runner-specific config/registration builders.
+//! generic document engine under test). The process topology lives in
+//! [`crate::steps::infrastructure`]; this file holds only the Gherkin
+//! step wiring and the flats-specific registration parameters.
 
 use std::time::Duration;
 
-use bdd_infra::rp_harness::{start_rp, write_temp_config_file, OmniSimHandle, WebhookReceiver};
-use bdd_infra::ServiceHandle;
 use cucumber::{given, then, when};
 
+use crate::steps::infrastructure::{
+    add_event_plugin, configure_default_equipment, ensure_omnisim, ensure_webhook_receiver,
+    register_orchestrator, start_rp_service, start_session_runner_service,
+};
 use crate::world::SessionRunnerWorld;
 
 // ---------------------------------------------------------------------------
@@ -20,9 +22,7 @@ use crate::world::SessionRunnerWorld;
 
 #[given("a running Alpaca simulator")]
 async fn running_alpaca_simulator(world: &mut SessionRunnerWorld) {
-    if world.omnisim.is_none() {
-        world.omnisim = Some(OmniSimHandle::start().await);
-    }
+    ensure_omnisim(world).await;
 }
 
 #[given(expr = "a flat plan of {int} {string} flats and {int} {string} flats")]
@@ -46,7 +46,7 @@ async fn webhook_receiver_subscribed_to(world: &mut SessionRunnerWorld, event_ty
 async fn rp_running_with_equipment_and_session_runner(world: &mut SessionRunnerWorld) {
     configure_default_equipment(world).await;
     start_session_runner_service(world).await;
-    register_session_runner_plugin(world);
+    register_calibrator_flats(world);
     start_rp_service(world).await;
 }
 
@@ -76,19 +76,8 @@ async fn workflow_runs_to_completion(world: &mut SessionRunnerWorld) {
     // per-filter exposure search, batch captures, calibrator off (~2s),
     // open cover (~5s). Allow 120s total, matching the Rust
     // calibrator-flats suite this port must stay equivalent to.
-    let client = reqwest::Client::new();
-    let url = format!("{}/api/session/status", world.rp_url());
-    for _ in 0..480 {
-        tokio::time::sleep(Duration::from_millis(250)).await;
-        if let Ok(resp) = client.get(&url).send().await {
-            if let Ok(body) = resp.json::<serde_json::Value>().await {
-                if body.get("status").and_then(|v| v.as_str()) == Some("idle") {
-                    return;
-                }
-            }
-        }
-    }
-    panic!(
+    assert!(
+        world.wait_for_session_idle(Duration::from_secs(120)).await,
         "the calibrator flats document did not complete within 120s \
          (expected the session to return to idle)"
     );
@@ -140,184 +129,25 @@ async fn should_receive_at_least_n_events(
 // Helpers
 // ---------------------------------------------------------------------------
 
-async fn configure_default_equipment(world: &mut SessionRunnerWorld) {
-    if world.omnisim.is_none() {
-        world.omnisim = Some(OmniSimHandle::start().await);
-    }
-    let alpaca_url = world.omnisim_url();
-
-    if world.cameras.is_empty() {
-        world.cameras.push(bdd_infra::rp_harness::CameraConfig {
-            id: "main-cam".to_string(),
-            alpaca_url: alpaca_url.clone(),
-            device_number: 0,
-        });
-    }
-    if world.filter_wheels.is_empty() {
-        world
-            .filter_wheels
-            .push(bdd_infra::rp_harness::FilterWheelConfig {
-                id: "main-fw".to_string(),
-                alpaca_url: alpaca_url.clone(),
-                device_number: 0,
-                filters: vec![
-                    "Luminance".to_string(),
-                    "Red".to_string(),
-                    "Green".to_string(),
-                    "Blue".to_string(),
-                ],
-            });
-    }
-    if world.cover_calibrators.is_empty() {
-        world
-            .cover_calibrators
-            .push(bdd_infra::rp_harness::CoverCalibratorConfig {
-                id: "flat-panel".to_string(),
-                alpaca_url,
-                device_number: 0,
-                poll_interval: Some(std::time::Duration::from_millis(100)),
-            });
-    }
-}
-
-/// Start the session-runner service under test: an ephemeral port, the
-/// package's shipped `workflows/` directory (the cucumber runner's cwd is
-/// the package dir — `bdd_main!` chdirs to `BDD_PACKAGE_DIR` under Bazel),
-/// and a scenario-scoped temp `state_dir`.
-async fn start_session_runner_service(world: &mut SessionRunnerWorld) {
-    if world.session_runner.is_some() {
-        return;
-    }
-
-    let workflows_dir = std::env::current_dir()
-        .expect("cannot read the cwd")
-        .join("workflows");
-    assert!(
-        workflows_dir.is_dir(),
-        "shipped workflows directory not found at {}",
-        workflows_dir.display()
-    );
-    let state_dir = tempfile::tempdir().expect("cannot create a state_dir");
-
-    let config = serde_json::json!({
-        "port": 0,
-        "workflows_dir": workflows_dir,
-        "state_dir": state_dir.path(),
-    });
-    let config_path = write_temp_config_file("session-runner-config", &config).await;
-    world.state_dir = Some(state_dir);
-
-    world.session_runner = Some(ServiceHandle::start(env!("CARGO_PKG_NAME"), &config_path).await);
-}
-
-/// Register session-runner as rp's orchestrator plugin. The registration's
-/// `config` object — forwarded verbatim by rp at invocation — names the
-/// shipped document and carries the invocation parameters. Tolerance `1.0`
-/// and `max_iterations = 1` mirror the Rust calibrator-flats suite: these
-/// scenarios verify end-to-end plumbing, not convergence math (the engine's
-/// unit tests own that).
-fn register_session_runner_plugin(world: &mut SessionRunnerWorld) {
-    let handle = world
-        .session_runner
-        .as_ref()
-        .expect("session-runner not started");
-    let invoke_url = format!("{}/invoke", handle.base_url);
-
+/// Register the shipped calibrator_flats document as the orchestrator's
+/// workflow. Tolerance `1.0` and `max_iterations = 1` mirror the Rust
+/// calibrator-flats suite: these scenarios verify end-to-end plumbing,
+/// not convergence math (the engine's unit tests own that).
+fn register_calibrator_flats(world: &mut SessionRunnerWorld) {
     let filters: Vec<serde_json::Value> = world
         .flat_plan
         .iter()
         .map(|(name, count)| serde_json::json!({ "name": name, "count": count }))
         .collect();
-
-    world.plugin_configs.push(serde_json::json!({
-        "name": "session-runner",
-        "type": "orchestrator",
-        "invoke_url": invoke_url,
-        "requires_tools": [],
-        "config": {
-            "workflow": "calibrator_flats",
-            "parameters": {
-                "camera_id": "main-cam",
-                "filter_wheel_id": "main-fw",
-                "calibrator_id": "flat-panel",
-                "target_adu_fraction": 0.5,
-                "tolerance": 1.0,
-                "max_iterations": 1,
-                "initial_duration": "100ms",
-                "filters": filters
-            }
-        }
-    }));
-}
-
-async fn start_rp_service(world: &mut SessionRunnerWorld) {
-    if world.rp.as_ref().is_some_and(|h| h.is_running()) {
-        return;
-    }
-
-    let config = world.build_rp_config();
-    world.rp = Some(start_rp(&config).await);
-
-    assert!(
-        world.wait_for_rp_healthy().await,
-        "rp did not become healthy within timeout"
-    );
-}
-
-async fn ensure_webhook_receiver(world: &mut SessionRunnerWorld) {
-    if world.webhook_receiver.is_some() {
-        return;
-    }
-    let (estimated, max) = world
-        .webhook_ack_config
-        .unwrap_or((Duration::from_secs(5), Duration::from_secs(10)));
-    let events = world.received_events.clone();
-    world.webhook_receiver = Some(WebhookReceiver::start(events, estimated, max).await);
-}
-
-fn add_event_plugin(world: &mut SessionRunnerWorld, events: Vec<String>) {
-    let url = world
-        .webhook_receiver
-        .as_ref()
-        .expect("webhook receiver not started")
-        .url
-        .clone();
-
-    let already_exists = world
-        .plugin_configs
-        .iter()
-        .any(|p| p.get("name").and_then(|v| v.as_str()) == Some("test-event-plugin"));
-
-    if already_exists {
-        if let Some(config) = world
-            .plugin_configs
-            .iter_mut()
-            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("test-event-plugin"))
-        {
-            let existing = config
-                .get("subscribes_to")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-
-            let mut merged = existing;
-            for e in events {
-                if !merged.contains(&e) {
-                    merged.push(e);
-                }
-            }
-            config["subscribes_to"] = serde_json::json!(merged);
-        }
-    } else {
-        world.plugin_configs.push(serde_json::json!({
-            "name": "test-event-plugin",
-            "type": "event",
-            "webhook_url": url,
-            "subscribes_to": events
-        }));
-    }
+    let parameters = serde_json::json!({
+        "camera_id": "main-cam",
+        "filter_wheel_id": "main-fw",
+        "calibrator_id": "flat-panel",
+        "target_adu_fraction": 0.5,
+        "tolerance": 1.0,
+        "max_iterations": 1,
+        "initial_duration": "100ms",
+        "filters": filters
+    });
+    register_orchestrator(world, "calibrator_flats", Some(parameters));
 }

--- a/services/session-runner/tests/bdd/steps/infrastructure.rs
+++ b/services/session-runner/tests/bdd/steps/infrastructure.rs
@@ -1,0 +1,199 @@
+//! Shared BDD infrastructure helpers for the session-runner suite: the
+//! three-process topology (OmniSim + rp + session-runner) and the
+//! orchestrator registration, reused by every feature's step definitions.
+
+use std::time::Duration;
+
+use bdd_infra::rp_harness::{start_rp, write_temp_config_file, OmniSimHandle, WebhookReceiver};
+use bdd_infra::ServiceHandle;
+use serde_json::Value;
+
+use crate::world::SessionRunnerWorld;
+
+pub async fn ensure_omnisim(world: &mut SessionRunnerWorld) {
+    if world.omnisim.is_none() {
+        world.omnisim = Some(OmniSimHandle::start().await);
+    }
+}
+
+/// The default equipment set: one camera, one filter wheel, one cover
+/// calibrator, all on OmniSim device 0. Scenarios that need less simply
+/// don't reference the rest.
+pub async fn configure_default_equipment(world: &mut SessionRunnerWorld) {
+    ensure_omnisim(world).await;
+    let alpaca_url = world.omnisim_url();
+
+    if world.cameras.is_empty() {
+        world.cameras.push(bdd_infra::rp_harness::CameraConfig {
+            id: "main-cam".to_string(),
+            alpaca_url: alpaca_url.clone(),
+            device_number: 0,
+        });
+    }
+    if world.filter_wheels.is_empty() {
+        world
+            .filter_wheels
+            .push(bdd_infra::rp_harness::FilterWheelConfig {
+                id: "main-fw".to_string(),
+                alpaca_url: alpaca_url.clone(),
+                device_number: 0,
+                filters: vec![
+                    "Luminance".to_string(),
+                    "Red".to_string(),
+                    "Green".to_string(),
+                    "Blue".to_string(),
+                ],
+            });
+    }
+    if world.cover_calibrators.is_empty() {
+        world
+            .cover_calibrators
+            .push(bdd_infra::rp_harness::CoverCalibratorConfig {
+                id: "flat-panel".to_string(),
+                alpaca_url,
+                device_number: 0,
+                poll_interval: Some(std::time::Duration::from_millis(100)),
+            });
+    }
+}
+
+/// Start the session-runner service under test: an ephemeral port, a
+/// scenario-scoped temp `state_dir`, and a temp `workflows_dir` merging
+/// the package's shipped `workflows/` with the suite's purpose-built
+/// documents from `tests/fixtures/workflows/` (the cucumber runner's cwd
+/// is the package dir — `bdd_main!` chdirs to `BDD_PACKAGE_DIR` under
+/// Bazel).
+pub async fn start_session_runner_service(world: &mut SessionRunnerWorld) {
+    if world.session_runner.is_some() {
+        return;
+    }
+
+    let cwd = std::env::current_dir().expect("cannot read the cwd");
+    let workflows_dir = tempfile::tempdir().expect("cannot create a workflows_dir");
+    let mut copied = 0;
+    for source in [cwd.join("workflows"), cwd.join("tests/fixtures/workflows")] {
+        let entries = std::fs::read_dir(&source)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", source.display()));
+        for entry in entries {
+            let path = entry.expect("cannot read a workflows entry").path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                let name = path.file_name().expect("a file has a name");
+                std::fs::copy(&path, workflows_dir.path().join(name))
+                    .unwrap_or_else(|e| panic!("cannot copy {}: {e}", path.display()));
+                copied += 1;
+            }
+        }
+    }
+    assert!(copied > 0, "no workflow documents found to copy");
+
+    let state_dir = tempfile::tempdir().expect("cannot create a state_dir");
+    let config = serde_json::json!({
+        "port": 0,
+        "workflows_dir": workflows_dir.path(),
+        "state_dir": state_dir.path(),
+    });
+    let config_path = write_temp_config_file("session-runner-config", &config).await;
+    world.workflows_dir = Some(workflows_dir);
+    world.state_dir = Some(state_dir);
+
+    world.session_runner = Some(ServiceHandle::start(env!("CARGO_PKG_NAME"), &config_path).await);
+}
+
+/// Register session-runner as rp's orchestrator plugin. The registration's
+/// `config` object — forwarded verbatim by rp at invocation — names the
+/// workflow document and carries its invocation parameters.
+pub fn register_orchestrator(
+    world: &mut SessionRunnerWorld,
+    workflow: &str,
+    parameters: Option<Value>,
+) {
+    let handle = world
+        .session_runner
+        .as_ref()
+        .expect("session-runner not started");
+    let invoke_url = format!("{}/invoke", handle.base_url);
+
+    let mut config = serde_json::json!({ "workflow": workflow });
+    if let Some(parameters) = parameters {
+        config["parameters"] = parameters;
+    }
+    world.plugin_configs.push(serde_json::json!({
+        "name": "session-runner",
+        "type": "orchestrator",
+        "invoke_url": invoke_url,
+        "requires_tools": [],
+        "config": config
+    }));
+}
+
+pub async fn start_rp_service(world: &mut SessionRunnerWorld) {
+    if world.rp.as_ref().is_some_and(|h| h.is_running()) {
+        return;
+    }
+
+    let config = world.build_rp_config();
+    world.rp = Some(start_rp(&config).await);
+
+    assert!(
+        world.wait_for_rp_healthy().await,
+        "rp did not become healthy within timeout"
+    );
+}
+
+pub async fn ensure_webhook_receiver(world: &mut SessionRunnerWorld) {
+    if world.webhook_receiver.is_some() {
+        return;
+    }
+    let (estimated, max) = world
+        .webhook_ack_config
+        .unwrap_or((Duration::from_secs(5), Duration::from_secs(10)));
+    let events = world.received_events.clone();
+    world.webhook_receiver = Some(WebhookReceiver::start(events, estimated, max).await);
+}
+
+pub fn add_event_plugin(world: &mut SessionRunnerWorld, events: Vec<String>) {
+    let url = world
+        .webhook_receiver
+        .as_ref()
+        .expect("webhook receiver not started")
+        .url
+        .clone();
+
+    let already_exists = world
+        .plugin_configs
+        .iter()
+        .any(|p| p.get("name").and_then(|v| v.as_str()) == Some("test-event-plugin"));
+
+    if already_exists {
+        if let Some(config) = world
+            .plugin_configs
+            .iter_mut()
+            .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("test-event-plugin"))
+        {
+            let existing = config
+                .get("subscribes_to")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+
+            let mut merged = existing;
+            for e in events {
+                if !merged.contains(&e) {
+                    merged.push(e);
+                }
+            }
+            config["subscribes_to"] = serde_json::json!(merged);
+        }
+    } else {
+        world.plugin_configs.push(serde_json::json!({
+            "name": "test-event-plugin",
+            "type": "event",
+            "webhook_url": url,
+            "subscribes_to": events
+        }));
+    }
+}

--- a/services/session-runner/tests/bdd/steps/mod.rs
+++ b/services/session-runner/tests/bdd/steps/mod.rs
@@ -1,3 +1,5 @@
 //! BDD step definitions for the session-runner service.
 
+pub mod event_steps;
 pub mod flat_calibration_steps;
+pub mod infrastructure;

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -29,6 +29,10 @@ pub struct SessionRunnerWorld {
     /// Blackboard persistence directory for the spawned session-runner;
     /// held here so it outlives the scenario's service process.
     pub state_dir: Option<tempfile::TempDir>,
+    /// The spawned session-runner's workflows directory: the shipped
+    /// `workflows/` merged with `tests/fixtures/workflows/`, built per
+    /// scenario.
+    pub workflows_dir: Option<tempfile::TempDir>,
 
     // --- rp config building ---
     pub cameras: Vec<CameraConfig>,
@@ -88,6 +92,25 @@ impl SessionRunnerWorld {
     /// Wait for rp's `/health` endpoint to return 200.
     pub async fn wait_for_rp_healthy(&self) -> bool {
         bdd_infra::rp_harness::wait_for_rp_healthy(&self.rp_url()).await
+    }
+
+    /// Poll rp's session status until it reports `idle`, or `budget`
+    /// elapses.
+    pub async fn wait_for_session_idle(&self, budget: Duration) -> bool {
+        let client = reqwest::Client::new();
+        let url = format!("{}/api/session/status", self.rp_url());
+        let deadline = std::time::Instant::now() + budget;
+        while std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            if let Ok(resp) = client.get(&url).send().await {
+                if let Ok(body) = resp.json::<serde_json::Value>().await {
+                    if body.get("status").and_then(|v| v.as_str()) == Some("idle") {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 
     /// Wait for at least `count` events of the given type. 40 × 250ms = 10s.

--- a/services/session-runner/tests/features/events.feature
+++ b/services/session-runner/tests/features/events.feature
@@ -1,0 +1,24 @@
+@serial
+Feature: Event subscription (SSE)
+  session-runner consumes rp's SSE event stream (/api/events/subscribe)
+  for the whole life of a session: the subscription opens before the first
+  instruction runs, so an event emitted while an earlier instruction ran
+  still satisfies a later until_event wait. A wait whose event never
+  arrives raises a workflow error at its timeout, and that failure ends
+  the session rather than hanging it.
+
+  The fixture documents these scenarios execute live in
+  tests/fixtures/workflows/ — they pin the wait timeouts these outcomes
+  depend on (5m for the satisfied wait, 2s for the expiring one).
+
+  Scenario: An until_event wait is satisfied by an event emitted during an earlier instruction
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "wait_for_exposure_event" workflow
+    When a session is started via the REST API
+    Then the session ends within 60 seconds
+
+  Scenario: An until_event wait whose event never arrives fails the session at its timeout
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "wait_for_missing_event" workflow
+    When a session is started via the REST API
+    Then the session ends within 60 seconds

--- a/services/session-runner/tests/fixtures/workflows/wait_for_exposure_event.json
+++ b/services/session-runner/tests/fixtures/workflows/wait_for_exposure_event.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "name": "wait-for-exposure-event",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "root": {
+    "sequence": [
+      {
+        "id": "expose",
+        "tool": "capture",
+        "args": {
+          "camera_id": { "$expr": "params.camera_id" },
+          "duration": "100ms"
+        }
+      },
+      {
+        "id": "wait-for-the-event-the-capture-already-emitted",
+        "wait": { "until_event": "exposure_complete", "timeout": "5m" }
+      }
+    ]
+  }
+}

--- a/services/session-runner/tests/fixtures/workflows/wait_for_missing_event.json
+++ b/services/session-runner/tests/fixtures/workflows/wait_for_missing_event.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "name": "wait-for-missing-event",
+  "estimated_duration": "1m",
+  "max_duration": "5m",
+  "root": {
+    "wait": { "until_event": "meridian_flip", "timeout": "2s" }
+  }
+}


### PR DESCRIPTION
Phase D of `docs/plans/workflow-dsl.md`, slice 1 of 3: the engine's event intake. (Slice 2 = trigger engine, slice 3 = resume/outage BDD.)

## What

- **`src/events.rs` — per-run SSE client** for rp's `/api/events/subscribe`, following the workspace house pattern (chunked `reqwest` + hand-rolled `id:`/`event:`/`data:` parser, as in sentinel's watchdog and bdd-infra's harness client). `Last-Event-ID` reconnect on a 1 s backoff; `stream_gap` is logged at `info!` and the stream continues; the client task exits when the run's intake drops.
- **Engine event seam**: `EngineEvent` + `EventIntake` in `engine/io.rs`, and `Clock` gains a `monotonic()` reading. `run()` now takes the intake, which opens **before the first instruction** executes.
- **`wait.until_event` implemented** (was a Phase-C stub error): matches events buffered since run start — so an event emitted during an earlier instruction (e.g. the `exposure_complete` of a capture the document just made) still satisfies a later wait; the buffer is checked once more exactly at expiry (mirroring `until`'s final evaluation); the timeout budget is monotonic time spent waiting, immune to NTP steps and (in D2) to trigger-action time.
- **Routes**: the events URL derives from the invocation's `mcp_server_url` origin, `config.events_url` overrides; subscription is spawned before the engine run.

## Tests

- 21 new unit tests: the SSE client against a scripted raw-TCP SSE server (forwarding order, reconnect cursor, retry-on-reject, exit-on-drop, frame parsing) and the `until_event` semantics against the mock clock/intake.
- `events.feature` (BDD, three-process topology): a wait satisfied by an already-emitted event, and a never-arriving event failing the session at its timeout instead of hanging. These run purpose-built documents from `tests/fixtures/workflows/`, merged with the shipped `workflows/` into the spawned service's `workflows_dir`; shared step helpers moved to `tests/bdd/steps/infrastructure.rs`.

## Docs

Design-doc pins in § `wait` and § Event Subscription (buffering-from-run-start, final check at expiry, reconnect/backoff/buffer, house transport); testing table gains the `events.feature` row; plan Phase D bullet 1 checked.

## Verification

- `bazel build //... && bazel test //...` green (incl. `buildifier_check`)
- `bazel test --test_tag_filters=bdd //services/session-runner:bdd` green with OmniSim (41 s)
- cargo BDD green (2 features, 4 scenarios, 22 steps)
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)