### PR TITLE
feat(rp): safety recovery — interrupt on unsafe, re-invoke on safe, /invoke retry

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -524,7 +524,7 @@
           "FILE:@@//services/qhy-focuser/Cargo.toml aa7bfea0140f581f61318acc2f14b22b90afbf0ed43e8fd7c8b7b0ee008cd0a0",
           "FILE:@@//services/calibrator-flats/Cargo.toml 66296d3389d9f2a6fc0a1f94059e82a822b871c8509c2abf72d6f0b387cdff74",
           "FILE:@@//services/dsd-fp2/Cargo.toml b987ddce744ec9aac54301c035b46bf5b05f00336782281f88d17b84d235464c",
-          "FILE:@@//services/rp/Cargo.toml 5cd59b0daa28b533cf271a3c8c3546ad20954eeedd4d46ba7ad739b6538677d3",
+          "FILE:@@//services/rp/Cargo.toml 7eab583550f0b23bb2c42276564edee22c2185bff53db519010f56972c78f115",
           "FILE:@@//services/plate-solver/Cargo.toml a749de9b36138fbc21fe64b0617839bb06b13b0f8def08eb28bfd36ceb4dca91",
           "FILE:@@//services/sentinel/Cargo.toml 1d3a0438ab0ab5d71628a08c6b867f874639277c8a976e6b416773613a4257c3",
           "FILE:@@//services/session-runner/Cargo.toml 51ba117ff19bf1126e68352cd7810910a63b584c2977331b0a43e265c0d35a3e",

--- a/crates/bdd-infra/src/rp_harness/config.rs
+++ b/crates/bdd-infra/src/rp_harness/config.rs
@@ -74,6 +74,14 @@ pub struct MountConfig {
     pub settle_after_slew: Option<std::time::Duration>,
 }
 
+/// Safety-monitor equipment entry.
+#[derive(Debug, Clone)]
+pub struct SafetyMonitorConfig {
+    pub id: String,
+    pub alpaca_url: String,
+    pub device_number: u32,
+}
+
 /// Plate-solver service config — emitted as the top-level
 /// `plate_solver` block in rp's JSON config (parallel to `mount`,
 /// `guider`, etc.; the plate solver is an rp-managed service, not
@@ -97,6 +105,12 @@ pub struct RpConfigBuilder {
     pub filter_wheels: Vec<FilterWheelConfig>,
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
     pub focusers: Vec<FocuserConfig>,
+    /// Safety monitors gating the session (see rp.md § Safety).
+    pub safety_monitors: Vec<SafetyMonitorConfig>,
+    /// Override `safety.poll_interval` in the emitted rp config.
+    /// `None` ⇒ rp's default (10 s). Safety scenarios pin this short
+    /// (~250 ms) so unsafe/safe transitions are detected quickly.
+    pub safety_poll_interval: Option<std::time::Duration>,
     /// Singular mount — at most one per `rp` deployment.
     pub mount: Option<MountConfig>,
     /// Optional plate-solver service config. `None` ⇒ omit the
@@ -148,6 +162,19 @@ impl RpConfigBuilder {
 
     pub fn add_focuser(&mut self, foc: FocuserConfig) -> &mut Self {
         self.focusers.push(foc);
+        self
+    }
+
+    pub fn add_safety_monitor(&mut self, sm: SafetyMonitorConfig) -> &mut Self {
+        self.safety_monitors.push(sm);
+        self
+    }
+
+    /// Override rp's safety poll interval (overwrites any prior call).
+    /// When unset, the emitted `safety` block is empty and rp's default
+    /// (10 s) applies.
+    pub fn with_safety_poll_interval(&mut self, interval: std::time::Duration) -> &mut Self {
+        self.safety_poll_interval = Some(interval);
         self
     }
 
@@ -284,6 +311,23 @@ impl RpConfigBuilder {
             })
             .collect();
 
+        let safety_monitors: Vec<Value> = self
+            .safety_monitors
+            .iter()
+            .map(|sm| {
+                serde_json::json!({
+                    "id": sm.id,
+                    "alpaca_url": sm.alpaca_url,
+                    "device_number": sm.device_number,
+                })
+            })
+            .collect();
+
+        let mut safety = serde_json::json!({});
+        if let Some(poll) = self.safety_poll_interval {
+            safety["poll_interval"] = serde_json::json!(format!("{}ms", poll.as_millis()));
+        }
+
         let pid = std::process::id();
         let seq = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
 
@@ -323,7 +367,7 @@ impl RpConfigBuilder {
                 "focusers": focusers,
                 "filter_wheels": filter_wheels,
                 "cover_calibrators": cover_calibrators,
-                "safety_monitors": []
+                "safety_monitors": safety_monitors
             },
             "plugins": self.plugin_configs,
             "targets": [],
@@ -333,12 +377,7 @@ impl RpConfigBuilder {
                 "prefer_transiting": true,
                 "minimize_filter_changes": true
             },
-            "safety": {
-                "polling_interval_secs": 10,
-                "park_on_unsafe": true,
-                "resume_on_safe": true,
-                "resume_delay_secs": 300
-            },
+            "safety": safety,
             "server": {
                 "port": 0,
                 "bind_address": "127.0.0.1"
@@ -599,6 +638,33 @@ mod tests {
         let c = &cfg["centering"];
         assert_eq!(c["solve_time_estimate"], "1000ms");
         assert_eq!(c["slew_overhead_estimate"], "500ms");
+    }
+
+    #[test]
+    fn safety_block_empty_and_no_monitors_by_default() {
+        let cfg = RpConfigBuilder::new().build();
+        assert_eq!(cfg["safety"], serde_json::json!({}));
+        assert!(cfg["equipment"]["safety_monitors"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn safety_monitor_and_poll_interval_are_emitted() {
+        let mut b = RpConfigBuilder::new();
+        b.add_safety_monitor(SafetyMonitorConfig {
+            id: "weather-watcher".to_string(),
+            alpaca_url: "http://127.0.0.1:32323".to_string(),
+            device_number: 0,
+        });
+        b.with_safety_poll_interval(std::time::Duration::from_millis(250));
+        let cfg = b.build();
+        let sm = &cfg["equipment"]["safety_monitors"][0];
+        assert_eq!(sm["id"], "weather-watcher");
+        assert_eq!(sm["alpaca_url"], "http://127.0.0.1:32323");
+        assert_eq!(sm["device_number"], 0);
+        assert_eq!(cfg["safety"]["poll_interval"], "250ms");
     }
 
     #[test]

--- a/crates/bdd-infra/src/rp_harness/mod.rs
+++ b/crates/bdd-infra/src/rp_harness/mod.rs
@@ -33,7 +33,7 @@ mod webhook;
 
 pub use config::{
     build_calibrator_flats_config, CameraConfig, CoverCalibratorConfig, FilterWheelConfig,
-    FocuserConfig, MountConfig, PlateSolverConfig, RpConfigBuilder,
+    FocuserConfig, MountConfig, PlateSolverConfig, RpConfigBuilder, SafetyMonitorConfig,
 };
 pub use launcher::{start_rp, wait_for_rp_healthy, write_temp_config_file};
 pub use mcp_client::McpTestClient;

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -35,7 +35,7 @@ static OMNISIM: OnceCell<OmniSimProcess> = OnceCell::const_new();
 /// Process-wide serialization of `/restart` PUTs. OmniSim's restart
 /// handler (`DriverManager.Load{Class}(n)`) mutates unsynchronised
 /// process-wide static state, so concurrent restarts race inside the
-/// simulator. `reset_all_devices` already issues its 5 PUTs
+/// simulator. `reset_all_devices` already issues its per-device PUTs
 /// sequentially (#171), but that only serialises *within* one hook —
 /// cucumber runs untagged scenarios concurrently, and every
 /// concurrently-drawn scenario runs its own before-hook. In the
@@ -98,14 +98,24 @@ impl OmniSimHandle {
         Self::restart_device("covercalibrator", 0).await
     }
 
+    /// Reset the safety-monitor simulator device 0 to its OmniSim default
+    /// state. `restart` reloads the device from its persisted profile, and
+    /// [`Self::set_safety_monitor_is_safe`] writes only the in-memory
+    /// setting — so this restores the profile's `IsSafe` (true in our
+    /// seeded config) after a safety scenario flipped it.
+    pub async fn reset_safety_monitor() -> Result<(), String> {
+        Self::restart_device("safetymonitor", 0).await
+    }
+
     /// Reset every device class our BDD suites currently exercise
-    /// (telescope, camera, filter wheel, focuser, cover calibrator) to
-    /// OmniSim defaults. Issued **sequentially** — one PUT at a time.
+    /// (telescope, camera, filter wheel, focuser, cover calibrator,
+    /// safety monitor) to OmniSim defaults. Issued **sequentially** —
+    /// one PUT at a time.
     ///
     /// Why not parallel? OmniSim's `DriverManager.Load{Class}(n)`
     /// mutates a process-wide `static List<AlpacaConfiguredDevice>
     /// AlpacaDevices` via unsynchronised `List.Remove(...)` +
-    /// `List.Add(...)`. When two of our 5 PUTs landed on different
+    /// `List.Add(...)`. When two of our PUTs landed on different
     /// Kestrel threads they raced inside that list, leaving a `null`
     /// entry that the management endpoint then serialised verbatim
     /// into `configureddevices` responses. rp's deserialiser hit
@@ -118,8 +128,8 @@ impl OmniSimHandle {
     /// end-of-run burst of non-`@serial` scenarios deadlocked OmniSim
     /// on the Pi nightly (#431).
     ///
-    /// The wall-time cost is small: 5 localhost round-trips serialised
-    /// is ~10-25 ms per scenario depending on runner.
+    /// The wall-time cost is small: 6 localhost round-trips serialised
+    /// is ~10-30 ms per scenario depending on runner.
     ///
     /// Errors are collected and returned. **Exception:** when the
     /// shared `OMNISIM` singleton has not been initialised yet (i.e.
@@ -133,9 +143,9 @@ impl OmniSimHandle {
     /// failure is fatal — that's the loud-reset behaviour from #172
     /// that catches state leakage between scenarios.
     ///
-    /// Other device classes (dome, rotator, switch, observingconditions,
-    /// safetymonitor) also expose `/restart`, but our scenarios don't
-    /// touch them yet; add a call here when that changes.
+    /// Other device classes (dome, rotator, switch, observingconditions)
+    /// also expose `/restart`, but our scenarios don't touch them yet;
+    /// add a call here when that changes.
     pub async fn reset_all_devices() -> Result<(), Vec<String>> {
         let omnisim_was_started = OMNISIM.get().is_some();
         let mut errors: Vec<String> = Vec::new();
@@ -145,6 +155,7 @@ impl OmniSimHandle {
             Self::reset_filter_wheel().await,
             Self::reset_focuser().await,
             Self::reset_cover_calibrator().await,
+            Self::reset_safety_monitor().await,
         ];
         for result in results {
             if let Err(e) = result {
@@ -186,6 +197,53 @@ impl OmniSimHandle {
             .map(|p| p.base_url.clone())
             .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT));
         Self::restart_device_at(&base_url, class, n).await
+    }
+
+    /// Set what the safety-monitor simulator device 0 reports for
+    /// `IsSafe`, via OmniSim's private
+    /// `PUT /simulator/v1/safetymonitor/{n}/issafesetting` endpoint.
+    ///
+    /// This writes the device's in-memory setting only (OmniSim persists
+    /// it to the profile on its own save path, which this endpoint does
+    /// not trigger), so [`Self::reset_safety_monitor`] — or the next
+    /// process restart — restores the profile default (safe). Safety
+    /// scenarios still set `true` explicitly during setup so they never
+    /// depend on reset ordering.
+    pub async fn set_safety_monitor_is_safe(is_safe: bool) -> Result<(), String> {
+        let base_url = OMNISIM
+            .get()
+            .map(|p| p.base_url.clone())
+            .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT));
+        Self::set_safety_monitor_is_safe_at(&base_url, 0, is_safe).await
+    }
+
+    /// `set_safety_monitor_is_safe` extracted to take an explicit
+    /// `base_url` and device number so unit tests can drive the HTTP
+    /// path against an axum stub without touching the global `OMNISIM`
+    /// singleton.
+    async fn set_safety_monitor_is_safe_at(
+        base_url: &str,
+        n: u32,
+        is_safe: bool,
+    ) -> Result<(), String> {
+        let url = format!(
+            "{}/simulator/v1/safetymonitor/{}/issafesetting",
+            base_url, n
+        );
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|e| format!("reqwest client build failed: {e}"))?;
+        let resp = client
+            .put(&url)
+            .form(&[("IsSafeSetting", if is_safe { "true" } else { "false" })])
+            .send()
+            .await
+            .map_err(|e| format!("PUT {url} failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("PUT {url} returned HTTP {}", resp.status()));
+        }
+        Ok(())
     }
 
     /// `restart_device` extracted to take an explicit `base_url` so unit
@@ -619,6 +677,72 @@ mod tests {
             0,
             "restart PUTs overlapped despite RESTART_SERIALIZER"
         );
+        let _ = tx.send(());
+    }
+
+    #[tokio::test]
+    async fn set_safety_monitor_is_safe_puts_form_value() {
+        use axum::Form;
+        use std::collections::HashMap;
+
+        let (tx_seen, rx_seen) = tokio::sync::oneshot::channel::<String>();
+        let tx_seen = std::sync::Arc::new(std::sync::Mutex::new(Some(tx_seen)));
+        let app = Router::new().route(
+            "/simulator/v1/safetymonitor/0/issafesetting",
+            put(move |Form(form): Form<HashMap<String, String>>| {
+                let tx_seen = tx_seen.clone();
+                async move {
+                    if let Some(tx) = tx_seen.lock().unwrap().take() {
+                        let _ = tx.send(form.get("IsSafeSetting").cloned().unwrap_or_default());
+                    }
+                    StatusCode::OK
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        OmniSimHandle::set_safety_monitor_is_safe_at(&base_url, 0, false)
+            .await
+            .unwrap();
+        assert_eq!(rx_seen.await.unwrap(), "false");
+        let _ = tx.send(());
+    }
+
+    #[tokio::test]
+    async fn set_safety_monitor_is_safe_returns_err_on_server_error() {
+        let route = "/simulator/v1/safetymonitor/0/issafesetting";
+        let app = Router::new().route(
+            route,
+            put(move || async move { StatusCode::INTERNAL_SERVER_ERROR }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        let err = OmniSimHandle::set_safety_monitor_is_safe_at(&base_url, 0, true)
+            .await
+            .expect_err("expected an error for 500 response");
+        assert!(err.contains("500"), "expected 500 in error: {err}");
         let _ = tx.send(());
     }
 

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -383,12 +383,20 @@ committable on its own.
       rp outage mid-loop → the request-level MCP failure terminates the
       run (service healthy, blackboard kept) → re-invoke against the
       restarted rp captures exactly the remaining frames. The scenarios
-      POST `/invoke` directly because **rp's recovery re-invocation
-      machinery does not exist** — its `/invoke` body hard-codes
-      `recovery: null`, nothing re-invokes on the safety safe-transition
-      or after an rp restart (session state is in-memory), and a failed
-      `/invoke` leaves the session active forever; closing that is rp
-      work, tracked in its own issue.
+      POST `/invoke` directly because rp's recovery re-invocation
+      machinery did not exist at the time.
+
+      **Follow-up (2026-07-07):** rp's safety-recovery machinery is now
+      implemented (rp.md § Safety): SafetyMonitor polling, unsafe →
+      MCP-session termination + `/mcp` 503 gate + session `interrupted`,
+      safe → re-invocation with `recovery.reason = "safety_interruption"`,
+      and a failed `/invoke` now returns the session to idle
+      (`session_stopped` / `orchestrator_invoke_failed`) instead of
+      wedging it active. `recovery.feature` gained the end-to-end safety
+      interruption + resume scenario through rp's real machinery; rp's own
+      `safety.feature` pins the rp-side contract. Still deferred: rp-side
+      *startup* recovery (session registry is in-memory; rp.md § Recovery
+      Behavior).
 
 ### Phase E — Deep-sky workflow
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -1568,8 +1568,20 @@ Content-Type: application/json
 }
 ```
 
-On recovery after a safety event or power failure, `recovery` contains
-the last known session state so the orchestrator can resume.
+On recovery re-invocation `recovery` is a non-null object carrying the
+reason for the interruption (today `{"reason": "safety_interruption"}`,
+emitted when a safety monitor returns to safe — see § Safety). `rp`
+keeps no per-workflow progress of its own; the orchestrator persists
+whatever state it needs to resume (for `session-runner` that is the
+blackboard, keyed by the unchanged `session_id`) and receives the same
+`workflow_id`/`session_id`/`config` as the original invocation.
+
+The invoke POST is retried on transport errors and 5xx responses
+(3 attempts, 1 s apart); a 4xx response is treated as permanent. If
+all attempts fail, the session returns to `idle` and a
+`session_stopped` event with `reason: "orchestrator_invoke_failed"`
+is emitted — a session never sits `active` with an orchestrator that
+was never reached.
 
 `config` is the orchestrator's registered `config` object, passed through
 verbatim — `rp` never interprets it. The key is always present: when the
@@ -1676,9 +1688,12 @@ in the catalog. Safety is enforced at the tool level, universally:
   cancels the workflow, moves equipment to a safe state, and proceeds
   with the next orchestration phase. The MCP session is terminated.
 - **Safety override**: a safety event (unsafe transition) immediately
-  cancels any active workflow. The MCP session is terminated — the
-  plugin's next tool call returns an error indicating the workflow was
-  cancelled.
+  cancels any active workflow. Every open MCP session is closed
+  (cancelling in-flight tool calls) and the `/mcp` endpoint rejects all
+  requests with `503` while conditions remain unsafe — the plugin's
+  next tool call surfaces as a terminated session. The session itself
+  is *interrupted*, not ended: on the safe transition `rp` re-invokes
+  the orchestrator with recovery context (see § Safety).
 
 ### Config-Time Validation
 
@@ -1855,9 +1870,10 @@ User starts session via API
   → rp emits events as tools execute (exposure_started, slew_complete, etc.)
 
 Safety event (unsafe transition)
-  → rp immediately: aborts exposures, stops guiding, parks mount
-  → rp terminates the orchestrator's MCP session
-  → rp persists session state
+  → rp terminates the orchestrator's MCP sessions and gates /mcp
+  → rp aborts in-progress exposures (guiding stop / mount park planned)
+  → the session is marked interrupted; the orchestrator's own persisted
+    state (e.g. session-runner's blackboard) survives
   → on safe transition: rp re-invokes the orchestrator with recovery context
 
 Session ends (orchestrator completes, user stops, or dawn)
@@ -2823,6 +2839,14 @@ The application must survive power failures and resume from where it left off.
 
 ### Recovery Behavior
 
+> **Status:** designed, not yet implemented. `rp`'s session registry is
+> in-memory today, so an `rp` restart orphans an interrupted session —
+> the orchestrator's own persisted state (e.g. `session-runner`'s
+> blackboard) survives and the session can be resumed by re-invoking
+> the orchestrator, but `rp` does not yet do so on startup. The
+> safety-event recovery path (terminate on unsafe, re-invoke on safe
+> within one `rp` process) **is** implemented — see § Safety.
+
 On startup, `rp` checks for an existing session state file:
 
 1. If no session file exists, start fresh (wait for user to start a session).
@@ -2852,24 +2876,45 @@ can override any operation, including cancelling the active orchestrator.
 
 ### SafetyMonitor Polling
 
-`rp` polls configured ASCOM Alpaca SafetyMonitor devices at a configurable
-interval. On an unsafe transition:
+`rp` polls every configured ASCOM Alpaca SafetyMonitor device
+(`equipment.safety_monitors`, connected at startup like any other
+device) at `safety.poll_interval` (humantime string, default `"10s"`).
+When no monitors are configured the loop never starts and sessions run
+ungated. A monitor read is **fail-unsafe**: a device that is
+disconnected or errors on `IsSafe` counts as unsafe, and the overall
+state is safe only when *all* monitors report safe. Each per-monitor
+transition emits a `safety_changed` event (`monitor`, `new_state`).
 
-1. Terminate the orchestrator's MCP session (cancel any in-flight tool
-   calls).
-2. Abort all in-progress exposures (discard partial frames).
-3. Stop guiding.
-4. Park the mount.
-5. Persist session state.
-6. Emit `safety_changed` event.
-7. Wait in parked state.
+On the overall safe → unsafe transition:
 
-On a safe transition while in parked state:
-1. Unpark mount.
-2. Re-invoke the orchestrator with recovery context (last session state,
-   reason for interruption).
+1. Gate the `/mcp` endpoint: every request is rejected with `503`
+   while conditions remain unsafe.
+2. Close all open MCP sessions (cancelling in-flight tool calls); the
+   orchestrator's next tool call surfaces as a terminated session, and
+   a `session-runner`-style orchestrator exits without completion,
+   keeping its persisted state.
+3. Mark the active session `interrupted` (`/api/session/status`
+   reports `"interrupted"`; starting another session is still refused).
+4. Abort in-progress exposures on all connected cameras (best-effort).
+
+Not yet implemented on unsafe: stopping guiding and parking the mount
+(no guider integration in `rp` yet; parking is planned alongside it).
+
+On the overall unsafe → safe transition:
+
+1. Lift the `/mcp` gate.
+2. If a session is interrupted, mark it `active` again and re-invoke
+   the orchestrator with recovery context
+   (`{"reason": "safety_interruption"}`) and the same
+   `workflow_id`/`session_id`/`config` — retry/failure semantics as in
+   § Orchestrator Invocation Protocol.
 3. The orchestrator decides how to resume (verify pointing, re-acquire
-   guiding, continue from last target).
+   guiding, continue from its persisted progress).
+
+There is no resume-delay/debounce knob yet: `rp` re-invokes on the
+first safe poll. Flapping conditions produce repeated
+interrupt/resume cycles, each of which is safe by construction (the
+re-entrancy contract makes resume idempotent).
 
 ### Sentinel Watchdog Integration
 
@@ -3153,9 +3198,9 @@ return a structured "site not configured" error.
     ],
     "safety_monitors": [
       {
+        "id": "weather-watcher",
         "alpaca_url": "http://localhost:11111",
-        "device_number": 0,
-        "polling_interval_secs": 10
+        "device_number": 0
       }
     ],
     "cover_calibrators": [
@@ -3247,10 +3292,7 @@ return a structured "site not configured" error.
     "minimize_filter_changes": true
   },
   "safety": {
-    "polling_interval_secs": 10,
-    "park_on_unsafe": true,
-    "resume_on_safe": true,
-    "resume_delay_secs": 300
+    "poll_interval": "10s"
   },
   "server": {
     "port": 11115,
@@ -3300,7 +3342,9 @@ services/rp/src/
                         guider client work lands)
 
   # Safety enforcement
-  safety.rs             SafetyMonitor polling, park/resume, orchestrator cancellation
+  safety.rs             SafetyMonitor polling loop, /mcp gate, session
+                        interrupt/resume, MCP session termination,
+                        exposure abort (park/guiding-stop planned)
 
   # Planning (exposed as MCP tools — see Planning and Ephemeris)
   # Math and catalog data live in workspace crates rp-ephemeris and
@@ -3472,7 +3516,8 @@ Testing follows the conventions in `docs/skills/testing.md`.
 - **Planner tools**: Given a target list, progress, and sky state, assert
   correct target/filter selection. Pure function, easy to test exhaustively.
 - **Safety enforcement**: Assert correct behavior on unsafe transitions
-  (orchestrator cancellation, mount parking, session persistence).
+  (transition detection, MCP session termination, `/mcp` gate, session
+  interrupt/resume, invoke retry classification).
 - **Document**: Serialization round-trips, section merging, atomic persistence.
 - **Configuration**: Deserialization, validation, defaults.
 - **Config-time validation**: Missing tools, conflicting plugins, circular
@@ -3489,11 +3534,17 @@ Testing follows the conventions in `docs/skills/testing.md`.
 
 Behavioral specifications for `rp`'s responsibilities:
 
-- Session lifecycle (start → invoke orchestrator, stop, safety override)
-- Safety override (cancel orchestrator, park mount, persist state, resume)
+- Session lifecycle (start → invoke orchestrator, stop, unreachable
+  orchestrator fails loud back to idle)
+- Safety override (unsafe interrupts the session and gates `/mcp`;
+  safe re-invokes the orchestrator with recovery context — the
+  end-to-end resume against a real engine lives in
+  `services/session-runner/tests/features/recovery.feature`)
 - MCP tool validation and safety guardrails
 - Event delivery to webhook endpoints
-- Power failure recovery (re-invoke orchestrator with recovery context)
+- Power failure recovery (re-invoke orchestrator with recovery context
+  on `rp` restart — designed, not yet implemented; see § Recovery
+  Behavior)
 
 Note: orchestration workflow tests (capture loops, target switching,
 meridian flips) belong to the orchestrator plugin, not to `rp`. For

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1153,13 +1153,14 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 | Event subscription | `events.feature` | an `until_event` wait satisfied by an event emitted during an earlier instruction (pins subscription-from-run-start); a wait whose event never arrives fails the session at its timeout rather than hanging |
 | Triggers | `triggers.feature` | a trigger action lands between exposures, never during one (proved by SSE seq order); `once` fires exactly once across three captures; cooldown suppresses firings inside its window; a poll trigger fires through its `when` gate |
 | Resume | `recovery.feature` | SIGKILL the engine mid-capture-loop → restart → re-invoke with recovery → progress continues without repeated frames (exposure totals prove it); `once` marker not re-run (`filter_switch` count proves it); an rp outage terminates the run (service stays healthy, blackboard kept) and the session resumes against the restarted rp |
-| Safety | `safety.feature` | unsafe transition → engine exits without completion → safe transition → re-invocation resumes. **Blocked on rp**: rp has no safety re-invocation machinery yet (its `/invoke` hard-codes `recovery: null` — tracked as an rp issue); until then the engine-side path (request-level failure → terminated run → blackboard kept → recovery) is covered by `recovery.feature`'s rp-outage scenario and the unit pins |
+| Safety | `recovery.feature` | a SafetyMonitor unsafe reading interrupts the session end-to-end through rp's own machinery (rp terminates the MCP session, the run terminates keeping its blackboard) and the safe transition re-invokes the engine with `recovery.reason = "safety_interruption"` — the resumed run captures exactly the remaining frames, the once marker is not re-run, and the completion deletes the blackboard. rp-side specifics (session `interrupted` status, `/mcp` 503 gate, `safety_changed` events) are pinned in rp's own `safety.feature` |
 
-Because rp never sends a non-null `recovery` yet, the resume scenarios
-POST `/invoke` directly — same ids, the registration's forwarded
-`config`, a non-null `recovery` object — standing in for rp's future
-re-invocation. When rp grows that machinery, the scenarios hand the
-re-invoke back to rp.
+The safety scenario exercises rp's real recovery re-invocation. The
+engine-kill and rp-outage scenarios POST `/invoke` directly — same ids,
+the registration's forwarded `config`, a non-null `recovery` object —
+standing in for rp-side *startup* recovery (rp's session registry is
+in-memory; re-invocation after an rp or engine process loss is designed
+but not implemented — `rp.md` § Recovery Behavior).
 
 Scenarios that need a document the shipped set doesn't provide (a
 targeted `until_event` wait, resume fixtures) execute purpose-built

--- a/services/rp/Cargo.toml
+++ b/services/rp/Cargo.toml
@@ -40,7 +40,7 @@ ndarray-ndimage = { workspace = true }
 rmpfit = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel", "cover_calibrator", "focuser", "telescope"] }
+ascom-alpaca = { workspace = true, features = ["client", "camera", "filter_wheel", "cover_calibrator", "focuser", "telescope", "safety_monitor"] }
 rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server", "schemars"] }
 schemars = { workspace = true }
 tempfile = { workspace = true }

--- a/services/rp/src/config/equipment.rs
+++ b/services/rp/src/config/equipment.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
-use serde_json::Value;
 
 use super::camera::CameraConfig;
 use super::cover_calibrator::CoverCalibratorConfig;
 use super::filter_wheel::FilterWheelConfig;
 use super::focuser::FocuserConfig;
 use super::mount::MountConfig;
+use super::safety_monitor::SafetyMonitorConfig;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct EquipmentConfig {
@@ -20,5 +20,5 @@ pub struct EquipmentConfig {
     #[serde(default)]
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
     #[serde(default)]
-    pub safety_monitors: Vec<Value>,
+    pub safety_monitors: Vec<SafetyMonitorConfig>,
 }

--- a/services/rp/src/config/mod.rs
+++ b/services/rp/src/config/mod.rs
@@ -17,6 +17,8 @@ pub mod focuser;
 pub mod imaging;
 pub mod mount;
 pub mod plate_solver;
+pub mod safety;
+pub mod safety_monitor;
 pub mod server;
 pub mod session;
 pub mod site;
@@ -30,6 +32,8 @@ pub use focuser::FocuserConfig;
 pub use imaging::ImagingConfig;
 pub use mount::MountConfig;
 pub use plate_solver::PlateSolverConfig;
+pub use safety::SafetyConfig;
+pub use safety_monitor::SafetyMonitorConfig;
 pub use server::ServerConfig;
 pub use session::SessionConfig;
 pub use site::SiteConfig;
@@ -59,8 +63,10 @@ pub struct Config {
     pub targets: Value,
     #[serde(default)]
     pub planner: Value,
+    /// Safety-enforcement knobs (rp.md § Safety); the monitors
+    /// themselves live under `equipment.safety_monitors`.
     #[serde(default)]
-    pub safety: Value,
+    pub safety: SafetyConfig,
     #[serde(default)]
     pub imaging: ImagingConfig,
     /// Per-rig estimates that size the advisory `center_on_target`

--- a/services/rp/src/config/safety.rs
+++ b/services/rp/src/config/safety.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Safety-enforcement settings (rp.md § Safety). The monitors themselves
+/// are equipment (`equipment.safety_monitors`); this block holds the
+/// enforcement knobs shared across them.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SafetyConfig {
+    /// How often every configured SafetyMonitor is polled (default `"10s"`).
+    #[serde(default = "default_safety_poll_interval", with = "humantime_serde")]
+    pub poll_interval: Duration,
+}
+
+impl Default for SafetyConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: default_safety_poll_interval(),
+        }
+    }
+}
+
+fn default_safety_poll_interval() -> Duration {
+    Duration::from_secs(10)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::config::load_config;
+    use crate::config::test_support::MINIMAL_CONFIG_JSON;
+
+    #[test]
+    fn safety_block_omitted_applies_default_poll_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, MINIMAL_CONFIG_JSON).unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.safety.poll_interval, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn safety_poll_interval_parses_humantime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {},
+                "safety": {"poll_interval": "250ms"},
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        assert_eq!(config.safety.poll_interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn safety_block_rejects_unknown_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {},
+                "safety": {"park_on_unsafe": true},
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("park_on_unsafe") || msg.contains("unknown field"),
+            "expected unknown-field diagnostic, got: {msg}"
+        );
+    }
+}

--- a/services/rp/src/config/safety_monitor.rs
+++ b/services/rp/src/config/safety_monitor.rs
@@ -3,7 +3,12 @@ use serde::Deserialize;
 /// An ASCOM Alpaca SafetyMonitor device gating the session (rp.md
 /// § Safety). Polled at `safety.poll_interval`; a monitor that cannot
 /// be read counts as unsafe.
+///
+/// Unknown fields are rejected — stricter than the other equipment
+/// entries, deliberately: a typo in safety-critical config must fail
+/// at load, not be silently ignored.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SafetyMonitorConfig {
     pub id: String,
     pub alpaca_url: String,
@@ -44,5 +49,31 @@ mod tests {
         assert_eq!(sm.alpaca_url, "http://127.0.0.1:32323");
         assert_eq!(sm.device_number, 0);
         assert!(sm.auth.is_none());
+    }
+
+    #[test]
+    fn safety_monitor_entry_rejects_unknown_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "safety_monitors": [
+                        {"id": "sm", "alpaca_url": "http://127.0.0.1:32323", "pol_interval": "1s"}
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pol_interval") || msg.contains("unknown field"),
+            "expected unknown-field diagnostic, got: {msg}"
+        );
     }
 }

--- a/services/rp/src/config/safety_monitor.rs
+++ b/services/rp/src/config/safety_monitor.rs
@@ -1,0 +1,48 @@
+use serde::Deserialize;
+
+/// An ASCOM Alpaca SafetyMonitor device gating the session (rp.md
+/// § Safety). Polled at `safety.poll_interval`; a monitor that cannot
+/// be read counts as unsafe.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SafetyMonitorConfig {
+    pub id: String,
+    pub alpaca_url: String,
+    #[serde(default)]
+    pub device_number: u32,
+    /// Optional HTTP Basic Auth credentials for connecting to auth-enabled Alpaca services
+    #[serde(default)]
+    pub auth: Option<rp_auth::config::ClientAuthConfig>,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use crate::config::load_config;
+
+    #[test]
+    fn safety_monitor_entry_parses_with_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "session": {"data_directory": "/tmp/rp-test"},
+                "equipment": {
+                    "safety_monitors": [
+                        {"id": "weather-watcher", "alpaca_url": "http://127.0.0.1:32323"}
+                    ]
+                },
+                "server": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_config(&path).unwrap();
+        let sm = &config.equipment.safety_monitors[0];
+        assert_eq!(sm.id, "weather-watcher");
+        assert_eq!(sm.alpaca_url, "http://127.0.0.1:32323");
+        assert_eq!(sm.device_number, 0);
+        assert!(sm.auth.is_none());
+    }
+}

--- a/services/rp/src/equipment/mod.rs
+++ b/services/rp/src/equipment/mod.rs
@@ -19,6 +19,7 @@ pub mod cover_calibrator;
 pub mod filter_wheel;
 pub mod focuser;
 pub mod mount;
+pub mod safety_monitor;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
@@ -29,6 +30,7 @@ pub use cover_calibrator::CoverCalibratorEntry;
 pub use filter_wheel::FilterWheelEntry;
 pub use focuser::FocuserEntry;
 pub use mount::MountEntry;
+pub use safety_monitor::SafetyMonitorEntry;
 
 use serde::Serialize;
 use tracing::debug;
@@ -41,6 +43,7 @@ pub struct EquipmentRegistry {
     pub filter_wheels: Vec<FilterWheelEntry>,
     pub cover_calibrators: Vec<CoverCalibratorEntry>,
     pub focusers: Vec<FocuserEntry>,
+    pub safety_monitors: Vec<SafetyMonitorEntry>,
     pub mount: Option<MountEntry>,
 }
 
@@ -50,6 +53,7 @@ pub struct EquipmentStatus {
     pub filter_wheels: Vec<DeviceStatus>,
     pub cover_calibrators: Vec<DeviceStatus>,
     pub focusers: Vec<DeviceStatus>,
+    pub safety_monitors: Vec<DeviceStatus>,
     pub mount: Option<MountStatus>,
 }
 
@@ -97,6 +101,12 @@ impl EquipmentRegistry {
             focusers.push(entry);
         }
 
+        let mut safety_monitors = Vec::new();
+        for sm_config in &equipment_config.safety_monitors {
+            let entry = safety_monitor::connect_safety_monitor(sm_config).await;
+            safety_monitors.push(entry);
+        }
+
         let mount = match &equipment_config.mount {
             Some(mount_config) => Some(mount::connect_mount(mount_config).await),
             None => None,
@@ -107,6 +117,7 @@ impl EquipmentRegistry {
             filter_wheels,
             cover_calibrators,
             focusers,
+            safety_monitors,
             mount,
         }
     }
@@ -145,6 +156,14 @@ impl EquipmentRegistry {
                     connected: f.connected,
                 })
                 .collect(),
+            safety_monitors: self
+                .safety_monitors
+                .iter()
+                .map(|sm| DeviceStatus {
+                    id: sm.id.clone(),
+                    connected: sm.connected,
+                })
+                .collect(),
             mount: self.mount.as_ref().map(|m| MountStatus {
                 connected: m.connected,
             }),
@@ -165,6 +184,10 @@ impl EquipmentRegistry {
 
     pub fn find_focuser(&self, id: &str) -> Option<&FocuserEntry> {
         self.focusers.iter().find(|f| f.id == id)
+    }
+
+    pub fn find_safety_monitor(&self, id: &str) -> Option<&SafetyMonitorEntry> {
+        self.safety_monitors.iter().find(|sm| sm.id == id)
     }
 
     /// Returns the singular mount entry, or `None` when no mount is

--- a/services/rp/src/equipment/safety_monitor.rs
+++ b/services/rp/src/equipment/safety_monitor.rs
@@ -99,3 +99,177 @@ pub(super) async fn connect_safety_monitor(
         }
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+    use crate::config;
+    use crate::equipment::test_support::spawn_stub;
+
+    use axum::{
+        routing::{get, put},
+        Json, Router,
+    };
+
+    fn sm_config_for(url: &str, device_number: u32) -> config::SafetyMonitorConfig {
+        config::SafetyMonitorConfig {
+            id: "weather-watcher".to_string(),
+            alpaca_url: url.to_string(),
+            device_number,
+            auth: None,
+        }
+    }
+
+    /// Stub advertising two SafetyMonitors that accept
+    /// `set_connected(true)` — two so a `device_number = 1` connect has
+    /// to skip past index 0.
+    fn two_monitor_router() -> Router {
+        Router::new()
+            .route(
+                "/management/v1/configureddevices",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": [
+                            {
+                                "DeviceName": "Safety Monitor 0",
+                                "DeviceType": "SafetyMonitor",
+                                "DeviceNumber": 0,
+                                "UniqueID": "test-sm-uid-0"
+                            },
+                            {
+                                "DeviceName": "Safety Monitor 1",
+                                "DeviceType": "SafetyMonitor",
+                                "DeviceNumber": 1,
+                                "UniqueID": "test-sm-uid-1"
+                            }
+                        ],
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/safetymonitor/0/connected",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/safetymonitor/1/connected",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+    }
+
+    #[tokio::test]
+    async fn connect_safety_monitor_success_returns_connected_entry() {
+        let stub = spawn_stub(two_monitor_router()).await;
+        let entry = connect_safety_monitor(&sm_config_for(&stub.url(), 0)).await;
+        assert!(entry.connected, "expected entry to be connected");
+        assert!(entry.device.is_some(), "expected entry to hold a device");
+        assert_eq!(entry.id, "weather-watcher");
+    }
+
+    /// `device_number` indexes among the server's SafetyMonitors, so
+    /// connecting to index 1 must skip past the monitor at index 0.
+    #[tokio::test]
+    async fn connect_safety_monitor_skips_to_the_requested_index() {
+        let stub = spawn_stub(two_monitor_router()).await;
+        let entry = connect_safety_monitor(&sm_config_for(&stub.url(), 1)).await;
+        assert!(entry.connected, "expected entry to be connected");
+        assert!(entry.device.is_some(), "expected entry to hold a device");
+    }
+
+    /// A server that answers but has no SafetyMonitor at the requested
+    /// index is a permanent failure — no retries, disconnected entry.
+    /// The entry then reads as unsafe (fail-unsafe posture).
+    #[tokio::test]
+    async fn connect_safety_monitor_not_found_returns_disconnected_entry() {
+        let app = Router::new().route(
+            "/management/v1/configureddevices",
+            get(|| async {
+                Json(serde_json::json!({
+                    "Value": [],
+                    "ErrorNumber": 0,
+                    "ErrorMessage": ""
+                }))
+            }),
+        );
+        let stub = spawn_stub(app).await;
+        let entry = connect_safety_monitor(&sm_config_for(&stub.url(), 0)).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_safety_monitor_client_build_failure_returns_disconnected_entry() {
+        let entry = connect_safety_monitor(&sm_config_for("not-a-url", 0)).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    /// A failed `get_devices` maps to `Transient`, so the loop exhausts
+    /// all attempts and returns a disconnected (→ fail-unsafe) entry.
+    /// `start_paused` collapses the retry backoff.
+    #[tokio::test(start_paused = true)]
+    async fn connect_safety_monitor_get_devices_error_returns_disconnected_entry() {
+        let app = Router::new().route(
+            "/management/v1/configureddevices",
+            get(|| async {
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "simulated get_devices failure",
+                )
+            }),
+        );
+        let stub = spawn_stub(app).await;
+        let entry = connect_safety_monitor(&sm_config_for(&stub.url(), 0)).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+
+    /// A `set_connected` error maps to `Transient`: the monitor is found,
+    /// but turning it on fails on every attempt. `start_paused` collapses
+    /// the retry backoff.
+    #[tokio::test(start_paused = true)]
+    async fn connect_safety_monitor_set_connected_error_returns_disconnected_entry() {
+        let app = Router::new()
+            .route(
+                "/management/v1/configureddevices",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": [{
+                            "DeviceName": "Safety Monitor 0",
+                            "DeviceType": "SafetyMonitor",
+                            "DeviceNumber": 0,
+                            "UniqueID": "test-sm-uid"
+                        }],
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/safetymonitor/0/connected",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 1025,
+                        "ErrorMessage": "simulated set_connected failure"
+                    }))
+                }),
+            );
+        let stub = spawn_stub(app).await;
+        let entry = connect_safety_monitor(&sm_config_for(&stub.url(), 0)).await;
+        assert!(!entry.connected);
+        assert!(entry.device.is_none());
+    }
+}

--- a/services/rp/src/equipment/safety_monitor.rs
+++ b/services/rp/src/equipment/safety_monitor.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use ascom_alpaca::api::{SafetyMonitor, TypedDevice};
+use tracing::{debug, error};
+
+use super::alpaca::{
+    build_alpaca_client, retry_connect_attempt, AttemptOutcome, GET_DEVICES_TIMEOUT,
+};
+use crate::config;
+
+pub struct SafetyMonitorEntry {
+    pub id: String,
+    pub connected: bool,
+    pub config: config::SafetyMonitorConfig,
+    pub device: Option<Arc<dyn SafetyMonitor>>,
+}
+
+pub(super) async fn connect_safety_monitor(
+    config: &config::SafetyMonitorConfig,
+) -> SafetyMonitorEntry {
+    debug!(sm_id = %config.id, alpaca_url = %config.alpaca_url, device_number = config.device_number, "connecting to safety monitor");
+
+    let client = match build_alpaca_client(&config.alpaca_url, config.auth.as_ref()) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(sm_id = %config.id, error = %e, "failed to create Alpaca client for safety monitor");
+            return SafetyMonitorEntry {
+                id: config.id.clone(),
+                connected: false,
+                config: config.clone(),
+                device: None,
+            };
+        }
+    };
+
+    let label = format!("safety monitor {}", config.id);
+    let outcome = retry_connect_attempt(&label, |_attempt| async {
+        let devices = match tokio::time::timeout(GET_DEVICES_TIMEOUT, client.get_devices()).await {
+            Ok(Ok(devices)) => devices,
+            Ok(Err(e)) => return AttemptOutcome::Transient(format!("get_devices: {e}")),
+            Err(_) => {
+                return AttemptOutcome::Transient(format!(
+                    "get_devices: timeout after {:?}",
+                    GET_DEVICES_TIMEOUT
+                ));
+            }
+        };
+
+        let mut sm_index = 0u32;
+        let mut found_sm: Option<Arc<dyn SafetyMonitor>> = None;
+        for device in devices {
+            if let TypedDevice::SafetyMonitor(sm) = device {
+                if sm_index == config.device_number {
+                    found_sm = Some(sm);
+                    break;
+                }
+                sm_index += 1;
+            }
+        }
+
+        let sm = match found_sm {
+            Some(s) => s,
+            None => {
+                return AttemptOutcome::Permanent(format!(
+                    "safety monitor at index {} not found on Alpaca server",
+                    config.device_number
+                ));
+            }
+        };
+
+        match sm.set_connected(true).await {
+            Ok(()) => AttemptOutcome::Ok(sm),
+            Err(e) => AttemptOutcome::Transient(format!("set_connected: {e}")),
+        }
+    })
+    .await;
+
+    match outcome {
+        Ok(sm) => {
+            debug!(sm_id = %config.id, "safety monitor connected successfully");
+            SafetyMonitorEntry {
+                id: config.id.clone(),
+                connected: true,
+                config: config.clone(),
+                device: Some(sm),
+            }
+        }
+        Err(msg) => {
+            // A safety monitor that cannot be read counts as unsafe
+            // (fail-unsafe, rp.md § Safety) — so a failed connect here
+            // will gate the session until the device becomes reachable.
+            error!(sm_id = %config.id, error = %msg, "failed to connect safety monitor");
+            SafetyMonitorEntry {
+                id: config.id.clone(),
+                connected: false,
+                config: config.clone(),
+                device: None,
+            }
+        }
+    }
+}

--- a/services/rp/src/lib.rs
+++ b/services/rp/src/lib.rs
@@ -9,15 +9,18 @@ pub mod mcp;
 pub mod persistence;
 pub mod planner;
 pub mod routes;
+pub mod safety;
 pub mod session;
 pub mod tls_cmd;
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use tracing::{debug, info};
 
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rp_tls::config::TlsConfig;
 use tokio_util::sync::CancellationToken;
 
@@ -28,6 +31,7 @@ use crate::events::EventBus;
 use crate::mcp::McpHandler;
 use crate::persistence::ImageCache;
 use crate::routes::{build_router, AppState};
+use crate::safety::{AlpacaSafetyProbe, SafetyEnforcer};
 use crate::session::{SessionConfig, SessionManager};
 
 /// Builder for the rp server.
@@ -156,12 +160,30 @@ impl ServerBuilder {
         // would block axum's graceful shutdown from ever completing.
         let sse_shutdown = CancellationToken::new();
 
+        // Safety enforcement (rp.md § Safety): the gate flag is read by the
+        // `/mcp` middleware, the session registry is shared with the
+        // enforcer so an unsafe transition can terminate every open MCP
+        // session. `None` when no safety monitors are configured — sessions
+        // then run ungated and no polling task is spawned.
+        let safety_ok = Arc::new(AtomicBool::new(true));
+        let mcp_sessions = Arc::new(LocalSessionManager::default());
+        let safety = SafetyEnforcer::from_registry(
+            equipment.clone(),
+            event_bus.clone(),
+            session.clone(),
+            mcp_sessions.clone(),
+            safety_ok.clone(),
+            config.safety.poll_interval,
+        );
+
         let state = AppState {
             equipment,
             mcp,
             session: session.clone(),
             image_cache,
             sse_shutdown: sse_shutdown.clone(),
+            safety_ok,
+            mcp_sessions,
         };
 
         let router = build_router(state);
@@ -202,6 +224,7 @@ impl ServerBuilder {
             local_addr,
             tls,
             sse_shutdown,
+            safety,
         })
     }
 }
@@ -222,6 +245,9 @@ pub struct BoundServer {
     /// in-flight `/api/events/subscribe` SSE streams end and axum's graceful
     /// shutdown can drain. A clone lives in `AppState` for the handler.
     sse_shutdown: CancellationToken,
+    /// Safety polling loop, spawned by `start()` and cancelled on shutdown.
+    /// `None` when no safety monitors are configured.
+    safety: Option<SafetyEnforcer<AlpacaSafetyProbe>>,
 }
 
 impl BoundServer {
@@ -234,11 +260,18 @@ impl BoundServer {
         // signal fires, cancel in-flight `/api/events/subscribe` streams first
         // so their long-lived response bodies end, then let axum's graceful
         // shutdown drain the remaining connections. Without this, a connected
-        // SSE consumer would keep the server from ever shutting down.
+        // SSE consumer would keep the server from ever shutting down. The
+        // safety polling loop rides the same signal.
+        let safety_cancel = CancellationToken::new();
+        let safety_task = self.safety.map(|enforcer| {
+            let cancel = safety_cancel.clone();
+            tokio::spawn(enforcer.run(cancel))
+        });
         let sse_shutdown = self.sse_shutdown;
         let graceful = async move {
             shutdown.await;
             sse_shutdown.cancel();
+            safety_cancel.cancel();
         };
 
         match self.tls {
@@ -254,6 +287,12 @@ impl BoundServer {
                     .with_graceful_shutdown(graceful)
                     .await?;
             }
+        }
+
+        // The safety loop was cancelled by `graceful`; join it so the
+        // process doesn't exit mid-transition.
+        if let Some(task) = safety_task {
+            let _ = task.await;
         }
 
         debug!("rp service shut down");

--- a/services/rp/src/mcp/tests.rs
+++ b/services/rp/src/mcp/tests.rs
@@ -884,6 +884,7 @@ fn camera_registry_with_meta(
     meta: CachedCameraMeta,
 ) -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![crate::equipment::CameraEntry {
             id: "cam".to_string(),
             connected: true,
@@ -918,6 +919,7 @@ fn filter_wheel_registry(
     fw: Arc<dyn ascom_alpaca::api::FilterWheel>,
 ) -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![crate::equipment::FilterWheelEntry {
             id: "fw".to_string(),
@@ -942,6 +944,7 @@ fn calibrator_registry(
     cc: Arc<dyn ascom_alpaca::api::CoverCalibrator>,
 ) -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![crate::equipment::CoverCalibratorEntry {
@@ -967,6 +970,7 @@ fn focuser_registry(
     max_position: Option<i32>,
 ) -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -994,6 +998,7 @@ fn mount_registry(
     settle_after_slew: Option<Duration>,
 ) -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -1026,6 +1031,7 @@ fn camera_mount_registry(
 
 fn empty_registry() -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -1036,6 +1042,7 @@ fn empty_registry() -> crate::equipment::EquipmentRegistry {
 
 fn disconnected_mount_registry() -> crate::equipment::EquipmentRegistry {
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -1713,6 +1720,7 @@ async fn test_persist_capture_artifact_skips_cache_on_sidecar_failure() {
     let cache = ImageCache::new(64, 4, std::path::PathBuf::from("/nonexistent"));
     let handler = McpHandler::new(
         Arc::new(crate::equipment::EquipmentRegistry {
+            safety_monitors: vec![],
             cameras: vec![],
             filter_wheels: vec![],
             cover_calibrators: vec![],
@@ -1958,6 +1966,7 @@ async fn test_compute_image_stats_bad_fits() {
     std::fs::write(&bad_file, b"not a fits file").unwrap();
 
     let handler = test_handler(crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -1979,6 +1988,7 @@ async fn test_compute_image_stats_missing_arguments() {
     // or image_path"): callers must supply at least one. Mirrors the
     // missing-args branch tested for measure_basic / estimate_background.
     let handler = test_handler(crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -2045,6 +2055,7 @@ async fn test_compute_image_stats_persists_section_via_document_id() {
 
     let handler = McpHandler::new(
         Arc::new(crate::equipment::EquipmentRegistry {
+            safety_monitors: vec![],
             cameras: vec![],
             filter_wheels: vec![],
             cover_calibrators: vec![],
@@ -2335,6 +2346,7 @@ async fn test_move_focuser_timeout() {
 #[tokio::test]
 async fn test_move_focuser_not_connected() {
     let registry = crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -2388,6 +2400,7 @@ async fn test_get_focuser_position_success() {
 #[tokio::test]
 async fn test_get_focuser_position_not_connected() {
     let registry = crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -3449,6 +3462,7 @@ fn handler_with_site_and_mount() -> McpHandler {
     // Skip the connect-time HTTP fetch by hand-building a registry
     // with the mock device wired in directly.
     let registry = crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],
@@ -4328,6 +4342,7 @@ fn auto_focus_registry(starting_position: i32) -> crate::equipment::EquipmentReg
     let camera = FixtureCamera::new(load_auto_focus_fixtures());
     let focuser = TrackingFocuser::new(starting_position, 4.5);
     crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![crate::equipment::CameraEntry {
             id: "cam".to_string(),
             connected: true,
@@ -5007,6 +5022,7 @@ async fn slew_started_omits_deadline_when_pointing_read_fails() {
 #[tokio::test]
 async fn slew_deadline_overflow_falls_back_without_panic() {
     let registry = crate::equipment::EquipmentRegistry {
+        safety_monitors: vec![],
         cameras: vec![],
         filter_wheels: vec![],
         cover_calibrators: vec![],

--- a/services/rp/src/routes.rs
+++ b/services/rp/src/routes.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,6 +40,13 @@ pub struct AppState {
     /// it to end in-flight `/api/events/subscribe` streams. See
     /// `BoundServer::start`.
     pub sse_shutdown: CancellationToken,
+    /// `false` while safety conditions are unsafe — the `/mcp` gate below
+    /// rejects every request with 503 (rp.md § Safety). Written by the
+    /// safety enforcer.
+    pub safety_ok: Arc<AtomicBool>,
+    /// The MCP transport's session registry, shared with the safety
+    /// enforcer so an unsafe transition can terminate every open session.
+    pub mcp_sessions: Arc<LocalSessionManager>,
 }
 
 pub fn build_router(state: AppState) -> Router {
@@ -47,14 +55,39 @@ pub fn build_router(state: AppState) -> Router {
     mcp_config.json_response = true;
     let mcp_service = StreamableHttpService::new(
         move || Ok(mcp_handler.clone()),
-        Arc::new(LocalSessionManager::default()),
+        state.mcp_sessions.clone(),
         mcp_config,
     );
+
+    // The safety gate (rp.md § Safety): while conditions are unsafe every
+    // MCP request — a new session or an in-flight workflow's next call —
+    // is rejected with 503, surfacing to the orchestrator as a terminated
+    // session instead of quietly driving hardware under unsafe skies.
+    let safety_ok = state.safety_ok.clone();
+    let gated_mcp =
+        Router::new()
+            .nest_service("/mcp", mcp_service)
+            .layer(axum::middleware::from_fn(
+                move |request: axum::extract::Request, next: axum::middleware::Next| {
+                    let safety_ok = safety_ok.clone();
+                    async move {
+                        if safety_ok.load(Ordering::SeqCst) {
+                            next.run(request).await
+                        } else {
+                            (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                "safety: conditions are unsafe; the workflow was cancelled",
+                            )
+                                .into_response()
+                        }
+                    }
+                },
+            ));
 
     Router::new()
         .route("/health", get(health))
         .route("/api/equipment", get(get_equipment))
-        .nest_service("/mcp", mcp_service)
+        .merge(gated_mcp)
         .route("/api/session/start", post(session_start))
         .route("/api/session/stop", post(session_stop))
         .route("/api/session/status", get(session_status))
@@ -407,6 +440,7 @@ mod tests {
     fn test_app_state(image_cache: ImageCache) -> AppState {
         let event_bus = Arc::new(EventBus::from_config(&[]));
         let equipment = Arc::new(crate::equipment::EquipmentRegistry {
+            safety_monitors: vec![],
             cameras: vec![],
             filter_wheels: vec![],
             cover_calibrators: vec![],
@@ -429,7 +463,65 @@ mod tests {
             session,
             image_cache,
             sse_shutdown: CancellationToken::new(),
+            safety_ok: Arc::new(AtomicBool::new(true)),
+            mcp_sessions: Arc::new(LocalSessionManager::default()),
         }
+    }
+
+    #[tokio::test]
+    async fn mcp_gate_rejects_with_503_while_unsafe_and_lifts_after() {
+        let state = test_app_state(ImageCache::new(64, 4, std::path::PathBuf::from("/tmp")));
+        let safety_ok = state.safety_ok.clone();
+        let app = build_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let probe = || {
+            client
+                .post(format!("http://{addr}/mcp"))
+                .header("accept", "application/json, text/event-stream")
+                .json(&serde_json::json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "gate-test", "version": "0"}
+                    }
+                }))
+                .send()
+        };
+
+        safety_ok.store(false, Ordering::SeqCst);
+        let gated = probe().await.unwrap();
+        assert_eq!(gated.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+        safety_ok.store(true, Ordering::SeqCst);
+        let open = probe().await.unwrap();
+        assert_ne!(
+            open.status(),
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "the gate must lift once conditions are safe again"
+        );
+
+        // Only /mcp is gated — the REST API keeps answering while unsafe.
+        safety_ok.store(false, Ordering::SeqCst);
+        let health = client
+            .get(format!("http://{addr}/health"))
+            .send()
+            .await
+            .unwrap();
+        assert!(health.status().is_success());
+        let _ = tx.send(());
     }
 
     fn cached_u16(arr: ndarray::Array2<u16>) -> CachedImage {

--- a/services/rp/src/safety.rs
+++ b/services/rp/src/safety.rs
@@ -1,0 +1,437 @@
+//! Safety enforcement (rp.md § Safety): poll every configured ASCOM
+//! SafetyMonitor, and on the overall safe → unsafe transition gate the
+//! `/mcp` endpoint, terminate all open MCP sessions (cancelling in-flight
+//! tool calls), interrupt the active session, and abort in-progress
+//! exposures. On unsafe → safe, lift the gate and resume the interrupted
+//! session by re-invoking the orchestrator with recovery context.
+//!
+//! Readings are **fail-unsafe**: a monitor that is disconnected or
+//! errors counts as unsafe, and conditions are safe only while *all*
+//! monitors report safe. Every per-monitor change emits a
+//! `safety_changed` event; the assumed baseline is safe, so a monitor
+//! that starts out safe emits nothing at startup while one that starts
+//! out unsafe announces itself.
+//!
+//! Not yet implemented on unsafe: stopping guiding and parking the
+//! mount (no guider integration in rp yet; parking lands with it).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::equipment::EquipmentRegistry;
+use crate::events::EventBus;
+use crate::session::SessionManager;
+
+/// One pollable safety source. A seam over the Alpaca device so the
+/// polling loop is unit-testable with scripted probes.
+pub trait SafetyProbe: Send + Sync {
+    fn id(&self) -> &str;
+    fn is_safe(&self) -> impl Future<Output = Result<bool, String>> + Send;
+}
+
+/// Production probe over a connected (or not) ASCOM Alpaca SafetyMonitor.
+pub struct AlpacaSafetyProbe {
+    id: String,
+    device: Option<Arc<dyn ascom_alpaca::api::SafetyMonitor>>,
+}
+
+impl SafetyProbe for AlpacaSafetyProbe {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn is_safe(&self) -> Result<bool, String> {
+        let Some(device) = &self.device else {
+            return Err("safety monitor is not connected".to_string());
+        };
+        device.is_safe().await.map_err(|e| e.to_string())
+    }
+}
+
+/// The polling loop plus everything it drives on a transition.
+pub struct SafetyEnforcer<P: SafetyProbe> {
+    probes: Vec<P>,
+    poll_interval: Duration,
+    event_bus: Arc<EventBus>,
+    session: Arc<SessionManager>,
+    mcp_sessions: Arc<LocalSessionManager>,
+    equipment: Arc<EquipmentRegistry>,
+    /// Read by the `/mcp` gate in `routes`: `false` rejects every MCP
+    /// request with 503 while conditions are unsafe.
+    safety_ok: Arc<AtomicBool>,
+}
+
+impl SafetyEnforcer<AlpacaSafetyProbe> {
+    /// Build the enforcer over the registry's connected safety monitors.
+    /// Returns `None` when none are configured — the loop never starts
+    /// and sessions run ungated.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_registry(
+        equipment: Arc<EquipmentRegistry>,
+        event_bus: Arc<EventBus>,
+        session: Arc<SessionManager>,
+        mcp_sessions: Arc<LocalSessionManager>,
+        safety_ok: Arc<AtomicBool>,
+        poll_interval: Duration,
+    ) -> Option<Self> {
+        if equipment.safety_monitors.is_empty() {
+            debug!("no safety monitors configured; safety polling disabled");
+            return None;
+        }
+        let probes = equipment
+            .safety_monitors
+            .iter()
+            .map(|entry| AlpacaSafetyProbe {
+                id: entry.id.clone(),
+                device: entry.device.clone(),
+            })
+            .collect();
+        Some(Self {
+            probes,
+            poll_interval,
+            event_bus,
+            session,
+            mcp_sessions,
+            equipment,
+            safety_ok,
+        })
+    }
+}
+
+impl<P: SafetyProbe> SafetyEnforcer<P> {
+    /// Poll until cancelled (rp shutdown).
+    pub async fn run(self, cancel: CancellationToken) {
+        info!(
+            monitors = self.probes.len(),
+            interval = ?self.poll_interval,
+            "safety monitoring started"
+        );
+        // Assumed-safe baselines: transitions are relative to these, so
+        // a monitor that starts out safe is quiet and one that starts
+        // out unsafe announces itself on the first poll.
+        let mut per_monitor: HashMap<String, bool> = HashMap::new();
+        let mut overall = true;
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    debug!("safety monitoring stopped");
+                    return;
+                }
+                () = tokio::time::sleep(self.poll_interval) => {}
+            }
+            overall = self.poll_once(&mut per_monitor, overall).await;
+        }
+    }
+
+    /// One polling pass: read every probe, emit per-monitor
+    /// `safety_changed` events, and act when the overall state flips.
+    /// Returns the new overall state.
+    async fn poll_once(&self, per_monitor: &mut HashMap<String, bool>, prev_overall: bool) -> bool {
+        let mut overall = true;
+        for probe in &self.probes {
+            let reading = match probe.is_safe().await {
+                Ok(reading) => reading,
+                Err(e) => {
+                    warn!(monitor = probe.id(), error = %e,
+                          "safety monitor read failed; treating as unsafe");
+                    false
+                }
+            };
+            overall &= reading;
+            let prev = per_monitor
+                .insert(probe.id().to_owned(), reading)
+                .unwrap_or(true);
+            if prev != reading {
+                let new_state = if reading { "safe" } else { "unsafe" };
+                debug!(monitor = probe.id(), new_state, "safety monitor transition");
+                self.event_bus.emit(
+                    "safety_changed",
+                    serde_json::json!({
+                        "monitor": probe.id(),
+                        "new_state": new_state,
+                    }),
+                );
+            }
+        }
+        if overall != prev_overall {
+            if overall {
+                self.on_safe().await;
+            } else {
+                self.on_unsafe().await;
+            }
+        }
+        overall
+    }
+
+    /// Overall safe → unsafe: gate first so nothing new gets in, then
+    /// tear down the workflow's transport and stop the hardware.
+    async fn on_unsafe(&self) {
+        warn!("conditions unsafe; cancelling the active workflow");
+        self.safety_ok.store(false, Ordering::SeqCst);
+        let interrupted = self.session.interrupt().await;
+        close_all_mcp_sessions(&self.mcp_sessions).await;
+        abort_exposures(&self.equipment).await;
+        if interrupted {
+            info!("session interrupted; awaiting safe conditions to resume");
+        }
+    }
+
+    /// Overall unsafe → safe: lift the gate before re-invoking, so the
+    /// orchestrator's immediate MCP connect isn't rejected.
+    async fn on_safe(&self) {
+        info!("conditions safe again");
+        self.safety_ok.store(true, Ordering::SeqCst);
+        if self.session.resume().await {
+            info!("session resumed; orchestrator re-invoked with recovery context");
+        }
+    }
+}
+
+/// Close every open MCP session, cancelling in-flight tool calls; the
+/// orchestrator's next call on a closed session surfaces as a terminated
+/// session (the engine exits without completion and keeps its state).
+async fn close_all_mcp_sessions(manager: &LocalSessionManager) {
+    let handles: Vec<_> = manager.sessions.write().await.drain().collect();
+    for (id, handle) in handles {
+        debug!(mcp_session = %id, "terminating MCP session");
+        if let Err(e) = handle.close().await {
+            // The worker may already be gone; nothing to enforce then.
+            debug!(mcp_session = %id, error = %e, "MCP session close reported an error");
+        }
+    }
+}
+
+/// Best-effort `AbortExposure` on every connected camera — the tool task
+/// driving an exposure was just cancelled with its MCP session, so the
+/// camera would otherwise keep exposing into the (unsafe) night.
+async fn abort_exposures(equipment: &EquipmentRegistry) {
+    for camera in &equipment.cameras {
+        let Some(device) = &camera.device else {
+            continue;
+        };
+        match device.abort_exposure().await {
+            Ok(()) => debug!(camera = %camera.id, "aborted in-progress exposure"),
+            Err(e) => {
+                // Usually just "no exposure in progress" — worth a debug
+                // line, not an operator-facing warning.
+                debug!(camera = %camera.id, error = %e, "abort_exposure failed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use std::sync::Mutex;
+
+    use rmcp::transport::streamable_http_server::session::SessionManager as _;
+
+    use super::*;
+
+    /// Probe whose readings are scripted: pops the front of the queue,
+    /// repeating the last entry once drained.
+    struct ScriptedProbe {
+        id: String,
+        readings: Mutex<Vec<Result<bool, String>>>,
+    }
+
+    impl ScriptedProbe {
+        fn new(id: &str, readings: Vec<Result<bool, String>>) -> Self {
+            Self {
+                id: id.to_string(),
+                readings: Mutex::new(readings),
+            }
+        }
+    }
+
+    impl SafetyProbe for ScriptedProbe {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        async fn is_safe(&self) -> Result<bool, String> {
+            let mut readings = self.readings.lock().unwrap();
+            if readings.len() > 1 {
+                readings.remove(0)
+            } else {
+                readings[0].clone()
+            }
+        }
+    }
+
+    fn empty_registry() -> Arc<EquipmentRegistry> {
+        Arc::new(EquipmentRegistry {
+            cameras: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            focusers: vec![],
+            safety_monitors: vec![],
+            mount: None,
+        })
+    }
+
+    fn enforcer_with(probes: Vec<ScriptedProbe>) -> SafetyEnforcer<ScriptedProbe> {
+        let event_bus = Arc::new(EventBus::from_config(&[]));
+        let session = Arc::new(SessionManager::new(event_bus.clone(), &[]));
+        SafetyEnforcer {
+            probes,
+            poll_interval: Duration::from_millis(1),
+            event_bus,
+            session,
+            mcp_sessions: Arc::new(LocalSessionManager::default()),
+            equipment: empty_registry(),
+            safety_ok: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    #[tokio::test]
+    async fn quiet_when_monitors_start_out_safe() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(true)])]);
+        let mut events = enforcer.event_bus.subscribe();
+        let mut state = HashMap::new();
+
+        let overall = enforcer.poll_once(&mut state, true).await;
+        assert!(overall);
+        assert!(enforcer.safety_ok.load(Ordering::SeqCst));
+        assert!(
+            events.try_recv().is_err(),
+            "a safe first reading matches the assumed baseline; no event expected"
+        );
+    }
+
+    #[tokio::test]
+    async fn unsafe_transition_gates_interrupts_and_terminates_mcp_sessions() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(false)])]);
+        let mut events = enforcer.event_bus.subscribe();
+        enforcer.session.start().await.unwrap();
+
+        // Two live MCP sessions that must be torn down.
+        enforcer.mcp_sessions.create_session().await.unwrap();
+        enforcer.mcp_sessions.create_session().await.unwrap();
+
+        let mut state = HashMap::new();
+        let overall = enforcer.poll_once(&mut state, true).await;
+
+        assert!(!overall);
+        assert!(
+            !enforcer.safety_ok.load(Ordering::SeqCst),
+            "gate must close"
+        );
+        assert_eq!(enforcer.session.status().await, "interrupted");
+        assert!(
+            enforcer.mcp_sessions.sessions.read().await.is_empty(),
+            "all MCP sessions must be terminated"
+        );
+
+        // session_started (from start), then the safety transition.
+        assert_eq!(events.recv().await.unwrap().event, "session_started");
+        let changed = events.recv().await.unwrap();
+        assert_eq!(changed.event, "safety_changed");
+        assert_eq!(changed.payload["monitor"], "sm");
+        assert_eq!(changed.payload["new_state"], "unsafe");
+    }
+
+    #[tokio::test]
+    async fn read_errors_count_as_unsafe() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new(
+            "sm",
+            vec![Err("boom".to_string())],
+        )]);
+        let mut events = enforcer.event_bus.subscribe();
+
+        let mut state = HashMap::new();
+        let overall = enforcer.poll_once(&mut state, true).await;
+
+        assert!(!overall, "a failed read must be treated as unsafe");
+        let changed = events.recv().await.unwrap();
+        assert_eq!(changed.payload["new_state"], "unsafe");
+    }
+
+    #[tokio::test]
+    async fn safe_transition_lifts_gate_and_resumes_the_session() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(false), Ok(true)])]);
+        let mut events = enforcer.event_bus.subscribe();
+        enforcer.session.start().await.unwrap();
+
+        let mut state = HashMap::new();
+        let overall = enforcer.poll_once(&mut state, true).await;
+        assert!(!overall);
+        assert_eq!(enforcer.session.status().await, "interrupted");
+
+        let overall = enforcer.poll_once(&mut state, overall).await;
+        assert!(overall);
+        assert!(enforcer.safety_ok.load(Ordering::SeqCst), "gate must lift");
+        assert_eq!(enforcer.session.status().await, "active");
+
+        assert_eq!(events.recv().await.unwrap().event, "session_started");
+        assert_eq!(events.recv().await.unwrap().payload["new_state"], "unsafe");
+        assert_eq!(events.recv().await.unwrap().payload["new_state"], "safe");
+    }
+
+    #[tokio::test]
+    async fn any_unsafe_monitor_makes_the_overall_state_unsafe() {
+        let enforcer = enforcer_with(vec![
+            ScriptedProbe::new("one", vec![Ok(true)]),
+            ScriptedProbe::new("two", vec![Ok(false)]),
+        ]);
+        let mut events = enforcer.event_bus.subscribe();
+
+        let mut state = HashMap::new();
+        let overall = enforcer.poll_once(&mut state, true).await;
+
+        assert!(!overall);
+        // Only the flipping monitor emits.
+        let changed = events.recv().await.unwrap();
+        assert_eq!(changed.payload["monitor"], "two");
+        assert!(events.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn unsafe_without_a_session_still_gates() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(false)])]);
+        let mut state = HashMap::new();
+
+        enforcer.poll_once(&mut state, true).await;
+
+        assert!(!enforcer.safety_ok.load(Ordering::SeqCst));
+        assert_eq!(enforcer.session.status().await, "idle");
+    }
+
+    #[tokio::test]
+    async fn run_stops_on_cancellation() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(true)])]);
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(enforcer.run(cancel.clone()));
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("run() did not stop on cancellation")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn from_registry_is_none_without_monitors() {
+        let event_bus = Arc::new(EventBus::from_config(&[]));
+        let session = Arc::new(SessionManager::new(event_bus.clone(), &[]));
+        let enforcer = SafetyEnforcer::from_registry(
+            empty_registry(),
+            event_bus,
+            session,
+            Arc::new(LocalSessionManager::default()),
+            Arc::new(AtomicBool::new(true)),
+            Duration::from_secs(10),
+        );
+        assert!(enforcer.is_none());
+    }
+}

--- a/services/rp/src/safety.rs
+++ b/services/rp/src/safety.rs
@@ -119,6 +119,10 @@ impl<P: SafetyProbe> SafetyEnforcer<P> {
         let mut per_monitor: HashMap<String, bool> = HashMap::new();
         let mut overall = true;
         loop {
+            // Poll before sleeping: a monitor that is unsafe (or
+            // unreadable) at startup must gate immediately, not after
+            // the first interval elapses.
+            overall = self.poll_once(&mut per_monitor, overall).await;
             tokio::select! {
                 () = cancel.cancelled() => {
                     debug!("safety monitoring stopped");
@@ -126,7 +130,6 @@ impl<P: SafetyProbe> SafetyEnforcer<P> {
                 }
                 () = tokio::time::sleep(self.poll_interval) => {}
             }
-            overall = self.poll_once(&mut per_monitor, overall).await;
         }
     }
 
@@ -420,6 +423,48 @@ mod tests {
             .unwrap();
     }
 
+    /// The first poll happens immediately, not after the first interval:
+    /// a monitor that is unsafe at startup must gate `/mcp` right away.
+    /// The interval here is far longer than the wait, so a pass proves
+    /// the gate closed on the immediate poll.
+    #[tokio::test]
+    async fn run_polls_immediately_at_startup() {
+        let mut enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(false)])]);
+        enforcer.poll_interval = Duration::from_secs(3600);
+        let safety_ok = enforcer.safety_ok.clone();
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(enforcer.run(cancel.clone()));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while safety_ok.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            !safety_ok.load(Ordering::SeqCst),
+            "the gate never closed — the loop slept a full interval before its first poll"
+        );
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("run() did not stop on cancellation")
+            .unwrap();
+    }
+
+    /// Terminating a session whose worker already died must be harmless
+    /// (the close reports an error; the registry still ends up empty).
+    #[tokio::test]
+    async fn terminating_already_dead_mcp_sessions_is_harmless() {
+        let enforcer = enforcer_with(vec![ScriptedProbe::new("sm", vec![Ok(false)])]);
+        let (_id, transport) = enforcer.mcp_sessions.create_session().await.unwrap();
+        // Dropping the transport kills the session's worker.
+        drop(transport);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut state = HashMap::new();
+        enforcer.poll_once(&mut state, true).await;
+        assert!(enforcer.mcp_sessions.sessions.read().await.is_empty());
+    }
+
     #[tokio::test]
     async fn from_registry_is_none_without_monitors() {
         let event_bus = Arc::new(EventBus::from_config(&[]));
@@ -433,5 +478,155 @@ mod tests {
             Duration::from_secs(10),
         );
         assert!(enforcer.is_none());
+    }
+
+    /// Build the enforcer from a real registry so the production
+    /// [`AlpacaSafetyProbe`] is exercised (not the scripted test probe):
+    /// a connected monitor reads through the Alpaca `issafe` endpoint,
+    /// and a monitor whose connect failed reads as an error → unsafe.
+    /// The registry also carries cameras so the unsafe transition's
+    /// exposure abort covers all three arms: abort acknowledged, abort
+    /// rejected (no exposure in progress), and camera not connected.
+    #[tokio::test]
+    async fn alpaca_probe_reads_issafe_and_unsafe_aborts_exposures() {
+        use axum::routing::{get, put};
+        use axum::{Json, Router};
+
+        let app = Router::new()
+            .route(
+                "/management/v1/configureddevices",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": [
+                            {
+                                "DeviceName": "Safety Monitor 0",
+                                "DeviceType": "SafetyMonitor",
+                                "DeviceNumber": 0,
+                                "UniqueID": "test-sm-uid"
+                            },
+                            {
+                                "DeviceName": "Camera 0",
+                                "DeviceType": "Camera",
+                                "DeviceNumber": 0,
+                                "UniqueID": "test-cam-0"
+                            },
+                            {
+                                "DeviceName": "Camera 1",
+                                "DeviceType": "Camera",
+                                "DeviceNumber": 1,
+                                "UniqueID": "test-cam-1"
+                            }
+                        ],
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/safetymonitor/0/connected",
+                put(|| async { Json(serde_json::json!({"ErrorNumber": 0, "ErrorMessage": ""})) }),
+            )
+            .route(
+                "/api/v1/safetymonitor/0/issafe",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "Value": true,
+                        "ErrorNumber": 0,
+                        "ErrorMessage": ""
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/camera/0/connected",
+                put(|| async { Json(serde_json::json!({"ErrorNumber": 0, "ErrorMessage": ""})) }),
+            )
+            .route(
+                "/api/v1/camera/1/connected",
+                put(|| async { Json(serde_json::json!({"ErrorNumber": 0, "ErrorMessage": ""})) }),
+            )
+            .route(
+                "/api/v1/camera/0/abortexposure",
+                put(|| async { Json(serde_json::json!({"ErrorNumber": 0, "ErrorMessage": ""})) }),
+            )
+            .route(
+                "/api/v1/camera/1/abortexposure",
+                put(|| async {
+                    Json(serde_json::json!({
+                        "ErrorNumber": 1035,
+                        "ErrorMessage": "no exposure in progress"
+                    }))
+                }),
+            );
+        let stub = crate::equipment::test_support::spawn_stub(app).await;
+
+        fn camera_cfg(id: &str, url: &str, device_number: u32) -> crate::config::CameraConfig {
+            crate::config::CameraConfig {
+                id: id.to_string(),
+                name: id.to_string(),
+                alpaca_url: url.to_string(),
+                device_type: String::new(),
+                device_number,
+                cooler_target_c: None,
+                gain: None,
+                offset: None,
+                focal_length_mm: None,
+                readout_time_estimate: None,
+                auth: None,
+            }
+        }
+        let equipment_cfg = crate::config::EquipmentConfig {
+            cameras: vec![
+                camera_cfg("aborts-ok", &stub.url(), 0),
+                camera_cfg("abort-rejected", &stub.url(), 1),
+                // Client construction fails instantly on a bad URL, so
+                // this entry is disconnected without any retry delay.
+                camera_cfg("never-connected-cam", "not-a-url", 0),
+            ],
+            mount: None,
+            focusers: vec![],
+            filter_wheels: vec![],
+            cover_calibrators: vec![],
+            safety_monitors: vec![
+                crate::config::SafetyMonitorConfig {
+                    id: "reachable".to_string(),
+                    alpaca_url: stub.url(),
+                    device_number: 0,
+                    auth: None,
+                },
+                crate::config::SafetyMonitorConfig {
+                    id: "never-connected".to_string(),
+                    alpaca_url: "not-a-url".to_string(),
+                    device_number: 0,
+                    auth: None,
+                },
+            ],
+        };
+        let equipment = Arc::new(EquipmentRegistry::new(&equipment_cfg).await);
+        let event_bus = Arc::new(EventBus::from_config(&[]));
+        let session = Arc::new(SessionManager::new(event_bus.clone(), &[]));
+        let enforcer = SafetyEnforcer::from_registry(
+            equipment,
+            event_bus.clone(),
+            session,
+            Arc::new(LocalSessionManager::default()),
+            Arc::new(AtomicBool::new(true)),
+            Duration::from_millis(1),
+        )
+        .expect("monitors are configured");
+        let mut events = event_bus.subscribe();
+
+        let mut state = HashMap::new();
+        let overall = enforcer.poll_once(&mut state, true).await;
+
+        // The reachable monitor reads safe; the disconnected one reads
+        // as an error and counts unsafe — overall unsafe, and only the
+        // disconnected monitor emits a transition. The unsafe handling
+        // ran the exposure abort against all three cameras (asserted
+        // implicitly: poll_once returned, no panic on any arm).
+        assert!(!overall);
+        assert!(!enforcer.safety_ok.load(Ordering::SeqCst));
+        let changed = events.recv().await.unwrap();
+        assert_eq!(changed.payload["monitor"], "never-connected");
+        assert_eq!(changed.payload["new_state"], "unsafe");
     }
 }

--- a/services/rp/src/session.rs
+++ b/services/rp/src/session.rs
@@ -91,8 +91,16 @@ impl SessionManager {
     pub async fn start(self: &Arc<Self>) -> Result<Value, String> {
         let mut state = self.state.write().await;
 
-        if !matches!(*state, SessionState::Idle) {
-            return Err("a session is already active".to_string());
+        match &*state {
+            SessionState::Idle => {}
+            SessionState::Active { .. } => {
+                return Err("a session is already active".to_string());
+            }
+            SessionState::Interrupted { .. } => {
+                return Err(
+                    "a session is interrupted, awaiting safe conditions to resume".to_string(),
+                );
+            }
         }
 
         let session_id = Uuid::new_v4().to_string();
@@ -411,8 +419,13 @@ mod tests {
         Arc::new(SessionManager::new(event_bus, &plugins))
     }
 
+    // 300 × 50ms = 15s. Generous because the unreachable-orchestrator test
+    // sits through the full retry schedule first, and on Windows a refused
+    // localhost connect is not instant — WinSock retries SYNs for about a
+    // second before reporting `WSAECONNREFUSED`, so three attempts plus two
+    // 1s backoffs already burn ~5s there.
     async fn wait_for_status(manager: &Arc<SessionManager>, expected: &str) -> bool {
-        for _ in 0..100 {
+        for _ in 0..300 {
             if manager.status().await == expected {
                 return true;
             }
@@ -524,14 +537,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_is_refused_while_interrupted() {
+    async fn start_is_refused_while_active_and_while_interrupted() {
         let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
         let manager = manager_for(&stub.url);
         manager.start().await.unwrap();
-        manager.interrupt().await;
 
         let err = manager.start().await.unwrap_err();
         assert!(err.contains("already active"), "got: {err}");
+
+        manager.interrupt().await;
+        // The refusal must name the interrupted state, not claim the
+        // session is active — the operator would otherwise look for a
+        // running workflow that isn't there.
+        let err = manager.start().await.unwrap_err();
+        assert!(err.contains("interrupted"), "got: {err}");
     }
 
     #[tokio::test]
@@ -572,5 +591,15 @@ mod tests {
         // current session.
         manager.fail_invoke("some-older-workflow").await;
         assert_eq!(manager.status().await, "active");
+
+        // Nor may a late failure resurrect activity once the session is
+        // over: fail_invoke on an idle manager stays idle.
+        let workflow_id = stub.bodies.read().await[0]["workflow_id"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        manager.stop().await.unwrap();
+        manager.fail_invoke(&workflow_id).await;
+        assert_eq!(manager.status().await, "idle");
     }
 }

--- a/services/rp/src/session.rs
+++ b/services/rp/src/session.rs
@@ -1,11 +1,35 @@
+//! Session lifecycle: the state machine behind `/api/session/*` and the
+//! orchestrator invocation protocol (rp.md § Orchestrator Invocation
+//! Protocol, § Safety).
+//!
+//! A session is `Idle`, `Active`, or `Interrupted`. Starting a session
+//! invokes the configured orchestrator plugin; a safety unsafe
+//! transition moves an active session to `Interrupted` (the safety
+//! enforcer also tears down the MCP transport — see `crate::safety`);
+//! the safe transition re-invokes the orchestrator with recovery
+//! context and the same ids. The invoke POST is retried on transport
+//! errors and 5xx responses; a 4xx is permanent. When every attempt
+//! fails the session returns to `Idle` and a `session_stopped` event
+//! with `reason: "orchestrator_invoke_failed"` is emitted — a session
+//! never sits active with an orchestrator that was never reached.
+
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde_json::Value;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::events::EventBus;
+
+/// Attempts made for one orchestrator invocation (initial or recovery).
+const INVOKE_ATTEMPTS: u32 = 3;
+
+/// Delay between invocation attempts. Short: the retry exists to ride
+/// out an engine mid-restart (systemd brings it back in seconds), not
+/// to wait out a long outage.
+const INVOKE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub struct SessionConfig {
@@ -15,7 +39,15 @@ pub struct SessionConfig {
 enum SessionState {
     Idle,
     Active {
-        _session_id: String,
+        session_id: String,
+        workflow_id: String,
+    },
+    /// A safety event interrupted the workflow; the ids are kept so the
+    /// safe transition can re-invoke the orchestrator for the same
+    /// session (its persisted state — e.g. session-runner's blackboard —
+    /// is keyed by `session_id`).
+    Interrupted {
+        session_id: String,
         workflow_id: String,
     },
 }
@@ -56,10 +88,10 @@ impl SessionManager {
         *self.mcp_base_url.write().await = url;
     }
 
-    pub async fn start(&self) -> Result<Value, String> {
+    pub async fn start(self: &Arc<Self>) -> Result<Value, String> {
         let mut state = self.state.write().await;
 
-        if matches!(*state, SessionState::Active { .. }) {
+        if !matches!(*state, SessionState::Idle) {
             return Err("a session is already active".to_string());
         }
 
@@ -67,13 +99,13 @@ impl SessionManager {
         let workflow_id = Uuid::new_v4().to_string();
 
         *state = SessionState::Active {
-            _session_id: session_id.clone(),
+            session_id: session_id.clone(),
             workflow_id: workflow_id.clone(),
         };
+        drop(state);
 
         debug!(session_id = %session_id, workflow_id = %workflow_id, "session started");
 
-        // Emit session_started event
         self.event_bus.emit(
             "session_started",
             serde_json::json!({
@@ -82,40 +114,121 @@ impl SessionManager {
             }),
         );
 
-        // Invoke orchestrator if configured
-        if let Some(invoke_url) = &self.orchestrator_invoke_url {
-            let mcp_url = self.mcp_base_url.read().await.clone();
-            let mcp_server_url = format!("{}/mcp", mcp_url);
-            let invoke_url = invoke_url.clone();
-            let wf_id = workflow_id.clone();
-            let s_id = session_id.clone();
-            let config = self.orchestrator_config.clone();
-
-            tokio::spawn(async move {
-                debug!(url = %invoke_url, "invoking orchestrator");
-                let client = reqwest::Client::new();
-                let body = serde_json::json!({
-                    "workflow_id": wf_id,
-                    "session_id": s_id,
-                    "mcp_server_url": mcp_server_url,
-                    "recovery": null,
-                    "config": config,
-                });
-                match client.post(&invoke_url).json(&body).send().await {
-                    Ok(resp) => {
-                        debug!(status = %resp.status(), "orchestrator invoked");
-                    }
-                    Err(e) => {
-                        debug!(error = %e, "failed to invoke orchestrator");
-                    }
-                }
-            });
-        }
+        self.spawn_invoke(workflow_id.clone(), session_id.clone(), None)
+            .await;
 
         Ok(serde_json::json!({
             "session_id": session_id,
             "workflow_id": workflow_id,
         }))
+    }
+
+    /// Move an active session to `Interrupted` (safety unsafe
+    /// transition). Returns whether there was an active session to
+    /// interrupt. The MCP teardown happens in `crate::safety` — this is
+    /// only the bookkeeping half.
+    pub async fn interrupt(&self) -> bool {
+        let mut state = self.state.write().await;
+        match &*state {
+            SessionState::Active {
+                session_id,
+                workflow_id,
+            } => {
+                debug!(session_id = %session_id, workflow_id = %workflow_id,
+                       "session interrupted by safety event");
+                *state = SessionState::Interrupted {
+                    session_id: session_id.clone(),
+                    workflow_id: workflow_id.clone(),
+                };
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Resume an interrupted session (safety safe transition): mark it
+    /// active again and re-invoke the orchestrator with recovery
+    /// context. Returns whether there was an interrupted session.
+    pub async fn resume(self: &Arc<Self>) -> bool {
+        let mut state = self.state.write().await;
+        let SessionState::Interrupted {
+            session_id,
+            workflow_id,
+        } = &*state
+        else {
+            return false;
+        };
+        let (session_id, workflow_id) = (session_id.clone(), workflow_id.clone());
+        *state = SessionState::Active {
+            session_id: session_id.clone(),
+            workflow_id: workflow_id.clone(),
+        };
+        drop(state);
+
+        debug!(session_id = %session_id, workflow_id = %workflow_id,
+               "conditions safe again; re-invoking the orchestrator with recovery context");
+        let recovery = serde_json::json!({ "reason": "safety_interruption" });
+        self.spawn_invoke(workflow_id, session_id, Some(recovery))
+            .await;
+        true
+    }
+
+    /// POST the orchestrator invocation in the background, retrying per
+    /// the protocol (rp.md § Orchestrator Invocation Protocol). No-op
+    /// when no orchestrator is configured.
+    async fn spawn_invoke(
+        self: &Arc<Self>,
+        workflow_id: String,
+        session_id: String,
+        recovery: Option<Value>,
+    ) {
+        let Some(invoke_url) = self.orchestrator_invoke_url.clone() else {
+            return;
+        };
+        let mcp_url = self.mcp_base_url.read().await.clone();
+        let body = serde_json::json!({
+            "workflow_id": workflow_id,
+            "session_id": session_id,
+            "mcp_server_url": format!("{}/mcp", mcp_url),
+            "recovery": recovery,
+            "config": self.orchestrator_config.clone(),
+        });
+
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            if !invoke_with_retry(&invoke_url, &body).await {
+                manager.fail_invoke(&workflow_id).await;
+            }
+        });
+    }
+
+    /// Every invocation attempt failed: return the session to idle so
+    /// the operator can see the failure and start over, unless the
+    /// session has already moved on (completed, stopped, restarted).
+    async fn fail_invoke(&self, failed_workflow_id: &str) {
+        let mut state = self.state.write().await;
+        let matches = match &*state {
+            SessionState::Active { workflow_id, .. }
+            | SessionState::Interrupted { workflow_id, .. } => workflow_id == failed_workflow_id,
+            SessionState::Idle => false,
+        };
+        if !matches {
+            debug!(workflow_id = %failed_workflow_id,
+                   "invoke failure for a session that already moved on; ignoring");
+            return;
+        }
+        warn!(workflow_id = %failed_workflow_id,
+              "orchestrator could not be invoked; session returns to idle");
+        *state = SessionState::Idle;
+        drop(state);
+
+        self.event_bus.emit(
+            "session_stopped",
+            serde_json::json!({
+                "reason": "orchestrator_invoke_failed",
+                "workflow_id": failed_workflow_id,
+            }),
+        );
     }
 
     pub async fn stop(&self) -> Result<(), String> {
@@ -139,17 +252,24 @@ impl SessionManager {
         match *state {
             SessionState::Idle => "idle".to_string(),
             SessionState::Active { .. } => "active".to_string(),
+            SessionState::Interrupted { .. } => "interrupted".to_string(),
         }
     }
 
     pub async fn workflow_complete(&self, workflow_id: &str) {
         let mut state = self.state.write().await;
 
+        // An interrupted session can complete too: the engine may post
+        // completion in the same instant the safety monitor turns
+        // unsafe — the completion wins, there is nothing left to resume.
         let matches = match &*state {
             SessionState::Active {
                 workflow_id: wf_id, ..
+            }
+            | SessionState::Interrupted {
+                workflow_id: wf_id, ..
             } => wf_id == workflow_id,
-            _ => false,
+            SessionState::Idle => false,
         };
 
         if matches {
@@ -166,5 +286,291 @@ impl SessionManager {
         } else {
             debug!(workflow_id = %workflow_id, "workflow_complete received but no matching active session");
         }
+    }
+}
+
+/// POST `body` to the orchestrator's invoke URL, retrying transient
+/// failures (transport errors, 5xx) up to [`INVOKE_ATTEMPTS`] times with
+/// [`INVOKE_RETRY_DELAY`] between attempts. A 4xx response is permanent —
+/// the same request will fail the same way. Returns whether an attempt
+/// was acknowledged with a success status.
+async fn invoke_with_retry(invoke_url: &str, body: &Value) -> bool {
+    let client = reqwest::Client::new();
+    for attempt in 1..=INVOKE_ATTEMPTS {
+        debug!(url = %invoke_url, attempt, "invoking orchestrator");
+        match client.post(invoke_url).json(body).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                debug!(status = %resp.status(), attempt, "orchestrator invoked");
+                return true;
+            }
+            Ok(resp) if resp.status().is_client_error() => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                warn!(%status, %body, "orchestrator rejected the invocation; not retrying");
+                return false;
+            }
+            Ok(resp) => {
+                warn!(status = %resp.status(), attempt, max = INVOKE_ATTEMPTS,
+                      "orchestrator invocation failed");
+            }
+            Err(e) => {
+                warn!(error = %e, attempt, max = INVOKE_ATTEMPTS,
+                      "failed to reach the orchestrator");
+            }
+        }
+        if attempt < INVOKE_ATTEMPTS {
+            tokio::time::sleep(INVOKE_RETRY_DELAY).await;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::routing::post;
+    use axum::Json;
+    use axum::Router;
+    use serde_json::json;
+
+    use super::*;
+
+    /// In-process orchestrator stub: records every `/invoke` body and
+    /// answers with the scripted status sequence (last entry repeats).
+    struct InvokeStub {
+        url: String,
+        bodies: Arc<RwLock<Vec<Value>>>,
+        hits: Arc<AtomicU32>,
+        _shutdown: tokio::sync::oneshot::Sender<()>,
+    }
+
+    async fn spawn_invoke_stub(statuses: Vec<StatusCode>) -> InvokeStub {
+        #[derive(Clone)]
+        struct StubState {
+            bodies: Arc<RwLock<Vec<Value>>>,
+            hits: Arc<AtomicU32>,
+            statuses: Arc<Vec<StatusCode>>,
+        }
+        let state = StubState {
+            bodies: Arc::new(RwLock::new(Vec::new())),
+            hits: Arc::new(AtomicU32::new(0)),
+            statuses: Arc::new(statuses),
+        };
+        let app = Router::new()
+            .route(
+                "/invoke",
+                post(
+                    |State(state): State<StubState>, Json(body): Json<Value>| async move {
+                        state.bodies.write().await.push(body);
+                        let n = state.hits.fetch_add(1, Ordering::SeqCst) as usize;
+                        let status = *state
+                            .statuses
+                            .get(n)
+                            .or(state.statuses.last())
+                            .unwrap_or(&StatusCode::OK);
+                        (
+                            status,
+                            Json(json!({"estimated_duration": "1s", "max_duration": "0s"})),
+                        )
+                    },
+                ),
+            )
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        InvokeStub {
+            url: format!("http://127.0.0.1:{port}/invoke"),
+            bodies: state.bodies,
+            hits: state.hits,
+            _shutdown: tx,
+        }
+    }
+
+    fn manager_for(invoke_url: &str) -> Arc<SessionManager> {
+        let event_bus = Arc::new(EventBus::from_config(&[]));
+        let plugins = vec![json!({
+            "name": "test-orchestrator",
+            "type": "orchestrator",
+            "invoke_url": invoke_url,
+            "config": {"workflow": "w"},
+        })];
+        Arc::new(SessionManager::new(event_bus, &plugins))
+    }
+
+    async fn wait_for_status(manager: &Arc<SessionManager>, expected: &str) -> bool {
+        for _ in 0..100 {
+            if manager.status().await == expected {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    async fn wait_for_hits(stub: &InvokeStub, expected: u32) -> bool {
+        for _ in 0..100 {
+            if stub.hits.load(Ordering::SeqCst) >= expected {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn start_invokes_orchestrator_with_null_recovery() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+
+        let response = manager.start().await.unwrap();
+        assert!(response.get("session_id").is_some());
+        assert!(wait_for_hits(&stub, 1).await, "orchestrator never invoked");
+
+        let bodies = stub.bodies.read().await;
+        assert!(bodies[0]["recovery"].is_null());
+        assert_eq!(bodies[0]["config"], json!({"workflow": "w"}));
+        drop(bodies);
+        assert_eq!(manager.status().await, "active");
+    }
+
+    #[tokio::test]
+    async fn invoke_retries_a_5xx_then_succeeds() {
+        let stub = spawn_invoke_stub(vec![StatusCode::INTERNAL_SERVER_ERROR, StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+
+        manager.start().await.unwrap();
+        assert!(wait_for_hits(&stub, 2).await, "no retry after the 5xx");
+        // The session must remain active: the retry succeeded.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(manager.status().await, "active");
+    }
+
+    #[tokio::test]
+    async fn invoke_gives_up_immediately_on_4xx() {
+        let stub = spawn_invoke_stub(vec![StatusCode::BAD_REQUEST]).await;
+        let manager = manager_for(&stub.url);
+        let mut events = manager.event_bus.subscribe();
+
+        manager.start().await.unwrap();
+        assert!(
+            wait_for_status(&manager, "idle").await,
+            "session did not return to idle after the permanent invoke failure"
+        );
+        assert_eq!(
+            stub.hits.load(Ordering::SeqCst),
+            1,
+            "a 4xx must not be retried"
+        );
+
+        // session_started, then session_stopped with the failure reason.
+        let started = events.recv().await.unwrap();
+        assert_eq!(started.event, "session_started");
+        let stopped = events.recv().await.unwrap();
+        assert_eq!(stopped.event, "session_stopped");
+        assert_eq!(stopped.payload["reason"], "orchestrator_invoke_failed");
+    }
+
+    #[tokio::test]
+    async fn invoke_unreachable_exhausts_retries_and_returns_to_idle() {
+        // Bind a port then drop the listener: connects are refused.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let manager = manager_for(&format!("http://127.0.0.1:{port}/invoke"));
+
+        manager.start().await.unwrap();
+        assert!(
+            wait_for_status(&manager, "idle").await,
+            "session did not return to idle with an unreachable orchestrator"
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupt_then_resume_reinvokes_with_recovery_and_same_ids() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+
+        manager.start().await.unwrap();
+        assert!(wait_for_hits(&stub, 1).await);
+
+        assert!(manager.interrupt().await);
+        assert_eq!(manager.status().await, "interrupted");
+
+        assert!(manager.resume().await);
+        assert_eq!(manager.status().await, "active");
+        assert!(wait_for_hits(&stub, 2).await, "resume never re-invoked");
+
+        let bodies = stub.bodies.read().await;
+        assert_eq!(
+            bodies[1]["recovery"],
+            json!({"reason": "safety_interruption"})
+        );
+        assert_eq!(bodies[1]["workflow_id"], bodies[0]["workflow_id"]);
+        assert_eq!(bodies[1]["session_id"], bodies[0]["session_id"]);
+    }
+
+    #[tokio::test]
+    async fn start_is_refused_while_interrupted() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+        manager.start().await.unwrap();
+        manager.interrupt().await;
+
+        let err = manager.start().await.unwrap_err();
+        assert!(err.contains("already active"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn workflow_complete_ends_an_interrupted_session() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+        manager.start().await.unwrap();
+        assert!(wait_for_hits(&stub, 1).await);
+        let workflow_id = stub.bodies.read().await[0]["workflow_id"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        manager.interrupt().await;
+        manager.workflow_complete(&workflow_id).await;
+        assert_eq!(manager.status().await, "idle");
+        // Nothing left to resume.
+        assert!(!manager.resume().await);
+    }
+
+    #[tokio::test]
+    async fn interrupt_and_resume_are_noops_when_idle() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+        assert!(!manager.interrupt().await);
+        assert!(!manager.resume().await);
+        assert_eq!(manager.status().await, "idle");
+    }
+
+    #[tokio::test]
+    async fn invoke_failure_for_a_moved_on_session_is_ignored() {
+        let stub = spawn_invoke_stub(vec![StatusCode::OK]).await;
+        let manager = manager_for(&stub.url);
+        manager.start().await.unwrap();
+        assert!(wait_for_hits(&stub, 1).await);
+
+        // A stale failure from a previous workflow must not clobber the
+        // current session.
+        manager.fail_invoke("some-older-workflow").await;
+        assert_eq!(manager.status().await, "active");
     }
 }

--- a/services/rp/tests/bdd/steps/event_steps.rs
+++ b/services/rp/tests/bdd/steps/event_steps.rs
@@ -161,6 +161,35 @@ async fn timing_estimates_recorded(world: &mut RpWorld) {
     );
 }
 
+#[then(expr = "the {string} event payload field {string} should be {string}")]
+async fn event_payload_field_equals(
+    world: &mut RpWorld,
+    event_type: String,
+    field: String,
+    expected: String,
+) {
+    let events = world.received_events.read().await;
+    let event = events
+        .iter()
+        .find(|e| e.event_type == event_type)
+        .unwrap_or_else(|| panic!("no '{}' event found", event_type));
+
+    let actual = event
+        .payload
+        .get(&field)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected string field '{}' in '{}' event payload, got: {:?}",
+                field, event_type, event.payload
+            )
+        });
+    assert_eq!(
+        actual, expected,
+        "expected '{event_type}' payload field '{field}' to be '{expected}', got '{actual}'"
+    );
+}
+
 #[then(expr = "the {string} event payload should contain a {string}")]
 async fn event_payload_contains_field(world: &mut RpWorld, event_type: String, field: String) {
     let events = world.received_events.read().await;

--- a/services/rp/tests/bdd/steps/mod.rs
+++ b/services/rp/tests/bdd/steps/mod.rs
@@ -22,6 +22,7 @@ pub mod measure_stars_steps;
 pub mod mount_steps;
 pub mod operation_event_steps;
 pub mod plate_solve_steps;
+pub mod safety_steps;
 pub mod session_steps;
 pub mod sky_survey_camera_steps;
 pub mod sse_steps;

--- a/services/rp/tests/bdd/steps/safety_steps.rs
+++ b/services/rp/tests/bdd/steps/safety_steps.rs
@@ -1,0 +1,142 @@
+//! BDD step definitions for safety enforcement (rp.md § Safety): a
+//! SafetyMonitor unsafe transition interrupts the active session and
+//! gates `/mcp`; the safe transition re-invokes the orchestrator with
+//! recovery context.
+//!
+//! The monitor is OmniSim's safety-monitor simulator; its reported
+//! `IsSafe` is flipped at runtime through OmniSim's private
+//! `issafesetting` endpoint.
+
+use std::time::Duration;
+
+use cucumber::{given, then, when};
+
+use bdd_infra::rp_harness::{OmniSimHandle, SafetyMonitorConfig};
+
+use crate::world::RpWorld;
+
+/// How long a poll-until-observed step waits before failing the scenario.
+const OBSERVATION_BUDGET: Duration = Duration::from_secs(5);
+
+#[given("a safety monitor on the simulator")]
+async fn safety_monitor_on_simulator(world: &mut RpWorld) {
+    crate::steps::tool_steps::ensure_omnisim(world).await;
+    // Start from a known-safe reading regardless of what a previous
+    // scenario (or crashed run) left in the simulator's memory.
+    OmniSimHandle::set_safety_monitor_is_safe(true)
+        .await
+        .expect("failed to reset OmniSim's safety monitor to safe");
+    world.safety_monitors.push(SafetyMonitorConfig {
+        id: "weather-watcher".to_string(),
+        alpaca_url: world.omnisim_url(),
+        device_number: 0,
+    });
+    // Fast polling so transitions are detected in test time, not the
+    // production default (10 s).
+    world.safety_poll_interval = Some(Duration::from_millis(250));
+}
+
+#[when("the safety monitor reports unsafe")]
+async fn safety_monitor_reports_unsafe(_world: &mut RpWorld) {
+    OmniSimHandle::set_safety_monitor_is_safe(false)
+        .await
+        .expect("failed to flip OmniSim's safety monitor to unsafe");
+}
+
+#[when("the safety monitor reports safe again")]
+async fn safety_monitor_reports_safe(_world: &mut RpWorld) {
+    OmniSimHandle::set_safety_monitor_is_safe(true)
+        .await
+        .expect("failed to flip OmniSim's safety monitor to safe");
+}
+
+#[then(expr = "the test orchestrator should have been re-invoked with recovery reason {string}")]
+async fn orchestrator_reinvoked_with_recovery(world: &mut RpWorld, reason: String) {
+    let deadline = std::time::Instant::now() + OBSERVATION_BUDGET;
+    loop {
+        {
+            let invocations = world.orchestrator_invocations.read().await;
+            if invocations.len() >= 2 {
+                let recovery = invocations
+                    .last()
+                    .and_then(|inv| inv.recovery.clone())
+                    .expect("the re-invocation carries no `recovery` key at all");
+                assert_eq!(
+                    recovery.get("reason").and_then(|v| v.as_str()),
+                    Some(reason.as_str()),
+                    "unexpected recovery object: {recovery}"
+                );
+                return;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the orchestrator was not re-invoked within {OBSERVATION_BUDGET:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[then("the recovery invocation should carry the original workflow and session ids")]
+async fn recovery_invocation_carries_original_ids(world: &mut RpWorld) {
+    let invocations = world.orchestrator_invocations.read().await;
+    let first = invocations.first().expect("no invocations recorded");
+    let last = invocations.last().expect("no invocations recorded");
+    assert_eq!(
+        (&first.workflow_id, &first.session_id),
+        (&last.workflow_id, &last.session_id),
+        "the recovery invocation must reuse the interrupted session's ids"
+    );
+}
+
+#[then(expr = "the MCP endpoint should reject requests with 503 within {int} seconds")]
+async fn mcp_rejects_with_503(world: &mut RpWorld, seconds: u64) {
+    assert!(
+        poll_mcp_gate(world, true, Duration::from_secs(seconds)).await,
+        "the MCP endpoint never answered 503 while conditions were unsafe"
+    );
+}
+
+#[then(expr = "the MCP endpoint should accept requests again within {int} seconds")]
+async fn mcp_accepts_again(world: &mut RpWorld, seconds: u64) {
+    assert!(
+        poll_mcp_gate(world, false, Duration::from_secs(seconds)).await,
+        "the MCP endpoint kept answering 503 after conditions returned to safe"
+    );
+}
+
+/// Poll `POST /mcp` until its status is (or stops being) 503. The body is
+/// a JSON-RPC `initialize` so an ungated rp answers with a normal MCP
+/// response; the step only discriminates on the 503 gate, not on rmcp's
+/// protocol details.
+async fn poll_mcp_gate(world: &mut RpWorld, expect_gated: bool, budget: Duration) -> bool {
+    let client = reqwest::Client::new();
+    let url = world.rp_mcp_url();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": { "name": "bdd-gate-probe", "version": "0" }
+        }
+    });
+    let deadline = std::time::Instant::now() + budget;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client
+            .post(&url)
+            .header("accept", "application/json, text/event-stream")
+            .json(&body)
+            .send()
+            .await
+        {
+            let gated = resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE;
+            if gated == expect_gated {
+                return true;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}

--- a/services/rp/tests/bdd/steps/session_steps.rs
+++ b/services/rp/tests/bdd/steps/session_steps.rs
@@ -322,6 +322,14 @@ async fn session_status_is(world: &mut RpWorld, expected: String) {
     );
 }
 
+#[then(expr = "the session status should become {string}")]
+async fn session_status_becomes(world: &mut RpWorld, expected: String) {
+    assert!(
+        world.wait_for_session_status(&expected).await,
+        "session status did not become '{expected}' within the wait budget"
+    );
+}
+
 #[then("the test orchestrator should have been cancelled")]
 async fn orchestrator_was_cancelled(world: &mut RpWorld) {
     // The orchestrator's WaitForStop behavior checks the cancelled flag.

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 use bdd_infra::rp_harness::{
     CameraConfig, CoverCalibratorConfig, FilterWheelConfig, FocuserConfig, McpTestClient,
     MountConfig, OmniSimHandle, OrchestratorInvocation, PlateSolverConfig, PlateSolverStub,
-    ReceivedEvent, RpConfigBuilder, SseClient, TestOrchestrator, WebhookReceiver,
+    ReceivedEvent, RpConfigBuilder, SafetyMonitorConfig, SseClient, TestOrchestrator,
+    WebhookReceiver,
 };
 use bdd_infra::sky_survey_camera_harness::SkyViewStub;
 use bdd_infra::ServiceHandle;
@@ -71,6 +72,11 @@ pub struct RpWorld {
     /// the generated rp config. Used by `target_catalog`,
     /// `ephemeris_primitives`, and `planner` BDD features.
     pub site: Option<(f64, f64)>,
+    /// Safety monitors accumulated via Given steps (safety.feature).
+    pub safety_monitors: Vec<SafetyMonitorConfig>,
+    /// Override rp's `safety.poll_interval`; safety scenarios pin this
+    /// short so transitions are detected in test time.
+    pub safety_poll_interval: Option<Duration>,
     /// Plugin configs accumulated via Given steps
     pub plugin_configs: Vec<Value>,
 
@@ -255,6 +261,12 @@ impl RpWorld {
         }
         if let Some((lat, lon)) = self.site {
             builder.with_site(lat, lon);
+        }
+        for sm in &self.safety_monitors {
+            builder.add_safety_monitor(sm.clone());
+        }
+        if let Some(interval) = self.safety_poll_interval {
+            builder.with_safety_poll_interval(interval);
         }
         for plugin in &self.plugin_configs {
             builder.add_plugin(plugin.clone());

--- a/services/rp/tests/features/safety.feature
+++ b/services/rp/tests/features/safety.feature
@@ -1,0 +1,37 @@
+@serial
+Feature: Safety enforcement
+  rp owns safety. Configured ASCOM SafetyMonitor devices are polled at
+  safety.poll_interval, and conditions are safe only while every monitor
+  reports safe; a monitor that cannot be read counts as unsafe. An
+  unsafe transition interrupts the active session: open MCP sessions
+  are terminated, the /mcp endpoint answers 503, and the session waits
+  in "interrupted". The safe transition lifts the gate and re-invokes
+  the orchestrator with recovery context — the same workflow and
+  session ids, recovery reason "safety_interruption" — returning the
+  session to "active". Each monitor transition emits a "safety_changed"
+  event.
+
+  Scenario: An unsafe transition interrupts the session and the safe transition re-invokes the orchestrator
+    Given a running Alpaca simulator
+    And a test orchestrator that waits for a stop signal
+    And a safety monitor on the simulator
+    And a test webhook receiver subscribed to "safety_changed"
+    And rp is running with equipment and both plugins configured
+    When a session is started via the REST API
+    And the safety monitor reports unsafe
+    Then the test webhook receiver should receive a "safety_changed" event
+    And the "safety_changed" event payload field "new_state" should be "unsafe"
+    And the session status should become "interrupted"
+    When the safety monitor reports safe again
+    Then the session status should become "active"
+    And the test orchestrator should have been re-invoked with recovery reason "safety_interruption"
+    And the recovery invocation should carry the original workflow and session ids
+
+  Scenario: The MCP endpoint rejects requests while conditions are unsafe
+    Given a running Alpaca simulator
+    And a safety monitor on the simulator
+    And rp is running with a camera and filter wheel on the simulator
+    When the safety monitor reports unsafe
+    Then the MCP endpoint should reject requests with 503 within 5 seconds
+    When the safety monitor reports safe again
+    Then the MCP endpoint should accept requests again within 5 seconds

--- a/services/rp/tests/features/session_lifecycle.feature
+++ b/services/rp/tests/features/session_lifecycle.feature
@@ -103,12 +103,15 @@ Feature: Session lifecycle with flat calibration orchestrator
     And a workflow completion is posted with an unknown workflow id
     Then the session status should be "active"
 
-  Scenario: Session with unreachable orchestrator still starts
+  Scenario: A session whose orchestrator is unreachable fails loud and returns to idle
     Given a running Alpaca simulator
     And a plugin configured as orchestrator with invoke URL "http://localhost:1/invoke"
-    And rp is running with a camera and filter wheel on the simulator and the test orchestrator
+    And a test webhook receiver subscribed to "session_stopped"
+    And rp is running with equipment and both plugins configured
     When a session is started via the REST API
-    Then the session status should be "active"
+    Then the session status should become "idle"
+    And the test webhook receiver should receive a "session_stopped" event
+    And the "session_stopped" event payload field "reason" should be "orchestrator_invoke_failed"
 
   Scenario: Session can be restarted after completion
     Given a running Alpaca simulator

--- a/services/session-runner/tests/bdd/steps/recovery_steps.rs
+++ b/services/session-runner/tests/bdd/steps/recovery_steps.rs
@@ -1,18 +1,26 @@
 //! BDD step definitions for the resume contract (design § Re-entrancy
-//! Contract): a session interrupted mid-run — the engine killed, or `rp`
-//! itself gone — continues from the persisted blackboard when re-invoked
-//! with recovery context, without repeating recorded work.
+//! Contract): a session interrupted mid-run — the engine killed, `rp`
+//! itself gone, or a safety monitor turning unsafe — continues from the
+//! persisted blackboard when re-invoked with recovery context, without
+//! repeating recorded work.
 //!
-//! `rp`'s own recovery re-invocation machinery is not implemented yet
-//! (`services/rp/src/session.rs` hard-codes `"recovery": null`), so these
-//! steps POST `/invoke` directly, standing in for it — same ids, same
-//! forwarded `config`, a non-null `recovery` object.
+//! The safety scenario exercises `rp`'s own recovery re-invocation
+//! end-to-end (unsafe terminates the run, safe re-invokes). The other
+//! two interrupt the session in ways `rp` cannot recover from yet — an
+//! engine kill and an `rp` restart both need `rp`-side startup recovery,
+//! which is designed but not implemented — so their steps POST `/invoke`
+//! directly, standing in for it: same ids, same forwarded `config`, a
+//! non-null `recovery` object.
 
 use std::time::Duration;
 
-use cucumber::{then, when};
+use cucumber::{given, then, when};
 
-use crate::steps::infrastructure::{start_rp_service, start_session_runner_service};
+use bdd_infra::rp_harness::{OmniSimHandle, SafetyMonitorConfig};
+
+use crate::steps::infrastructure::{
+    ensure_omnisim, start_rp_service, start_session_runner_service,
+};
 use crate::steps::trigger_steps::settled_event_count;
 use crate::world::SessionRunnerWorld;
 
@@ -32,6 +40,69 @@ async fn blackboard_records_frames(world: &mut SessionRunnerWorld, frames: u64) 
         "the blackboard never recorded {frames} frames within {OBSERVATION_BUDGET:?} \
          (last: {:?})",
         world.blackboard_frames().await
+    );
+}
+
+#[given("a safety monitor guards the session")]
+async fn safety_monitor_guards_session(world: &mut SessionRunnerWorld) {
+    ensure_omnisim(world).await;
+    // Start from a known-safe reading regardless of what a previous
+    // scenario (or crashed run) left in the simulator's memory.
+    OmniSimHandle::set_safety_monitor_is_safe(true)
+        .await
+        .expect("failed to reset OmniSim's safety monitor to safe");
+    world.safety_monitors.push(SafetyMonitorConfig {
+        id: "weather-watcher".to_string(),
+        alpaca_url: world.omnisim_url(),
+        device_number: 0,
+    });
+    // Fast polling so rp detects the flips in test time, not the
+    // production default (10 s).
+    world.safety_poll_interval = Some(Duration::from_millis(250));
+}
+
+#[when("the safety monitor reports unsafe")]
+async fn safety_monitor_reports_unsafe(_world: &mut SessionRunnerWorld) {
+    OmniSimHandle::set_safety_monitor_is_safe(false)
+        .await
+        .expect("failed to flip OmniSim's safety monitor to unsafe");
+}
+
+#[when("the safety monitor reports safe again")]
+async fn safety_monitor_reports_safe(_world: &mut SessionRunnerWorld) {
+    OmniSimHandle::set_safety_monitor_is_safe(true)
+        .await
+        .expect("failed to flip OmniSim's safety monitor to safe");
+}
+
+#[then(expr = "rp reports the session as {string} within {int} seconds")]
+async fn rp_reports_session_status(world: &mut SessionRunnerWorld, expected: String, seconds: u64) {
+    let client = reqwest::Client::new();
+    let url = format!("{}/api/session/status", world.rp_url());
+    let deadline = std::time::Instant::now() + Duration::from_secs(seconds);
+    let mut last = None;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(&url).send().await {
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                last = body
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                if last.as_deref() == Some(expected.as_str()) {
+                    return;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("rp never reported the session as '{expected}' within {seconds}s (last: {last:?})");
+}
+
+#[then("the blackboard is kept")]
+async fn blackboard_is_kept(world: &mut SessionRunnerWorld) {
+    assert!(
+        world.blackboard_path().exists(),
+        "an interrupted session must keep its blackboard for the recovery invocation"
     );
 }
 

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bdd_infra::rp_harness::{
     CameraConfig, CoverCalibratorConfig, FilterWheelConfig, ReceivedEvent, RpConfigBuilder,
-    SseClient, WebhookReceiver,
+    SafetyMonitorConfig, SseClient, WebhookReceiver,
 };
 use bdd_infra::ServiceHandle;
 use cucumber::World;
@@ -41,6 +41,12 @@ pub struct SessionRunnerWorld {
     pub cameras: Vec<CameraConfig>,
     pub filter_wheels: Vec<FilterWheelConfig>,
     pub cover_calibrators: Vec<CoverCalibratorConfig>,
+    /// Safety monitors gating the session (recovery.feature's safety
+    /// interruption scenario).
+    pub safety_monitors: Vec<SafetyMonitorConfig>,
+    /// Override rp's `safety.poll_interval`; pinned short so unsafe/safe
+    /// transitions are detected in test time.
+    pub safety_poll_interval: Option<Duration>,
     pub plugin_configs: Vec<Value>,
     /// The orchestrator registration's `config` object (workflow name +
     /// parameters), kept so the recovery scenarios can re-invoke the
@@ -95,6 +101,12 @@ impl SessionRunnerWorld {
         }
         for cc in &self.cover_calibrators {
             builder.add_cover_calibrator(cc.clone());
+        }
+        for sm in &self.safety_monitors {
+            builder.add_safety_monitor(sm.clone());
+        }
+        if let Some(interval) = self.safety_poll_interval {
+            builder.with_safety_poll_interval(interval);
         }
         for plugin in &self.plugin_configs {
             builder.add_plugin(plugin.clone());

--- a/services/session-runner/tests/features/recovery.feature
+++ b/services/session-runner/tests/features/recovery.feature
@@ -5,10 +5,15 @@ Feature: Resume (the re-entrancy contract)
   once-marked setup and picks the capture loop up at the recorded frame
   count instead of starting over.
 
-  rp's own recovery re-invocation machinery is not implemented yet, so
-  these scenarios POST /invoke directly, standing in for it. The fixture
-  document (recovery_capture_loop, tests/fixtures/workflows/) plans 4
-  frames of 2s each; its progress counter lives in session.frames.
+  The safety scenario exercises rp's own recovery machinery end-to-end:
+  an unsafe SafetyMonitor reading terminates the run, and the safe
+  transition re-invokes the engine with recovery context. The other two
+  scenarios interrupt the session in ways rp cannot recover from yet (an
+  engine kill and an rp restart both need rp-side startup recovery,
+  designed but not implemented), so they POST /invoke directly, standing
+  in for it. The fixture document (recovery_capture_loop,
+  tests/fixtures/workflows/) plans 4 frames of 2s each; its progress
+  counter lives in session.frames.
 
   Scenario: A killed engine resumes without repeating recorded frames
     Given a running Alpaca simulator
@@ -36,3 +41,20 @@ Feature: Resume (the re-entrancy contract)
     And the session is re-invoked with recovery context
     Then the blackboard is deleted within 60 seconds
     And the SSE stream should show only the remaining "exposure_complete" events
+
+  Scenario: A safety interruption pauses the session and rp resumes it once conditions are safe
+    Given a running Alpaca simulator
+    And a safety monitor guards the session
+    And rp is running with a camera and the session-runner orchestrator running the "recovery_capture_loop" workflow
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    And the blackboard records at least 2 frames
+    And the safety monitor reports unsafe
+    Then rp reports the session as "interrupted" within 5 seconds
+    And the blackboard is kept
+    When the safety monitor reports safe again
+    Then rp reports the session as "active" within 5 seconds
+    And the blackboard is deleted within 60 seconds
+    And the SSE stream should show between 4 and 5 "exposure_complete" events
+    And the SSE stream should show exactly 1 "filter_switch" event
+    And the SSE stream should show exactly 2 "safety_changed" events


### PR DESCRIPTION
Implements rp's recovery re-invocation machinery — the gap PR #458 documented (its resume scenarios had to POST `/invoke` themselves because rp hard-coded `"recovery": null` and had no safety enforcement at all), plus the `/invoke` fire-and-forget bug.

## What rp does now (rp.md § Safety)

**SafetyMonitor polling.** `equipment.safety_monitors` (ASCOM Alpaca SafetyMonitor devices, connected like any other equipment) are polled at `safety.poll_interval` (humantime, default `10s`). Readings are **fail-unsafe**: a disconnected or erroring monitor counts as unsafe, and conditions are safe only while *all* monitors report safe. Per-monitor transitions emit `safety_changed` events. No monitors configured → no polling task, sessions run ungated (zero change for existing deployments).

**Unsafe transition.**
1. Gate `/mcp`: every request answers 503 while conditions stay unsafe.
2. Terminate every open MCP session (cancelling in-flight tool calls) — the engine's next call surfaces as a terminated session, so it exits without completion and keeps its blackboard (the Phase D contract, unchanged).
3. Mark the session `interrupted` (`/api/session/status`; starting another session stays refused).
4. Best-effort `AbortExposure` on all connected cameras — the tool task driving an exposure was just cancelled, the camera would otherwise keep exposing into rain.

**Safe transition.** Lift the gate, then re-invoke the orchestrator with `recovery: {"reason": "safety_interruption"}` and the *same* `workflow_id`/`session_id`/`config` — the engine resumes from its blackboard per the re-entrancy contract.

**`/invoke` is no longer fire-and-forget.** Transport errors and 5xx are retried (3 attempts, 1 s apart); 4xx is permanent. When every attempt fails the session returns to `idle` and emits `session_stopped` with `reason: "orchestrator_invoke_failed"` — previously it sat `active` forever with an orchestrator that was never reached.

## Living spec

- **rp `safety.feature` (new):** unsafe interrupts the session and safe re-invokes the test orchestrator with recovery context (same ids, reason pinned); the `/mcp` endpoint 503s while unsafe and recovers after. Driven through OmniSim's safety-monitor simulator via its `issafesetting` endpoint (new bdd-infra helper).
- **rp `session_lifecycle.feature`:** the "unreachable orchestrator still starts" scenario now pins the fixed behavior — fails loud back to `idle` with the `orchestrator_invoke_failed` event.
- **session-runner `recovery.feature`:** new end-to-end scenario through rp's *real* machinery — capture loop interrupted at ≥2 frames by an unsafe flip, resumed by the safe flip: exposure totals stay within plan+1, the once-marked filter setup is not re-run (`filter_switch` = 1), exactly 2 `safety_changed` events, blackboard deleted on completion. The engine-kill and rp-outage scenarios still POST `/invoke` directly — they need rp-side *startup* recovery, which remains deferred (below).
- Unit pins: session state machine (interrupt/resume/complete/refuse-start, invoke retry classification, stale-failure guard), safety poll loop (fail-unsafe reads, baseline seeding, MCP teardown, gate flips, multi-monitor aggregation), `/mcp` gate middleware, config parsing.

## Deferred (documented in rp.md)

- **rp startup recovery** (§ Recovery Behavior): the session registry is in-memory, so an rp restart still orphans an interrupted session.
- **Guiding stop / mount park on unsafe** (§ Safety): lands with the guider integration.
- No resume-delay/debounce knob: rp re-invokes on the first safe poll; flapping produces repeated interrupt/resume cycles, each safe by construction.

Config schema change (pre-1.0, no back-compat kept): `safety` is now typed (`{"poll_interval": "10s"}`, unknown fields rejected) and `equipment.safety_monitors` entries are `{id, alpaca_url, device_number, auth?}`. `services/rp/Cargo.toml` enables ascom-alpaca's `safety_monitor` feature (MODULE.bazel.lock repinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
