### PR TITLE
feat(rp): planner tells dawn from dusk; end_of_session reachable (closes #465)

### DIFF
--- a/crates/bdd-infra/BUILD.bazel
+++ b/crates/bdd-infra/BUILD.bazel
@@ -26,7 +26,7 @@ rust_library(
 # module (SkyView stub, sky-survey-camera config builder, process
 # spawner). The rp-harness feature gates the deps on rp-fits (the
 # plate-solver stub's CRVAL round-trip and the SkyView stub's
-# WCS-bearing FITS minting) and rp-ephemeris (the NightSky computed
+# WCS-bearing FITS minting) and rp-ephemeris (the ComputedSky
 # site/targets for planner-driven scenarios).
 rust_library(
     name = "bdd-infra_rp_harness",

--- a/crates/bdd-infra/src/rp_harness/computed_sky.rs
+++ b/crates/bdd-infra/src/rp_harness/computed_sky.rs
@@ -1,14 +1,22 @@
-//! A computed night sky for planner-driven BDD scenarios.
+//! A computed sky for planner-driven BDD scenarios.
 //!
 //! rp's `get_next_target` gates on real ephemeris: a target is viable
 //! only when it sits above its altitude floor while the Sun is below
 //! astronomical dusk (−18°) at the configured site — all evaluated at
 //! wall-clock "now". A scenario that hard-codes a site and target would
 //! therefore only pass at certain times of day. This module removes the
-//! time dependence by *choosing the site to fit the clock*: an observer
-//! on the equator at the anti-solar longitude always has the Sun at
-//! lower culmination, altitude ≈ −(90° − |δ☉|) ≤ −66° — deep
-//! astronomical night at any moment of any date.
+//! time dependence by *choosing the site to fit the clock*, in either
+//! of two directions:
+//!
+//! - [`ComputedSky::night_at`] — an observer on the equator at the
+//!   anti-solar longitude always has the Sun at lower culmination,
+//!   altitude ≈ −(90° − |δ☉|) ≤ −66° — deep astronomical night at any
+//!   moment of any date.
+//! - [`ComputedSky::morning_at`] — an equatorial observer 45° west of
+//!   the sub-solar longitude has local apparent solar time ≈ 09:00:
+//!   the Sun is ≈ 40–45° up and climbing at roughly 13°/hour — a
+//!   risen, unambiguous morning at any moment of any date. This is
+//!   the lever for "the planner declares the night over" scenarios.
 //!
 //! Targets are then placed on the celestial equator by hour angle. At
 //! an equatorial site a dec-0 target's altitude is 90° − 15°·|HA| and it
@@ -23,17 +31,19 @@
 use chrono::{DateTime, Utc};
 use rp_ephemeris::{Ephemeris, ErfarsEphemeris, IcrsCoord, Site};
 
-/// A site + instant where it is guaranteed to be astronomical night,
-/// with helpers to place planner targets by hour angle.
+/// A site + instant computed so the Sun is where the scenario needs it
+/// (deep night or risen morning), with helpers to place planner
+/// targets by hour angle.
 #[derive(Debug)]
-pub struct NightSky {
+pub struct ComputedSky {
     site: Site,
     now: DateTime<Utc>,
     eph: ErfarsEphemeris,
 }
 
-impl NightSky {
-    /// Compute the equatorial anti-solar site for `now`.
+impl ComputedSky {
+    /// Compute the equatorial anti-solar site for `now` — guaranteed
+    /// deep astronomical night.
     ///
     /// The Sun transits (upper culmination) where local sidereal time
     /// equals its right ascension; the anti-solar meridian is 180°
@@ -41,7 +51,25 @@ impl NightSky {
     /// the site longitude is `(RA☉ − GMST)·15 + 180`, normalised to
     /// Alpaca/ASCOM's ±180 convention. Latitude 0 puts the Sun's lower
     /// culmination at −90° + |δ☉| — never brighter than −66°.
-    pub fn at(now: DateTime<Utc>) -> Self {
+    pub fn night_at(now: DateTime<Utc>) -> Self {
+        Self::at_solar_offset(now, 180.0)
+    }
+
+    /// Compute an equatorial site 45° west of the sub-solar longitude
+    /// for `now` — guaranteed risen morning.
+    ///
+    /// Local apparent solar time there is ≈ 09:00, so the Sun stands
+    /// ≈ 40–45° above the horizon (declination shrinks it toward the
+    /// solstices) and climbs toward its noon culmination — the
+    /// planner's dawn-side trend check reads it as "the night is
+    /// over" at any moment of any date.
+    pub fn morning_at(now: DateTime<Utc>) -> Self {
+        Self::at_solar_offset(now, -45.0)
+    }
+
+    /// The equatorial site whose longitude sits `offset_degrees` east
+    /// of the sub-solar longitude at `now`.
+    fn at_solar_offset(now: DateTime<Utc>, offset_degrees: f64) -> Self {
         let eph = ErfarsEphemeris::new();
         // Greenwich reference site: LST at longitude 0 is GMST.
         let greenwich = Site::new(0.0, 0.0).expect("the Greenwich reference site is valid");
@@ -49,7 +77,7 @@ impl NightSky {
         let sun_ra_hours = eph.sun_position(&greenwich, now).coords.ra_hours;
 
         let sub_solar_lon = (sun_ra_hours - gmst_hours) * 15.0;
-        let mut lon = sub_solar_lon + 180.0;
+        let mut lon = sub_solar_lon + offset_degrees;
         // Normalise to (−180, 180] for Site's range check.
         lon = lon.rem_euclid(360.0);
         if lon > 180.0 {
@@ -67,11 +95,19 @@ impl NightSky {
         self.site.longitude_degrees
     }
 
-    /// The Sun's altitude at the site at `now` — negative and well
-    /// below −18° by construction; exposed so tests can assert it.
+    /// The Sun's altitude at the site at `now` — far below −18° for a
+    /// night sky, well risen for a morning sky; exposed so tests can
+    /// assert the construction.
     pub fn sun_altitude_degrees(&self) -> f64 {
+        self.sun_altitude_degrees_in(0)
+    }
+
+    /// The Sun's altitude at the site `seconds` after `now` — the
+    /// morning-sky tests assert the climb with it.
+    pub fn sun_altitude_degrees_in(&self, seconds: i64) -> f64 {
+        let at = self.now + chrono::Duration::seconds(seconds);
         self.eph
-            .sun_position(&self.site, self.now)
+            .sun_position(&self.site, at)
             .alt_az
             .altitude_degrees
     }
@@ -110,8 +146,8 @@ mod tests {
     use chrono::TimeZone;
 
     fn moments() -> Vec<DateTime<Utc>> {
-        // Solstices, equinox, and odd hours across the day — the site
-        // must produce deep night at all of them.
+        // Solstices, equinox, and odd hours across the day — the
+        // computed sites must hold their guarantee at all of them.
         vec![
             Utc.with_ymd_and_hms(2026, 6, 21, 12, 0, 0).unwrap(),
             Utc.with_ymd_and_hms(2026, 12, 21, 0, 30, 0).unwrap(),
@@ -124,7 +160,7 @@ mod tests {
     #[test]
     fn the_sun_is_in_deep_astronomical_night_at_every_moment() {
         for now in moments() {
-            let sky = NightSky::at(now);
+            let sky = ComputedSky::night_at(now);
             let sun_alt = sky.sun_altitude_degrees();
             assert!(
                 sun_alt < -60.0,
@@ -134,22 +170,40 @@ mod tests {
     }
 
     #[test]
-    fn the_site_is_equatorial_with_in_range_longitude() {
+    fn the_morning_sun_is_well_risen_and_climbing_at_every_moment() {
         for now in moments() {
-            let sky = NightSky::at(now);
-            assert_eq!(sky.latitude_degrees(), 0.0);
+            let sky = ComputedSky::morning_at(now);
+            let sun_alt = sky.sun_altitude_degrees();
             assert!(
-                (-180.0..=180.0).contains(&sky.longitude_degrees()),
-                "longitude out of Site range at {now}: {}",
-                sky.longitude_degrees()
+                sun_alt > 35.0,
+                "expected a well-risen morning Sun at {now}, got {sun_alt}°"
             );
+            let climb = sky.sun_altitude_degrees_in(600) - sun_alt;
+            assert!(
+                climb > 1.0,
+                "expected the morning Sun to climb ≈ 2° over 600 s at {now}, got {climb}°"
+            );
+        }
+    }
+
+    #[test]
+    fn the_sites_are_equatorial_with_in_range_longitude() {
+        for now in moments() {
+            for sky in [ComputedSky::night_at(now), ComputedSky::morning_at(now)] {
+                assert_eq!(sky.latitude_degrees(), 0.0);
+                assert!(
+                    (-180.0..=180.0).contains(&sky.longitude_degrees()),
+                    "longitude out of Site range at {now}: {}",
+                    sky.longitude_degrees()
+                );
+            }
         }
     }
 
     #[test]
     fn a_target_half_an_hour_past_transit_stands_near_82_degrees() {
         for now in moments() {
-            let sky = NightSky::at(now);
+            let sky = ComputedSky::night_at(now);
             let target = sky.target_at_hour_angle(0.5);
             let alt = sky.altitude_degrees_in(target, 0);
             // 90 − 15·0.5 = 82.5°; refraction adds well under a degree.
@@ -162,7 +216,7 @@ mod tests {
 
     #[test]
     fn a_descending_target_sinks_a_quarter_degree_per_minute() {
-        let sky = NightSky::at(Utc.with_ymd_and_hms(2026, 7, 7, 3, 0, 0).unwrap());
+        let sky = ComputedSky::night_at(Utc.with_ymd_and_hms(2026, 7, 7, 3, 0, 0).unwrap());
         let target = sky.target_at_hour_angle(3.0);
         let now_alt = sky.altitude_degrees_in(target, 0);
         let later_alt = sky.altitude_degrees_in(target, 120);
@@ -175,7 +229,7 @@ mod tests {
 
     #[test]
     fn hour_angle_zero_is_the_zenith_at_an_equatorial_site() {
-        let sky = NightSky::at(Utc.with_ymd_and_hms(2026, 7, 7, 3, 0, 0).unwrap());
+        let sky = ComputedSky::night_at(Utc.with_ymd_and_hms(2026, 7, 7, 3, 0, 0).unwrap());
         let target = sky.target_at_hour_angle(0.0);
         let alt = sky.altitude_degrees_in(target, 0);
         assert!(alt > 89.0, "expected the zenith, got {alt}°");

--- a/crates/bdd-infra/src/rp_harness/mod.rs
+++ b/crates/bdd-infra/src/rp_harness/mod.rs
@@ -22,16 +22,17 @@
 //! rp's own types, which keeps the dependency direction one-way (rp's tests
 //! and plugin tests depend on bdd-infra; bdd-infra does not depend on rp).
 
+mod computed_sky;
 mod config;
 mod launcher;
 mod mcp_client;
-mod night_sky;
 mod omnisim;
 mod orchestrator;
 mod plate_solver_stub;
 mod sse;
 mod webhook;
 
+pub use computed_sky::ComputedSky;
 pub use config::{
     build_calibrator_flats_config, CameraConfig, CoverCalibratorConfig, ExposurePlanConfig,
     FilterWheelConfig, FocuserConfig, MountConfig, PlannerTargetConfig, PlateSolverConfig,
@@ -39,13 +40,12 @@ pub use config::{
 };
 pub use launcher::{start_rp, wait_for_rp_healthy, write_temp_config_file};
 pub use mcp_client::McpTestClient;
-pub use night_sky::NightSky;
 pub use omnisim::OmniSimHandle;
 pub use orchestrator::{OrchestratorBehavior, OrchestratorInvocation, TestOrchestrator};
 pub use plate_solver_stub::{CannedWcs, PlateSolverStub, StubBehavior};
 pub use sse::{SseClient, SseFrame};
 pub use webhook::{ReceivedEvent, WebhookReceiver};
 
-// Re-exported so harness consumers can hold NightSky's target coords
+// Re-exported so harness consumers can hold ComputedSky's target coords
 // without depending on rp-ephemeris themselves.
 pub use rp_ephemeris::IcrsCoord;

--- a/docs/plans/workflow-dsl.md
+++ b/docs/plans/workflow-dsl.md
@@ -444,7 +444,9 @@ committable on its own.
       `get_session_progress` (#463, so no progress-aware dispatch or
       goal-driven target rotation); no guider tools (`start_guiding` /
       `stop_guiding` / `dither`) (#464); `end_of_session` unreachable
-      (#465, dawn is a document-side heuristic until then). All are
+      (#465 — since closed: the planner reads the Sun's trend to tell
+      dawn from dusk and the document dropped its frames-captured dawn
+      heuristic). All are
       also recorded in `session-runner.md` § `deep_sky.json`
       ("v1 adaptations") with what the document does meanwhile and
       what changes when each lands.

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -2748,9 +2748,11 @@ table.
    exposure if `compute_meridian_flip` returns a `time_to_flip`
    shorter than the per-target `exposures[].duration_secs` plus a
    safety margin.
-6. If no targets are viable, return a `WaitForTwilight` (when
-   `get_twilight` says astronomical dusk has not yet begun) or
-   `EndOfSession` recommendation.
+6. If no targets are viable, return a `WaitForTwilight`
+   recommendation when the night has not started (the Sun is above
+   astronomical dusk, −18°, and not rising — wait and re-ask), or
+   `EndOfSession` when the night is over (the Sun is back above
+   −18° and rising) or every target has met its integration goal.
 
 The orchestrator decides when to call `get_next_target` — typically
 after each exposure, after each target switch, or when conditions change.
@@ -2758,10 +2760,13 @@ after each exposure, after each target switch, or when conditions change.
 > **v1 implementation status.** Three of the six bullets land
 > partially in v1: the altitude half of bullet 1 (per-target /
 > per-planner-default floor), bullet 2 (smallest-|HA| transit
-> preference), and the `WaitForTwilight` /
-> `AllBelowMinAltitude` half of bullet 6 (the Sun-elevation
-> cut-off uses astronomical dusk, -18°, matching the
-> "astronomical dusk has not yet begun" wording above).
+> preference), and bullet 6's sky gating — when no target survives
+> the altitude floors, the Sun-elevation cut-off (astronomical
+> dusk, -18°) separates a bright sky from `AllBelowMinAltitude`,
+> and the Sun's trend (sampled 60 s ahead) separates dusk from
+> dawn: `WaitForTwilight` while the Sun is descending toward
+> tonight's dark window (or holding level), `EndOfSession` once it
+> is climbing out of it — the night is over.
 > The recommendation also carries the exposure plan: `filter`
 > and `duration_secs` are the recommended target's **first**
 > `exposures[]` entry (null when the target defines none) —
@@ -2786,10 +2791,11 @@ after each exposure, after each target switch, or when conditions change.
 >   so the smallest-|HA| pick tends to avoid imminent flips. The
 >   planner does *not* check `time_to_flip` against
 >   `exposures[].duration_secs` explicitly.
-> - **`EndOfSession`** — wired in the reason-discriminant for
->   forward compatibility but unreachable from the v1 code path
->   (would need session-state plumbing to detect "all targets
->   exhausted" or "the night is over").
+> - **`EndOfSession` (exhausted-targets half)** — the reason is
+>   reachable for "the night is over" (dawn-side bright sky,
+>   above), but the planner cannot yet end a session mid-night
+>   because every target met its integration goal — that needs the
+>   per-target `record_exposure` counters from bullet 3.
 >
 > A follow-up will close these gaps once session state is wired
 > through.

--- a/docs/services/session-runner.md
+++ b/docs/services/session-runner.md
@@ -1035,9 +1035,8 @@ The full document lives in `workflows/deep_sky.json`; the shape:
     { "repeat": { "while": "session.session_over != true", "max_iterations": 20000 },
       "body": [
         { "tool": "get_next_target" },
-        /* end_of_session → done; target == null → dawn heuristic
-           (wait_for_twilight after frames were captured ends the
-           session) or a 5m wait-and-re-ask; target change → stash
+        /* end_of_session → done; target == null → 5m
+           wait-and-re-ask; target change → stash
            coords + the exposure plan (result.filter /
            result.duration_secs, falling back to params.filter /
            params.exposure when null), slew, set_filter if the plan
@@ -1081,11 +1080,14 @@ the document simplifies when it lands:
   catalog validation rightly rejects a document naming unknown tools.
   The capture loop runs unguided; the guide/dither steps join the
   document when the tools land.
-- **Dawn is a heuristic.** `EndOfSession` is unreachable from `rp`'s v1
-  code path, and v1's `wait_for_twilight` reason fires whenever the Sun
-  is above −18° — dusk and dawn alike. The document disambiguates by
-  progress: `wait_for_twilight` with zero frames captured is dusk (wait
-  5 minutes, re-ask), with frames captured it is dawn (end the session).
+- **Dawn belongs to the planner.** `get_next_target` distinguishes dusk
+  from dawn by the Sun's trend (rp issue #465, closed): `end_of_session`
+  when the sky is bright and the Sun is rising, `wait_for_twilight` when
+  it is not yet dark and the Sun is descending. The document trusts the
+  reason alone — `end_of_session` ends the session, any other
+  target-less reason waits 5 minutes and re-asks. (An earlier revision
+  disambiguated dawn by frames-captured progress in the document; the
+  heuristic is gone.)
 
 **Triggers.** Three reactive rules, all gated `while session.imaging ==
 true` so they stay silent during acquisition and shutdown:
@@ -1215,7 +1217,7 @@ Full three-process topology (OmniSim + `rp` + `session-runner`) via
 | Triggers | `triggers.feature` | a trigger action lands between exposures, never during one (proved by SSE seq order); `once` fires exactly once across three captures; cooldown suppresses firings inside its window; a poll trigger fires through its `when` gate |
 | Resume | `recovery.feature` | SIGKILL the engine mid-capture-loop → restart → re-invoke with recovery → progress continues without repeated frames (exposure totals prove it); `once` marker not re-run (`filter_switch` count proves it); an rp outage terminates the run (service stays healthy, blackboard kept) and the session resumes against the restarted rp |
 | Safety | `recovery.feature` | a SafetyMonitor unsafe reading interrupts the session end-to-end through rp's own machinery (rp terminates the MCP session, the run terminates keeping its blackboard) and the safe transition re-invokes the engine with `recovery.reason = "safety_interruption"` — the resumed run captures exactly the remaining frames, the once marker is not re-run, and the completion deletes the blackboard. rp-side specifics (session `interrupted` status, `/mcp` 503 gate, `safety_changed` events) are pinned in rp's own `safety.feature` |
-| Deep-sky document | `deep_sky.feature` | the shipped `deep_sky.json` against a computed night sky (site + planner targets placed so a candidate is viable at test time): the full cycle completes (unpark → slew → center → capture ×N → park); the planner's exposure plan drives the capture duration (a 2 s plan finishes a session the 300 s parameter default could not); a target sinking below its per-target altitude floor switches the dispatch loop to the second target (a second slew, frames on both sides of it); `refocus_every` fires `auto_focus` from the trigger overlay (`focus_started` count proves it); a due meridian flip re-slews between exposures, never during one; a safety interruption resumes with re-acquisition (two `centering_complete`) |
+| Deep-sky document | `deep_sky.feature` | the shipped `deep_sky.json` against a computed night sky (site + planner targets placed so a candidate is viable at test time): the full cycle completes (unpark → slew → center → capture ×N → park); the planner's exposure plan drives the capture duration (a 2 s plan finishes a session the 300 s parameter default could not); a session started after dawn (a computed morning site — Sun risen and climbing) ends on the planner's `end_of_session` with zero slews and zero frames; a target sinking below its per-target altitude floor switches the dispatch loop to the second target (a second slew, frames on both sides of it); `refocus_every` fires `auto_focus` from the trigger overlay (`focus_started` count proves it); a due meridian flip re-slews between exposures, never during one; a safety interruption resumes with re-acquisition (two `centering_complete`) |
 
 The safety scenario exercises rp's real recovery re-invocation. The
 engine-kill and rp-outage scenarios POST `/invoke` directly — same ids,

--- a/services/rp/src/mcp/built_in/planner.rs
+++ b/services/rp/src/mcp/built_in/planner.rs
@@ -497,7 +497,10 @@ impl McpHandler {
                        Returns target=null and a structured reason \
                        (no_targets_configured / all_below_min_altitude / \
                        wait_for_twilight / end_of_session) when no candidate is \
-                       viable. Requires `site`."
+                       viable: wait_for_twilight = the Sun is brighter than \
+                       astronomical dusk and not rising (evening — wait and \
+                       re-ask); end_of_session = brighter and rising (dawn — \
+                       the night is over). Requires `site`."
     )]
     pub(crate) async fn get_next_target(
         &self,

--- a/services/rp/src/planner/decision.rs
+++ b/services/rp/src/planner/decision.rs
@@ -5,15 +5,18 @@
 //!
 //! v1 implements three of the rp.md §"Dynamic Planner" decision-logic
 //! bullets: altitude elimination (the first half of bullet 1),
-//! transit preference (bullet 2), and the
-//! `WaitForTwilight` / `AllBelowMinAltitude` fallback (the half of
-//! bullet 6 that's reachable from this code path). Documented gaps:
+//! transit preference (bullet 2), and bullet 6's sky gating — when
+//! no target survives, the Sun-elevation cut-off plus the Sun's
+//! trend separates `WaitForTwilight` (dusk side), `EndOfSession`
+//! (dawn side: the night is over), and `AllBelowMinAltitude` (true
+//! astronomical night). Documented gaps:
 //! the set-time half of bullet 1, bullet 3 (least-progress preference),
 //! bullet 4 (filter-change minimization), explicit bullet 5
 //! (meridian-flip-aware exposure-fit check; the choice of
-//! smallest-|HA| target satisfies it indirectly), and `EndOfSession`
-//! reachability — all need session-state plumbing to land cleanly,
-//! tracked in the rp.md §"v1 implementation status" callout.
+//! smallest-|HA| target satisfies it indirectly), and the
+//! exhausted-targets half of `EndOfSession` — all need session-state
+//! plumbing to land cleanly, tracked in the rp.md §"v1 implementation
+//! status" callout.
 //!
 //! The returned `NextTargetReason` is a structured discriminant so
 //! a planner plugin can branch without parsing free-form text.
@@ -28,6 +31,13 @@ use serde_json::Value;
 /// sky is still too bright for deep-sky imaging (daylight, civil, or
 /// nautical twilight); below it, true astronomical night.
 const ASTRONOMICAL_DUSK_DEG: f64 = -18.0;
+
+/// How far ahead the Sun is re-sampled to read its altitude trend
+/// when the sky is brighter than astronomical dusk. Over 60 s the Sun
+/// moves up to ≈ 0.25° in altitude — far above floating-point noise,
+/// yet short enough that the sample cannot jump across a culmination
+/// to the other side of the night.
+const SUN_TREND_SAMPLE_SECS: i64 = 60;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct PlannerTarget {
@@ -127,24 +137,30 @@ pub fn next_target(
 
     if survivors.is_empty() {
         // Distinguish "the sky is too bright to image" from "all
-        // targets are genuinely below the altitude floor". The
-        // rp.md prose for `WaitForTwilight` says "astronomical dusk
-        // has not yet begun", which is the Sun-altitude threshold
-        // for astronomical twilight (-18°). Anything brighter than
-        // that — daylight, civil, or nautical twilight — is the
-        // "wait" branch; below -18° (true astronomical night) and
-        // every target still below floor is `AllBelowMinAltitude`.
+        // targets are genuinely below the altitude floor": below the
+        // Sun-altitude threshold for astronomical twilight (-18°,
+        // true astronomical night) every target under its floor is
+        // `AllBelowMinAltitude`. Brighter than that, the Sun's own
+        // trend tells the two bright ends of the night apart: a
+        // climbing Sun (re-sampled `SUN_TREND_SAMPLE_SECS` ahead) is
+        // the dawn side — the night is over, `EndOfSession` — while
+        // a descending Sun matches rp.md's "astronomical dusk has
+        // not yet begun", `WaitForTwilight`. A level Sun (only at
+        // the culminations) ties to waiting, because a wait loop
+        // re-asks and self-corrects while ending a session is final.
         //
-        // `EndOfSession` is in the discriminant for forward
-        // compatibility but unreachable from this v1 code path: it
-        // belongs in a future revision that knows the difference
-        // between "all targets exhausted" (per-target progress
-        // counters all met) and "the night is over" (set times have
-        // all passed). Both require state we don't yet thread
-        // through — see rp.md §"Dynamic Planner" bullets 1, 3.
+        // The other `EndOfSession` trigger — every target met its
+        // integration goal — still needs the per-target progress
+        // counters of rp.md §"Dynamic Planner" bullet 3.
         let sun_alt = eph.sun_position(site, now).alt_az.altitude_degrees;
         let reason = if sun_alt > ASTRONOMICAL_DUSK_DEG {
-            NextTargetReason::WaitForTwilight
+            let resample = now + chrono::Duration::seconds(SUN_TREND_SAMPLE_SECS);
+            let sun_alt_later = eph.sun_position(site, resample).alt_az.altitude_degrees;
+            if sun_alt_later > sun_alt {
+                NextTargetReason::EndOfSession
+            } else {
+                NextTargetReason::WaitForTwilight
+            }
         } else {
             NextTargetReason::AllBelowMinAltitude
         };
@@ -324,7 +340,12 @@ mod tests {
     struct MockEphemeris {
         /// (ra_hours, dec_degrees) → altitude_degrees
         alt_overrides: Vec<((f64, f64), f64)>,
+        /// Sun altitude at the tests' `now()` epoch.
         sun_alt: f64,
+        /// Sun-altitude change per minute after `now()` — drives the
+        /// dusk/dawn trend check. `0.0` freezes the Sun (a level Sun
+        /// reads as the dusk side).
+        sun_alt_rate_deg_per_min: f64,
         lst_hours: f64,
     }
 
@@ -391,14 +412,15 @@ mod tests {
         ) -> Option<chrono::Duration> {
             None
         }
-        fn sun_position(&self, _site: &Site, _t: DateTime<Utc>) -> SunInfo {
+        fn sun_position(&self, _site: &Site, t: DateTime<Utc>) -> SunInfo {
+            let minutes = (t - now()).num_seconds() as f64 / 60.0;
             SunInfo {
                 coords: IcrsCoord {
                     ra_hours: 0.0,
                     dec_degrees: 0.0,
                 },
                 alt_az: AltAz {
-                    altitude_degrees: self.sun_alt,
+                    altitude_degrees: self.sun_alt + self.sun_alt_rate_deg_per_min * minutes,
                     azimuth_degrees: 0.0,
                 },
             }
@@ -456,6 +478,7 @@ mod tests {
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7123, 41.27), 10.0)],
             sun_alt: -25.0, // true astronomical night (sun < -18°)
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 12.0,
         };
         let targets = vec![PlannerTarget {
@@ -474,7 +497,8 @@ mod tests {
     fn daytime_returns_wait_for_twilight() {
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7123, 41.27), 10.0)],
-            sun_alt: 30.0, // sun is up
+            sun_alt: 30.0, // the Sun is up and, frozen at rate 0, not climbing
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 12.0,
         };
         let targets = vec![PlannerTarget {
@@ -497,6 +521,7 @@ mod tests {
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7123, 41.27), 10.0)],
             sun_alt: -10.0,
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 12.0,
         };
         let targets = vec![PlannerTarget {
@@ -511,12 +536,147 @@ mod tests {
     }
 
     #[test]
+    fn a_descending_twilight_sun_is_wait_for_twilight() {
+        // Evening twilight: the Sun at -10° and sinking — the night
+        // has not started, wait for it.
+        let eph = MockEphemeris {
+            alt_overrides: vec![((0.7123, 41.27), 10.0)],
+            sun_alt: -10.0,
+            sun_alt_rate_deg_per_min: -0.2,
+            lst_hours: 12.0,
+        };
+        let targets = vec![PlannerTarget {
+            name: "M31".into(),
+            ra_hours: 0.7123,
+            dec_degrees: 41.27,
+            min_altitude_degrees: None,
+            exposures: Vec::new(),
+        }];
+        let rec = next_target(&eph, &site(), now(), &targets, 30.0);
+        assert_eq!(rec.reason, NextTargetReason::WaitForTwilight);
+    }
+
+    #[test]
+    fn a_climbing_twilight_sun_is_end_of_session() {
+        // Morning twilight: the Sun at -10° and climbing — the night
+        // is over.
+        let eph = MockEphemeris {
+            alt_overrides: vec![((0.7123, 41.27), 10.0)],
+            sun_alt: -10.0,
+            sun_alt_rate_deg_per_min: 0.2,
+            lst_hours: 12.0,
+        };
+        let targets = vec![PlannerTarget {
+            name: "M31".into(),
+            ra_hours: 0.7123,
+            dec_degrees: 41.27,
+            min_altitude_degrees: None,
+            exposures: Vec::new(),
+        }];
+        let rec = next_target(&eph, &site(), now(), &targets, 30.0);
+        assert!(rec.target.is_none());
+        assert_eq!(rec.reason, NextTargetReason::EndOfSession);
+    }
+
+    #[test]
+    fn a_climbing_daytime_sun_is_end_of_session() {
+        // A session invoked mid-morning: the Sun is high and still
+        // climbing. This calendar night is over — end, don't wait.
+        let eph = MockEphemeris {
+            alt_overrides: vec![((0.7123, 41.27), 10.0)],
+            sun_alt: 30.0,
+            sun_alt_rate_deg_per_min: 0.2,
+            lst_hours: 12.0,
+        };
+        let targets = vec![PlannerTarget {
+            name: "M31".into(),
+            ra_hours: 0.7123,
+            dec_degrees: 41.27,
+            min_altitude_degrees: None,
+            exposures: Vec::new(),
+        }];
+        let rec = next_target(&eph, &site(), now(), &targets, 30.0);
+        assert_eq!(rec.reason, NextTargetReason::EndOfSession);
+    }
+
+    #[test]
+    fn a_climbing_sun_still_below_astronomical_dusk_is_all_below_min_altitude() {
+        // Pre-dawn astronomical night: the Sun rises toward -18° but
+        // has not crossed it. It is still properly dark, so a
+        // below-floor target set is reported as such — dawn is only
+        // declared once the sky is actually bright.
+        let eph = MockEphemeris {
+            alt_overrides: vec![((0.7123, 41.27), 10.0)],
+            sun_alt: -25.0,
+            sun_alt_rate_deg_per_min: 0.2,
+            lst_hours: 12.0,
+        };
+        let targets = vec![PlannerTarget {
+            name: "M31".into(),
+            ra_hours: 0.7123,
+            dec_degrees: 41.27,
+            min_altitude_degrees: None,
+            exposures: Vec::new(),
+        }];
+        let rec = next_target(&eph, &site(), now(), &targets, 30.0);
+        assert_eq!(rec.reason, NextTargetReason::AllBelowMinAltitude);
+    }
+
+    /// A target no computed altitude can reach — forces the
+    /// no-survivors branch against the real ephemeris.
+    fn never_visible_target() -> Vec<PlannerTarget> {
+        vec![PlannerTarget {
+            name: "below floor".into(),
+            ra_hours: 0.0,
+            dec_degrees: 0.0,
+            min_altitude_degrees: Some(90.0),
+            exposures: Vec::new(),
+        }]
+    }
+
+    // The two real-ephemeris tests below pin the same equinox
+    // instants the BDD dusk/dawn scenarios use, but through
+    // `next_target` directly — the mock tests above fix the trend
+    // maths, these keep it honest against the real sky. At the UK
+    // site on 2026-03-20 the Sun sits near -11° descending at
+    // 19:20 UTC and near -10° climbing at 05:00 UTC.
+
+    #[test]
+    fn real_ephemeris_evening_twilight_is_wait_for_twilight() {
+        let eph = rp_ephemeris::ErfarsEphemeris::new();
+        let site = Site::new(51.0786, -0.2944).unwrap();
+        let t = Utc.with_ymd_and_hms(2026, 3, 20, 19, 20, 0).unwrap();
+        let sun_alt = eph.sun_position(&site, t).alt_az.altitude_degrees;
+        assert!(
+            (-18.0..0.0).contains(&sun_alt),
+            "the pinned instant must sit in twilight; the Sun is at {sun_alt}°"
+        );
+        let rec = next_target(&eph, &site, t, &never_visible_target(), 20.0);
+        assert_eq!(rec.reason, NextTargetReason::WaitForTwilight);
+    }
+
+    #[test]
+    fn real_ephemeris_morning_twilight_is_end_of_session() {
+        let eph = rp_ephemeris::ErfarsEphemeris::new();
+        let site = Site::new(51.0786, -0.2944).unwrap();
+        let t = Utc.with_ymd_and_hms(2026, 3, 20, 5, 0, 0).unwrap();
+        let sun_alt = eph.sun_position(&site, t).alt_az.altitude_degrees;
+        assert!(
+            (-18.0..0.0).contains(&sun_alt),
+            "the pinned instant must sit in twilight; the Sun is at {sun_alt}°"
+        );
+        let rec = next_target(&eph, &site, t, &never_visible_target(), 20.0);
+        assert_eq!(rec.reason, NextTargetReason::EndOfSession);
+    }
+
+    #[test]
     fn full_astronomical_night_with_no_targets_above_floor_is_all_below_min() {
         // Sun well below -18° (true astronomical night) and every
         // target still below the floor → distinguish from twilight.
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7123, 41.27), 10.0)],
             sun_alt: -25.0,
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 12.0,
         };
         let targets = vec![PlannerTarget {
@@ -538,6 +698,7 @@ mod tests {
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7, 41.0), 50.0), ((11.0, -5.0), 50.0)],
             sun_alt: -20.0,
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 12.0,
         };
         let targets = vec![
@@ -567,6 +728,7 @@ mod tests {
         let eph = MockEphemeris {
             alt_overrides: vec![((1.0, 0.0), 25.0)],
             sun_alt: -20.0,
+            sun_alt_rate_deg_per_min: 0.0,
             lst_hours: 1.0,
         };
         let targets = vec![PlannerTarget {

--- a/services/rp/src/planner/decision.rs
+++ b/services/rp/src/planner/decision.rs
@@ -494,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn daytime_returns_wait_for_twilight() {
+    fn a_level_daytime_sun_is_wait_for_twilight() {
         let eph = MockEphemeris {
             alt_overrides: vec![((0.7123, 41.27), 10.0)],
             sun_alt: 30.0, // the Sun is up and, frozen at rate 0, not climbing

--- a/services/rp/tests/bdd/steps/ephemeris_steps.rs
+++ b/services/rp/tests/bdd/steps/ephemeris_steps.rs
@@ -60,6 +60,22 @@ fn target_without_exposure_plan(world: &mut RpWorld, name: String) {
         .push(always_visible_target(name, Vec::new()));
 }
 
+/// The mirror of [`always_visible_target`]: `min_altitude_degrees: 90`
+/// exceeds any computed altitude (short of an exact zenith crossing,
+/// which dec 0 at this latitude never approaches), so the planner
+/// always eliminates the target — forcing the no-survivors branch
+/// whose reason the dusk/dawn scenarios pin.
+#[given(expr = "rp is configured with the never-visible target {string}")]
+fn never_visible_target(world: &mut RpWorld, name: String) {
+    world.planner_targets.push(PlannerTargetConfig {
+        name,
+        ra_hours: 0.0,
+        dec_degrees: 0.0,
+        min_altitude_degrees: Some(90.0),
+        exposures: Vec::new(),
+    });
+}
+
 // --- When steps ---
 
 /// Polaris ICRS coords (J2000.0): RA = 2.530... h, Dec = +89.264°.
@@ -120,6 +136,16 @@ async fn call_next_target(world: &mut RpWorld) {
     let result = world
         .mcp()
         .call_tool("get_next_target", serde_json::json!({}))
+        .await;
+    world.last_tool_result = Some(result);
+}
+
+#[when(expr = "the MCP client calls \"get_next_target\" at time {string}")]
+async fn call_next_target_at(world: &mut RpWorld, time: String) {
+    ensure_mcp_client(world).await;
+    let result = world
+        .mcp()
+        .call_tool("get_next_target", serde_json::json!({ "time": time }))
         .await;
     world.last_tool_result = Some(result);
 }

--- a/services/rp/tests/features/planner.feature
+++ b/services/rp/tests/features/planner.feature
@@ -76,6 +76,35 @@ Feature: Planner convenience tools
     And the result filter should be null
     And the result duration_secs should be null
 
+  # The dusk/dawn pair pins bullet 6's sky gating end-to-end against
+  # the real ephemeris: a never-visible target (floor 90 degrees, which
+  # no computed altitude reaches) forces the no-survivors branch, and
+  # the explicit evaluation time puts the Sun in evening vs morning
+  # twilight at the configured site. 2026-03-20 is the March equinox:
+  # at this longitude the Sun sits near -10 degrees and descending at
+  # 19:20 UTC, near -10 degrees and climbing at 05:00 UTC.
+  Scenario: get_next_target in evening twilight says wait_for_twilight
+    Given a running Alpaca simulator
+    And rp is configured with site latitude 51.0786 longitude -0.2944
+    And rp is configured with the never-visible target "Below Floor"
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_next_target" at time "2026-03-20T19:20:00Z"
+    Then the tool call should succeed
+    And the result reason should be "wait_for_twilight"
+    And the result target should be null
+
+  Scenario: get_next_target in morning twilight says end_of_session
+    Given a running Alpaca simulator
+    And rp is configured with site latitude 51.0786 longitude -0.2944
+    And rp is configured with the never-visible target "Below Floor"
+    And rp is running with a mount on the simulator
+    And an MCP client connected to rp
+    When the MCP client calls "get_next_target" at time "2026-03-20T05:00:00Z"
+    Then the tool call should succeed
+    And the result reason should be "end_of_session"
+    And the result target should be null
+
   Scenario: get_target_status fails when site is missing
     Given a running Alpaca simulator
     And rp is running with a mount on the simulator

--- a/services/session-runner/src/engine/exec_tests.rs
+++ b/services/session-runner/src/engine/exec_tests.rs
@@ -2151,3 +2151,39 @@ async fn test_golden_deep_sky_fails_when_the_plan_names_a_filter_but_no_wheel_is
         "the failure must land after the slew and before any set_filter/capture"
     );
 }
+
+#[tokio::test]
+async fn test_golden_deep_sky_ends_the_session_when_the_planner_says_end_of_session() {
+    // The planner owns dawn (rp #465): an `end_of_session` reason ends
+    // the session on the spot — no frames-captured heuristic, no slew,
+    // no capture, no 5-minute wait.
+    let doc = make_doc(crate::document::corpus::golden_deep_sky());
+    let params = deep_sky_params(
+        &doc,
+        json!({
+            "focus": false,
+            "centering": false,
+            "max_frames": 1,
+            "park_on_finish": false
+        }),
+    );
+    let tools = MockTools::new(|_, tool, _| match tool {
+        "unpark" | "set_tracking" => Ok(json!({})),
+        "get_next_target" => Ok(json!({
+            "target": null,
+            "reason": "end_of_session",
+            "filter": null,
+            "duration_secs": null
+        })),
+        other => panic!("unexpected tool call `{other}` after end_of_session"),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (outcome, _) = run_in(&dir, &doc, &params, &tools, &MockClock::new()).await;
+
+    assert_eq!(outcome, RunOutcome::Completed);
+    assert_eq!(
+        tools.call_names(),
+        vec!["unpark", "set_tracking", "get_next_target"],
+        "end_of_session must terminate the dispatch loop immediately"
+    );
+}

--- a/services/session-runner/tests/bdd/steps/deep_sky_steps.rs
+++ b/services/session-runner/tests/bdd/steps/deep_sky_steps.rs
@@ -6,11 +6,14 @@
 //!
 //! The planner evaluates real ephemeris at wall-clock now, so these
 //! steps compute the observing site to fit the clock
-//! (`bdd_infra::rp_harness::NightSky`): an equatorial site at the
+//! (`bdd_infra::rp_harness::ComputedSky`): an equatorial site at the
 //! anti-solar longitude is always in deep astronomical night, and
 //! celestial-equator targets placed by hour angle sink at a constant
 //! ≈ 0.25°/minute — which makes "the first target drops below its
-//! floor N seconds from now" exact. The simulated mount is taught the
+//! floor N seconds from now" exact. The dawn scenario flips the
+//! trick: a site 45° west of the sub-solar longitude has a risen,
+//! still-climbing morning Sun at any moment, so the planner declares
+//! the night over. The simulated mount is taught the
 //! same site (rp hard-errors on mount connect when the mount's
 //! reported site disagrees with config) and synced onto the first
 //! target so every document slew stays sub-degree (OmniSim slews at
@@ -22,7 +25,7 @@ use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
 
 use bdd_infra::rp_harness::{
-    CameraConfig, CannedWcs, ExposurePlanConfig, FocuserConfig, MountConfig, NightSky,
+    CameraConfig, CannedWcs, ComputedSky, ExposurePlanConfig, FocuserConfig, MountConfig,
     OmniSimHandle, PlannerTargetConfig, PlateSolverConfig, PlateSolverStub, StubBehavior,
 };
 
@@ -58,7 +61,7 @@ async fn night_sky_with_one_planned_target(world: &mut SessionRunnerWorld, secon
 }
 
 fn push_one_night_target(world: &mut SessionRunnerWorld, exposures: Vec<ExposurePlanConfig>) {
-    let sky = NightSky::at(chrono::Utc::now());
+    let sky = ComputedSky::night_at(chrono::Utc::now());
     // Half an hour past transit: ≈ 82.5° altitude and sinking, next
     // meridian crossing ≈ 23.5 sidereal hours away — no flip pressure,
     // viable for hours against the planner-wide 20° floor.
@@ -79,7 +82,7 @@ fn push_one_night_target(world: &mut SessionRunnerWorld, exposures: Vec<Exposure
             targets sinks below its floor after {int} seconds"
 )]
 async fn night_sky_with_sinking_target(world: &mut SessionRunnerWorld, seconds: i64) {
-    let sky = NightSky::at(chrono::Utc::now());
+    let sky = ComputedSky::night_at(chrono::Utc::now());
     // Both targets descend in the west near 45° altitude, 0.05 h of
     // hour angle (0.75° of sky) apart so the switch slew is quick. The
     // sinker is closer to transit, so the planner prefers it while it
@@ -107,6 +110,28 @@ async fn night_sky_with_sinking_target(world: &mut SessionRunnerWorld, seconds: 
     });
     world.night_targets.push(sinker);
     world.night_targets.push(backup);
+}
+
+#[given(
+    "an observing site where the morning sun has risen and one planner target sits below \
+     its floor"
+)]
+async fn morning_sky_with_one_unviable_target(world: &mut SessionRunnerWorld) {
+    let sky = ComputedSky::morning_at(chrono::Utc::now());
+    // High in the sky (so the mount can sync onto it) but pinned below
+    // its own floor: no altitude reaches 90°, so the planner never
+    // recommends it and must fall through to the sky gating — a bright
+    // rising Sun, i.e. end_of_session.
+    let target = sky.target_at_hour_angle(0.5);
+    world.site = Some((sky.latitude_degrees(), sky.longitude_degrees()));
+    world.planner_targets.push(PlannerTargetConfig {
+        name: "unreachable".to_string(),
+        ra_hours: target.ra_hours,
+        dec_degrees: target.dec_degrees,
+        min_altitude_degrees: Some(90.0),
+        exposures: Vec::new(),
+    });
+    world.night_targets.push(target);
 }
 
 #[given("the simulated mount matches the site and points at the first target")]

--- a/services/session-runner/tests/bdd/world.rs
+++ b/services/session-runner/tests/bdd/world.rs
@@ -52,7 +52,7 @@ pub struct SessionRunnerWorld {
     /// transitions are detected in test time.
     pub safety_poll_interval: Option<Duration>,
     /// Observer site `(latitude, longitude)` — computed per scenario by
-    /// `NightSky` so the planner sees astronomical night at test time.
+    /// `ComputedSky` so the planner sees the sky the scenario needs at test time.
     pub site: Option<(f64, f64)>,
     /// Planner targets emitted into rp's `targets[]` (order matters:
     /// exact |hour-angle| ties break by position).

--- a/services/session-runner/tests/features/deep_sky.feature
+++ b/services/session-runner/tests/features/deep_sky.feature
@@ -10,7 +10,10 @@ Feature: Deep-sky workflow document
   clock: an equatorial site at the anti-solar longitude is always in
   deep astronomical night, and celestial-equator targets placed by hour
   angle sink at a constant 0.25 degrees per minute — which makes "this
-  target drops below its floor in N seconds" exact. The simulated mount
+  target drops below its floor in N seconds" exact. The dawn scenario
+  flips the trick: a site 45 degrees west of the sub-solar longitude
+  has a risen, still-climbing morning sun at any moment, so the planner
+  answers end_of_session. The simulated mount
   is taught the same site (rp refuses a mount whose reported site
   disagrees with config) and synced onto the first target so document
   slews stay sub-degree.
@@ -58,6 +61,27 @@ Feature: Deep-sky workflow document
     # plan is what reaches the camera.
     Then the session ends within 90 seconds
     And the SSE stream should show exactly 2 "exposure_complete" events
+
+  Scenario: A session started after dawn ends immediately with no frames
+    Given a running Alpaca simulator
+    And an observing site where the morning sun has risen and one planner target sits below its floor
+    And the simulated mount matches the site and points at the first target
+    And rp is running with a camera, a mount, and the session-runner orchestrator running the "deep_sky" workflow with parameters:
+      | exposure       | 2s    |
+      | max_frames     | 2     |
+      | focus          | false |
+      | centering      | false |
+      | park_on_finish | false |
+    And an SSE client is watching rp's event stream
+    When a session is started via the REST API
+    # The planner sees a bright rising Sun and no viable target, so its
+    # first answer is end_of_session and the document ends the session
+    # before slewing or capturing anything. Before rp #465 the reason
+    # was wait_for_twilight and the document's zero-frames heuristic
+    # read it as dusk — it would have waited forever.
+    Then the session ends within 30 seconds
+    And the SSE stream should show exactly 0 "slew_complete" events
+    And the SSE stream should show exactly 0 "exposure_complete" events
 
   Scenario: A target sinking below its altitude floor switches the dispatch loop to the next target
     Given a running Alpaca simulator

--- a/services/session-runner/workflows/deep_sky.json
+++ b/services/session-runner/workflows/deep_sky.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "deep-sky",
-  "description": "Classic multi-target deep-sky imaging session: unpark and start tracking, then a dispatch loop that asks rp's planner for the best target after every frame — acquiring on target change (slew, filter from the planner's exposure plan, optional plate-solve centering, optional auto-focus) and capturing one frame per pass — with reactive refocusing and meridian-flip handling, ending at the frame budget or dawn and optionally parking. Written against rp's v1 planner surface: get_next_target supplies filter/duration_secs from the target's first exposures[] entry with the exposure/filter parameters as fallback (rotation within a plan needs record_exposure, which does not exist yet — progress is counted in the blackboard), and there is no guiding or dithering (rp has no guider tools yet) — see docs/services/session-runner.md § deep_sky.json.",
+  "description": "Classic multi-target deep-sky imaging session: unpark and start tracking, then a dispatch loop that asks rp's planner for the best target after every frame — acquiring on target change (slew, filter from the planner's exposure plan, optional plate-solve centering, optional auto-focus) and capturing one frame per pass — with reactive refocusing and meridian-flip handling, ending at the frame budget or when the planner declares the night over (end_of_session) and optionally parking. Written against rp's v1 planner surface: get_next_target supplies filter/duration_secs from the target's first exposures[] entry with the exposure/filter parameters as fallback (rotation within a plan needs record_exposure, which does not exist yet — progress is counted in the blackboard), and there is no guiding or dithering (rp has no guider tools yet) — see docs/services/session-runner.md § deep_sky.json.",
   "parameters": {
     "camera_id": { "type": "string", "required": true },
     "exposure": { "type": "duration", "default": "300s" },
@@ -217,29 +217,14 @@
               {
                 "if": "result.target == null",
                 "then": [
+                  { "set": { "session.imaging": "false" } },
                   {
-                    "if": "result.reason == 'wait_for_twilight' && session.total_frames > 0",
-                    "then": [
-                      {
-                        "log": {
-                          "level": "info",
-                          "message": "dawn twilight reached — ending the session",
-                          "values": { "total_frames": "session.total_frames" }
-                        }
-                      },
-                      { "set": { "session.session_over": "true" } }
-                    ],
-                    "else": [
-                      { "set": { "session.imaging": "false" } },
-                      {
-                        "log": {
-                          "message": "no viable target — waiting before re-asking the planner",
-                          "values": { "reason": "result.reason" }
-                        }
-                      },
-                      { "wait": { "duration": "5m" } }
-                    ]
-                  }
+                    "log": {
+                      "message": "no viable target — waiting before re-asking the planner",
+                      "values": { "reason": "result.reason" }
+                    }
+                  },
+                  { "wait": { "duration": "5m" } }
                 ],
                 "else": [
                   {


### PR DESCRIPTION
Closes #465.

## What

`get_next_target` could not tell "the night hasn't started" from "the night is over": `wait_for_twilight` fired whenever the Sun was above −18°, at dusk *and* at dawn, and `end_of_session` was wired into the reason discriminant but unreachable. The shipped `deep_sky.json` papered over this with a document-side heuristic (`wait_for_twilight` with frames captured = dawn) — honest, but a planner concern living in a document, and wrong in one corner: a night that never yielded a frame read dawn as dusk and waited forever into the day.

## How

**rp** — in the no-survivors branch, when the sky is brighter than astronomical dusk, the planner re-samples the Sun 60 s ahead:

- climbing → **`end_of_session`** (dawn side — the night is over)
- descending or level → **`wait_for_twilight`** (dusk side; the tie goes to waiting because a wait loop re-asks and self-corrects, while ending a session is final)
- below −18° stays `all_below_min_altitude` — dawn is only declared once the sky is actually bright.

Per rp.md bullet 6 the gating stays scoped to "no targets are viable", so the always-visible-target BDD trick from #462 is untouched. The exhausted-targets half of `end_of_session` still needs the `record_exposure` counters and rides #463.

**session-runner** — `deep_sky.json` drops the dawn heuristic and trusts the reason alone: `end_of_session` ends the session, any other target-less reason waits 5 minutes and re-asks.

## Testing

- **decision.rs**: the mock Sun gains a slope; four trend unit tests plus two real-ERFA tests pinning March-equinox twilight instants (each asserts the Sun really sits in (−18°, 0°) at the pinned time, so a failure self-explains).
- **rp BDD**: dusk/dawn scenario pair through the MCP surface using the explicit `time` parameter and a *never-visible* target (floor 90° — the mirror of the always-visible trick).
- **bdd-infra**: `NightSky` generalises to `ComputedSky` (`night_at` / `morning_at`). The morning site sits 45° west of the sub-solar longitude — local solar time ≈ 09:00, Sun ≈ 40–45° up and climbing at any moment of any date — with unit tests sweeping solstice/equinox moments.
- **session-runner BDD**: a session started after dawn ends on `end_of_session` within 30 s with zero slews and zero frames (before this change the document would have waited forever). An exec-level golden test pins the document branch (`unpark`, `set_tracking`, `get_next_target` and nothing else).
- Full local gate: `bazel build //... && bazel test //...` (incl. both OmniSim BDD suites), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`.

## Docs

`rp.md` (bullet 6 + v1 status callout + tool description), `session-runner.md` (deep_sky sketch, v1 adaptations, BDD table), `workflow-dsl.md` plan note, feature-file preambles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
