### PR TITLE
feat(rp): get_next_target returns the exposure plan (closes #462)

### DIFF
--- a/crates/bdd-infra/src/rp_harness/config.rs
+++ b/crates/bdd-infra/src/rp_harness/config.rs
@@ -96,6 +96,20 @@ pub struct PlannerTargetConfig {
     /// planner-wide `planner.min_altitude_degrees` (20 in the emitted
     /// config) applies.
     pub min_altitude_degrees: Option<f64>,
+    /// Exposure plan — `get_next_target` returns the first entry as
+    /// the recommended `filter` / `duration_secs`. Empty ⇒ omit the
+    /// `exposures` field (the planner returns both as null).
+    pub exposures: Vec<ExposurePlanConfig>,
+}
+
+/// One `exposures[]` entry on a planner target (rp.md § Target
+/// Definition).
+#[derive(Debug, Clone)]
+pub struct ExposurePlanConfig {
+    /// `None` ⇒ omit the `filter` field (an unfiltered rig; the
+    /// planner returns `filter: null` for this entry).
+    pub filter: Option<String>,
+    pub duration_secs: f64,
 }
 
 /// Plate-solver service config — emitted as the top-level
@@ -409,6 +423,22 @@ impl RpConfigBuilder {
                     if let Some(floor) = t.min_altitude_degrees {
                         obj["min_altitude_degrees"] = serde_json::json!(floor);
                     }
+                    if !t.exposures.is_empty() {
+                        obj["exposures"] = t
+                            .exposures
+                            .iter()
+                            .map(|e| {
+                                let mut entry = serde_json::json!({
+                                    "duration_secs": e.duration_secs,
+                                });
+                                if let Some(filter) = &e.filter {
+                                    entry["filter"] = serde_json::json!(filter);
+                                }
+                                entry
+                            })
+                            .collect::<Vec<Value>>()
+                            .into();
+                    }
                     obj
                 })
                 .collect::<Vec<Value>>(),
@@ -719,22 +749,46 @@ mod tests {
             ra_hours: 2.5,
             dec_degrees: 0.0,
             min_altitude_degrees: Some(44.8),
+            exposures: vec![
+                ExposurePlanConfig {
+                    filter: Some("Red".to_string()),
+                    duration_secs: 120.0,
+                },
+                ExposurePlanConfig {
+                    filter: None,
+                    duration_secs: 60.0,
+                },
+            ],
         });
         b.add_target(PlannerTargetConfig {
             name: "backup".to_string(),
             ra_hours: 2.45,
             dec_degrees: 0.0,
             min_altitude_degrees: None,
+            exposures: Vec::new(),
         });
         let cfg = b.build();
         let targets = cfg["targets"].as_array().unwrap();
         assert_eq!(targets.len(), 2);
         assert_eq!(targets[0]["name"], "sinker");
         assert_eq!(targets[0]["min_altitude_degrees"], 44.8);
+        let exposures = targets[0]["exposures"].as_array().unwrap();
+        assert_eq!(exposures.len(), 2);
+        assert_eq!(exposures[0]["filter"], "Red");
+        assert_eq!(exposures[0]["duration_secs"], 120.0);
+        assert!(
+            exposures[1].get("filter").is_none(),
+            "a None filter must omit the field (unfiltered entry)"
+        );
+        assert_eq!(exposures[1]["duration_secs"], 60.0);
         assert_eq!(targets[1]["name"], "backup");
         assert!(
             targets[1].get("min_altitude_degrees").is_none(),
             "a None floor must omit the field so rp's planner-wide default applies"
+        );
+        assert!(
+            targets[1].get("exposures").is_none(),
+            "an empty plan must omit the exposures field"
         );
     }
 

--- a/crates/bdd-infra/src/rp_harness/mod.rs
+++ b/crates/bdd-infra/src/rp_harness/mod.rs
@@ -33,9 +33,9 @@ mod sse;
 mod webhook;
 
 pub use config::{
-    build_calibrator_flats_config, CameraConfig, CoverCalibratorConfig, FilterWheelConfig,
-    FocuserConfig, MountConfig, PlannerTargetConfig, PlateSolverConfig, RpConfigBuilder,
-    SafetyMonitorConfig,
+    build_calibrator_flats_config, CameraConfig, CoverCalibratorConfig, ExposurePlanConfig,
+    FilterWheelConfig, FocuserConfig, MountConfig, PlannerTargetConfig, PlateSolverConfig,
+    RpConfigBuilder, SafetyMonitorConfig,
 };
 pub use launcher::{start_rp, wait_for_rp_healthy, write_temp_config_file};
 pub use mcp_client::McpTestClient;

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -436,16 +436,18 @@ committable on its own.
       Planner) get issues filed — closing them is `rp` work, not
       `session-runner` work.
 
-      **Done (2026-07-07):** four gaps the document had to design
-      around, each an `rp` issue: `get_next_target` returns no
-      exposure plan; no `record_exposure` / `get_session_progress`
-      (so no progress-aware dispatch or goal-driven target rotation);
-      no guider tools (`start_guiding` / `stop_guiding` / `dither`);
-      `end_of_session` unreachable (dawn is a document-side heuristic
-      until then). All four are also recorded in
-      `session-runner.md` § `deep_sky.json` ("v1 adaptations") with
-      what the document does meanwhile and what changes when each
-      lands.
+      **Done (2026-07-07, filed 2026-07-08):** four gaps the document
+      had to design around, each an `rp` issue: `get_next_target`
+      returns no exposure plan (#462 — since closed: the planner now
+      returns the first `exposures[]` entry and the document falls
+      back to its parameters); no `record_exposure` /
+      `get_session_progress` (#463, so no progress-aware dispatch or
+      goal-driven target rotation); no guider tools (`start_guiding` /
+      `stop_guiding` / `dither`) (#464); `end_of_session` unreachable
+      (#465, dawn is a document-side heuristic until then). All are
+      also recorded in `session-runner.md` § `deep_sky.json`
+      ("v1 adaptations") with what the document does meanwhile and
+      what changes when each lands.
 
 ### Phase F — Polish and adoption
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -827,7 +827,7 @@ hours, `dec` is degrees. See
 
 | Action | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
-| `get_next_target` | time (optional) | target, reason, filter, duration_secs | Evaluate candidates and recommend next target. v1 returns `filter`/`duration_secs` as null — see §"Dynamic Planner" |
+| `get_next_target` | time (optional) | target, reason, filter, duration_secs | Evaluate candidates and recommend next target. `filter`/`duration_secs` come from the recommended target's first `exposures[]` entry; null when the target defines none — see §"Dynamic Planner" |
 | `get_target_status` | target_name *or* (ra + dec); time (optional) | target_name, altitude_degrees, azimuth_degrees, hour_angle_hours, time_to_set_seconds, progress | Sky position + progress for a catalog target or raw ICRS coords. `progress` is null in v1 |
 | `get_meridian_status` | time (optional) | time_to_flip_seconds, side_of_pier, mount_ra_hours, mount_dec_degrees | Time-to-flip + side-of-pier from the mount's current pointing |
 | `record_exposure` | target, filter | completed, goal | Increment counter, return updated progress |
@@ -2762,6 +2762,11 @@ after each exposure, after each target switch, or when conditions change.
 > `AllBelowMinAltitude` half of bullet 6 (the Sun-elevation
 > cut-off uses astronomical dusk, -18°, matching the
 > "astronomical dusk has not yet begun" wording above).
+> The recommendation also carries the exposure plan: `filter`
+> and `duration_secs` are the recommended target's **first**
+> `exposures[]` entry (null when the target defines none) —
+> rotating *within* a target's plan by progress is the bullet-3/4
+> work below.
 > Documented v1 gaps:
 >
 > - **Bullet 1 set-time elimination** — `next_target` does *not*
@@ -2806,6 +2811,18 @@ after each exposure, after each target switch, or when conditions change.
   "priority": 1
 }
 ```
+
+v1 reads `name`, `ra_hours`, `dec_degrees`, `min_altitude_degrees`,
+and `exposures[]`. Within an exposure entry, `duration_secs` is
+required (positive, finite); `filter` is optional — omit it (or set
+it to `null` / `""`) for an unfiltered rig, and `get_next_target`
+returns `filter: null`. `count` (and the target-level `priority`)
+are parsed-over but unused until per-target progress lands
+(`record_exposure`). A
+malformed exposure entry is skipped with a `debug!` log; a target
+whose plan is missing or entirely invalid still recommends, with
+`filter` / `duration_secs` null — the orchestrator's fallback
+(e.g. `deep_sky.json`'s `exposure` / `filter` parameters) applies.
 
 ## Session Persistence
 

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1059,9 +1059,12 @@ the document simplifies when it lands:
   the recommended target's first `exposures[]` entry (rp issue #462,
   closed). At acquisition the document stashes them — converting
   `duration_secs` to a humantime string with the `humantime()`
-  builtin — and falls back to the `exposure` / `filter` parameters when
-  the planner returns null (a target without `exposures[]`). A plan
-  that names a filter while `filter_wheel_id` is empty fails the
+  builtin — and falls back to the `exposure` / `filter` parameters
+  only when the target has **no plan** (`duration_secs` null). A plan
+  is authoritative for the whole exposure spec: an explicitly
+  unfiltered entry images unfiltered rather than merging with the
+  `filter` parameter. A plan that names a filter while
+  `filter_wheel_id` is empty fails the
   session loudly, mirroring the parameter guard. `max_frames`
   (`0` = unbounded) remains an invocation parameter. Rotating *within*
   a target's plan (Red after 20 Luminance frames) still needs progress

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1012,11 +1012,11 @@ Abridged to the load-bearing shape:
 ### `deep_sky.json` (the night-cycle document)
 
 The classic deep-sky session as a shipped first-party document: startup
-(unpark, tracking, optional filter) → a dispatch loop (`get_next_target` →
-acquire on target change: slew → optional `center_on_target` → optional
-`auto_focus` → one `capture` per pass, re-asking the planner after every
-frame) → shutdown (optional `park`). The full document lives in
-`workflows/deep_sky.json`; the shape:
+(unpark, tracking) → a dispatch loop (`get_next_target` → acquire on
+target change: slew → `set_filter` when the plan names one → optional
+`center_on_target` → optional `auto_focus` → one `capture` per pass,
+re-asking the planner after every frame) → shutdown (optional `park`).
+The full document lives in `workflows/deep_sky.json`; the shape:
 
 ```jsonc
 {
@@ -1031,16 +1031,20 @@ frame) → shutdown (optional `park`). The full document lives in
     { "if": "has(params._recovery.reason)",
       "then": [ { "set": { "session.target_name": "null",
                            "session.imaging": "false" } } ] },
-    /* unpark, set_tracking, optional set_filter — all idempotent */
+    /* unpark, set_tracking — both idempotent */
     { "repeat": { "while": "session.session_over != true", "max_iterations": 20000 },
       "body": [
         { "tool": "get_next_target" },
         /* end_of_session → done; target == null → dawn heuristic
            (wait_for_twilight after frames were captured ends the
            session) or a 5m wait-and-re-ask; target change → stash
-           coords, slew, center, focus, commit session.target_* and
-           session.imaging = true; then one capture + counter updates,
-           ending when params.max_frames (> 0) is reached */ ] },
+           coords + the exposure plan (result.filter /
+           result.duration_secs, falling back to params.filter /
+           params.exposure when null), slew, set_filter if the plan
+           names one, center, focus, commit session.target_* and
+           session.imaging = true; then one capture at the plan
+           duration + counter updates, ending when params.max_frames
+           (> 0) is reached */ ] },
     /* shutdown: session.imaging = false, optional park */ ] }
 }
 ```
@@ -1050,12 +1054,18 @@ tool surface, and its shape reflects the documented planner v1 gaps
 (`rp.md` § Dynamic Planner) — each is `rp` work, tracked as an issue, and
 the document simplifies when it lands:
 
-- **The exposure plan is a parameter, not a planner output.**
-  `get_next_target` v1 returns `filter: null` / `duration_secs: null`
-  (the per-target `exposures[]` config is not yet threaded through), so
-  the document takes `exposure` (per-frame duration), an optional fixed
-  `filter`, and a `max_frames` budget (`0` = unbounded) as invocation
-  parameters.
+- **The planner supplies the exposure plan; parameters are the
+  fallback.** `get_next_target` returns `filter` / `duration_secs` from
+  the recommended target's first `exposures[]` entry (rp issue #462,
+  closed). At acquisition the document stashes them — converting
+  `duration_secs` to a humantime string with the `humantime()`
+  builtin — and falls back to the `exposure` / `filter` parameters when
+  the planner returns null (a target without `exposures[]`). A plan
+  that names a filter while `filter_wheel_id` is empty fails the
+  session loudly, mirroring the parameter guard. `max_frames`
+  (`0` = unbounded) remains an invocation parameter. Rotating *within*
+  a target's plan (Red after 20 Luminance frames) still needs progress
+  counters — that part rides the `record_exposure` issue.
 - **Progress lives in the blackboard, not in `rp`.** `record_exposure` /
   `get_session_progress` do not exist yet, so the document counts frames
   in `session.total_frames` (mirrored to `session.report.total_frames`
@@ -1202,7 +1212,7 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 | Triggers | `triggers.feature` | a trigger action lands between exposures, never during one (proved by SSE seq order); `once` fires exactly once across three captures; cooldown suppresses firings inside its window; a poll trigger fires through its `when` gate |
 | Resume | `recovery.feature` | SIGKILL the engine mid-capture-loop → restart → re-invoke with recovery → progress continues without repeated frames (exposure totals prove it); `once` marker not re-run (`filter_switch` count proves it); an rp outage terminates the run (service stays healthy, blackboard kept) and the session resumes against the restarted rp |
 | Safety | `recovery.feature` | a SafetyMonitor unsafe reading interrupts the session end-to-end through rp's own machinery (rp terminates the MCP session, the run terminates keeping its blackboard) and the safe transition re-invokes the engine with `recovery.reason = "safety_interruption"` — the resumed run captures exactly the remaining frames, the once marker is not re-run, and the completion deletes the blackboard. rp-side specifics (session `interrupted` status, `/mcp` 503 gate, `safety_changed` events) are pinned in rp's own `safety.feature` |
-| Deep-sky document | `deep_sky.feature` | the shipped `deep_sky.json` against a computed night sky (site + planner targets placed so a candidate is viable at test time): the full cycle completes (unpark → slew → center → capture ×N → park); a target sinking below its per-target altitude floor switches the dispatch loop to the second target (a second slew, frames on both sides of it); `refocus_every` fires `auto_focus` from the trigger overlay (`focus_started` count proves it); a due meridian flip re-slews between exposures, never during one; a safety interruption resumes with re-acquisition (two `centering_complete`) |
+| Deep-sky document | `deep_sky.feature` | the shipped `deep_sky.json` against a computed night sky (site + planner targets placed so a candidate is viable at test time): the full cycle completes (unpark → slew → center → capture ×N → park); the planner's exposure plan drives the capture duration (a 2 s plan finishes a session the 300 s parameter default could not); a target sinking below its per-target altitude floor switches the dispatch loop to the second target (a second slew, frames on both sides of it); `refocus_every` fires `auto_focus` from the trigger overlay (`focus_started` count proves it); a due meridian flip re-slews between exposures, never during one; a safety interruption resumes with re-acquisition (two `centering_complete`) |
 
 The safety scenario exercises rp's real recovery re-invocation. The
 engine-kill and rp-outage scenarios POST `/invoke` directly — same ids,

--- a/services/rp/src/planner/convenience.rs
+++ b/services/rp/src/planner/convenience.rs
@@ -73,7 +73,17 @@ pub fn next_target_view(rec: NextTargetRecommendation) -> Value {
     // practice; fall back to `Value::Null` rather than panicking if
     // serde ever rejects the variant.
     let reason = serde_json::to_value(rec.reason).unwrap_or(serde_json::Value::Null);
-    let target = rec.target.map(|t| {
+    // The exposure plan: the first `exposures[]` entry of the
+    // recommended target, null when it defines none. Rotating within
+    // the plan (least progress, filter batching) is deferred until
+    // `record_exposure` counters exist — see rp.md §"Dynamic Planner"
+    // decision-logic bullets 3–4.
+    let plan = rec.target.as_ref().and_then(|t| t.exposures.first());
+    let filter = plan
+        .and_then(|p| p.filter.clone())
+        .map_or(Value::Null, Value::String);
+    let duration_secs = plan.map_or(Value::Null, |p| json!(p.duration_secs));
+    let target = rec.target.as_ref().map(|t| {
         json!({
             "name": t.name,
             "ra_hours": t.ra_hours,
@@ -84,11 +94,8 @@ pub fn next_target_view(rec: NextTargetRecommendation) -> Value {
     json!({
         "target": target,
         "reason": reason,
-        // v1 does not yet pick filters or per-frame durations — the
-        // planner returns the target, the orchestrator picks an
-        // exposure plan from the target's `exposures[]` config.
-        "filter": serde_json::Value::Null,
-        "duration_secs": serde_json::Value::Null,
+        "filter": filter,
+        "duration_secs": duration_secs,
     })
 }
 
@@ -125,7 +132,7 @@ pub fn meridian_status_view(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
 mod tests {
     use super::*;
-    use crate::planner::decision::{NextTargetReason, PlannerTarget};
+    use crate::planner::decision::{ExposureSpec, NextTargetReason, PlannerTarget};
 
     fn site() -> Site {
         Site::new(47.6062, -122.3321).unwrap()
@@ -158,6 +165,8 @@ mod tests {
         let v = next_target_view(rec);
         assert_eq!(v["reason"], "no_targets_configured");
         assert!(v["target"].is_null());
+        assert!(v["filter"].is_null());
+        assert!(v["duration_secs"].is_null());
     }
 
     #[test]
@@ -168,6 +177,7 @@ mod tests {
                 ra_hours: 0.7,
                 dec_degrees: 41.0,
                 min_altitude_degrees: Some(25.0),
+                exposures: Vec::new(),
             }),
             reason: NextTargetReason::BestTransitingCandidate,
         };
@@ -175,6 +185,60 @@ mod tests {
         assert_eq!(v["reason"], "best_transiting_candidate");
         assert_eq!(v["target"]["name"], "M31");
         assert_eq!(v["target"]["min_altitude_degrees"], 25.0);
+        assert!(
+            v["filter"].is_null() && v["duration_secs"].is_null(),
+            "a target without exposures[] must leave the plan null: {v}"
+        );
+    }
+
+    #[test]
+    fn next_target_view_returns_the_first_exposure_plan_entry() {
+        let rec = NextTargetRecommendation {
+            target: Some(PlannerTarget {
+                name: "M31".into(),
+                ra_hours: 0.7,
+                dec_degrees: 41.0,
+                min_altitude_degrees: None,
+                exposures: vec![
+                    ExposureSpec {
+                        filter: Some("Luminance".to_string()),
+                        duration_secs: 300.0,
+                    },
+                    ExposureSpec {
+                        filter: Some("Red".to_string()),
+                        duration_secs: 120.0,
+                    },
+                ],
+            }),
+            reason: NextTargetReason::BestTransitingCandidate,
+        };
+        let v = next_target_view(rec);
+        assert_eq!(v["filter"], "Luminance");
+        assert_eq!(v["duration_secs"], 300.0);
+        assert!(
+            v["target"].get("exposures").is_none(),
+            "the wire target object carries coordinates only: {v}"
+        );
+    }
+
+    #[test]
+    fn next_target_view_leaves_filter_null_for_an_unfiltered_plan_entry() {
+        let rec = NextTargetRecommendation {
+            target: Some(PlannerTarget {
+                name: "OSC Field".into(),
+                ra_hours: 0.7,
+                dec_degrees: 41.0,
+                min_altitude_degrees: None,
+                exposures: vec![ExposureSpec {
+                    filter: None,
+                    duration_secs: 60.0,
+                }],
+            }),
+            reason: NextTargetReason::BestTransitingCandidate,
+        };
+        let v = next_target_view(rec);
+        assert!(v["filter"].is_null());
+        assert_eq!(v["duration_secs"], 60.0);
     }
 
     #[test]

--- a/services/rp/src/planner/decision.rs
+++ b/services/rp/src/planner/decision.rs
@@ -283,7 +283,7 @@ fn parse_exposures(entry: &Value, target: &str) -> Vec<ExposureSpec> {
         if !duration_secs.is_finite() || duration_secs <= 0.0 {
             tracing::debug!(
                 target = %target, duration_secs,
-                "skipping exposure entry with a non-positive `duration_secs`"
+                "skipping exposure entry with a non-finite or non-positive `duration_secs`"
             );
             continue;
         }

--- a/services/rp/src/planner/decision.rs
+++ b/services/rp/src/planner/decision.rs
@@ -37,6 +37,23 @@ pub struct PlannerTarget {
     /// Per-target altitude floor. `None` falls back to the
     /// planner-wide minimum supplied by the caller.
     pub min_altitude_degrees: Option<f64>,
+    /// The target's `exposures[]` plan, in config order. The
+    /// recommendation surfaces the first entry as `filter` /
+    /// `duration_secs`; empty ⇒ both null (the orchestrator's own
+    /// exposure parameters apply).
+    pub exposures: Vec<ExposureSpec>,
+}
+
+/// One entry of a target's `exposures[]` plan (rp.md § Target
+/// Definition). v1 reads `filter` and `duration_secs`; `count` stays
+/// unread until per-target progress (`record_exposure`) lands.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ExposureSpec {
+    /// `None` for an unfiltered entry (no `filter` key, `null`, or
+    /// `""` in config — e.g. an OSC rig without a filter wheel).
+    pub filter: Option<String>,
+    /// Exposure duration in seconds; positive and finite.
+    pub duration_secs: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -231,6 +248,60 @@ pub fn parse_targets_from_value(v: &Value) -> Vec<PlannerTarget> {
             ra_hours: ra,
             dec_degrees: dec,
             min_altitude_degrees: min_alt,
+            exposures: parse_exposures(entry, name),
+        });
+    }
+    out
+}
+
+/// Parse a target row's `exposures[]` into typed entries, skipping
+/// (with a `debug!` log) entries without a positive finite
+/// `duration_secs` or with a non-string `filter`. Same rationale as
+/// the target rows themselves: flag a config typo at parse time
+/// instead of letting it surface as a confusing null plan at night.
+fn parse_exposures(entry: &Value, target: &str) -> Vec<ExposureSpec> {
+    let exposures = match entry.get("exposures") {
+        None => return Vec::new(),
+        Some(v) => v,
+    };
+    let Some(arr) = exposures.as_array() else {
+        tracing::debug!(
+            target = %target,
+            "ignoring `exposures` that is not an array"
+        );
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for e in arr {
+        let Some(duration_secs) = e.get("duration_secs").and_then(|n| n.as_f64()) else {
+            tracing::debug!(
+                target = %target, entry = ?e,
+                "skipping exposure entry missing a numeric `duration_secs`"
+            );
+            continue;
+        };
+        if !duration_secs.is_finite() || duration_secs <= 0.0 {
+            tracing::debug!(
+                target = %target, duration_secs,
+                "skipping exposure entry with a non-positive `duration_secs`"
+            );
+            continue;
+        }
+        let filter = match e.get("filter") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(s)) if s.is_empty() => None,
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(other) => {
+                tracing::debug!(
+                    target = %target, filter = ?other,
+                    "skipping exposure entry whose `filter` is not a string"
+                );
+                continue;
+            }
+        };
+        out.push(ExposureSpec {
+            filter,
+            duration_secs,
         });
     }
     out
@@ -392,6 +463,7 @@ mod tests {
             ra_hours: 0.7123,
             dec_degrees: 41.27,
             min_altitude_degrees: None,
+            exposures: Vec::new(),
         }];
         let rec = next_target(&eph, &site(), now(), &targets, 30.0);
         assert!(rec.target.is_none());
@@ -410,6 +482,7 @@ mod tests {
             ra_hours: 0.7123,
             dec_degrees: 41.27,
             min_altitude_degrees: None,
+            exposures: Vec::new(),
         }];
         let rec = next_target(&eph, &site(), now(), &targets, 30.0);
         assert!(rec.target.is_none());
@@ -431,6 +504,7 @@ mod tests {
             ra_hours: 0.7123,
             dec_degrees: 41.27,
             min_altitude_degrees: None,
+            exposures: Vec::new(),
         }];
         let rec = next_target(&eph, &site(), now(), &targets, 30.0);
         assert_eq!(rec.reason, NextTargetReason::WaitForTwilight);
@@ -450,6 +524,7 @@ mod tests {
             ra_hours: 0.7123,
             dec_degrees: 41.27,
             min_altitude_degrees: None,
+            exposures: Vec::new(),
         }];
         let rec = next_target(&eph, &site(), now(), &targets, 30.0);
         assert_eq!(rec.reason, NextTargetReason::AllBelowMinAltitude);
@@ -471,12 +546,14 @@ mod tests {
                 ra_hours: 0.7,
                 dec_degrees: 41.0,
                 min_altitude_degrees: None,
+                exposures: Vec::new(),
             },
             PlannerTarget {
                 name: "M42".into(),
                 ra_hours: 11.0,
                 dec_degrees: -5.0,
                 min_altitude_degrees: None,
+                exposures: Vec::new(),
             },
         ];
         let rec = next_target(&eph, &site(), now(), &targets, 20.0);
@@ -497,6 +574,7 @@ mod tests {
             ra_hours: 1.0,
             dec_degrees: 0.0,
             min_altitude_degrees: Some(20.0),
+            exposures: Vec::new(),
         }];
         // default 30 would eliminate; per-target 20 keeps it.
         let rec = next_target(&eph, &site(), now(), &targets, 30.0);
@@ -547,5 +625,83 @@ mod tests {
         let parsed = parse_targets_from_value(&v);
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].name, "good");
+    }
+
+    #[test]
+    fn parse_targets_reads_exposures_in_order() {
+        let v = serde_json::json!([{
+            "name": "M31",
+            "ra_hours": 0.7,
+            "dec_degrees": 41.0,
+            "exposures": [
+                {"filter": "Luminance", "duration_secs": 300, "count": 40},
+                {"filter": "Red", "duration_secs": 120.5},
+                {"duration_secs": 60},
+            ],
+        }]);
+        let parsed = parse_targets_from_value(&v);
+        assert_eq!(
+            parsed[0].exposures,
+            vec![
+                ExposureSpec {
+                    filter: Some("Luminance".to_string()),
+                    duration_secs: 300.0,
+                },
+                ExposureSpec {
+                    filter: Some("Red".to_string()),
+                    duration_secs: 120.5,
+                },
+                ExposureSpec {
+                    filter: None,
+                    duration_secs: 60.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_targets_without_exposures_yields_an_empty_plan() {
+        let v = serde_json::json!([
+            {"name": "bare", "ra_hours": 1.0, "dec_degrees": 0.0},
+            {"name": "not_array", "ra_hours": 2.0, "dec_degrees": 0.0, "exposures": "oops"},
+        ]);
+        let parsed = parse_targets_from_value(&v);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed[0].exposures.is_empty());
+        assert!(parsed[1].exposures.is_empty());
+    }
+
+    #[test]
+    fn parse_exposures_skips_invalid_entries_and_normalises_empty_filters() {
+        let v = serde_json::json!([{
+            "name": "M31",
+            "ra_hours": 0.7,
+            "dec_degrees": 41.0,
+            "exposures": [
+                {"filter": "Red"},
+                {"filter": "Red", "duration_secs": 0},
+                {"filter": "Red", "duration_secs": -5},
+                {"filter": "Red", "duration_secs": "300"},
+                {"filter": 5, "duration_secs": 300},
+                {"filter": "", "duration_secs": 30},
+                {"filter": null, "duration_secs": 45},
+            ],
+        }]);
+        let parsed = parse_targets_from_value(&v);
+        assert_eq!(
+            parsed[0].exposures,
+            vec![
+                ExposureSpec {
+                    filter: None,
+                    duration_secs: 30.0,
+                },
+                ExposureSpec {
+                    filter: None,
+                    duration_secs: 45.0,
+                },
+            ],
+            "only entries with a positive numeric duration survive; \
+             empty/null filters normalise to None"
+        );
     }
 }

--- a/services/rp/tests/bdd/steps/ephemeris_steps.rs
+++ b/services/rp/tests/bdd/steps/ephemeris_steps.rs
@@ -1,5 +1,7 @@
 //! BDD step definitions for the ephemeris primitive MCP tools.
 
+use bdd_infra::rp_harness::{ExposurePlanConfig, PlannerTargetConfig};
+use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
 use serde_json::Value;
 
@@ -11,6 +13,51 @@ use crate::world::RpWorld;
 #[given(expr = "rp is configured with site latitude {float} longitude {float}")]
 fn site_configured(world: &mut RpWorld, lat: f64, lon: f64) {
     world.site = Some((lat, lon));
+}
+
+/// A target that survives altitude elimination at any wall-clock
+/// time: `min_altitude_degrees: -90` can never exceed a computed
+/// altitude, so the planner always recommends it — no computed-sky
+/// setup needed to make `get_next_target` deterministic.
+fn always_visible_target(name: String, exposures: Vec<ExposurePlanConfig>) -> PlannerTargetConfig {
+    PlannerTargetConfig {
+        name,
+        ra_hours: 0.0,
+        dec_degrees: 0.0,
+        min_altitude_degrees: Some(-90.0),
+        exposures,
+    }
+}
+
+#[given(expr = "rp is configured with the always-visible target {string} whose exposure plan is:")]
+fn target_with_exposure_plan(world: &mut RpWorld, name: String, step: &Step) {
+    let table = step
+        .table
+        .as_ref()
+        .expect("step requires a `| filter | duration_secs |` table");
+    let mut rows = table.rows.iter();
+    let header = rows.next().expect("exposure-plan table must have a header");
+    assert_eq!(
+        header,
+        &vec!["filter".to_string(), "duration_secs".to_string()],
+        "exposure-plan table header must be `| filter | duration_secs |`"
+    );
+    let exposures = rows
+        .map(|row| ExposurePlanConfig {
+            filter: Some(row[0].clone()),
+            duration_secs: row[1].parse().expect("duration_secs must parse as f64"),
+        })
+        .collect();
+    world
+        .planner_targets
+        .push(always_visible_target(name, exposures));
+}
+
+#[given(expr = "rp is configured with the always-visible target {string} and no exposure plan")]
+fn target_without_exposure_plan(world: &mut RpWorld, name: String) {
+    world
+        .planner_targets
+        .push(always_visible_target(name, Vec::new()));
 }
 
 // --- When steps ---
@@ -113,6 +160,47 @@ fn result_target_null(world: &mut RpWorld) {
     assert!(
         value.get("target").is_some_and(|v| v.is_null()),
         "expected target=null, got: {value}"
+    );
+}
+
+#[then(expr = "the result filter should be {string}")]
+fn result_filter(world: &mut RpWorld, expected: String) {
+    let value = success_payload(world);
+    let filter = value
+        .get("filter")
+        .and_then(|v| v.as_str())
+        .expect("missing `filter`");
+    assert_eq!(filter, expected.as_str());
+}
+
+#[then("the result filter should be null")]
+fn result_filter_null(world: &mut RpWorld) {
+    let value = success_payload(world);
+    assert!(
+        value.get("filter").is_some_and(|v| v.is_null()),
+        "expected filter=null, got: {value}"
+    );
+}
+
+#[then(expr = "the result duration_secs should be {float}")]
+fn result_duration_secs(world: &mut RpWorld, expected: f64) {
+    let value = success_payload(world);
+    let duration = value
+        .get("duration_secs")
+        .and_then(|v| v.as_f64())
+        .expect("missing `duration_secs`");
+    assert!(
+        (duration - expected).abs() < f64::EPSILON,
+        "expected duration_secs={expected}, got {duration}"
+    );
+}
+
+#[then("the result duration_secs should be null")]
+fn result_duration_secs_null(world: &mut RpWorld) {
+    let value = success_payload(world);
+    assert!(
+        value.get("duration_secs").is_some_and(|v| v.is_null()),
+        "expected duration_secs=null, got: {value}"
     );
 }
 

--- a/services/rp/tests/bdd/world.rs
+++ b/services/rp/tests/bdd/world.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 
 use bdd_infra::rp_harness::{
     CameraConfig, CoverCalibratorConfig, FilterWheelConfig, FocuserConfig, McpTestClient,
-    MountConfig, OmniSimHandle, OrchestratorInvocation, PlateSolverConfig, PlateSolverStub,
-    ReceivedEvent, RpConfigBuilder, SafetyMonitorConfig, SseClient, TestOrchestrator,
-    WebhookReceiver,
+    MountConfig, OmniSimHandle, OrchestratorInvocation, PlannerTargetConfig, PlateSolverConfig,
+    PlateSolverStub, ReceivedEvent, RpConfigBuilder, SafetyMonitorConfig, SseClient,
+    TestOrchestrator, WebhookReceiver,
 };
 use bdd_infra::sky_survey_camera_harness::SkyViewStub;
 use bdd_infra::ServiceHandle;
@@ -72,6 +72,9 @@ pub struct RpWorld {
     /// the generated rp config. Used by `target_catalog`,
     /// `ephemeris_primitives`, and `planner` BDD features.
     pub site: Option<(f64, f64)>,
+    /// Planner targets accumulated via Given steps — emitted as the
+    /// top-level `targets` array `get_next_target` recommends from.
+    pub planner_targets: Vec<PlannerTargetConfig>,
     /// Safety monitors accumulated via Given steps (safety.feature).
     pub safety_monitors: Vec<SafetyMonitorConfig>,
     /// Override rp's `safety.poll_interval`; safety scenarios pin this
@@ -261,6 +264,9 @@ impl RpWorld {
         }
         if let Some((lat, lon)) = self.site {
             builder.with_site(lat, lon);
+        }
+        for target in &self.planner_targets {
+            builder.add_target(target.clone());
         }
         for sm in &self.safety_monitors {
             builder.add_safety_monitor(sm.clone());

--- a/services/rp/tests/features/planner.feature
+++ b/services/rp/tests/features/planner.feature
@@ -14,6 +14,11 @@ Feature: Planner convenience tools
   `all_below_min_altitude`, `wait_for_twilight`, `end_of_session`)
   so a planner plugin can branch without parsing free-form text.
 
+  A recommendation also carries the target's exposure plan: `filter`
+  and `duration_secs` are the first entry of the target's
+  `exposures[]` config, or null when the target defines none — the
+  orchestrator then falls back to its own exposure parameters.
+
   Scenario: Tool catalog includes the convenience tools
     Given a running Alpaca simulator
     And rp is configured with site latitude 51.0786 longitude -0.2944
@@ -43,6 +48,33 @@ Feature: Planner convenience tools
     Then the tool call should succeed
     And the result reason should be "no_targets_configured"
     And the result target should be null
+
+  Scenario: get_next_target returns the first exposure-plan entry for the recommended target
+    Given a running Alpaca simulator
+    And rp is configured with site latitude 51.0786 longitude -0.2944
+    And rp is configured with the always-visible target "Test Field" whose exposure plan is:
+      | filter | duration_secs |
+      | Red    | 120           |
+      | Blue   | 60            |
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_next_target"
+    Then the tool call should succeed
+    And the result reason should be "best_transiting_candidate"
+    And the result filter should be "Red"
+    And the result duration_secs should be 120
+
+  Scenario: get_next_target leaves the exposure plan null for a target without one
+    Given a running Alpaca simulator
+    And rp is configured with site latitude 51.0786 longitude -0.2944
+    And rp is configured with the always-visible target "Bare Field" and no exposure plan
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_next_target"
+    Then the tool call should succeed
+    And the result reason should be "best_transiting_candidate"
+    And the result filter should be null
+    And the result duration_secs should be null
 
   Scenario: get_target_status fails when site is missing
     Given a running Alpaca simulator

--- a/services/session-runner/src/engine/exec_tests.rs
+++ b/services/session-runner/src/engine/exec_tests.rs
@@ -1974,3 +1974,139 @@ async fn test_golden_deep_sky_rejects_a_filter_without_a_filter_wheel_before_mov
     );
     assert!(tools.call_names().is_empty());
 }
+
+/// `get_next_target` result carrying an exposure plan, as rp returns
+/// it after #462: `filter` / `duration_secs` are the recommended
+/// target's first `exposures[]` entry.
+fn planned_recommendation(filter: Value, duration_secs: Value) -> Value {
+    json!({
+        "target": {
+            "name": "M31",
+            "ra_hours": 0.7,
+            "dec_degrees": 41.0,
+            "min_altitude_degrees": null
+        },
+        "reason": "best_transiting_candidate",
+        "filter": filter,
+        "duration_secs": duration_secs
+    })
+}
+
+#[tokio::test]
+async fn test_golden_deep_sky_captures_at_the_planner_duration_and_filter() {
+    // The planner recommends Red at 120 s; the `exposure` parameter
+    // stays at its 300s default and `filter` at "". The acquisition
+    // must set the plan's filter and the capture must run at the
+    // plan's duration (120 s → "2m" through the humantime() builtin).
+    let doc = make_doc(crate::document::corpus::golden_deep_sky());
+    let params = deep_sky_params(
+        &doc,
+        json!({
+            "focus": false,
+            "centering": false,
+            "filter_wheel_id": "fw",
+            "max_frames": 1,
+            "park_on_finish": false
+        }),
+    );
+    let tools = MockTools::new(|_, tool, _| match tool {
+        "unpark" | "set_tracking" | "slew" | "set_filter" => Ok(json!({})),
+        "get_next_target" => Ok(planned_recommendation(json!("Red"), json!(120))),
+        "capture" => Ok(json!({ "image_path": "/tmp/light.fits", "document_id": "doc-1" })),
+        other => panic!("unexpected tool call `{other}`"),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _) = run_in(&dir, &doc, &params, &tools, &MockClock::new()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    let calls = tools.calls();
+    let set_filter = calls
+        .iter()
+        .find(|(name, _)| name == "set_filter")
+        .expect("set_filter must be called for a plan that names a filter");
+    assert_eq!(set_filter.1["filter_wheel_id"], "fw");
+    assert_eq!(set_filter.1["filter_name"], "Red");
+    let capture = calls
+        .iter()
+        .find(|(name, _)| name == "capture")
+        .expect("capture must be called");
+    assert_eq!(
+        capture.1["duration"], "2m",
+        "the capture must run at the plan's 120 s, not params.exposure"
+    );
+}
+
+#[tokio::test]
+async fn test_golden_deep_sky_falls_back_to_the_exposure_parameter_without_a_plan() {
+    // A target without `exposures[]` recommends with a null plan; the
+    // capture falls back to `params.exposure` (default 300s) and no
+    // filter change happens.
+    let doc = make_doc(crate::document::corpus::golden_deep_sky());
+    let params = deep_sky_params(
+        &doc,
+        json!({
+            "focus": false,
+            "centering": false,
+            "max_frames": 1,
+            "park_on_finish": false
+        }),
+    );
+    let tools = MockTools::new(|_, tool, _| match tool {
+        "unpark" | "set_tracking" | "slew" => Ok(json!({})),
+        "get_next_target" => Ok(planned_recommendation(Value::Null, Value::Null)),
+        "capture" => Ok(json!({ "image_path": "/tmp/light.fits", "document_id": "doc-1" })),
+        other => panic!("unexpected tool call `{other}`"),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _) = run_in(&dir, &doc, &params, &tools, &MockClock::new()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    let calls = tools.calls();
+    assert!(
+        !calls.iter().any(|(name, _)| name == "set_filter"),
+        "no plan filter and no filter parameter ⇒ no set_filter call"
+    );
+    let capture = calls
+        .iter()
+        .find(|(name, _)| name == "capture")
+        .expect("capture must be called");
+    assert_eq!(capture.1["duration"], "300s");
+}
+
+#[tokio::test]
+async fn test_golden_deep_sky_fails_when_the_plan_names_a_filter_but_no_wheel_is_configured() {
+    // The t=0 guard can only see the `filter` parameter; a filter
+    // arriving in the planner's exposure plan mid-session must fail
+    // just as loudly instead of silently imaging unfiltered.
+    let doc = make_doc(crate::document::corpus::golden_deep_sky());
+    let params = deep_sky_params(
+        &doc,
+        json!({
+            "focus": false,
+            "centering": false,
+            "max_frames": 1,
+            "park_on_finish": false
+        }),
+    );
+    let tools = MockTools::new(|_, tool, _| match tool {
+        "unpark" | "set_tracking" | "slew" => Ok(json!({})),
+        "get_next_target" => Ok(planned_recommendation(json!("Red"), json!(120))),
+        other => panic!("unexpected tool call `{other}` after the plan-filter guard"),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _) = run_in(&dir, &doc, &params, &tools, &MockClock::new()).await;
+
+    let error = failure(outcome);
+    assert!(
+        error
+            .message
+            .contains("the exposure plan names a filter but filter_wheel_id is empty"),
+        "{}",
+        error.message
+    );
+    assert_eq!(
+        tools.call_names(),
+        vec!["unpark", "set_tracking", "get_next_target", "slew"],
+        "the failure must land after the slew and before any set_filter/capture"
+    );
+}

--- a/services/session-runner/src/engine/exec_tests.rs
+++ b/services/session-runner/src/engine/exec_tests.rs
@@ -2074,6 +2074,47 @@ async fn test_golden_deep_sky_falls_back_to_the_exposure_parameter_without_a_pla
 }
 
 #[tokio::test]
+async fn test_golden_deep_sky_respects_an_unfiltered_plan_over_the_filter_parameter() {
+    // A plan whose first entry is explicitly unfiltered (filter null,
+    // duration_secs set) must image unfiltered — the `filter`
+    // parameter is a fallback for a *missing* plan, not a default the
+    // plan merges with. Falling back here would force a filter change
+    // the plan deliberately avoided.
+    let doc = make_doc(crate::document::corpus::golden_deep_sky());
+    let params = deep_sky_params(
+        &doc,
+        json!({
+            "focus": false,
+            "centering": false,
+            "filter": "Red",
+            "filter_wheel_id": "fw",
+            "max_frames": 1,
+            "park_on_finish": false
+        }),
+    );
+    let tools = MockTools::new(|_, tool, _| match tool {
+        "unpark" | "set_tracking" | "slew" => Ok(json!({})),
+        "get_next_target" => Ok(planned_recommendation(Value::Null, json!(60))),
+        "capture" => Ok(json!({ "image_path": "/tmp/light.fits", "document_id": "doc-1" })),
+        other => panic!("unexpected tool call `{other}`"),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _) = run_in(&dir, &doc, &params, &tools, &MockClock::new()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    let calls = tools.calls();
+    assert!(
+        !calls.iter().any(|(name, _)| name == "set_filter"),
+        "an explicitly unfiltered plan must not fall back to params.filter"
+    );
+    let capture = calls
+        .iter()
+        .find(|(name, _)| name == "capture")
+        .expect("capture must be called");
+    assert_eq!(capture.1["duration"], "1m");
+}
+
+#[tokio::test]
 async fn test_golden_deep_sky_fails_when_the_plan_names_a_filter_but_no_wheel_is_configured() {
     // The t=0 guard can only see the `filter` parameter; a filter
     // arriving in the planner's exposure plan mid-session must fail

--- a/services/session-runner/tests/bdd/steps/deep_sky_steps.rs
+++ b/services/session-runner/tests/bdd/steps/deep_sky_steps.rs
@@ -22,8 +22,8 @@ use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
 
 use bdd_infra::rp_harness::{
-    CameraConfig, CannedWcs, FocuserConfig, MountConfig, NightSky, OmniSimHandle,
-    PlannerTargetConfig, PlateSolverConfig, PlateSolverStub, StubBehavior,
+    CameraConfig, CannedWcs, ExposurePlanConfig, FocuserConfig, MountConfig, NightSky,
+    OmniSimHandle, PlannerTargetConfig, PlateSolverConfig, PlateSolverStub, StubBehavior,
 };
 
 use crate::steps::infrastructure::{
@@ -40,6 +40,24 @@ const OBSERVATION_BUDGET: Duration = Duration::from_secs(30);
 
 #[given("an observing site where it is astronomical night with one planner target")]
 async fn night_sky_with_one_target(world: &mut SessionRunnerWorld) {
+    push_one_night_target(world, Vec::new());
+}
+
+#[given(
+    expr = "an observing site where it is astronomical night with one planner target whose \
+            exposure plan is a single unfiltered {int}-second frame"
+)]
+async fn night_sky_with_one_planned_target(world: &mut SessionRunnerWorld, seconds: u64) {
+    push_one_night_target(
+        world,
+        vec![ExposurePlanConfig {
+            filter: None,
+            duration_secs: seconds as f64,
+        }],
+    );
+}
+
+fn push_one_night_target(world: &mut SessionRunnerWorld, exposures: Vec<ExposurePlanConfig>) {
     let sky = NightSky::at(chrono::Utc::now());
     // Half an hour past transit: ≈ 82.5° altitude and sinking, next
     // meridian crossing ≈ 23.5 sidereal hours away — no flip pressure,
@@ -51,6 +69,7 @@ async fn night_sky_with_one_target(world: &mut SessionRunnerWorld) {
         ra_hours: target.ra_hours,
         dec_degrees: target.dec_degrees,
         min_altitude_degrees: None,
+        exposures,
     });
     world.night_targets.push(target);
 }
@@ -77,12 +96,14 @@ async fn night_sky_with_sinking_target(world: &mut SessionRunnerWorld, seconds: 
         ra_hours: sinker.ra_hours,
         dec_degrees: sinker.dec_degrees,
         min_altitude_degrees: Some(floor),
+        exposures: Vec::new(),
     });
     world.planner_targets.push(PlannerTargetConfig {
         name: "backup".to_string(),
         ra_hours: backup.ra_hours,
         dec_degrees: backup.dec_degrees,
         min_altitude_degrees: None,
+        exposures: Vec::new(),
     });
     world.night_targets.push(sinker);
     world.night_targets.push(backup);
@@ -290,7 +311,8 @@ async fn sse_shows_at_least(world: &mut SessionRunnerWorld, minimum: usize, even
 /// The deep-sky equipment set: one camera and the singular mount, plus
 /// a focuser for the refocus scenarios. No filter wheel — the
 /// scenarios leave the document's `filter` parameter at its empty
-/// default, so `set_filter` never runs.
+/// default and give their planner targets unfiltered exposure plans
+/// (if any), so `set_filter` never runs.
 async fn configure_deep_sky_equipment(world: &mut SessionRunnerWorld, with_focuser: bool) {
     ensure_omnisim(world).await;
     let alpaca_url = world.omnisim_url();

--- a/services/session-runner/tests/features/deep_sky.feature
+++ b/services/session-runner/tests/features/deep_sky.feature
@@ -42,6 +42,23 @@ Feature: Deep-sky workflow document
     And the SSE stream should show exactly 4 "exposure_complete" events
     And the SSE stream should show exactly 1 "park_complete" event
 
+  Scenario: The planner's exposure plan drives the capture duration
+    Given a running Alpaca simulator
+    And an observing site where it is astronomical night with one planner target whose exposure plan is a single unfiltered 2-second frame
+    And the simulated mount matches the site and points at the first target
+    And rp is running with a camera, a mount, and the session-runner orchestrator running the "deep_sky" workflow with parameters:
+      | max_frames     | 2     |
+      | focus          | false |
+      | centering      | false |
+      | park_on_finish | false |
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    # `exposure` is deliberately not supplied: its default is 300s, so
+    # the session can only finish this fast if the planner-returned 2s
+    # plan is what reaches the camera.
+    Then the session ends within 90 seconds
+    And the SSE stream should show exactly 2 "exposure_complete" events
+
   Scenario: A target sinking below its altitude floor switches the dispatch loop to the next target
     Given a running Alpaca simulator
     And an observing site where it is astronomical night and the first of two planner targets sinks below its floor after 120 seconds

--- a/services/session-runner/workflows/deep_sky.json
+++ b/services/session-runner/workflows/deep_sky.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "deep-sky",
-  "description": "Classic multi-target deep-sky imaging session: unpark and start tracking, then a dispatch loop that asks rp's planner for the best target after every frame — acquiring on target change (slew, optional plate-solve centering, optional auto-focus) and capturing one frame per pass — with reactive refocusing and meridian-flip handling, ending at the frame budget or dawn and optionally parking. Written against rp's v1 planner surface: the exposure plan is parameters (get_next_target returns no filter/duration yet), progress is counted in the blackboard (record_exposure does not exist yet), and there is no guiding or dithering (rp has no guider tools yet) — see docs/services/session-runner.md § deep_sky.json.",
+  "description": "Classic multi-target deep-sky imaging session: unpark and start tracking, then a dispatch loop that asks rp's planner for the best target after every frame — acquiring on target change (slew, filter from the planner's exposure plan, optional plate-solve centering, optional auto-focus) and capturing one frame per pass — with reactive refocusing and meridian-flip handling, ending at the frame budget or dawn and optionally parking. Written against rp's v1 planner surface: get_next_target supplies filter/duration_secs from the target's first exposures[] entry with the exposure/filter parameters as fallback (rotation within a plan needs record_exposure, which does not exist yet — progress is counted in the blackboard), and there is no guiding or dithering (rp has no guider tools yet) — see docs/services/session-runner.md § deep_sky.json.",
   "parameters": {
     "camera_id": { "type": "string", "required": true },
     "exposure": { "type": "duration", "default": "300s" },
@@ -203,18 +203,6 @@
       { "tool": "unpark", "args": {} },
       { "tool": "set_tracking", "args": { "enabled": true } },
       {
-        "if": "params.filter != ''",
-        "then": [
-          {
-            "tool": "set_filter",
-            "args": {
-              "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
-              "filter_name": { "$expr": "params.filter" }
-            }
-          }
-        ]
-      },
-      {
         "id": "dispatch",
         "repeat": { "while": "session.session_over != true", "max_iterations": 20000 },
         "body": [
@@ -263,14 +251,20 @@
                           "session.imaging": "false",
                           "session.acquire_name": "result.target.name",
                           "session.acquire_ra": "result.target.ra_hours",
-                          "session.acquire_dec": "result.target.dec_degrees"
+                          "session.acquire_dec": "result.target.dec_degrees",
+                          "session.acquire_filter": "result.filter != null ? result.filter : params.filter",
+                          "session.acquire_duration": "result.duration_secs != null ? humantime(result.duration_secs) : params.exposure"
                         }
                       },
                       {
                         "log": {
                           "level": "info",
                           "message": "acquiring target",
-                          "values": { "target": "session.acquire_name" }
+                          "values": {
+                            "target": "session.acquire_name",
+                            "filter": "session.acquire_filter",
+                            "duration": "session.acquire_duration"
+                          }
                         }
                       },
                       {
@@ -279,6 +273,28 @@
                           "ra": { "$expr": "session.acquire_ra" },
                           "dec": { "$expr": "session.acquire_dec" }
                         }
+                      },
+                      {
+                        "if": "session.acquire_filter != ''",
+                        "then": [
+                          {
+                            "if": "params.filter_wheel_id == ''",
+                            "then": [
+                              {
+                                "fail": {
+                                  "message": "'the exposure plan names a filter but filter_wheel_id is empty — supply filter_wheel_id or remove filters from the target exposures[] in rp config'"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "tool": "set_filter",
+                            "args": {
+                              "filter_wheel_id": { "$expr": "params.filter_wheel_id" },
+                              "filter_name": { "$expr": "session.acquire_filter" }
+                            }
+                          }
+                        ]
                       },
                       {
                         "if": "params.centering == true",
@@ -343,7 +359,7 @@
                     "tool": "capture",
                     "args": {
                       "camera_id": { "$expr": "params.camera_id" },
-                      "duration": { "$expr": "params.exposure" }
+                      "duration": { "$expr": "session.acquire_duration" }
                     }
                   },
                   {

--- a/services/session-runner/workflows/deep_sky.json
+++ b/services/session-runner/workflows/deep_sky.json
@@ -252,7 +252,7 @@
                           "session.acquire_name": "result.target.name",
                           "session.acquire_ra": "result.target.ra_hours",
                           "session.acquire_dec": "result.target.dec_degrees",
-                          "session.acquire_filter": "result.filter != null ? result.filter : params.filter",
+                          "session.acquire_filter": "result.duration_secs != null ? (result.filter != null ? result.filter : '') : params.filter",
                           "session.acquire_duration": "result.duration_secs != null ? humantime(result.duration_secs) : params.exposure"
                         }
                       },


### PR DESCRIPTION
Closes #462.

`get_next_target` now returns the exposure plan: `filter` and `duration_secs` are the recommended target's **first** `exposures[]` entry (rp.md § Target Definition), or null when the target defines none. Selecting *within* a plan by progress (least-progress rotation, filter batching — decision-logic bullets 3–4) stays deferred to `record_exposure` (#463).

## rp

- `ExposureSpec { filter: Option<String>, duration_secs: f64 }` on `PlannerTarget`; `parse_exposures` extends `parse_targets_from_value`'s skip-bad-rows pattern — entries without a positive finite numeric `duration_secs` or with a non-string `filter` are skipped with a `debug!` log, and `""`/null filters normalise to `None` (unfiltered/OSC rigs).
- `next_target_view` surfaces the first entry; the wire `target` object still carries coordinates only, and every no-target branch keeps `filter`/`duration_secs` null.
- Two new `planner.feature` scenarios pin the contract (first-entry pick, null plan). They use an **always-visible target** — `min_altitude_degrees: -90` can never exceed a computed altitude, so the recommendation is deterministic at any wall-clock time with no computed-sky setup.

## deep_sky.json — parameters demoted to fallbacks

- Acquisition stashes `session.acquire_filter` / `session.acquire_duration` from the recommendation, converting `duration_secs` with the existing `humantime()` expression builtin (the `capture` tool takes a humantime string); `params.filter` / `params.exposure` apply when the plan is null.
- `set_filter` moves from once-at-startup to per-acquisition (different targets can name different filters). A plan that names a filter while `filter_wheel_id` is empty **fails loudly** mid-session, mirroring the t=0 parameter guard from #461's review round.
- Four new golden engine tests: capture at the plan duration (120 s → `"2m"`), parameter fallback (`"300s"`), `set_filter` args, and the plan-filter-without-wheel failure landing after `slew` and before any `set_filter`/`capture`.
- One new BDD scenario: with `exposure` deliberately **omitted** (default 300s), a target whose plan is a single unfiltered 2 s frame finishes a 2-frame session inside 90 s — only possible if the plan is what reaches the camera.

## Test infra

`PlannerTargetConfig` (bdd-infra) gains `exposures: Vec<ExposurePlanConfig>` (empty ⇒ field omitted, planner returns null); rp's own BDD world can now register planner targets via the shared builder.

## Docs

rp.md (planner tool table, § Dynamic Planner v1 callout, § Target Definition field semantics incl. `count`/`priority` staying parsed-over until #463), session-runner.md (§ deep_sky.json shape, v1 adaptations, BDD table), workflow-dsl.md Phase E note records the filed issue numbers #462–#465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
