### PR TITLE
test(session-runner): resume + rp-outage BDD scenarios (workflow DSL Phase D3)

### DIFF
--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -383,14 +383,16 @@ impl ServiceHandle {
         }
     }
 
-    /// Kill the service immediately with SIGKILL — no shutdown path runs.
+    /// Kill the service immediately and forcibly (SIGKILL on Unix,
+    /// `TerminateProcess` on Windows) — no shutdown path runs.
     ///
     /// This simulates a crash / power failure for resume and recovery
-    /// scenarios; use [`stop`](Self::stop) everywhere else (SIGKILL also
-    /// forfeits the process's coverage flush). The wait + stdout-drain
-    /// handling is delegated to `stop`: with the unblockable SIGKILL
-    /// already pending, the process can never run its SIGTERM shutdown
-    /// path, so `stop` just reaps it and joins the drain.
+    /// scenarios; use [`stop`](Self::stop) everywhere else (a forced kill
+    /// also forfeits the process's coverage flush). The wait +
+    /// stdout-drain handling is delegated to `stop`: the forced kill is
+    /// already pending and cannot be handled, so the process never runs
+    /// its graceful shutdown path — `stop` just reaps it and joins the
+    /// drain.
     pub async fn kill(&mut self) {
         if let Some(child) = self.child.as_mut() {
             let _ = child.start_kill();

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -382,6 +382,21 @@ impl ServiceHandle {
             }
         }
     }
+
+    /// Kill the service immediately with SIGKILL — no shutdown path runs.
+    ///
+    /// This simulates a crash / power failure for resume and recovery
+    /// scenarios; use [`stop`](Self::stop) everywhere else (SIGKILL also
+    /// forfeits the process's coverage flush). The wait + stdout-drain
+    /// handling is delegated to `stop`: with the unblockable SIGKILL
+    /// already pending, the process can never run its SIGTERM shutdown
+    /// path, so `stop` just reaps it and joins the drain.
+    pub async fn kill(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.start_kill();
+        }
+        self.stop().await;
+    }
 }
 
 impl Drop for ServiceHandle {

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -368,9 +368,27 @@ committable on its own.
       connect inline, before `/invoke` acknowledges — previously the
       first instruction could outrun the subscription and lose its
       events.
-- [ ] Resume: recovery invocation → blackboard reload → re-execution;
+- [x] Resume: recovery invocation → blackboard reload → re-execution;
       BDD scenarios for kill-mid-session → re-invoke → session continues
       without repeating completed work (frame counts prove it).
+
+      **Done (2026-07-06):** the engine machinery already existed
+      (recovery `/invoke` → `Blackboard::load`, eager replace for fresh
+      sessions, `params._recovery.*`, Terminated-keeps-blackboard); this
+      slice proves it end-to-end. `recovery.feature` runs a purpose-built
+      re-entrant fixture (`recovery_capture_loop`: once-marked filter
+      setup + a capture loop counting frames in the blackboard): SIGKILL
+      the engine mid-loop → restart → re-invoke with recovery → exposure
+      totals stay ≤ plan + 1 and the once marker is not re-run; and an
+      rp outage mid-loop → the request-level MCP failure terminates the
+      run (service healthy, blackboard kept) → re-invoke against the
+      restarted rp captures exactly the remaining frames. The scenarios
+      POST `/invoke` directly because **rp's recovery re-invocation
+      machinery does not exist** — its `/invoke` body hard-codes
+      `recovery: null`, nothing re-invokes on the safety safe-transition
+      or after an rp restart (session state is in-memory), and a failed
+      `/invoke` leaves the session active forever; closing that is rp
+      work, tracked in its own issue.
 
 ### Phase E — Deep-sky workflow
 

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1152,8 +1152,14 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 | Flats port equivalence | `flat_calibration.feature` | the scenarios from `calibrator-flats`' suite, run against the document — same events, frame counts, cleanup-on-failure |
 | Event subscription | `events.feature` | an `until_event` wait satisfied by an event emitted during an earlier instruction (pins subscription-from-run-start); a wait whose event never arrives fails the session at its timeout rather than hanging |
 | Triggers | `triggers.feature` | a trigger action lands between exposures, never during one (proved by SSE seq order); `once` fires exactly once across three captures; cooldown suppresses firings inside its window; a poll trigger fires through its `when` gate |
-| Resume | `recovery.feature` | kill mid-capture-loop → re-invoke with recovery → progress continues without repeated frames; `once` marker not re-run |
-| Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes |
+| Resume | `recovery.feature` | SIGKILL the engine mid-capture-loop → restart → re-invoke with recovery → progress continues without repeated frames (exposure totals prove it); `once` marker not re-run (`filter_switch` count proves it); an rp outage terminates the run (service stays healthy, blackboard kept) and the session resumes against the restarted rp |
+| Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes. **Blocked on rp**: rp has no safety re-invocation machinery yet (its `/invoke` hard-codes `recovery: null` — tracked as an rp issue); until then the engine-side path (request-level failure → terminated run → blackboard kept → recovery) is covered by `recovery.feature`'s rp-outage scenario and the unit pins |
+
+Because rp never sends a non-null `recovery` yet, the resume scenarios
+POST `/invoke` directly — same ids, the registration's forwarded
+`config`, a non-null `recovery` object — standing in for rp's future
+re-invocation. When rp grows that machinery, the scenarios hand the
+re-invoke back to rp.
 
 Scenarios that need a document the shipped set doesn't provide (a
 targeted `until_event` wait, resume fixtures) execute purpose-built

--- a/services/session-runner/tests/bdd/steps/event_steps.rs
+++ b/services/session-runner/tests/bdd/steps/event_steps.rs
@@ -25,6 +25,11 @@ async fn rp_running_with_fixture_workflow(world: &mut SessionRunnerWorld, workfl
             Some(serde_json::json!({ "camera_id": "main-cam", "filter_wheel_id": "main-fw" }))
         }
         "trigger_poll" => Some(serde_json::json!({ "filter_wheel_id": "main-fw" })),
+        // 4 × 2s exposures: slow enough to interrupt mid-loop after two
+        // recorded frames, fast enough for the suite's time budget.
+        "recovery_capture_loop" => Some(serde_json::json!({
+            "camera_id": "main-cam", "filter_wheel_id": "main-fw", "plan": 4
+        })),
         other => panic!("no registration parameters defined for fixture workflow `{other}`"),
     };
     register_orchestrator(world, &workflow, parameters);

--- a/services/session-runner/tests/bdd/steps/infrastructure.rs
+++ b/services/session-runner/tests/bdd/steps/infrastructure.rs
@@ -63,38 +63,45 @@ pub async fn configure_default_equipment(world: &mut SessionRunnerWorld) {
 /// documents from `tests/fixtures/workflows/` (the cucumber runner's cwd
 /// is the package dir — `bdd_main!` chdirs to `BDD_PACKAGE_DIR` under
 /// Bazel).
+///
+/// Both directories are created once per scenario and reused when the
+/// service is started again — a recovery scenario that kills and restarts
+/// session-runner needs the new process to find the old one's blackboard.
 pub async fn start_session_runner_service(world: &mut SessionRunnerWorld) {
     if world.session_runner.is_some() {
         return;
     }
 
-    let cwd = std::env::current_dir().expect("cannot read the cwd");
-    let workflows_dir = tempfile::tempdir().expect("cannot create a workflows_dir");
-    let mut copied = 0;
-    for source in [cwd.join("workflows"), cwd.join("tests/fixtures/workflows")] {
-        let entries = std::fs::read_dir(&source)
-            .unwrap_or_else(|e| panic!("cannot read {}: {e}", source.display()));
-        for entry in entries {
-            let path = entry.expect("cannot read a workflows entry").path();
-            if path.extension().is_some_and(|ext| ext == "json") {
-                let name = path.file_name().expect("a file has a name");
-                std::fs::copy(&path, workflows_dir.path().join(name))
-                    .unwrap_or_else(|e| panic!("cannot copy {}: {e}", path.display()));
-                copied += 1;
+    if world.workflows_dir.is_none() {
+        let cwd = std::env::current_dir().expect("cannot read the cwd");
+        let workflows_dir = tempfile::tempdir().expect("cannot create a workflows_dir");
+        let mut copied = 0;
+        for source in [cwd.join("workflows"), cwd.join("tests/fixtures/workflows")] {
+            let entries = std::fs::read_dir(&source)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", source.display()));
+            for entry in entries {
+                let path = entry.expect("cannot read a workflows entry").path();
+                if path.extension().is_some_and(|ext| ext == "json") {
+                    let name = path.file_name().expect("a file has a name");
+                    std::fs::copy(&path, workflows_dir.path().join(name))
+                        .unwrap_or_else(|e| panic!("cannot copy {}: {e}", path.display()));
+                    copied += 1;
+                }
             }
         }
+        assert!(copied > 0, "no workflow documents found to copy");
+        world.workflows_dir = Some(workflows_dir);
     }
-    assert!(copied > 0, "no workflow documents found to copy");
+    if world.state_dir.is_none() {
+        world.state_dir = Some(tempfile::tempdir().expect("cannot create a state_dir"));
+    }
 
-    let state_dir = tempfile::tempdir().expect("cannot create a state_dir");
     let config = serde_json::json!({
         "port": 0,
-        "workflows_dir": workflows_dir.path(),
-        "state_dir": state_dir.path(),
+        "workflows_dir": world.workflows_dir.as_ref().expect("just ensured").path(),
+        "state_dir": world.state_dir.as_ref().expect("just ensured").path(),
     });
     let config_path = write_temp_config_file("session-runner-config", &config).await;
-    world.workflows_dir = Some(workflows_dir);
-    world.state_dir = Some(state_dir);
 
     world.session_runner = Some(ServiceHandle::start(env!("CARGO_PKG_NAME"), &config_path).await);
 }
@@ -117,6 +124,7 @@ pub fn register_orchestrator(
     if let Some(parameters) = parameters {
         config["parameters"] = parameters;
     }
+    world.orchestrator_config = Some(config.clone());
     world.plugin_configs.push(serde_json::json!({
         "name": "session-runner",
         "type": "orchestrator",

--- a/services/session-runner/tests/bdd/steps/mod.rs
+++ b/services/session-runner/tests/bdd/steps/mod.rs
@@ -3,4 +3,5 @@
 pub mod event_steps;
 pub mod flat_calibration_steps;
 pub mod infrastructure;
+pub mod recovery_steps;
 pub mod trigger_steps;

--- a/services/session-runner/tests/bdd/steps/recovery_steps.rs
+++ b/services/session-runner/tests/bdd/steps/recovery_steps.rs
@@ -120,23 +120,32 @@ async fn reinvoke_with_recovery(world: &mut SessionRunnerWorld) {
 
 #[then("the session-runner is still healthy and the blackboard is kept")]
 async fn runner_healthy_blackboard_kept(world: &mut SessionRunnerWorld) {
-    // Give the engine a moment to hit the request-level MCP failure and
-    // terminate the run (never retried, so this is quick).
-    tokio::time::sleep(Duration::from_secs(2)).await;
-
+    // With rp dead the tool transport is gone, so run progress is
+    // physically impossible and termination itself cannot be observed
+    // from outside — the scenario proves it downstream, where the
+    // resumed run captures exactly the remaining frames. What this step
+    // pins is the engine's *reaction* to rp's loss: the process must
+    // survive and must not tear down its persisted state. Both
+    // invariants are asserted continuously across the window in which
+    // the failed tool call lands (within moments of the kill), so a
+    // crash or a blackboard deletion is caught rather than slipping
+    // between a sleep and a single check.
     let handle = world
         .session_runner
         .as_ref()
         .expect("session-runner not started");
-    let response = reqwest::get(format!("{}/health", handle.base_url))
-        .await
-        .expect("session-runner did not answer /health after rp died");
-    assert!(response.status().is_success(), "{}", response.status());
-
-    assert!(
-        world.blackboard_path().exists(),
-        "a terminated run must keep its blackboard for the recovery invocation"
-    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        let response = reqwest::get(format!("{}/health", handle.base_url))
+            .await
+            .expect("session-runner did not answer /health after rp died");
+        assert!(response.status().is_success(), "{}", response.status());
+        assert!(
+            world.blackboard_path().exists(),
+            "a terminated run must keep its blackboard for the recovery invocation"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }
 
 #[then(expr = "the blackboard is deleted within {int} seconds")]

--- a/services/session-runner/tests/bdd/steps/recovery_steps.rs
+++ b/services/session-runner/tests/bdd/steps/recovery_steps.rs
@@ -180,7 +180,10 @@ async fn sse_shows_remaining(world: &mut SessionRunnerWorld, event_type: String)
     let frames = world
         .frames_before_resume
         .expect("no pre-resume frame count — add the re-invoke step first");
-    let remaining = usize::try_from(plan - frames).expect("plan fits usize");
+    let remaining = plan.checked_sub(frames).unwrap_or_else(|| {
+        panic!("the blackboard records more frames ({frames}) than the plan ({plan})")
+    });
+    let remaining = usize::try_from(remaining).expect("plan fits usize");
 
     let count = settled_event_count(world, &event_type, remaining).await;
     assert_eq!(

--- a/services/session-runner/tests/bdd/steps/recovery_steps.rs
+++ b/services/session-runner/tests/bdd/steps/recovery_steps.rs
@@ -1,0 +1,191 @@
+//! BDD step definitions for the resume contract (design § Re-entrancy
+//! Contract): a session interrupted mid-run — the engine killed, or `rp`
+//! itself gone — continues from the persisted blackboard when re-invoked
+//! with recovery context, without repeating recorded work.
+//!
+//! `rp`'s own recovery re-invocation machinery is not implemented yet
+//! (`services/rp/src/session.rs` hard-codes `"recovery": null`), so these
+//! steps POST `/invoke` directly, standing in for it — same ids, same
+//! forwarded `config`, a non-null `recovery` object.
+
+use std::time::Duration;
+
+use cucumber::{then, when};
+
+use crate::steps::infrastructure::{start_rp_service, start_session_runner_service};
+use crate::steps::trigger_steps::settled_event_count;
+use crate::world::SessionRunnerWorld;
+
+/// How long a poll-until-observed step waits before failing the scenario.
+const OBSERVATION_BUDGET: Duration = Duration::from_secs(30);
+
+#[when(expr = "the blackboard records at least {int} frames")]
+async fn blackboard_records_frames(world: &mut SessionRunnerWorld, frames: u64) {
+    let deadline = std::time::Instant::now() + OBSERVATION_BUDGET;
+    while std::time::Instant::now() < deadline {
+        if world.blackboard_frames().await.is_some_and(|f| f >= frames) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!(
+        "the blackboard never recorded {frames} frames within {OBSERVATION_BUDGET:?} \
+         (last: {:?})",
+        world.blackboard_frames().await
+    );
+}
+
+#[when("the session-runner is killed")]
+async fn session_runner_is_killed(world: &mut SessionRunnerWorld) {
+    world
+        .session_runner
+        .as_mut()
+        .expect("session-runner not started")
+        .kill()
+        .await;
+    world.session_runner = None;
+}
+
+#[when("the session-runner is restarted")]
+async fn session_runner_is_restarted(world: &mut SessionRunnerWorld) {
+    assert!(
+        world.session_runner.is_none(),
+        "restart follows a kill — the previous instance is still recorded as running"
+    );
+    // Reuses the scenario's state_dir, so the new process finds the old
+    // one's blackboard (and its workflows_dir, so the document resolves).
+    start_session_runner_service(world).await;
+}
+
+#[when("rp is killed")]
+async fn rp_is_killed(world: &mut SessionRunnerWorld) {
+    world.rp.as_mut().expect("rp not started").kill().await;
+    world.rp = None;
+    // The SSE client died with rp; drop it so a later "watching rp's event
+    // stream" step attaches a fresh one to the restarted instance.
+    world.sse_client = None;
+}
+
+#[when("rp is restarted")]
+async fn rp_is_restarted(world: &mut SessionRunnerWorld) {
+    assert!(
+        world.rp.is_none(),
+        "restart follows a kill — the previous instance is still recorded as running"
+    );
+    // Same accumulated config (equipment + the orchestrator registration),
+    // fresh process on a fresh port. rp's session state is in-memory, so
+    // the restarted instance knows nothing of the interrupted session —
+    // exactly the outage being simulated.
+    start_rp_service(world).await;
+}
+
+#[when("the session is re-invoked with recovery context")]
+async fn reinvoke_with_recovery(world: &mut SessionRunnerWorld) {
+    // The engine is down (or terminated the run), so the persisted frame
+    // counter is stable — note it: the resumed run must capture exactly
+    // the remaining `plan - frames` exposures.
+    let frames = world
+        .blackboard_frames()
+        .await
+        .expect("no persisted frame counter to resume from");
+    world.frames_before_resume = Some(frames);
+
+    let handle = world
+        .session_runner
+        .as_ref()
+        .expect("session-runner not started");
+    let body = serde_json::json!({
+        "workflow_id": world.workflow_id(),
+        "session_id": world.session_id(),
+        "mcp_server_url": format!("{}/mcp", world.rp_url()),
+        "recovery": { "reason": "test-injected interruption" },
+        "config": world
+            .orchestrator_config
+            .clone()
+            .expect("no orchestrator registration recorded"),
+    });
+    let response = reqwest::Client::new()
+        .post(format!("{}/invoke", handle.base_url))
+        .json(&body)
+        .send()
+        .await
+        .expect("failed to POST /invoke");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "the recovery invocation was not acknowledged: {:?}",
+        response.text().await
+    );
+}
+
+#[then("the session-runner is still healthy and the blackboard is kept")]
+async fn runner_healthy_blackboard_kept(world: &mut SessionRunnerWorld) {
+    // Give the engine a moment to hit the request-level MCP failure and
+    // terminate the run (never retried, so this is quick).
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let handle = world
+        .session_runner
+        .as_ref()
+        .expect("session-runner not started");
+    let response = reqwest::get(format!("{}/health", handle.base_url))
+        .await
+        .expect("session-runner did not answer /health after rp died");
+    assert!(response.status().is_success(), "{}", response.status());
+
+    assert!(
+        world.blackboard_path().exists(),
+        "a terminated run must keep its blackboard for the recovery invocation"
+    );
+}
+
+#[then(expr = "the blackboard is deleted within {int} seconds")]
+async fn blackboard_deleted_within(world: &mut SessionRunnerWorld, seconds: u64) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(seconds);
+    while std::time::Instant::now() < deadline {
+        if !world.blackboard_path().exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "the blackboard still exists after {seconds}s — the session did not complete \
+         (or the completion was not acknowledged)"
+    );
+}
+
+#[then(expr = "the SSE stream should show between {int} and {int} {string} events")]
+async fn sse_shows_between(
+    world: &mut SessionRunnerWorld,
+    minimum: usize,
+    maximum: usize,
+    event_type: String,
+) {
+    let count = settled_event_count(world, &event_type, minimum).await;
+    assert!(
+        (minimum..=maximum).contains(&count),
+        "expected between {minimum} and {maximum} '{event_type}' events on the SSE \
+         stream, saw {count}"
+    );
+}
+
+#[then(expr = "the SSE stream should show only the remaining {string} events")]
+async fn sse_shows_remaining(world: &mut SessionRunnerWorld, event_type: String) {
+    let plan = world
+        .orchestrator_config
+        .as_ref()
+        .and_then(|c| c.pointer("/parameters/plan"))
+        .and_then(serde_json::Value::as_u64)
+        .expect("the registered workflow carries no `plan` parameter");
+    let frames = world
+        .frames_before_resume
+        .expect("no pre-resume frame count — add the re-invoke step first");
+    let remaining = usize::try_from(plan - frames).expect("plan fits usize");
+
+    let count = settled_event_count(world, &event_type, remaining).await;
+    assert_eq!(
+        count, remaining,
+        "expected exactly the {remaining} remaining '{event_type}' events \
+         ({plan} planned, {frames} already recorded), saw {count}"
+    );
+}

--- a/services/session-runner/tests/bdd/steps/trigger_steps.rs
+++ b/services/session-runner/tests/bdd/steps/trigger_steps.rs
@@ -7,11 +7,14 @@
 use std::time::Duration;
 
 use bdd_infra::rp_harness::SseClient;
-use cucumber::{given, then};
+use cucumber::{given, then, when};
 
 use crate::world::SessionRunnerWorld;
 
+// Also a `when`: the recovery scenarios attach a fresh client mid-scenario
+// after restarting rp (the old client died with the old instance).
 #[given("an SSE client is watching rp's event stream")]
+#[when("an SSE client is watching rp's event stream")]
 async fn sse_client_watching(world: &mut SessionRunnerWorld) {
     world.sse_client = Some(SseClient::connect(&world.rp_url(), None).await);
 }
@@ -22,30 +25,37 @@ async fn sse_shows_exactly_n_events(
     expected: usize,
     event_type: String,
 ) {
+    let count = settled_event_count(world, &event_type, expected).await;
+    assert_eq!(
+        count, expected,
+        "expected exactly {expected} '{event_type}' event(s) on the SSE stream, saw {count}"
+    );
+}
+
+/// Wait (bounded) for at least `expected` events of the given type on the
+/// scenario's SSE client — the reader task consumes the stream
+/// asynchronously — then settle briefly so an over-firing straggler is
+/// caught by the caller's count assertion rather than sneaking in after
+/// it. Returns the final count.
+pub async fn settled_event_count(
+    world: &SessionRunnerWorld,
+    event_type: &str,
+    expected: usize,
+) -> usize {
     let client = world
         .sse_client
         .as_ref()
         .expect("no SSE client — add the 'an SSE client is watching' step");
-
-    // The reader task consumes the stream asynchronously, so give the
-    // expected frames a moment to land…
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     loop {
-        let count = count_events(client, &event_type).await;
+        let count = count_events(client, event_type).await;
         if count >= expected || std::time::Instant::now() >= deadline {
             break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    // …then settle briefly so an over-firing straggler would be caught by
-    // the exact-count assertion rather than sneak in after it.
     tokio::time::sleep(Duration::from_millis(500)).await;
-
-    let count = count_events(client, &event_type).await;
-    assert_eq!(
-        count, expected,
-        "expected exactly {expected} '{event_type}' event(s) on the SSE stream, saw {count}"
-    );
+    count_events(client, event_type).await
 }
 
 async fn count_events(client: &SseClient, event_type: &str) -> usize {

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -172,6 +172,14 @@ impl SessionRunnerWorld {
     pub async fn blackboard_frames(&self) -> Option<u64> {
         let bytes = tokio::fs::read(self.blackboard_path()).await.ok()?;
         let session: Value = serde_json::from_slice(&bytes).ok()?;
-        session.get("frames")?.as_f64().map(|f| f as u64)
+        // The engine's expression layer stores numbers as f64 (`2.0`,
+        // not `2`), so `as_u64()` would reject every real counter;
+        // accept exactly-integral values and fail loud on anything else.
+        let frames = session.get("frames")?.as_f64()?;
+        assert!(
+            frames >= 0.0 && frames.fract() == 0.0,
+            "the blackboard's `frames` is not a whole non-negative number: {frames}"
+        );
+        Some(frames as u64)
     }
 }

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -42,6 +42,16 @@ pub struct SessionRunnerWorld {
     pub filter_wheels: Vec<FilterWheelConfig>,
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
     pub plugin_configs: Vec<Value>,
+    /// The orchestrator registration's `config` object (workflow name +
+    /// parameters), kept so the recovery scenarios can re-invoke the
+    /// session with the exact object rp forwarded on the first invocation.
+    pub orchestrator_config: Option<Value>,
+
+    // --- Recovery scenario state ---
+    /// The blackboard's frame counter, read just before a recovery
+    /// re-invocation — the resumed run must capture exactly
+    /// `plan - frames_before_resume` more exposures.
+    pub frames_before_resume: Option<u64>,
 
     // --- Webhook state ---
     pub received_events: Arc<RwLock<Vec<ReceivedEvent>>>,
@@ -127,5 +137,41 @@ impl SessionRunnerWorld {
             }
         }
         false
+    }
+
+    /// The `session_id` from the last `/api/session/start` response.
+    pub fn session_id(&self) -> String {
+        self.start_response_field("session_id")
+    }
+
+    /// The `workflow_id` from the last `/api/session/start` response.
+    pub fn workflow_id(&self) -> String {
+        self.start_response_field("workflow_id")
+    }
+
+    fn start_response_field(&self, field: &str) -> String {
+        self.last_api_body
+            .as_ref()
+            .and_then(|body| body.get(field))
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("no `{field}` captured — start a session via the REST API"))
+            .to_owned()
+    }
+
+    /// The spawned session-runner's blackboard file for the current session.
+    pub fn blackboard_path(&self) -> std::path::PathBuf {
+        self.state_dir
+            .as_ref()
+            .expect("session-runner must be started before reading its state_dir")
+            .path()
+            .join(format!("{}.json", self.session_id()))
+    }
+
+    /// The persisted `session.frames` counter, when the blackboard file
+    /// exists and carries one.
+    pub async fn blackboard_frames(&self) -> Option<u64> {
+        let bytes = tokio::fs::read(self.blackboard_path()).await.ok()?;
+        let session: Value = serde_json::from_slice(&bytes).ok()?;
+        session.get("frames")?.as_f64().map(|f| f as u64)
     }
 }

--- a/services/session-runner/tests/features/recovery.feature
+++ b/services/session-runner/tests/features/recovery.feature
@@ -1,0 +1,38 @@
+@serial
+Feature: Resume (the re-entrancy contract)
+  A session interrupted mid-run continues from the persisted blackboard
+  when re-invoked with recovery context: re-execution from the root skips
+  once-marked setup and picks the capture loop up at the recorded frame
+  count instead of starting over.
+
+  rp's own recovery re-invocation machinery is not implemented yet, so
+  these scenarios POST /invoke directly, standing in for it. The fixture
+  document (recovery_capture_loop, tests/fixtures/workflows/) plans 4
+  frames of 2s each; its progress counter lives in session.frames.
+
+  Scenario: A killed engine resumes without repeating recorded frames
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "recovery_capture_loop" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    And the blackboard records at least 2 frames
+    And the session-runner is killed
+    And the session-runner is restarted
+    And the session is re-invoked with recovery context
+    Then the session ends within 60 seconds
+    And the SSE stream should show between 4 and 5 "exposure_complete" events
+    And the SSE stream should show exactly 1 "filter_switch" event
+    And the blackboard is deleted within 10 seconds
+
+  Scenario: An rp outage terminates the run; the session resumes against the restarted rp
+    Given a running Alpaca simulator
+    And rp is running with a camera and the session-runner orchestrator running the "recovery_capture_loop" workflow
+    When a session is started via the REST API
+    And the blackboard records at least 2 frames
+    And rp is killed
+    Then the session-runner is still healthy and the blackboard is kept
+    When rp is restarted
+    And an SSE client is watching rp's event stream
+    And the session is re-invoked with recovery context
+    Then the blackboard is deleted within 60 seconds
+    And the SSE stream should show only the remaining "exposure_complete" events

--- a/services/session-runner/tests/fixtures/workflows/recovery_capture_loop.json
+++ b/services/session-runner/tests/fixtures/workflows/recovery_capture_loop.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "name": "recovery-capture-loop",
+  "description": "Re-entrancy fixture for the resume scenarios: a once-marked filter setup plus a capture loop whose progress counter lives in the blackboard. Interrupted and re-invoked with recovery context, the loop continues from the persisted count instead of starting over - the exposure totals prove it, and the filter_switch count proves the once marker was not re-run. Exposures are 2s so a scenario can reliably interrupt mid-loop.",
+  "parameters": {
+    "camera_id": { "type": "string", "required": true },
+    "filter_wheel_id": { "type": "string", "required": true },
+    "plan": { "type": "number", "required": true }
+  },
+  "estimated_duration": "1m",
+  "max_duration": "10m",
+  "root": {
+    "sequence": [
+      {
+        "tool": "set_filter",
+        "args": {
+          "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+          "filter_name": "Red"
+        },
+        "once": "setup-filter"
+      },
+      {
+        "set": {
+          "session.frames": "has(session.frames) ? session.frames : 0"
+        }
+      },
+      {
+        "repeat": { "while": "session.frames < params.plan", "max_iterations": 20 },
+        "body": [
+          {
+            "tool": "capture",
+            "args": {
+              "camera_id": { "$expr": "params.camera_id" },
+              "duration": "2s"
+            }
+          },
+          { "set": { "session.frames": "session.frames + 1" } }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Phase D3 of `docs/plans/workflow-dsl.md` — the last Phase D slice. The engine's resume machinery already existed (recovery `/invoke` → blackboard reload, eager replace for fresh sessions, `params._recovery.*`, Terminated-keeps-blackboard); this PR proves it end-to-end and truths-up the docs.

## recovery.feature (new)

Both scenarios run a purpose-built re-entrant fixture (`recovery_capture_loop`: a once-marked `set_filter` + a capture loop counting frames in `session.frames`, 4 × 2s exposures — slow enough to interrupt mid-loop):

- **Killed engine resumes**: SIGKILL session-runner once the blackboard records ≥ 2 frames → restart (same `state_dir`) → re-invoke with recovery context → the loop continues from the persisted counter. Proof: `exposure_complete` totals stay ≤ plan + 1 (a fresh run would add plan + N), exactly one `filter_switch` (the once marker is not re-run), blackboard deleted on the acknowledged completion.
- **rp outage**: kill rp mid-loop → the request-level MCP failure terminates the run — session-runner stays healthy, blackboard kept — → restart rp → re-invoke → exactly the remaining `plan − K` frames are captured (K read from the blackboard before the re-invoke), blackboard deleted.

The scenarios POST `/invoke` directly, standing in for rp's recovery re-invocation machinery, which does not exist yet: `services/rp/src/session.rs` hard-codes `"recovery": null`, nothing re-invokes on the safety safe-transition or after an rp restart (session state is in-memory), and a failed `/invoke` leaves the session active forever. That gap is rp work — issue text is drafted and will be filed separately; `safety.feature` stays blocked on it (noted in the design doc's testing table).

## Supporting changes

- **bdd-infra**: `ServiceHandle::kill()` — immediate SIGKILL, the crash-simulation path (`stop()` remains the graceful default).
- **session-runner BDD harness**: `start_session_runner_service` reuses the scenario's `state_dir`/`workflows_dir` so a restarted process finds the old blackboard; the orchestrator registration's `config` is kept for re-invocation; blackboard path/frames world helpers; the SSE settle-and-count helper is shared out of `trigger_steps`; the SSE-watch step registered for both Given and When (mid-scenario reattach after an rp restart).
- **docs**: design-doc testing table Resume/Safety rows truth-up + the stand-in pin; plan Phase D bullet 3 checked with the rp-gap note.

Gate: `bazel build //...` + `bazel test //...` (70/70, BDD suites included), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` all green. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)