### PR TITLE
feat(session-runner): trigger engine — safe-point pump, gates, polls, corrections (workflow DSL Phase D2)

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -527,7 +527,7 @@
           "FILE:@@//services/rp/Cargo.toml 5cd59b0daa28b533cf271a3c8c3546ad20954eeedd4d46ba7ad739b6538677d3",
           "FILE:@@//services/plate-solver/Cargo.toml a749de9b36138fbc21fe64b0617839bb06b13b0f8def08eb28bfd36ceb4dca91",
           "FILE:@@//services/sentinel/Cargo.toml 1d3a0438ab0ab5d71628a08c6b867f874639277c8a976e6b416773613a4257c3",
-          "FILE:@@//services/session-runner/Cargo.toml a859ecc8088a57ba5e7e0839045ec1ac8548229e10568c0a143ee7dd53f54ca4",
+          "FILE:@@//services/session-runner/Cargo.toml 51ba117ff19bf1126e68352cd7810910a63b584c2977331b0a43e265c0d35a3e",
           "FILE:@@//services/sky-survey-camera/Cargo.toml bc9d2161ff86be9a331ab3a87b2732930faedb8e60b4155aa4943829e8a3ae46",
           "FILE:@@//services/star-adventurer-gti/Cargo.toml c2aab0c72d29c451a7dd1cc0258d275728015fdd6b4060de1087ddc127ff8d92",
           "FILE:@@//services/ui-htmx/Cargo.toml 6816163a63844190ac338a0c475ae5ff1788135ff17dad5f704a8ac19db53909",

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -347,9 +347,27 @@ committable on its own.
       merged into the spawned service's `workflows_dir`) proving the
       buffered-event wait and the timeout-ends-the-session path
       end-to-end.
-- [ ] Trigger engine: `event`, `poll`, and the synthetic
+- [x] Trigger engine: `event`, `poll`, and the synthetic
       `correction_requested` sources; `when` gating and `while`
       phase-gates; safe-point interleaving; `once` / `cooldown`.
+
+      **Done (2026-07-05):** the safe-point pump in
+      `services/session-runner/src/engine/exec.rs` — evaluation after
+      every instruction and continuously during waits, queued firings in
+      document order, `when` at queue time / `while` at fire time,
+      `once`/`cooldown` bookkeeping under `session._triggers.<id>` (recorded
+      on successful action completion), poll sources due one interval
+      after run start with gated-skip and debug-skip-on-failure, and
+      synthetic `correction_requested` from `aborted` /
+      `blocked_by_correction` / `pending_correction` tool results. Because
+      the pump now consumes events, `until_event` matching moved to
+      per-name unconsumed-occurrence counters (pins in the design doc's
+      § Triggers). Landing the BDD suite (`triggers.feature`: interleaving
+      by SSE seq order, `once`, cooldown, poll) also surfaced and fixed a
+      Phase D1 latent race: `events::subscribe` now completes its initial
+      connect inline, before `/invoke` acknowledges — previously the
+      first instruction could outrun the subscription and lose its
+      events.
 - [ ] Resume: recovery invocation → blackboard reload → re-execution;
       BDD scenarios for kill-mid-session → re-invoke → session continues
       without repeating completed work (frame counts prove it).

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -295,9 +295,10 @@ rendered as compact JSON (an error message is terminal output, not data).
   once more exactly when the timeout expires — only then does expiry
   raise (the same final-evaluation rule as `until`). Its budget is
   measured like `until`'s: monotonic time spent waiting, so trigger
-  actions running during the wait do not count against it. Non-matching
-  events are consumed and (Phase D2) feed trigger evaluation; the wait
-  neither extends nor aborts for them. If the event stream is down, the
+  actions running during the wait do not count against it. Every
+  consumed event — the matching one included — feeds trigger
+  evaluation; the wait neither extends nor aborts for non-matching
+  ones. If the event stream is down, the
   wait simply runs to its timeout — a missing stream is never an
   instruction error ([Event Subscription](#event-subscription)).
 
@@ -392,6 +393,89 @@ to the *correction* `rp` delivers rather than aborting on its own.
 **Poll lifecycle.** Poll triggers start when the workflow starts and stop
 when it completes or is cancelled. A poll whose tool call fails logs at
 `debug!` and skips that cycle — a flaky poll must not kill the session.
+
+Implementation pins (`src/engine/`, Phase D2):
+
+- **The pump.** Trigger evaluation is single-threaded and runs only at
+  safe points: drain buffered events (synthetic first, then the SSE
+  intake), match and gate them against each trigger, call due poll
+  sources, then run queued actions in document order. An event that
+  arrives mid-instruction waits in the intake until the instruction
+  completes. The run's last safe point follows its last instruction: an
+  event still in flight on the stream when the tree completes does not
+  fire its trigger — a document that must react to its final operation's
+  events ends with a short `wait`. Trigger evaluation never re-enters:
+  inside a trigger action
+  the pump only moves intake events into the engine's pending buffer
+  (an `until_event` inside a `do` block matches against that buffer
+  without feeding evaluation), and anything a trigger action itself
+  provokes — new events, a synthetic correction from one of its tool
+  calls — is evaluated at the next safe point on the procedure tree.
+- **Occurrence counters.** Because the pump consumes events for trigger
+  evaluation, the engine keeps a per-event-name count of *unconsumed
+  occurrences* (names and counts only — still no event history). An
+  `until_event` wait is satisfied by, and decrements, one unconsumed
+  occurrence of its event name — that is how "matches every event since
+  the run started" (§ `wait`) survives trigger evaluation running
+  first. A wait consumes only its own event name's occurrences; unlike
+  Phase D1's buffer draining, a wait no longer discards other names'
+  events (they remain for later waits — and have already fed
+  evaluation).
+- **Gate timing.** `when` (together with the `once`, `cooldown`, and
+  already-queued checks) is evaluated when the event is drained — a
+  passing trigger queues its firing with the event payload. `while` is
+  evaluated at fire time, immediately before the action runs, so an
+  earlier trigger's action in the same batch can retract a later one by
+  flipping the phase flag. An expression error or non-boolean value in
+  either gate is a workflow error: a gate that cannot be evaluated is an
+  authoring bug, and silently never-firing would hide it (write robust
+  gates with `has()` and `??`).
+- **Errors in actions.** An uncaught workflow error inside a `do` block
+  fails the session, its message prefixed with the trigger id; a trigger
+  that must not take the session down wraps its body in `try`. A safety
+  termination during an action behaves as § Safety Behavior.
+- **Bookkeeping.** `session._triggers.<id>.last_fired` (RFC 3339 wall
+  time) and `.fired_once` are recorded when the action **completes
+  successfully** — mirroring instruction `once` semantics, an action
+  interrupted by a crash or termination does not count as fired, and
+  instruction-level `once` markers inside the `do` block are the tool
+  for non-repeatable steps within it. Cooldowns compare wall-clock time
+  (they must survive resume, so they cannot use the monotonic reading
+  that measures `wait` budgets); a backwards clock step extends a
+  cooldown rather than firing early.
+- **Polls.** The first cycle of a poll source is due one `interval`
+  after the run starts, and each handled due reschedules the next at
+  now + `interval` (missed cycles collapse — no burst after a long
+  instruction). The schedule is in-memory: on a recovery invocation
+  polls restart with a fresh first-due. A due poll whose trigger cannot
+  fire anyway (`once` spent, cooldown open, firing already queued)
+  skips the tool call entirely. An argument-expression failure counts
+  as a call failure (`debug!`, skip the cycle) — poll args commonly
+  read session state a later phase sets, and a poll must not kill the
+  session before that phase arrives. During waits, sleep segments are
+  clamped to the next poll due so polls stay on schedule; between
+  instructions a due poll runs at the next safe point. A zero
+  `interval` is a validation error.
+- **Synthetic corrections.** A tool result with `status: "aborted"` or
+  `status: "blocked_by_correction"` carrying a `correction` object
+  synthesizes `correction_requested` with `event.delivery =
+  "immediate"`; a result carrying `pending_correction` synthesizes it
+  with `"after_current"` (`rp.md` § Corrections). The synthetic event is
+  evaluated at the safe point immediately after the carrying tool call,
+  ahead of that safe point's intake drain. A correction value that is
+  not a JSON object is logged at `debug!` and ignored.
+- **Action scoping.** A `do` block starts with `result = null` and
+  `error.*` null and sees the firing's payload as `event.*`; all three
+  are restored when the action ends (§ `result` scoping).
+- **Waits.** A wait is one long safe point: the pump runs continuously
+  between sleep segments, and time spent in trigger actions never
+  counts against a wait's duration or timeout budget (budgets measure
+  monotonic time around the sleeps alone). The awaited event of an
+  `until_event` also feeds trigger evaluation — a trigger on the same
+  event still fires, during the wait's own safe point, before the wait
+  returns. An `until` condition may be re-evaluated more often than
+  `poll_interval` while trigger actions run; `poll_interval` is the
+  guaranteed maximum gap between evaluations only while idle.
 
 ### Expressions
 
@@ -542,7 +626,8 @@ completed `set`" is what makes tenet 2 sound.
 
 Engine bookkeeping lives under reserved keys the schema forbids documents
 from setting directly: `session._once.*` (completed once-markers),
-`session._triggers.<id>.*` (last-fired, fired-once flags).
+`session._triggers.<id>.*` (`last_fired` RFC 3339 timestamp, `fired_once`
+flag — § Triggers implementation pins).
 
 The file is deleted when a session completes and the completion has been
 acknowledged by `rp`; a leftover file at `/invoke` time for a **new**
@@ -644,15 +729,21 @@ was gone long enough that its cursor was evicted, the stream leads with a
 continues — poll triggers re-observe current state on their next cycle, and
 the re-entrancy contract already assumes events can be missed across an
 outage. Events that arrive while no trigger matches
-are discarded — the engine keeps no event history. The stream URL is derived
+are discarded — the engine keeps no event history, only the per-name
+unconsumed-occurrence counters that serve `until_event` waits
+(§ Triggers implementation pins). The stream URL is derived
 from the invocation's `mcp_server_url` origin unless overridden in
 configuration.
 
 Implementation pins (`src/events.rs`, Phase D):
 
-- The subscription is **per session run**: it opens before the first
-  instruction executes (so nothing emitted mid-session is missed — the
-  `until_event` buffering above depends on this) and closes when the run
+- The subscription is **per session run**: the initial connect completes
+  inline on the `/invoke` path, before the invocation is acknowledged and
+  the first instruction executes — an event emitted milliseconds into the
+  first tool call is already being captured (the `until_event` buffering
+  and trigger evaluation depend on this). A failed or timed-out (5 s
+  connect cap) first attempt does not block the session; it just falls
+  through to the retry loop. The subscription closes when the run
   ends. Reconnects after a dropped stream or refused connect retry every
   1 s, indefinitely, carrying the cursor; a session with a dead stream
   keeps running — tool calls, not events, decide whether `rp` is alive
@@ -978,6 +1069,8 @@ persisted progress.
 | Tool result carries a correction | Synthetic `correction_requested` trigger; not an error. |
 | Expression error (null arithmetic, division by zero) | Workflow error at that instruction, same propagation as tool errors. |
 | `wait` timeout | Workflow error. |
+| Trigger `when`/`while` gate errors or yields a non-boolean | Workflow error — a gate that cannot be evaluated is an authoring bug; silently never-firing would hide it. |
+| Uncaught error in a trigger `do` block | Fails the session, message prefixed with the trigger id; wrap the body in `try` for a resilient trigger. |
 | Loop `max_iterations` exhausted (`until`/`while`) | Loop completes with `result.converged = false`; not an error. |
 | SSE stream drops | Reconnect with `Last-Event-ID`; exact replay within `rp`'s 512-event retention; on `stream_gap`, log and continue (§ Event Subscription). |
 | Poll-trigger tool call fails | `debug!` log, skip cycle. |
@@ -1053,7 +1146,7 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 | Invocation + validation | `invocation.feature` | invalid document rejected at `/invoke`; unknown tool named in error; parameter type mismatch |
 | Flats port equivalence | `flat_calibration.feature` | the scenarios from `calibrator-flats`' suite, run against the document — same events, frame counts, cleanup-on-failure |
 | Event subscription | `events.feature` | an `until_event` wait satisfied by an event emitted during an earlier instruction (pins subscription-from-run-start); a wait whose event never arrives fails the session at its timeout rather than hanging |
-| Triggers | `triggers.feature` | refocus fires between exposures, not during; cooldown respected; poll trigger fires flip action |
+| Triggers | `triggers.feature` | a trigger action lands between exposures, never during one (proved by SSE seq order); `once` fires exactly once across three captures; cooldown suppresses firings inside its window; a poll trigger fires through its `when` gate |
 | Resume | `recovery.feature` | kill mid-capture-loop → re-invoke with recovery → progress continues without repeated frames; `once` marker not re-run |
 | Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes |
 

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -741,9 +741,14 @@ Implementation pins (`src/events.rs`, Phase D):
   inline on the `/invoke` path, before the invocation is acknowledged and
   the first instruction executes — an event emitted milliseconds into the
   first tool call is already being captured (the `until_event` buffering
-  and trigger evaluation depend on this). A failed or timed-out (5 s
-  connect cap) first attempt does not block the session; it just falls
-  through to the retry loop. The subscription closes when the run
+  and trigger evaluation depend on this). A failed or timed-out first
+  attempt does not block the session; it just falls through to the retry
+  loop. Every subscribe attempt — initial and reconnect alike — is
+  capped at 5 s end to end (TCP, TLS, response headers), so an endpoint
+  that accepts the connection but never answers cannot hang the
+  invocation or wedge the reconnect loop; reads of the established
+  stream stay uncapped (an idle stream is healthy — `rp` keep-alives
+  every 15 s). The subscription closes when the run
   ends. Reconnects after a dropped stream or refused connect retry every
   1 s, indefinitely, carrying the cursor; a session with a dead stream
   keeps running — tool calls, not events, decide whether `rp` is alive

--- a/services/session-runner/Cargo.toml
+++ b/services/session-runner/Cargo.toml
@@ -38,6 +38,9 @@ bdd-infra = { workspace = true, features = ["rp-harness"] }
 cucumber = { workspace = true }
 derive_more = { workspace = true }
 proptest = { workspace = true }
+# `test-util` unlocks paused tokio time (`start_paused`), which the
+# events tests use to exercise the subscribe-attempt timeout instantly.
+tokio = { workspace = true, features = ["test-util"] }
 
 [[test]]
 name = "bdd"

--- a/services/session-runner/src/blackboard.rs
+++ b/services/session-runner/src/blackboard.rs
@@ -12,17 +12,21 @@
 //!
 //! Engine bookkeeping lives under reserved keys documents cannot set:
 //! `session._once.*` (completed once-markers) and `session._triggers.<id>.*`
-//! (trigger bookkeeping, Phase D). [`Blackboard::set_path`] rejects
+//! (`last_fired` / `fired_once`). [`Blackboard::set_path`] rejects
 //! `_`-prefixed roots as defense in depth — the document validator already
 //! refuses such `set` keys at load.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
 
 /// Root key of the completed-`once`-marker map (`session._once.*`).
 const ONCE_KEY: &str = "_once";
+
+/// Root key of the trigger-bookkeeping map (`session._triggers.<id>.*`).
+const TRIGGERS_KEY: &str = "_triggers";
 
 /// A blackboard I/O failure. Per the design's error table these fail loud:
 /// continuing with unpersistable state would silently break resume.
@@ -213,6 +217,65 @@ impl Blackboard {
             }
             if let Value::Object(markers) = once {
                 markers.insert(key.to_owned(), Value::Bool(true));
+            }
+        }
+        self.persist().await
+    }
+
+    /// Whether trigger `id` has completed a firing with `once` recorded
+    /// (in this or an earlier run of the session).
+    pub fn trigger_fired_once(&self, id: &str) -> bool {
+        self.trigger_entry(id)
+            .and_then(|t| t.get("fired_once"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    /// The wall-clock time trigger `id` last completed its action, for
+    /// cooldown gating. `None` when it never fired or the recorded value
+    /// is unreadable — engine-owned bookkeeping heals rather than errors,
+    /// and treating a corrupt timestamp as "never fired" only shortens a
+    /// cooldown once.
+    pub fn trigger_last_fired(&self, id: &str) -> Option<DateTime<Utc>> {
+        let recorded = self.trigger_entry(id)?.get("last_fired")?.as_str()?;
+        DateTime::parse_from_rfc3339(recorded)
+            .ok()
+            .map(|t| t.with_timezone(&Utc))
+    }
+
+    fn trigger_entry(&self, id: &str) -> Option<&Value> {
+        self.session.get(TRIGGERS_KEY)?.get(id)
+    }
+
+    /// Record that trigger `id`'s action completed at `at` — and, for a
+    /// `once` trigger, that it must not fire again this session — then
+    /// persist. Corrupt non-object bookkeeping values are replaced.
+    pub async fn mark_trigger_fired(
+        &mut self,
+        id: &str,
+        at: DateTime<Utc>,
+        once: bool,
+    ) -> Result<(), BlackboardError> {
+        if let Value::Object(root) = &mut self.session {
+            let triggers = root
+                .entry(TRIGGERS_KEY)
+                .or_insert_with(|| Value::Object(Map::new()));
+            if !triggers.is_object() {
+                *triggers = Value::Object(Map::new());
+            }
+            if let Value::Object(by_id) = triggers {
+                let entry = by_id
+                    .entry(id.to_owned())
+                    .or_insert_with(|| Value::Object(Map::new()));
+                if !entry.is_object() {
+                    *entry = Value::Object(Map::new());
+                }
+                if let Value::Object(bookkeeping) = entry {
+                    bookkeeping.insert("last_fired".to_owned(), Value::String(at.to_rfc3339()));
+                    if once {
+                        bookkeeping.insert("fired_once".to_owned(), Value::Bool(true));
+                    }
+                }
             }
         }
         self.persist().await
@@ -487,6 +550,59 @@ mod tests {
         assert!(!bb.once_done("a"));
         assert!(!bb.once_done("b"));
         assert!(!bb.once_done("missing"));
+    }
+
+    #[tokio::test]
+    async fn test_trigger_bookkeeping_records_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.json");
+        let mut bb = Blackboard::new_empty(path.clone());
+        assert!(!bb.trigger_fired_once("refocus"));
+        assert_eq!(bb.trigger_last_fired("refocus"), None);
+
+        let at = chrono::Utc::now();
+        bb.mark_trigger_fired("refocus", at, true).await.unwrap();
+        assert!(bb.trigger_fired_once("refocus"));
+        assert_eq!(bb.trigger_last_fired("refocus"), Some(at));
+
+        let reloaded = Blackboard::load(path).await.unwrap();
+        assert!(reloaded.trigger_fired_once("refocus"));
+        assert_eq!(reloaded.trigger_last_fired("refocus"), Some(at));
+    }
+
+    #[tokio::test]
+    async fn test_mark_trigger_fired_without_once_leaves_no_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut bb = Blackboard::new_empty(dir.path().join("s.json"));
+        let at = chrono::Utc::now();
+        bb.mark_trigger_fired("watch", at, false).await.unwrap();
+        assert!(!bb.trigger_fired_once("watch"));
+        assert_eq!(bb.trigger_last_fired("watch"), Some(at));
+        assert_eq!(
+            *bb.value(),
+            json!({"_triggers": {"watch": {"last_fired": at.to_rfc3339()}}})
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trigger_bookkeeping_heals_corrupt_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.json");
+        std::fs::write(
+            &path,
+            br#"{"_triggers": {"a": 5, "b": {"last_fired": "not a timestamp"}}}"#,
+        )
+        .unwrap();
+        let mut bb = Blackboard::load(path).await.unwrap();
+        // Unreadable bookkeeping reads as "never fired"…
+        assert!(!bb.trigger_fired_once("a"));
+        assert_eq!(bb.trigger_last_fired("a"), None);
+        assert_eq!(bb.trigger_last_fired("b"), None);
+        // …and is replaced on the next write.
+        let at = chrono::Utc::now();
+        bb.mark_trigger_fired("a", at, true).await.unwrap();
+        assert!(bb.trigger_fired_once("a"));
+        assert_eq!(bb.trigger_last_fired("a"), Some(at));
     }
 
     #[tokio::test]

--- a/services/session-runner/src/document/corpus.rs
+++ b/services/session-runner/src/document/corpus.rs
@@ -700,6 +700,21 @@ pub(super) fn cases() -> Vec<Case> {
                 "`event` is not in scope here",
             )],
         ),
+        invalid(
+            "zero_poll_interval",
+            json!({
+                "version": 1, "name": "t", "root": { "sequence": [] },
+                "triggers": [ {
+                    "id": "p",
+                    "on": { "poll": { "tool": "status", "interval": "0s" } },
+                    "do": [ { "log": { "message": "x" } } ]
+                } ]
+            }),
+            &[(
+                "/triggers/0/on/poll/interval",
+                "a poll `interval` must be positive",
+            )],
+        ),
         // ---- invalid: triggers ---------------------------------------------
         invalid(
             "triggers_not_an_array",

--- a/services/session-runner/src/document/validate.rs
+++ b/services/session-runner/src/document/validate.rs
@@ -1539,7 +1539,20 @@ impl Builder {
                 // event context: only params/session/result are in scope.
                 let args = self.args(p.get("args"), &child(&pptr, "args"), TREE);
                 let interval = match p.get("interval") {
-                    Some(v) => self.duration_field(v, &child(&pptr, "interval"), "`interval`"),
+                    Some(v) => {
+                        match self.duration_field(v, &child(&pptr, "interval"), "`interval`") {
+                            // A zero interval would make the poll due at every
+                            // safe point — a busy loop against `rp`.
+                            Some(d) if d.is_zero() => {
+                                self.issue(
+                                    &child(&pptr, "interval"),
+                                    "a poll `interval` must be positive",
+                                );
+                                None
+                            }
+                            other => other,
+                        }
+                    }
                     None => {
                         self.issue(&pptr, "`poll` requires an `interval`");
                         None

--- a/services/session-runner/src/engine/exec.rs
+++ b/services/session-runner/src/engine/exec.rs
@@ -1,15 +1,19 @@
 //! The procedure-tree walk: executes a validated [`Instruction`] tree
-//! against the blackboard, the tool client, and the clock.
+//! against the blackboard, the tool client, and the clock — and pumps the
+//! document's triggers at every safe point along the way.
 //!
 //! Semantics implemented here are pinned in
 //! `docs/services/session-runner.md` — § Instructions, § `result` scoping,
+//! § Triggers (the safe-point pump and its implementation pins),
 //! § Re-entrancy Contract (`once` markers), and § Safety Behavior (the
 //! terminated-session path). Two interrupts propagate outward: a workflow
 //! error (catchable by `try`) and a session termination (never caught;
 //! `finally` blocks still run best-effort).
 
+use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use serde_json::{json, Map, Value};
 use tracing::{debug, info};
@@ -17,11 +21,11 @@ use tracing::{debug, info};
 use crate::blackboard::Blackboard;
 use crate::document::{
     ArgValue, Bound, Instruction, InstructionKind, Log, LogLevel, Repeat, RepeatMode, SetEntry,
-    ToolCall, Wait,
+    ToolCall, Trigger, TriggerSource, Wait,
 };
 use crate::expr::{EvalContext, Expression};
 
-use super::{Clock, EventIntake, ToolCallError, ToolClient, WorkflowError};
+use super::{Clock, EngineEvent, EventIntake, ToolCallError, ToolClient, WorkflowError};
 
 /// Why execution stopped early.
 #[derive(Debug)]
@@ -44,6 +48,8 @@ pub(super) struct Exec<'a, T, C> {
     clock: &'a C,
     /// The session's event intake, live from before the first instruction.
     events: EventIntake,
+    /// The document's triggers, pumped at safe points.
+    triggers: &'a [Trigger],
     /// The `result` namespace: the structured result of the most recent
     /// result-producing instruction on the current path (`null` at
     /// session start).
@@ -51,6 +57,26 @@ pub(super) struct Exec<'a, T, C> {
     /// The `error.*` namespace value while a `catch` or an error-path
     /// `finally` runs; `None` elsewhere (expressions read `null`).
     error: Option<Value>,
+    /// The `event.*` namespace value while a trigger action runs; `None`
+    /// on the procedure tree.
+    event: Option<Value>,
+    /// Set while a trigger action runs: safe points inside it only move
+    /// intake events into `pending` — trigger evaluation never re-enters.
+    in_trigger_action: bool,
+    /// Events awaiting evaluation ahead of the intake: synthetic
+    /// `correction_requested` events, plus events received by a wait's
+    /// select or drained during a trigger action.
+    pending: VecDeque<EngineEvent>,
+    /// Unconsumed occurrences per event name — what an `until_event`
+    /// wait matches against (every event since run start, § `wait`),
+    /// maintained because the pump consumes the events themselves.
+    occurrences: BTreeMap<String, u64>,
+    /// Per-trigger queued firing (the `event.*` payload); at most one
+    /// each — a queued or running trigger does not queue again.
+    queued: Vec<Option<Value>>,
+    /// Per-trigger next poll due on the monotonic clock; `None` for
+    /// event triggers. First due is one interval after run start.
+    poll_due: Vec<Option<Duration>>,
 }
 
 impl<'a, T, C> Exec<'a, T, C>
@@ -64,15 +90,30 @@ where
         tools: &'a T,
         clock: &'a C,
         events: EventIntake,
+        triggers: &'a [Trigger],
     ) -> Self {
+        let poll_due = triggers
+            .iter()
+            .map(|t| match &t.on {
+                TriggerSource::Poll { interval, .. } => Some(clock.monotonic() + *interval),
+                TriggerSource::Event(_) => None,
+            })
+            .collect();
         Self {
             params,
             blackboard,
             tools,
             clock,
             events,
+            triggers,
             result: Value::Null,
             error: None,
+            event: None,
+            in_trigger_action: false,
+            pending: VecDeque::new(),
+            occurrences: BTreeMap::new(),
+            queued: vec![None; triggers.len()],
+            poll_due,
         }
     }
 
@@ -81,17 +122,19 @@ where
             params: Some(self.params),
             session: Some(self.blackboard.value()),
             result: Some(&self.result),
-            // Trigger `do` blocks (which carry `event.*`) land in Phase D.
-            event: None,
+            event: self.event.as_ref(),
             error: self.error.as_ref(),
             now: self.clock.now(),
         }
     }
 
-    /// Run a block of instructions in order.
+    /// Run a block of instructions in order, with a safe point after each
+    /// (§ Triggers: queued trigger actions run after the current
+    /// instruction completes).
     pub(super) async fn exec_block(&mut self, block: &'a [Instruction]) -> ExecResult {
         for ins in block {
             self.exec_boxed(ins).await?;
+            self.safe_point().await?;
         }
         Ok(())
     }
@@ -207,6 +250,12 @@ where
             debug!(tool = %call.tool, attempt, "calling tool");
             match self.tools.call(&call.tool, args.clone()).await {
                 Ok(result) => {
+                    if let Some(synthetic) = correction_event(&result) {
+                        debug!(tool = %call.tool,
+                               "tool result carries a correction; synthesizing \
+                                correction_requested for the next safe point");
+                        self.pending.push_back(synthetic);
+                    }
                     self.result = result;
                     return Ok(());
                 }
@@ -445,12 +494,25 @@ where
         self.error_here(ins, message)
     }
 
+    /// A `wait` is one long safe point (§ Triggers): every iteration pumps
+    /// the triggers, then sleeps one segment — clamped to the next poll
+    /// due and interrupted by an arriving event, which is buffered for the
+    /// next iteration's pump. Budgets accumulate the monotonic time spent
+    /// in the sleep segments alone, so a wall-clock step (NTP) can neither
+    /// fire a timeout early nor extend a wait, and time spent in trigger
+    /// actions (inside the pump) never counts.
     async fn exec_wait(&mut self, ins: &'a Instruction, wait: &'a Wait) -> ExecResult {
         match wait {
             Wait::Duration(duration) => {
                 debug!(duration = %humantime::format_duration(*duration), "waiting");
-                self.clock.sleep(*duration).await;
-                Ok(())
+                let mut remaining = *duration;
+                loop {
+                    self.safe_point().await?;
+                    if remaining.is_zero() {
+                        return Ok(());
+                    }
+                    remaining = remaining.saturating_sub(self.wait_segment(remaining).await);
+                }
             }
             Wait::UntilEvent { event, timeout } => {
                 debug!(
@@ -458,28 +520,18 @@ where
                     timeout = %humantime::format_duration(*timeout),
                     "waiting for event"
                 );
-                // The intake runs from before the first instruction, so an
-                // event emitted while an earlier instruction ran is still
-                // buffered here — a wait can be satisfied by an event that
-                // technically preceded it (design § Event Subscription).
-                //
-                // The timeout budget is the time spent *waiting* (measured
-                // on the monotonic clock, so an NTP step can neither fire
-                // the timeout early nor extend the wait); Phase D2's
-                // trigger actions, which run during a wait, will not count
-                // against it.
-                let mut elapsed = std::time::Duration::ZERO;
+                let mut elapsed = Duration::ZERO;
                 loop {
-                    // Drain the buffer first — and once more when the
-                    // budget expires, so an event that arrived exactly at
-                    // expiry still satisfies the wait (mirroring `until`'s
-                    // final evaluation at timeout).
-                    while let Some(received) = self.events.try_next() {
-                        if received.event == *event {
-                            return Ok(());
-                        }
-                        debug!(received = %received.event, awaiting = %event,
-                               "ignoring non-matching event during `until_event` wait");
+                    // The pump counts every drained event's occurrence, so
+                    // the consume below matches events from the whole run —
+                    // including one emitted while an earlier instruction
+                    // ran (design § `wait`). The pump runs once more when
+                    // the budget expires, so an event that arrived exactly
+                    // at expiry still satisfies the wait (mirroring
+                    // `until`'s final evaluation at timeout).
+                    self.safe_point().await?;
+                    if self.consume_occurrence(event) {
+                        return Ok(());
                     }
                     if elapsed >= *timeout {
                         return Err(self.error_here(
@@ -490,23 +542,7 @@ where
                             ),
                         ));
                     }
-                    let remaining = *timeout - elapsed;
-                    let waited_from = self.clock.monotonic();
-                    tokio::select! {
-                        // Biased so a just-arrived event beats an
-                        // already-expired sleep (the mock clock's sleeps
-                        // resolve instantly).
-                        biased;
-                        received = self.events.next() => {
-                            if received.event == *event {
-                                return Ok(());
-                            }
-                            debug!(received = %received.event, awaiting = %event,
-                                   "ignoring non-matching event during `until_event` wait");
-                        }
-                        () = self.clock.sleep(remaining) => {}
-                    }
-                    elapsed += self.clock.monotonic().saturating_sub(waited_from);
+                    elapsed += self.wait_segment(*timeout - elapsed).await;
                 }
             }
             Wait::Until {
@@ -514,18 +550,13 @@ where
                 poll_interval,
                 timeout,
             } => {
-                // The timeout budget is tracked by accumulating the
-                // durations actually slept — monotonic by construction
-                // (production `sleep` is tokio's monotonic timer), so a
-                // wall-clock step (NTP) can neither extend the wait nor
-                // fire the timeout early. `clock.now()` (wall time) is
-                // only for `seconds_until()` inside the condition, where
-                // calendar time is the point.
-                let mut elapsed = std::time::Duration::ZERO;
+                let mut elapsed = Duration::ZERO;
                 loop {
-                    // Evaluated on entry, after each interval, and once
-                    // more when the timeout expires (the last sleep is
-                    // clamped to the remaining budget).
+                    // Evaluated on entry, after each interval (or sooner,
+                    // when an event or trigger action ends a segment
+                    // early), and once more when the timeout expires (the
+                    // last sleep is clamped to the remaining budget).
+                    self.safe_point().await?;
                     if self.condition(ins, condition, "`wait` `until` condition")? {
                         return Ok(());
                     }
@@ -539,12 +570,313 @@ where
                             ),
                         ));
                     }
-                    let sleep_for = (*poll_interval).min(*timeout - elapsed);
-                    self.clock.sleep(sleep_for).await;
-                    elapsed += sleep_for;
+                    let segment = (*poll_interval).min(*timeout - elapsed);
+                    elapsed += self.wait_segment(segment).await;
                 }
             }
         }
+    }
+
+    /// One sleep segment of a wait: at most `remaining`, clamped to the
+    /// next poll due so poll sources stay on schedule, and ended early by
+    /// an arriving event (buffered into `pending` for the caller's next
+    /// pump). Returns the monotonic time actually spent — the only time
+    /// that counts against a wait's budget.
+    async fn wait_segment(&mut self, remaining: Duration) -> Duration {
+        let sleep_for = match self.next_poll_due_in() {
+            Some(until_due) => remaining.min(until_due),
+            None => remaining,
+        };
+        let waited_from = self.clock.monotonic();
+        tokio::select! {
+            // Biased so a just-arrived event beats an already-expired
+            // sleep (the mock clock's sleeps resolve instantly).
+            biased;
+            received = self.events.next() => self.pending.push_back(received),
+            () = self.clock.sleep(sleep_for) => {}
+        }
+        self.clock.monotonic().saturating_sub(waited_from)
+    }
+
+    /// Time until the earliest poll due, `None` when the document has no
+    /// poll triggers (or inside a trigger action, where polls cannot run
+    /// anyway — clamping there would spin on an already-due poll).
+    fn next_poll_due_in(&self) -> Option<Duration> {
+        if self.in_trigger_action {
+            return None;
+        }
+        let now = self.clock.monotonic();
+        self.poll_due
+            .iter()
+            .flatten()
+            .map(|due| due.saturating_sub(now))
+            .min()
+    }
+
+    /// Satisfy an `until_event`: decrement an unconsumed occurrence of
+    /// `name`, or — inside a trigger action, where the pump does not
+    /// count — consume a matching event straight from `pending`.
+    fn consume_occurrence(&mut self, name: &str) -> bool {
+        if let Some(n) = self.occurrences.get_mut(name) {
+            *n -= 1;
+            if *n == 0 {
+                self.occurrences.remove(name);
+            }
+            return true;
+        }
+        if let Some(pos) = self.pending.iter().position(|e| e.event == name) {
+            self.pending.remove(pos);
+            return true;
+        }
+        false
+    }
+
+    // ---- the trigger pump (design § Triggers, implementation pins) -------
+
+    /// A safe point on the procedure tree: feed buffered events (synthetic
+    /// first, then the intake) to trigger evaluation, run due poll
+    /// sources, then run queued trigger actions in document order.
+    ///
+    /// Inside a trigger action only the intake drain happens — evaluation
+    /// never re-enters; everything drained there is evaluated at the next
+    /// safe point on the tree.
+    async fn safe_point(&mut self) -> ExecResult {
+        while let Some(received) = self.events.try_next() {
+            self.pending.push_back(received);
+        }
+        if self.in_trigger_action {
+            return Ok(());
+        }
+        while let Some(received) = self.pending.pop_front() {
+            *self.occurrences.entry(received.event.clone()).or_insert(0) += 1;
+            self.consider_event(&received)?;
+        }
+        self.run_due_polls().await?;
+        self.run_queued().await
+    }
+
+    /// Queue every event trigger this event fires: name match, then the
+    /// payload-independent gates, then the `when` gate over `event.*`.
+    fn consider_event(&mut self, received: &EngineEvent) -> Result<(), Interrupt> {
+        let triggers = self.triggers;
+        for (idx, trigger) in triggers.iter().enumerate() {
+            let TriggerSource::Event(name) = &trigger.on else {
+                continue;
+            };
+            if *name != received.event || self.gated(idx, trigger) {
+                continue;
+            }
+            if !self.gate_passes(trigger, trigger.when.as_ref(), &received.payload, "`when`")? {
+                continue;
+            }
+            debug!(trigger = %trigger.id, event = %received.event, "trigger firing queued");
+            self.queued[idx] = Some(received.payload.clone());
+        }
+        Ok(())
+    }
+
+    /// The payload-independent fire gates: a firing already queued, a
+    /// spent `once`, an open cooldown.
+    fn gated(&self, idx: usize, trigger: &Trigger) -> bool {
+        if self.queued[idx].is_some() {
+            return true;
+        }
+        if trigger.once && self.blackboard.trigger_fired_once(&trigger.id) {
+            debug!(trigger = %trigger.id, "trigger already fired this session (`once`)");
+            return true;
+        }
+        if let Some(cooldown) = trigger.cooldown {
+            if let Some(last) = self.blackboard.trigger_last_fired(&trigger.id) {
+                // Wall-clock on purpose: cooldowns survive resume. A
+                // negative elapsed (backwards clock step) extends the
+                // cooldown rather than firing early, as does a cooldown
+                // too large for chrono to represent.
+                let since = self.clock.now().signed_duration_since(last);
+                let cooldown =
+                    chrono::Duration::from_std(cooldown).unwrap_or(chrono::Duration::MAX);
+                if since < cooldown {
+                    debug!(trigger = %trigger.id, "trigger inside its cooldown");
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Evaluate a `when`/`while` gate with `event.*` bound to the
+    /// firing's payload. Absent = passes. An evaluation error or
+    /// non-boolean value is a workflow error attributed to the trigger —
+    /// a gate that cannot be evaluated is an authoring bug, and silently
+    /// never-firing would hide it (design § Triggers pins).
+    fn gate_passes(
+        &self,
+        trigger: &Trigger,
+        gate: Option<&Expression>,
+        payload: &Value,
+        role: &str,
+    ) -> Result<bool, Interrupt> {
+        let Some(gate) = gate else {
+            return Ok(true);
+        };
+        let ctx = EvalContext {
+            event: Some(payload),
+            ..self.ctx()
+        };
+        let message = match gate.eval(&ctx) {
+            Ok(Value::Bool(b)) => return Ok(b),
+            Ok(other) => format!(
+                "trigger `{}`: {role} gate `{}` must yield a boolean, got {other}",
+                trigger.id,
+                gate.source()
+            ),
+            Err(e) => format!(
+                "trigger `{}`: {role} gate `{}` failed: {e}",
+                trigger.id,
+                gate.source()
+            ),
+        };
+        Err(Interrupt::Error(WorkflowError {
+            message,
+            instruction_id: None,
+            tool: None,
+        }))
+    }
+
+    /// Call every due poll source and queue the firings its result
+    /// gates through. Each handled due reschedules the next cycle at
+    /// now + interval (missed cycles collapse). A gated trigger skips
+    /// the tool call entirely; a failed call — argument evaluation
+    /// included — skips the cycle at `debug!` (a flaky poll must not
+    /// kill the session).
+    async fn run_due_polls(&mut self) -> ExecResult {
+        let triggers = self.triggers;
+        for (idx, trigger) in triggers.iter().enumerate() {
+            let TriggerSource::Poll {
+                tool,
+                args,
+                interval,
+            } = &trigger.on
+            else {
+                continue;
+            };
+            if self.poll_due[idx].is_some_and(|due| self.clock.monotonic() < due) {
+                continue;
+            }
+            self.poll_due[idx] = Some(self.clock.monotonic() + *interval);
+            if self.gated(idx, trigger) {
+                continue;
+            }
+            let Some(call_args) = self.poll_args(trigger, args) else {
+                continue;
+            };
+            debug!(trigger = %trigger.id, tool = %tool, "poll trigger due; calling its tool");
+            match self.tools.call(tool, call_args).await {
+                Ok(payload) => {
+                    if let Some(synthetic) = correction_event(&payload) {
+                        // Evaluated at the next safe point, like a
+                        // correction on any other tool call.
+                        self.pending.push_back(synthetic);
+                    }
+                    if self.gate_passes(trigger, trigger.when.as_ref(), &payload, "`when`")? {
+                        debug!(trigger = %trigger.id, "poll trigger firing queued");
+                        self.queued[idx] = Some(payload);
+                    }
+                }
+                Err(ToolCallError::SessionTerminated(message)) => {
+                    debug!(trigger = %trigger.id, %message,
+                           "MCP session terminated during a poll call");
+                    return Err(Interrupt::Terminated);
+                }
+                Err(ToolCallError::Failed(message)) => {
+                    debug!(trigger = %trigger.id, tool = %tool, %message,
+                           "poll tool call failed; skipping this cycle");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Evaluate a poll's arguments (params/session/result in scope, per
+    /// validation); `None` skips the cycle — poll args commonly read
+    /// session state a later phase sets, and a poll must not kill the
+    /// session before that phase arrives.
+    fn poll_args(
+        &self,
+        trigger: &Trigger,
+        args: &BTreeMap<String, ArgValue>,
+    ) -> Option<Map<String, Value>> {
+        let mut call_args = Map::new();
+        for (name, arg) in args {
+            let value = match arg {
+                ArgValue::Literal(v) => v.clone(),
+                ArgValue::Expr(expr) => match expr.eval(&self.ctx()) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        debug!(trigger = %trigger.id, argument = %name, error = %e,
+                               "poll argument failed to evaluate; skipping this cycle");
+                        return None;
+                    }
+                },
+            };
+            call_args.insert(name.clone(), value);
+        }
+        Some(call_args)
+    }
+
+    /// Run queued trigger actions in document order. The `while` gate is
+    /// re-checked at fire time (an earlier trigger's action in the same
+    /// batch can retract a later one); bookkeeping is recorded on
+    /// successful completion only, mirroring instruction `once`
+    /// semantics; an uncaught error fails the session, its message
+    /// prefixed with the trigger id.
+    async fn run_queued(&mut self) -> ExecResult {
+        let triggers = self.triggers;
+        for (idx, trigger) in triggers.iter().enumerate() {
+            let Some(payload) = self.queued[idx].take() else {
+                continue;
+            };
+            if !self.gate_passes(trigger, trigger.while_gate.as_ref(), &payload, "`while`")? {
+                debug!(trigger = %trigger.id,
+                       "`while` gate false at fire time; dropping the queued firing");
+                continue;
+            }
+            debug!(trigger = %trigger.id, "trigger fired; running its `do` block");
+            // A `do` block starts with `result` and `error.*` null and
+            // sees the firing's payload as `event.*`; all three are
+            // restored when the action ends (§ `result` scoping).
+            let saved_result = std::mem::replace(&mut self.result, Value::Null);
+            let saved_error = self.error.take();
+            let saved_event = self.event.replace(payload);
+            self.in_trigger_action = true;
+            // Boxed: this re-entry into block execution would otherwise
+            // make the safe-point future's type infinitely recursive.
+            let outcome = Box::pin(self.exec_block(&trigger.actions)).await;
+            self.in_trigger_action = false;
+            self.event = saved_event;
+            self.error = saved_error;
+            self.result = saved_result;
+            match outcome {
+                Ok(()) => {}
+                Err(Interrupt::Error(error)) => {
+                    return Err(Interrupt::Error(WorkflowError {
+                        message: format!("trigger `{}`: {}", trigger.id, error.message),
+                        ..error
+                    }));
+                }
+                Err(Interrupt::Terminated) => return Err(Interrupt::Terminated),
+            }
+            self.blackboard
+                .mark_trigger_fired(&trigger.id, self.clock.now(), trigger.once)
+                .await
+                .map_err(|e| {
+                    Interrupt::Error(WorkflowError {
+                        message: format!("trigger `{}`: {e}", trigger.id),
+                        instruction_id: None,
+                        tool: None,
+                    })
+                })?;
+        }
+        Ok(())
     }
 
     fn exec_log(&self, ins: &'a Instruction, log: &'a Log) -> ExecResult {
@@ -564,6 +896,31 @@ where
         }
         Ok(())
     }
+}
+
+/// The synthetic `correction_requested` event for a tool result that
+/// carries a correction (design § Triggers pins; `rp.md` § Corrections):
+/// `status: "aborted"` or `"blocked_by_correction"` with a `correction`
+/// object → `event.delivery = "immediate"`; a `pending_correction`
+/// object → `"after_current"`. A correction value that is not a JSON
+/// object is logged and ignored.
+fn correction_event(result: &Value) -> Option<EngineEvent> {
+    let status = result.get("status").and_then(Value::as_str);
+    let (correction, delivery) = if matches!(status, Some("aborted" | "blocked_by_correction")) {
+        (result.get("correction")?, "immediate")
+    } else {
+        (result.get("pending_correction")?, "after_current")
+    };
+    let Value::Object(fields) = correction else {
+        debug!(%correction, "ignoring a correction that is not a JSON object");
+        return None;
+    };
+    let mut payload = fields.clone();
+    payload.insert("delivery".to_owned(), Value::String(delivery.to_owned()));
+    Some(EngineEvent {
+        event: "correction_requested".to_owned(),
+        payload: Value::Object(payload),
+    })
 }
 
 /// A `Value` as a `u64` loop bound: any JSON number whose value is a

--- a/services/session-runner/src/engine/exec_tests.rs
+++ b/services/session-runner/src/engine/exec_tests.rs
@@ -1133,22 +1133,625 @@ async fn test_blackboard_reflects_every_completed_set_at_termination() {
     assert_eq!(on_disk["progress"], json!(7.0));
 }
 
-// --- documents with triggers (Phase D gap) ---------------------------------------
+// --- triggers: the safe-point pump ------------------------------------------
+
+/// A live event channel: the sender side is handed to tool responders so a
+/// tool call can emit an event mid-run (modelling `rp` emitting on the SSE
+/// stream while an instruction is in flight).
+fn live_events() -> (tokio::sync::mpsc::Sender<EngineEvent>, EventIntake) {
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    (tx, EventIntake::new(rx))
+}
+
+fn ev(event: &str, payload: Value) -> EngineEvent {
+    EngineEvent {
+        event: event.to_owned(),
+        payload,
+    }
+}
+
+/// Run a full document (triggers included) against a fresh blackboard and
+/// the given intake; returns the outcome and the final session value.
+async fn run_doc_with_events(
+    doc: &Document,
+    tools: &MockTools,
+    clock: &(impl Clock + Sync),
+    events: EventIntake,
+) -> (RunOutcome, Value) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut blackboard = Blackboard::load(dir.path().join("session.json"))
+        .await
+        .unwrap();
+    let outcome = run(doc, &json!({}), &mut blackboard, tools, clock, events).await;
+    let session = blackboard.value().clone();
+    (outcome, session)
+}
 
 #[tokio::test]
-async fn test_documents_with_triggers_run_but_triggers_do_not_fire() {
+async fn test_event_trigger_action_runs_at_the_next_safe_point_not_mid_instruction() {
+    let (tx, events) = live_events();
+    // The event is emitted while `a` is in flight; the trigger action must
+    // run after `a` completes and before `b` starts.
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("hfr_degraded", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "correct", "on": { "event": "hfr_degraded" },
+                        "do": [ { "tool": "refocus" } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "refocus", "b"]);
+}
+
+#[tokio::test]
+async fn test_queued_trigger_actions_run_in_document_order() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [
+            { "id": "t1", "on": { "event": "e" }, "do": [ { "tool": "first" } ] },
+            { "id": "t2", "on": { "event": "e" }, "do": [ { "tool": "second" } ] }
+        ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "first", "second", "b"]);
+}
+
+#[tokio::test]
+async fn test_a_queued_trigger_does_not_queue_again() {
+    let (tx, events) = live_events();
+    // Two occurrences drain in the same batch; the trigger queues once.
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" }, "do": [ { "tool": "act" } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "act", "b"]);
+}
+
+#[tokio::test]
+async fn test_when_gate_filters_on_the_event_payload() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        match tool {
+            "a" => tx
+                .try_send(ev("exposure_complete", json!({ "hfr": 2.0 })))
+                .unwrap(),
+            "b" => tx
+                .try_send(ev("exposure_complete", json!({ "hfr": 4.0 })))
+                .unwrap(),
+            _ => {}
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "refocus-on-degradation",
+                        "on": { "event": "exposure_complete" },
+                        "when": "event.hfr > 3.0",
+                        "do": [ { "tool": "refocus" } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" }, { "tool": "c" } ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "b", "refocus", "c"]);
+}
+
+#[tokio::test]
+async fn test_while_gate_is_evaluated_at_fire_time() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    // Both triggers queue from the same event; t1's action flips the flag
+    // t2's `while` reads, so t2's queued firing is dropped at fire time.
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [
+            { "id": "t1", "on": { "event": "e" },
+              "do": [ { "set": { "session.stop": "true" } } ] },
+            { "id": "t2", "on": { "event": "e" }, "while": "session.stop != true",
+              "do": [ { "tool": "never" } ] }
+        ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let (outcome, session) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "b"]);
+    assert_eq!(session["stop"], json!(true));
+    // t1 fired (bookkeeping recorded); t2's dropped firing did not.
+    assert!(session["_triggers"]["t1"]["last_fired"].is_string());
+    assert_eq!(session["_triggers"].get("t2"), None);
+}
+
+#[tokio::test]
+async fn test_once_trigger_fires_at_most_once_per_session_including_resume() {
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" }, "once": true,
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let dir = tempfile::tempdir().unwrap();
+
+    // First run: fires once; the second occurrence (after `b`) is gated.
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" || tool == "b" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let mut blackboard = Blackboard::load(dir.path().join("session.json"))
+        .await
+        .unwrap();
+    let outcome = run(
+        &doc,
+        &json!({}),
+        &mut blackboard,
+        &tools,
+        &MockClock::new(),
+        events,
+    )
+    .await;
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "act", "b"]);
+    assert_eq!(
+        blackboard.value()["_triggers"]["t"]["fired_once"],
+        json!(true)
+    );
+
+    // Resume (same blackboard file): `once` is per session, so a fresh
+    // occurrence must not fire it again.
+    let (tx2, events2) = live_events();
+    let tools2 = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx2.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let mut reloaded = Blackboard::load(dir.path().join("session.json"))
+        .await
+        .unwrap();
+    let outcome = run(
+        &doc,
+        &json!({}),
+        &mut reloaded,
+        &tools2,
+        &MockClock::new(),
+        events2,
+    )
+    .await;
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools2.call_names(), vec!["a", "b"]);
+}
+
+#[tokio::test]
+async fn test_cooldown_gates_by_wall_clock_and_reopens() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if matches!(tool, "a" | "b" | "c") {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    // `a` fires the trigger; `b`'s occurrence lands inside the 10m
+    // cooldown (no time has passed); the 15m wait reopens it for `c`'s.
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" }, "cooldown": "10m",
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "sequence": [
+            { "tool": "a" },
+            { "tool": "b" },
+            { "wait": { "duration": "15m" } },
+            { "tool": "c" },
+            { "tool": "d" }
+        ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "act", "b", "c", "act", "d"]);
+}
+
+#[tokio::test]
+async fn test_uncaught_trigger_action_error_fails_the_session_naming_the_trigger() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        if tool == "boom" {
+            return Err(ToolCallError::Failed("dew heater offline".to_owned()));
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" }, "do": [ { "tool": "boom" } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "never" } ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    let error = failure(outcome);
+    assert_eq!(
+        error.message,
+        "trigger `t`: tool `boom` failed: dew heater offline"
+    );
+    assert_eq!(tools.call_names(), vec!["a", "boom"]);
+}
+
+#[tokio::test]
+async fn test_a_try_inside_the_do_block_makes_a_trigger_resilient() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({}))).unwrap();
+        }
+        if tool == "boom" {
+            return Err(ToolCallError::Failed("still offline".to_owned()));
+        }
+        Ok(json!({}))
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" },
+                        "do": [ { "try": [ { "tool": "boom" } ],
+                                  "catch": [ { "tool": "cleanup" } ] } ] } ],
+        "root": { "sequence": [ { "tool": "a" }, { "tool": "b" } ] }
+    }));
+    let (outcome, session) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["a", "boom", "cleanup", "b"]);
+    // The caught firing still counts as fired.
+    assert!(session["_triggers"]["t"]["last_fired"].is_string());
+}
+
+#[tokio::test]
+async fn test_trigger_action_scoping_result_error_and_event() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("e", json!({ "reason": "drift" }))).unwrap();
+            return Ok(json!({ "v": "root" }));
+        }
+        Ok(json!({ "v": "trigger" }))
+    });
+    // The `do` block starts with `result` null and sees `event.*`; the
+    // tree's `result` is restored after the action (the trigger's own
+    // tool result must not leak into the `set` that follows `a`).
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" },
+                        "do": [
+                            { "set": { "session.result_was_null": "result == null",
+                                       "session.reason": "event.reason" } },
+                            { "tool": "inner" }
+                        ] } ],
+        "root": { "sequence": [
+            { "tool": "a" },
+            { "set": { "session.root_result": "result.v" } }
+        ] }
+    }));
+    let (outcome, session) = run_doc_with_events(&doc, &tools, &MockClock::new(), events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(session["result_was_null"], json!(true));
+    assert_eq!(session["reason"], json!("drift"));
+    assert_eq!(session["root_result"], json!("root"));
+}
+
+#[tokio::test]
+async fn test_when_gate_yielding_a_non_boolean_is_a_workflow_error() {
+    let events = buffered_events(&[("e", json!({ "x": 5 }))]);
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" }, "when": "event.x",
+                        "do": [ { "tool": "never" } ] } ],
+        "root": { "wait": { "duration": "1s" } }
+    }));
+    let (outcome, _) =
+        run_doc_with_events(&doc, &MockTools::none(), &MockClock::new(), events).await;
+
+    let error = failure(outcome);
+    assert_eq!(
+        error.message,
+        "trigger `t`: `when` gate `event.x` must yield a boolean, got 5"
+    );
+}
+
+// --- triggers: waits as long safe points -------------------------------------
+
+#[tokio::test]
+async fn test_trigger_fires_during_a_duration_wait_without_consuming_its_budget() {
+    // The action's own 3s wait must not count against the outer 30s wait:
+    // the sleep ledger shows both in full.
+    let events = buffered_events(&[("e", json!({}))]);
+    let clock = MockClock::new();
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "e" },
+                        "do": [ { "wait": { "duration": "3s" } } ] } ],
+        "root": { "wait": { "duration": "30s" } }
+    }));
+    let (outcome, session) = run_doc_with_events(&doc, &MockTools::none(), &clock, events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(
+        clock.sleeps(),
+        vec![Duration::from_secs(3), Duration::from_secs(30)]
+    );
+    assert!(session["_triggers"]["t"]["last_fired"].is_string());
+}
+
+#[tokio::test]
+async fn test_until_event_timeout_budget_excludes_trigger_action_time() {
+    let events = buffered_events(&[("progress", json!({}))]);
+    let clock = MockClock::new();
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "progress" },
+                        "do": [ { "wait": { "duration": "3s" } } ] } ],
+        "root": { "id": "settle",
+                  "wait": { "until_event": "never_comes", "timeout": "10s" } }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &MockTools::none(), &clock, events).await;
+
+    let error = failure(outcome);
+    assert_eq!(
+        error.message,
+        "`wait` `until_event` `never_comes` did not arrive within 10s"
+    );
+    // 3s of action time, then the full 10s budget — not 7s.
+    assert_eq!(
+        clock.sleeps(),
+        vec![Duration::from_secs(3), Duration::from_secs(10)]
+    );
+}
+
+#[tokio::test]
+async fn test_the_awaited_event_also_feeds_trigger_evaluation() {
+    let (tx, events) = live_events();
+    let tools = MockTools::new(move |_, tool, _| {
+        if tool == "a" {
+            tx.try_send(ev("done", json!({}))).unwrap();
+        }
+        Ok(json!({}))
+    });
+    let clock = MockClock::new();
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "on": { "event": "done" }, "do": [ { "tool": "act" } ] } ],
+        "root": { "sequence": [
+            { "tool": "a" },
+            { "wait": { "until_event": "done", "timeout": "5m" } },
+            { "tool": "b" }
+        ] }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &clock, events).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    // One `done`: the trigger fires at the safe point after `a`, and the
+    // wait is satisfied by the same occurrence — with no sleeping.
+    assert_eq!(tools.call_names(), vec!["a", "act", "b"]);
+    assert_eq!(clock.sleeps(), Vec::<Duration>::new());
+}
+
+// --- triggers: poll sources ---------------------------------------------------
+
+#[tokio::test]
+async fn test_poll_trigger_polls_on_schedule_and_fires_through_its_when_gate() {
+    let clock = MockClock::new();
+    // First cycle gated by `when`, second passes.
+    let responses = Mutex::new(VecDeque::from([
+        json!({ "ok": false }),
+        json!({ "ok": true }),
+    ]));
+    let tools = MockTools::new(move |_, tool, _| {
+        Ok(match tool {
+            "check" => responses.lock().unwrap().pop_front().unwrap(),
+            _ => json!({}),
+        })
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t",
+                        "on": { "poll": { "tool": "check", "interval": "10s" } },
+                        "when": "event.ok == true",
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "wait": { "duration": "25s" } }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &clock, EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    // First due one interval after run start; sleep segments clamp to the
+    // schedule: 10s, 10s, then the remaining 5s.
+    assert_eq!(tools.call_names(), vec!["check", "check", "act"]);
+    assert_eq!(
+        clock.sleeps(),
+        vec![
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(5)
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_poll_failure_skips_the_cycle_without_failing_the_session() {
+    let clock = MockClock::new();
+    let responses = Mutex::new(VecDeque::from([
+        Err(ToolCallError::Failed("flaky".to_owned())),
+        Ok(json!({})),
+    ]));
+    let tools = MockTools::new(move |_, tool, _| match tool {
+        "check" => responses.lock().unwrap().pop_front().unwrap(),
+        _ => Ok(json!({})),
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t",
+                        "on": { "poll": { "tool": "check", "interval": "10s" } },
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "wait": { "duration": "25s" } }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &clock, EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(tools.call_names(), vec!["check", "check", "act"]);
+}
+
+#[tokio::test]
+async fn test_a_due_poll_whose_trigger_cannot_fire_skips_the_tool_call() {
+    let clock = MockClock::new();
+    let tools = MockTools::ok(json!({}));
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "t", "once": true,
+                        "on": { "poll": { "tool": "check", "interval": "10s" } },
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "wait": { "duration": "35s" } }
+    }));
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &clock, EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    // Fires at 10s; the dues at 20s and 30s skip the call (`once` spent).
+    assert_eq!(tools.call_names(), vec!["check", "act"]);
+}
+
+#[tokio::test]
+async fn test_a_poll_argument_that_fails_to_evaluate_skips_the_cycle() {
+    let clock = MockClock::new();
     let tools = MockTools::none();
     let doc = make_doc(json!({
         "version": 1, "name": "t",
-        "triggers": [ { "id": "t1", "on": { "event": "exposure_complete" },
-                        "do": [ { "tool": "never" } ] } ],
-        "root": { "set": { "session.ran": "true" } }
+        "triggers": [ { "id": "t",
+                        "on": { "poll": { "tool": "check", "interval": "10s",
+                                          "args": { "pos": { "$expr": "1 / 0" } } } },
+                        "do": [ { "tool": "act" } ] } ],
+        "root": { "wait": { "duration": "15s" } }
     }));
-    let dir = tempfile::tempdir().unwrap();
-    let (outcome, session) = run_in(&dir, &doc, &json!({}), &tools, &MockClock::new()).await;
+    let (outcome, _) = run_doc_with_events(&doc, &tools, &clock, EventIntake::disconnected()).await;
+
     assert_eq!(outcome, RunOutcome::Completed);
-    assert_eq!(session["ran"], json!(true));
     assert!(tools.calls().is_empty());
+}
+
+// --- triggers: synthetic corrections ------------------------------------------
+
+#[tokio::test]
+async fn test_an_aborted_tool_result_synthesizes_an_immediate_correction() {
+    let tools = MockTools::new(|_, tool, _| {
+        Ok(match tool {
+            "capture" => json!({
+                "status": "aborted",
+                "correction": { "action": "focus", "reason": "HFR 4.8", "source": "analyzer" }
+            }),
+            _ => json!({}),
+        })
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "on-correction", "on": { "event": "correction_requested" },
+                        "do": [ { "set": {
+                            "session.action": "event.action",
+                            "session.delivery": "event.delivery",
+                            "session.source": "event.source" } } ] } ],
+        "root": { "sequence": [ { "tool": "capture" }, { "tool": "b" } ] }
+    }));
+    let (outcome, session) =
+        run_doc_with_events(&doc, &tools, &MockClock::new(), EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(session["action"], json!("focus"));
+    assert_eq!(session["delivery"], json!("immediate"));
+    assert_eq!(session["source"], json!("analyzer"));
+}
+
+#[tokio::test]
+async fn test_a_pending_correction_synthesizes_an_after_current_correction() {
+    let tools = MockTools::new(|_, tool, _| {
+        Ok(match tool {
+            "capture" => json!({
+                "image_path": "/data/f.fits",
+                "pending_correction": { "action": "focus", "reason": "trending" }
+            }),
+            _ => json!({}),
+        })
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "on-correction", "on": { "event": "correction_requested" },
+                        "do": [ { "set": { "session.delivery": "event.delivery" } } ] } ],
+        "root": { "sequence": [
+            { "tool": "capture" },
+            // The carrying result stays in scope for the tree.
+            { "set": { "session.path": "result.image_path" } }
+        ] }
+    }));
+    let (outcome, session) =
+        run_doc_with_events(&doc, &tools, &MockClock::new(), EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(session["delivery"], json!("after_current"));
+    assert_eq!(session["path"], json!("/data/f.fits"));
+}
+
+#[tokio::test]
+async fn test_a_blocked_by_correction_result_synthesizes_an_immediate_correction() {
+    let tools = MockTools::new(|_, tool, _| {
+        Ok(match tool {
+            "slew" => json!({
+                "status": "blocked_by_correction",
+                "correction": { "action": "focus", "reason": "frame bad", "source": "analyzer" }
+            }),
+            _ => json!({}),
+        })
+    });
+    let doc = make_doc(json!({
+        "version": 1, "name": "t",
+        "triggers": [ { "id": "on-correction", "on": { "event": "correction_requested" },
+                        "do": [ { "set": { "session.delivery": "event.delivery" } } ] } ],
+        "root": { "tool": "slew" }
+    }));
+    let (outcome, session) =
+        run_doc_with_events(&doc, &tools, &MockClock::new(), EventIntake::disconnected()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(session["delivery"], json!("immediate"));
 }
 
 // --- the golden document end-to-end ----------------------------------------------

--- a/services/session-runner/src/engine/io.rs
+++ b/services/session-runner/src/engine/io.rs
@@ -93,8 +93,8 @@ pub struct EngineEvent {
 ///
 /// A closed or absent stream is not an error — [`EventIntake::next`]
 /// simply never resolves, so an `until_event` wait runs to its timeout
-/// and (Phase D2) triggers never fire, matching the design's stance that
-/// events can always be missed across an outage.
+/// and event triggers never fire (poll triggers keep running), matching
+/// the design's stance that events can always be missed across an outage.
 #[derive(Debug)]
 pub struct EventIntake {
     /// `None` once the sending side is gone (or for

--- a/services/session-runner/src/engine/mod.rs
+++ b/services/session-runner/src/engine/mod.rs
@@ -10,9 +10,9 @@
 //!
 //! Phase boundary (`docs/plans/workflow-dsl.md`): the Phase C engine core
 //! plus the Phase D event intake (`wait` `until_event` against the SSE
-//! stream). Trigger evaluation — including the `event.*` namespace — is
-//! the remaining Phase D work; until it lands a document's declared
-//! triggers do not fire (warned at run start).
+//! stream) and trigger engine — the safe-point pump, `when`/`while`
+//! gates, `once`/`cooldown` bookkeeping, poll sources, and synthetic
+//! `correction_requested` events (design § Triggers).
 
 mod exec;
 mod io;
@@ -23,7 +23,7 @@ mod io;
 mod exec_tests;
 
 use serde_json::{json, Value};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 pub use io::{Clock, EngineEvent, EventIntake, SystemClock, ToolCallError, ToolClient};
 
@@ -92,15 +92,7 @@ where
     T: ToolClient + Sync,
     C: Clock + Sync,
 {
-    if !doc.triggers.is_empty() {
-        warn!(
-            document = %doc.name,
-            triggers = doc.triggers.len(),
-            "document declares triggers, which this engine does not evaluate yet \
-             (workflow-dsl plan, Phase D) — they will not fire"
-        );
-    }
-    let mut exec = exec::Exec::new(params, blackboard, tools, clock, events);
+    let mut exec = exec::Exec::new(params, blackboard, tools, clock, events, &doc.triggers);
     match exec.exec_block(std::slice::from_ref(&doc.root)).await {
         Ok(()) => {
             debug!(document = %doc.name, "workflow completed");

--- a/services/session-runner/src/events.rs
+++ b/services/session-runner/src/events.rs
@@ -35,9 +35,13 @@ const RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 /// consumer loose with a `stream_gap` — the designed slow-consumer path.
 const EVENT_BUFFER: usize = 256;
 
-/// Cap on establishing the TCP connection. `subscribe`'s initial connect
-/// runs inline on the `/invoke` path, so a black-holed `events_url`
-/// (e.g. a bad configuration override) must not hang the invocation.
+/// Cap on one whole subscribe attempt — TCP connect, TLS, and the
+/// response headers. `subscribe`'s initial attempt runs inline on the
+/// `/invoke` path, so an endpoint that is black-holed *or* accepts the
+/// connection and then never answers (reqwest's `connect_timeout` covers
+/// only the TCP phase) must not hang the invocation. Reads of the
+/// established stream are uncapped — an idle stream is healthy (`rp`
+/// keep-alives every 15 s).
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Subscribe to the SSE stream at `events_url` and return the engine's
@@ -50,19 +54,15 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// blocks the session.
 pub async fn subscribe(events_url: String) -> EventIntake {
     let (tx, rx) = mpsc::channel(EVENT_BUFFER);
-    let client = reqwest::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .build()
-        // The builder only fails over TLS/resolver setup; the default
-        // client (no connect timeout) is a working fallback.
-        .unwrap_or_default();
+    let client = reqwest::Client::new();
     let first = connect(&client, &events_url, None).await;
     tokio::spawn(client_loop(client, events_url, tx, first));
     EventIntake::new(rx)
 }
 
-/// One subscribe attempt; `None` on a refused, rejected, or failed
-/// connect (logged at `debug!` — reconnection is routine).
+/// One subscribe attempt, capped at [`CONNECT_TIMEOUT`] end to end;
+/// `None` on a refused, rejected, timed-out, or failed connect (logged
+/// at `debug!` — reconnection is routine).
 async fn connect(
     client: &reqwest::Client,
     url: &str,
@@ -72,7 +72,14 @@ async fn connect(
     if let Some(id) = last_seq {
         request = request.header("last-event-id", id.to_string());
     }
-    match request.send().await {
+    let response = match tokio::time::timeout(CONNECT_TIMEOUT, request.send()).await {
+        Ok(response) => response,
+        Err(_) => {
+            debug!(%url, "event stream subscribe attempt timed out");
+            return None;
+        }
+    };
+    match response {
         Ok(response) if response.status().is_success() => {
             debug!(%url, cursor = ?last_seq, "event stream connected");
             Some(response)
@@ -410,6 +417,26 @@ mod tests {
             heads.try_recv().is_ok(),
             "subscribe must complete the initial connect before returning"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_a_server_that_accepts_but_never_answers_does_not_hang_subscribe() {
+        // A wedged endpoint: the OS accepts the TCP connection (into the
+        // listener's backlog) but no response headers ever come. reqwest's
+        // `connect_timeout` would never fire here — only the attempt-level
+        // timeout gets `subscribe` off the `/invoke` path. Paused tokio
+        // time auto-advances past the cap, so this is instant.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut intake = timeout(
+            Duration::from_secs(60),
+            subscribe(format!("http://{addr}/api/events/subscribe")),
+        )
+        .await
+        .expect("subscribe must time out a wedged endpoint, not hang the /invoke path");
+        assert!(intake.try_next().is_none());
+        drop(listener);
     }
 
     #[tokio::test]

--- a/services/session-runner/src/events.rs
+++ b/services/session-runner/src/events.rs
@@ -35,43 +35,79 @@ const RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 /// consumer loose with a `stream_gap` — the designed slow-consumer path.
 const EVENT_BUFFER: usize = 256;
 
+/// Cap on establishing the TCP connection. `subscribe`'s initial connect
+/// runs inline on the `/invoke` path, so a black-holed `events_url`
+/// (e.g. a bad configuration override) must not hang the invocation.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Subscribe to the SSE stream at `events_url` and return the engine's
-/// intake. The connection (and every reconnect) happens on a background
-/// task that exits when the returned intake is dropped.
-pub fn subscribe(events_url: String) -> EventIntake {
+/// intake. The **initial connect happens inline** — when this returns,
+/// the subscription is live (or its first attempt has failed), so an
+/// event emitted while the session's first instruction runs is already
+/// being captured (design § Event Subscription). Reconnects happen on a
+/// background task that exits when the returned intake is dropped; a
+/// failed first attempt is retried there too — a dead stream never
+/// blocks the session.
+pub async fn subscribe(events_url: String) -> EventIntake {
     let (tx, rx) = mpsc::channel(EVENT_BUFFER);
-    tokio::spawn(client_loop(events_url, tx));
+    let client = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+        // The builder only fails over TLS/resolver setup; the default
+        // client (no connect timeout) is a working fallback.
+        .unwrap_or_default();
+    let first = connect(&client, &events_url, None).await;
+    tokio::spawn(client_loop(client, events_url, tx, first));
     EventIntake::new(rx)
 }
 
-async fn client_loop(url: String, tx: mpsc::Sender<EngineEvent>) {
-    let client = reqwest::Client::new();
-    let mut last_seq: Option<u64> = None;
-    loop {
-        let mut request = client.get(&url).header("accept", "text/event-stream");
-        if let Some(id) = last_seq {
-            request = request.header("last-event-id", id.to_string());
+/// One subscribe attempt; `None` on a refused, rejected, or failed
+/// connect (logged at `debug!` — reconnection is routine).
+async fn connect(
+    client: &reqwest::Client,
+    url: &str,
+    last_seq: Option<u64>,
+) -> Option<reqwest::Response> {
+    let mut request = client.get(url).header("accept", "text/event-stream");
+    if let Some(id) = last_seq {
+        request = request.header("last-event-id", id.to_string());
+    }
+    match request.send().await {
+        Ok(response) if response.status().is_success() => {
+            debug!(%url, cursor = ?last_seq, "event stream connected");
+            Some(response)
         }
-        let response = tokio::select! {
-            _ = tx.closed() => return,
-            sent = request.send() => sent,
-        };
-        match response {
-            Ok(response) if response.status().is_success() => {
-                debug!(%url, cursor = ?last_seq, "event stream connected");
-                read_stream(response, &tx, &mut last_seq).await;
-            }
-            Ok(response) => {
-                debug!(%url, status = %response.status(), "event stream subscribe rejected");
-            }
-            Err(e) => {
-                debug!(%url, error = %e, "event stream connect failed");
-            }
+        Ok(response) => {
+            debug!(%url, status = %response.status(), "event stream subscribe rejected");
+            None
+        }
+        Err(e) => {
+            debug!(%url, error = %e, "event stream connect failed");
+            None
+        }
+    }
+}
+
+async fn client_loop(
+    client: reqwest::Client,
+    url: String,
+    tx: mpsc::Sender<EngineEvent>,
+    first: Option<reqwest::Response>,
+) {
+    let mut last_seq: Option<u64> = None;
+    let mut connection = first;
+    loop {
+        if let Some(response) = connection.take() {
+            read_stream(response, &tx, &mut last_seq).await;
         }
         tokio::select! {
             _ = tx.closed() => return,
             () = tokio::time::sleep(RECONNECT_BACKOFF) => {}
         }
+        connection = tokio::select! {
+            _ = tx.closed() => return,
+            connected = connect(&client, &url, last_seq) => connected,
+        };
     }
 }
 
@@ -303,7 +339,7 @@ mod tests {
         }])
         .await;
 
-        let mut intake = subscribe(url);
+        let mut intake = subscribe(url).await;
         assert_eq!(
             next_event(&mut intake).await,
             EngineEvent {
@@ -341,7 +377,7 @@ mod tests {
         ])
         .await;
 
-        let mut intake = subscribe(url);
+        let mut intake = subscribe(url).await;
         for n in 1..=3 {
             assert_eq!(next_event(&mut intake).await.payload, json!({ "n": n }));
         }
@@ -354,6 +390,25 @@ mod tests {
         assert!(
             second_head.contains("last-event-id: 42"),
             "the reconnect must resume after the last seen event_seq: {second_head}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_returns_with_the_stream_already_connected() {
+        // The trigger/`until_event` contract needs the subscription live
+        // before the session's first instruction: an event emitted
+        // milliseconds into the first tool call must be captured.
+        let (url, mut heads) = spawn_sse_server(vec![Connection {
+            status: "200 OK",
+            body: "",
+            hold: true,
+        }])
+        .await;
+
+        let _intake = subscribe(url).await;
+        assert!(
+            heads.try_recv().is_ok(),
+            "subscribe must complete the initial connect before returning"
         );
     }
 
@@ -373,7 +428,7 @@ mod tests {
         ])
         .await;
 
-        let mut intake = subscribe(url);
+        let mut intake = subscribe(url).await;
         assert_eq!(next_event(&mut intake).await.event, "tick");
     }
 
@@ -394,7 +449,7 @@ mod tests {
         ])
         .await;
 
-        let intake = subscribe(url);
+        let intake = subscribe(url).await;
         // First connection established…
         heads.recv().await.unwrap();
         drop(intake);

--- a/services/session-runner/src/lib.rs
+++ b/services/session-runner/src/lib.rs
@@ -5,10 +5,11 @@
 //! Design: `docs/services/session-runner.md`; delivery plan:
 //! `docs/plans/workflow-dsl.md`. This crate ships the expression layer
 //! ([`expr`]), the document layer ([`document`]: model, validation layers
-//! 1–2, parameter binding), the engine ([`engine`] + [`blackboard`]), the
-//! SSE event client ([`events`]), and the service wiring ([`mcp_client`],
-//! [`routes`], [`config`]) behind the two-phase [`ServerBuilder`]. Still
-//! ahead in the plan: the trigger engine and resume BDD (Phase D).
+//! 1–2, parameter binding), the engine ([`engine`] + [`blackboard`],
+//! triggers included), the SSE event client ([`events`]), and the service
+//! wiring ([`mcp_client`], [`routes`], [`config`]) behind the two-phase
+//! [`ServerBuilder`]. Still ahead in the plan: the resume BDD proof
+//! (Phase D) and the deep-sky document (Phase E).
 
 pub mod blackboard;
 pub mod config;

--- a/services/session-runner/src/routes.rs
+++ b/services/session-runner/src/routes.rs
@@ -308,9 +308,10 @@ async fn invoke(
         "max_duration": humantime::format_duration(max).to_string(),
     });
 
-    // Subscribe to rp's SSE stream before the first instruction runs, so
-    // an event emitted during an early instruction still satisfies a later
-    // `until_event` wait (and, Phase D2, feeds triggers). The client task
+    // Subscribe to rp's SSE stream before the first instruction runs —
+    // the initial connect completes inside `subscribe`, so an event
+    // emitted during an early instruction still satisfies a later
+    // `until_event` wait and feeds trigger evaluation. The client task
     // lives exactly as long as the run: it exits when the intake drops.
     let events_url = config.events_url.clone().unwrap_or_else(|| {
         format!(
@@ -318,7 +319,7 @@ async fn invoke(
             rp_base_url(&request.mcp_server_url)
         )
     });
-    let intake = events::subscribe(events_url);
+    let intake = events::subscribe(events_url).await;
 
     tokio::spawn(run_session(
         document,

--- a/services/session-runner/tests/bdd/steps/event_steps.rs
+++ b/services/session-runner/tests/bdd/steps/event_steps.rs
@@ -21,6 +21,10 @@ async fn rp_running_with_fixture_workflow(world: &mut SessionRunnerWorld, workfl
     let parameters = match workflow.as_str() {
         "wait_for_exposure_event" => Some(serde_json::json!({ "camera_id": "main-cam" })),
         "wait_for_missing_event" => None,
+        "trigger_between_exposures" | "trigger_once" | "trigger_cooldown" => {
+            Some(serde_json::json!({ "camera_id": "main-cam", "filter_wheel_id": "main-fw" }))
+        }
+        "trigger_poll" => Some(serde_json::json!({ "filter_wheel_id": "main-fw" })),
         other => panic!("no registration parameters defined for fixture workflow `{other}`"),
     };
     register_orchestrator(world, &workflow, parameters);

--- a/services/session-runner/tests/bdd/steps/mod.rs
+++ b/services/session-runner/tests/bdd/steps/mod.rs
@@ -3,3 +3,4 @@
 pub mod event_steps;
 pub mod flat_calibration_steps;
 pub mod infrastructure;
+pub mod trigger_steps;

--- a/services/session-runner/tests/bdd/steps/trigger_steps.rs
+++ b/services/session-runner/tests/bdd/steps/trigger_steps.rs
@@ -1,0 +1,123 @@
+//! BDD step definitions for the trigger contract (design § Triggers): the
+//! safe-point interleaving, the `once`/`cooldown` gates, and poll sources,
+//! observed through rp's SSE stream — every fixture's trigger action is a
+//! `set_filter`, so each firing leaves a `filter_switch` frame whose
+//! stream sequence number proves ordering against the exposure events.
+
+use std::time::Duration;
+
+use bdd_infra::rp_harness::SseClient;
+use cucumber::{given, then};
+
+use crate::world::SessionRunnerWorld;
+
+#[given("an SSE client is watching rp's event stream")]
+async fn sse_client_watching(world: &mut SessionRunnerWorld) {
+    world.sse_client = Some(SseClient::connect(&world.rp_url(), None).await);
+}
+
+#[then(expr = "the SSE stream should show exactly {int} {string} event(s)")]
+async fn sse_shows_exactly_n_events(
+    world: &mut SessionRunnerWorld,
+    expected: usize,
+    event_type: String,
+) {
+    let client = world
+        .sse_client
+        .as_ref()
+        .expect("no SSE client — add the 'an SSE client is watching' step");
+
+    // The reader task consumes the stream asynchronously, so give the
+    // expected frames a moment to land…
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let count = count_events(client, &event_type).await;
+        if count >= expected || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    // …then settle briefly so an over-firing straggler would be caught by
+    // the exact-count assertion rather than sneak in after it.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let count = count_events(client, &event_type).await;
+    assert_eq!(
+        count, expected,
+        "expected exactly {expected} '{event_type}' event(s) on the SSE stream, saw {count}"
+    );
+}
+
+async fn count_events(client: &SseClient, event_type: &str) -> usize {
+    client
+        .frames()
+        .await
+        .iter()
+        .filter(|f| f.event_type().as_deref() == Some(event_type))
+        .count()
+}
+
+#[then(expr = "no {string} event should fall between an {string} and its {string}")]
+async fn no_event_inside_spans(
+    world: &mut SessionRunnerWorld,
+    needle: String,
+    span_start: String,
+    span_end: String,
+) {
+    let client = world
+        .sse_client
+        .as_ref()
+        .expect("no SSE client — add the 'an SSE client is watching' step");
+    let frames = client.frames().await;
+
+    // Pair start/end frames by operation_id — the shared id rp stamps on
+    // an operation's started/complete envelopes.
+    let mut spans = Vec::new();
+    for start in frames
+        .iter()
+        .filter(|f| f.event_type().as_deref() == Some(&span_start))
+    {
+        let operation = start
+            .operation_id()
+            .unwrap_or_else(|| panic!("a '{span_start}' frame carries no operation_id"));
+        let end = frames
+            .iter()
+            .find(|f| {
+                f.event_type().as_deref() == Some(&span_end)
+                    && f.operation_id().as_deref() == Some(&operation)
+            })
+            .unwrap_or_else(|| {
+                panic!("operation {operation} has a '{span_start}' but no '{span_end}'")
+            });
+        spans.push((seq_of(start, &span_start), seq_of(end, &span_end)));
+    }
+    assert!(
+        !spans.is_empty(),
+        "expected at least one '{span_start}'/'{span_end}' span on the SSE stream"
+    );
+
+    let needles: Vec<u64> = frames
+        .iter()
+        .filter(|f| f.event_type().as_deref() == Some(&needle))
+        .map(|f| seq_of(f, &needle))
+        .collect();
+    assert!(
+        !needles.is_empty(),
+        "expected at least one '{needle}' event to check placement for"
+    );
+    for seq in needles {
+        for (start, end) in &spans {
+            assert!(
+                !(*start < seq && seq < *end),
+                "'{needle}' at seq {seq} fell inside the '{span_start}'/'{span_end}' span \
+                 [{start}, {end}] — a trigger action ran during an in-flight instruction"
+            );
+        }
+    }
+}
+
+fn seq_of(frame: &bdd_infra::rp_harness::SseFrame, what: &str) -> u64 {
+    frame
+        .id
+        .unwrap_or_else(|| panic!("a '{what}' frame carries no stream sequence id"))
+}

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bdd_infra::rp_harness::{
     CameraConfig, CoverCalibratorConfig, FilterWheelConfig, ReceivedEvent, RpConfigBuilder,
-    WebhookReceiver,
+    SseClient, WebhookReceiver,
 };
 use bdd_infra::ServiceHandle;
 use cucumber::World;
@@ -26,6 +26,9 @@ pub struct SessionRunnerWorld {
     pub rp: Option<ServiceHandle>,
     pub session_runner: Option<ServiceHandle>,
     pub webhook_receiver: Option<WebhookReceiver>,
+    /// A test-side subscriber to rp's SSE stream, for seq-ordered
+    /// assertions on what the engine's triggers did.
+    pub sse_client: Option<SseClient>,
     /// Blackboard persistence directory for the spawned session-runner;
     /// held here so it outlives the scenario's service process.
     pub state_dir: Option<tempfile::TempDir>,

--- a/services/session-runner/tests/features/triggers.feature
+++ b/services/session-runner/tests/features/triggers.feature
@@ -1,0 +1,43 @@
+@serial
+Feature: Triggers (the reactive overlay)
+  Triggers fire while the procedure tree runs, but only at safe points: a
+  trigger action never preempts an in-flight instruction. These scenarios
+  observe firings through rp's SSE stream — every trigger action calls
+  set_filter, and the emitted filter_switch frame's stream sequence number
+  proves ordering against the exposure events.
+
+  The fixture documents live in tests/fixtures/workflows/; each pins the
+  capture counts and gate settings the expected event counts depend on.
+
+  Scenario: A trigger action runs between exposures, never during one
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "trigger_between_exposures" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    Then the session ends within 60 seconds
+    And the SSE stream should show exactly 2 "filter_switch" events
+    And no "filter_switch" event should fall between an "exposure_started" and its "exposure_complete"
+
+  Scenario: A once trigger fires at most once per session
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "trigger_once" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    Then the session ends within 60 seconds
+    And the SSE stream should show exactly 1 "filter_switch" event
+
+  Scenario: A cooldown suppresses firings inside its window
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "trigger_cooldown" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    Then the session ends within 60 seconds
+    And the SSE stream should show exactly 1 "filter_switch" event
+
+  Scenario: A poll trigger fires from a polled tool result
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "trigger_poll" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    Then the session ends within 60 seconds
+    And the SSE stream should show exactly 1 "filter_switch" event

--- a/services/session-runner/tests/fixtures/workflows/trigger_between_exposures.json
+++ b/services/session-runner/tests/fixtures/workflows/trigger_between_exposures.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "name": "trigger-between-exposures",
+  "description": "Pins the safe-point interleaving contract: the trigger fires on exposure_started (emitted while capture is in flight), so its set_filter must land after that exposure completes - filter_switch seqs fall between exposures, never inside one. The trailing wait keeps the run alive long enough for the last exposure's event to arrive over SSE and fire the trigger - a run that ends at its last instruction may legitimately miss it.",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true },
+    "filter_wheel_id": { "type": "string", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "triggers": [
+    {
+      "id": "switch-filter-between-exposures",
+      "on": { "event": "exposure_started" },
+      "do": [
+        {
+          "tool": "set_filter",
+          "args": {
+            "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+            "filter_name": "Red"
+          }
+        }
+      ]
+    }
+  ],
+  "root": {
+    "sequence": [
+      {
+        "repeat": { "count": 2 },
+        "body": [
+          {
+            "tool": "capture",
+            "args": {
+              "camera_id": { "$expr": "params.camera_id" },
+              "duration": "100ms"
+            }
+          }
+        ]
+      },
+      { "wait": { "duration": "2s" } }
+    ]
+  }
+}

--- a/services/session-runner/tests/fixtures/workflows/trigger_cooldown.json
+++ b/services/session-runner/tests/fixtures/workflows/trigger_cooldown.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "name": "trigger-cooldown",
+  "description": "Pins the cooldown gate: three captures each emit exposure_complete, but the 1h cooldown (longer than the whole session) admits only the first firing - one filter_switch on the stream.",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true },
+    "filter_wheel_id": { "type": "string", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "triggers": [
+    {
+      "id": "switch-filter-cooled",
+      "on": { "event": "exposure_complete" },
+      "cooldown": "1h",
+      "do": [
+        {
+          "tool": "set_filter",
+          "args": {
+            "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+            "filter_name": "Red"
+          }
+        }
+      ]
+    }
+  ],
+  "root": {
+    "repeat": { "count": 3 },
+    "body": [
+      {
+        "tool": "capture",
+        "args": {
+          "camera_id": { "$expr": "params.camera_id" },
+          "duration": "100ms"
+        }
+      }
+    ]
+  }
+}

--- a/services/session-runner/tests/fixtures/workflows/trigger_once.json
+++ b/services/session-runner/tests/fixtures/workflows/trigger_once.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "name": "trigger-once",
+  "description": "Pins the `once` gate: three captures each emit exposure_complete, but the trigger's set_filter runs exactly once - one filter_switch on the stream.",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true },
+    "filter_wheel_id": { "type": "string", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "triggers": [
+    {
+      "id": "switch-filter-once",
+      "on": { "event": "exposure_complete" },
+      "once": true,
+      "do": [
+        {
+          "tool": "set_filter",
+          "args": {
+            "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+            "filter_name": "Red"
+          }
+        }
+      ]
+    }
+  ],
+  "root": {
+    "repeat": { "count": 3 },
+    "body": [
+      {
+        "tool": "capture",
+        "args": {
+          "camera_id": { "$expr": "params.camera_id" },
+          "duration": "100ms"
+        }
+      }
+    ]
+  }
+}

--- a/services/session-runner/tests/fixtures/workflows/trigger_poll.json
+++ b/services/session-runner/tests/fixtures/workflows/trigger_poll.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "name": "trigger-poll",
+  "description": "Pins the poll source end-to-end: the engine polls get_filter every second during the wait, the `when` gate reads the polled result as event.*, and the firing's set_filter emits one filter_switch (`once` stops repeat firings).",
+  "parameters": {
+    "filter_wheel_id": { "type": "string", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "triggers": [
+    {
+      "id": "switch-filter-from-poll",
+      "on": {
+        "poll": {
+          "tool": "get_filter",
+          "args": { "filter_wheel_id": { "$expr": "params.filter_wheel_id" } },
+          "interval": "1s"
+        }
+      },
+      "when": "event.filter_name != null",
+      "once": true,
+      "do": [
+        {
+          "tool": "set_filter",
+          "args": {
+            "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+            "filter_name": "Blue"
+          }
+        }
+      ]
+    }
+  ],
+  "root": {
+    "wait": { "duration": "4s" }
+  }
+}


### PR DESCRIPTION
Phase D2 of `docs/plans/workflow-dsl.md` (PR 7 of the series): the engine now evaluates a document's triggers per `docs/services/session-runner.md` § Triggers.

## Engine

- **Safe-point pump** in the interpreter: after every instruction and continuously during waits, buffered events (synthetic first, then the SSE intake) are matched and gated against each trigger, due poll sources run, and queued firings execute in document order. Evaluation never re-enters — inside a `do` block the pump only drains the intake, and anything a trigger action provokes waits for the next safe point on the tree.
- **Gates**: `when` (with `once`/cooldown/already-queued checks) at queue time; `while` re-checked at fire time, so an earlier trigger's action in the same batch can retract a later one. Gate evaluation errors and non-boolean values are workflow errors — silently never-firing would hide an authoring bug.
- **Bookkeeping** under `session._triggers.<id>` (`last_fired` RFC 3339 wall time, `fired_once`), recorded on **successful action completion** — mirroring instruction `once` semantics — so cooldowns and once-flags survive resume.
- **Poll sources**: first due one interval after run start; missed cycles collapse; a trigger that cannot fire anyway skips the tool call entirely; failures (argument evaluation included) skip the cycle at `debug!`. Wait sleep segments clamp to the next poll due so polls stay on schedule. A zero `interval` is now a validation error.
- **Synthetic `correction_requested`** from tool results (`rp.md` § Corrections): `aborted` / `blocked_by_correction` + `correction` → `event.delivery = "immediate"`; `pending_correction` → `"after_current"`; evaluated at the safe point right after the carrying call.
- **Action scoping**: a `do` block starts with `result`/`error.*` null and `event.*` bound to the firing's payload, all restored afterwards. Uncaught action errors fail the session with the trigger id in the message; `try` inside the `do` block is the resilience tool.
- **Occurrence counters**: the pump now consumes events, so `until_event` matching moved from buffer scanning to per-name unconsumed-occurrence counters — "matches every event since run start" and trigger evaluation both hold. Wait budgets still measure monotonic sleep time only; trigger-action time never counts.

## Phase D1 latent race, fixed

The new BDD suite surfaced that `events::subscribe()` returned before the SSE stream was actually connected — the session's first instruction could outrun the subscription and lose events emitted milliseconds into the first tool call (the pinned contract says the subscription opens before the first instruction). The initial connect (with a 5 s connect cap) now completes inline on the `/invoke` path before the invocation is acknowledged; a failed first attempt falls through to the retry loop and never blocks the session. Pinned by a unit test and the interleaving BDD scenario.

## Tests

- 21 new unit tests: interleaving order, document-order firing, re-queue prevention, `when`/`while` gating, once-across-resume, wall-clock cooldown, action error propagation + `try` resilience, result/error/event scoping, wait-budget exclusion, poll scheduling/failure/gated-skip/arg-failure, and all three correction shapes. Corpus case for the zero poll interval.
- BDD `triggers.feature` (4 scenarios, rp + OmniSim): a trigger action lands between exposures and never during one — proved by SSE `event_seq` ordering via a stream-watching test client; `once` fires exactly once across three captures; a cooldown admits only the first firing; a poll trigger fires through its `when` gate over the polled result. Fixtures in `tests/fixtures/workflows/`.

## Docs

`docs/services/session-runner.md` § Triggers gains the implementation pins (pump, gate timing, bookkeeping, polls, corrections, scoping, waits, occurrence counters); § Event Subscription documents the inline initial connect; error-table rows for gate/action errors. Plan bullet 2 of Phase D checked with a completion note.

Gate: `bazel build //...` + `bazel test //...` green, `cargo clippy --all-targets --all-features -- -D warnings` clean, Bazel BDD suite (`--test_tag_filters=bdd`) green (8 scenarios / 47 steps).

Next (PR 8 / Phase D3): the resume BDD proof + rp-outage scenario, and filing the rp recovery-machinery gap issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)