### PR TITLE
feat(bdd): private OmniSim per test process + rp:bdd sharding (closes #467)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,19 +50,29 @@ test --test_tag_filters=-requires-cargo,-conformu
 test --test_env=OMNISIM_PATH
 test --test_env=OMNISIM_DIR
 
-# OmniSim allows only one instance per host (ASCOM.Alpaca.Simulators guards
-# startup with a machine-global named Mutex keyed on a fixed GUID, not the port).
-# The two BDD targets that spawn it (//services/rp:bdd,
-# //services/calibrator-flats:bdd) are tagged `resources:omnisim:1`; this defines
-# the matching pool with capacity 1 so Bazel never schedules those two
-# concurrently — while leaving them free to run in parallel with every
-# non-OmniSim test (unlike the `exclusive` tag, which would serialize against
-# everything). The pool MUST be defined or those tests fail loudly with "Resource
-# omnisim is not being tracked by the resource manager"; defining it here on
-# `test` (inherited by `coverage`) keeps it present for every test invocation,
-# local and CI. --local_resources is a scheduling-only flag, so it does not enter
-# action keys and never perturbs the remote cache.
-test --local_resources=omnisim=1
+# The `omnisim` resource pool. Every OmniSim-spawning BDD action (the four
+# suites rp:bdd / calibrator-flats:bdd / session-runner:bdd /
+# operation-watchdog-e2e:bdd, and each shard of a sharded suite) is tagged
+# `resources:omnisim:1` and takes one token. Since #467 the bdd-infra harness
+# gives every test process a PRIVATE OmniSim — spawned with the fork's
+# --multi-instance flag (skips upstream's machine-global single-instance
+# mutex) on a dynamically chosen port, with a per-instance XDG_CONFIG_HOME —
+# so on Linux/macOS these actions can genuinely run in parallel and the pool
+# is sized above the worst-case concurrent demand (8 rp shards + 3 suites);
+# it exists there only as a throttle to grab if OmniSim concurrency ever
+# turns flaky. Windows is different: OmniSim's profile store is
+# %USERPROFILE%\.ASCOM (ASCOM.Tools XMLProfile), which no environment
+# variable can redirect per-instance, so concurrent instances would race
+# each other's profile write-backs — capacity 1 keeps Windows serialized
+# (the platform-specific line wins because --enable_platform_specific_config
+# appends it after this one). The pool MUST be defined or the tagged tests
+# fail loudly with "Resource omnisim is not being tracked by the resource
+# manager"; defining it on `test` (inherited by `coverage`) keeps it present
+# for every test invocation, local and CI. --local_resources is a
+# scheduling-only flag, so it does not enter action keys and never perturbs
+# the remote cache.
+test --local_resources=omnisim=16
+test:windows --local_resources=omnisim=1
 
 # --- Rust toolchain --------------------------------------------------------
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -56,10 +56,11 @@ test --test_env=OMNISIM_DIR
 # `resources:omnisim:1` and takes one token. Since #467 the bdd-infra harness
 # gives every test process a PRIVATE OmniSim — spawned with the fork's
 # --multi-instance flag (skips upstream's machine-global single-instance
-# mutex) on a dynamically chosen port, with a per-instance XDG_CONFIG_HOME —
-# so on Linux/macOS these actions can genuinely run in parallel and the pool
-# is sized above the worst-case concurrent demand (8 rp shards + 3 suites)
-# on every OS; it exists only as a throttle to grab if OmniSim concurrency
+# mutex) on a dynamically chosen port, with a per-instance
+# OMNISIM_SETTINGS_DIR — so these actions can genuinely run in parallel on
+# every OS and the pool is sized above the worst-case concurrent demand
+# (8 rp:bdd shards + 8 session-runner:bdd shards + 2 suites = 18); it
+# exists only as a throttle to grab if OmniSim concurrency
 # ever turns flaky (e.g. `test:windows --local_resources=omnisim=1` would
 # re-serialize one platform — --enable_platform_specific_config appends
 # platform lines after this one, so they win). Profile-store isolation is
@@ -72,7 +73,7 @@ test --test_env=OMNISIM_DIR
 # for every test invocation, local and CI. --local_resources is a
 # scheduling-only flag, so it does not enter action keys and never perturbs
 # the remote cache.
-test --local_resources=omnisim=16
+test --local_resources=omnisim=24
 
 # --- Rust toolchain --------------------------------------------------------
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -58,21 +58,21 @@ test --test_env=OMNISIM_DIR
 # --multi-instance flag (skips upstream's machine-global single-instance
 # mutex) on a dynamically chosen port, with a per-instance XDG_CONFIG_HOME —
 # so on Linux/macOS these actions can genuinely run in parallel and the pool
-# is sized above the worst-case concurrent demand (8 rp shards + 3 suites);
-# it exists there only as a throttle to grab if OmniSim concurrency ever
-# turns flaky. Windows is different: OmniSim's profile store is
-# %USERPROFILE%\.ASCOM (ASCOM.Tools XMLProfile), which no environment
-# variable can redirect per-instance, so concurrent instances would race
-# each other's profile write-backs — capacity 1 keeps Windows serialized
-# (the platform-specific line wins because --enable_platform_specific_config
-# appends it after this one). The pool MUST be defined or the tagged tests
+# is sized above the worst-case concurrent demand (8 rp shards + 3 suites)
+# on every OS; it exists only as a throttle to grab if OmniSim concurrency
+# ever turns flaky (e.g. `test:windows --local_resources=omnisim=1` would
+# re-serialize one platform — --enable_platform_specific_config appends
+# platform lines after this one, so they win). Profile-store isolation is
+# the fork's OMNISIM_SETTINGS_DIR (release v0.5.0-467.2), which works on
+# every platform — XDG_CONFIG_HOME did not: .NET ignores it on macOS, and
+# the resulting shared store leaked session-runner's persisted telescope
+# site into rp's shards on macOS CI. The pool MUST be defined or the tagged tests
 # fail loudly with "Resource omnisim is not being tracked by the resource
 # manager"; defining it on `test` (inherited by `coverage`) keeps it present
 # for every test invocation, local and CI. --local_resources is a
 # scheduling-only flag, so it does not enter action keys and never perturbs
 # the remote cache.
 test --local_resources=omnisim=16
-test:windows --local_resources=omnisim=1
 
 # --- Rust toolchain --------------------------------------------------------
 

--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: OmniSim release version
     required: false
-    default: "v0.5.0-467.1"
+    default: "v0.5.0-467.2"
 
 runs:
   using: composite
@@ -20,14 +20,19 @@ runs:
     # Per-OS table. SHA-256 values are pinned against the OmniSim
     # release assets named below. They currently point at the patched
     # fork ivonnyssen/ASCOM.Alpaca.Simulators (default `repo` input,
-    # tag v0.5.0-467.1 = v0.5.0-326.4 + the --multi-instance flag).
+    # tag v0.5.0-467.2 = v0.5.0-326.4 + --multi-instance + OMNISIM_SETTINGS_DIR).
     #
-    # 467.1 (rusty-photon #467) adds `--multi-instance`: skips upstream's
-    # machine-global single-instance guard (named Mutex + named-pipe command
-    # server) so bdd-infra can run one private OmniSim per test process —
-    # the enabler for parallel OmniSim BDD suites and rp:bdd sharding.
-    # bdd-infra ALWAYS passes the flag now, so this pin is a hard floor:
-    # an older binary exits at startup whenever another instance is running.
+    # 467.x (rusty-photon #467) enables one private OmniSim per test process
+    # — the enabler for parallel OmniSim BDD suites and rp:bdd sharding.
+    # 467.1 adds `--multi-instance` (skips upstream's machine-global
+    # single-instance guard: named Mutex + named-pipe command server);
+    # 467.2 adds the OMNISIM_SETTINGS_DIR env var (re-roots the profile
+    # store — the default location is not redirectable on Windows or macOS,
+    # where concurrent instances otherwise share one store and leak
+    # persisted settings across suites; that took down 4 of 8 rp:bdd shards
+    # on macOS CI). bdd-infra ALWAYS passes both now, so this pin is a hard
+    # floor: an older binary exits at startup whenever another instance is
+    # running, or silently shares the profile store.
     #
     # The carried 326.x series fixes TelescopeHardware slew bugs behind the
     # center_on_target hang/flake (ivonnyssen/rusty-photon #326, #319):
@@ -49,23 +54,23 @@ runs:
         case "${{ runner.os }}-${{ runner.arch }}" in
           Linux-X64)
             ASSET="ascom.alpaca.simulators.linux-x64.tar.xz"
-            SHA256="68cca3f2b326579a71e02e70fd767987253fd7a700132cf23bd2fa5dace363e8"
+            SHA256="238cc7aa301b2d6cb3ad3ea07de8e55fa190007b086d49291eccd608741f834b"
             ;;
           Linux-ARM64)
             ASSET="ascom.alpaca.simulators.linux-aarch64.tar.xz"
-            SHA256="6c6dc32479b5a10e17b9a20b831940ccfb54e80576bd4946e2c1056ba432f1aa"
+            SHA256="22706e0f52d3ac46ab2c8612c4f231bb6e8c01a9eb814b3325f350ed5239ff49"
             ;;
           macOS-ARM64)
             ASSET="ascom.alpaca.simulators.macos-arm64.zip"
-            SHA256="3ab44c0abfa82c556f73da6c85c9d727956b67e6d66a9ae30996069ba168b7d0"
+            SHA256="8abc316ae14b9f40e860ff2423b377c32e6b348cd8d8b12dee4f4b37654aa4c3"
             ;;
           macOS-X64)
             ASSET="ascom.alpaca.simulators.macos-x64.zip"
-            SHA256="3b01f427f875c40e6ea4b5603e568ef9615ceea57e89f12c803449031bf8eff4"
+            SHA256="9f08339510ac72c14c073fc7e1d5cb7b14133d83564a5bbd1a95d7c3838d33e0"
             ;;
           Windows-X64)
             ASSET="ascom.alpaca.simulators.windows-x64.zip"
-            SHA256="ff2d558e661ce5d465da2c345be16164ba0ddea3837ea7f68ff76073427995b6"
+            SHA256="dc5dc71c7149b66ad9b5cc728d3a3c384d0b12587dc6f3b3d405f28fcf5f46ba"
             ;;
           *)
             echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"

--- a/.github/actions/install-omnisim/action.yml
+++ b/.github/actions/install-omnisim/action.yml
@@ -5,13 +5,14 @@ inputs:
   repo:
     description: GitHub repo to download OmniSim release assets from
     required: false
-    # Patched fork carrying the issue #326 TelescopeHardware locking fix.
+    # Patched fork carrying the issue #326 TelescopeHardware locking fixes
+    # and the issue #467 --multi-instance flag.
     # Set to "ASCOMInitiative/ASCOM.Alpaca.Simulators" to revert to upstream.
     default: "ivonnyssen/ASCOM.Alpaca.Simulators"
   version:
     description: OmniSim release version
     required: false
-    default: "v0.5.0-326.4"
+    default: "v0.5.0-467.1"
 
 runs:
   using: composite
@@ -19,21 +20,28 @@ runs:
     # Per-OS table. SHA-256 values are pinned against the OmniSim
     # release assets named below. They currently point at the patched
     # fork ivonnyssen/ASCOM.Alpaca.Simulators (default `repo` input,
-    # tag v0.5.0-326.4). The 326.x series fixes TelescopeHardware slew
-    # bugs behind the center_on_target hang/flake (ivonnyssen/rusty-photon
-    # #326, #319): 326.1 locked the slew-engine writers + IsSlewing/RA/Dec
-    # readers; 326.2 adds the AtPark/SlewState readers (closes the park-poll
-    # hang); 326.3 disposes the prior slew timer on Init() (was leaking one
-    # live timer on each per-scenario reset) and resets the slew state under
-    # hardwareLock; 326.4 closes the center_on_target IsSlewing wedge proper
-    # (issue #319) — a GEM goto whose short-path rotation crossed the
-    # hour-angle limit pinned IsSlewing=true forever; DoSlew now takes the
-    # limit-avoiding rotation to the same target (pier side unchanged), plus
-    # a no-progress guard. ConformU-clean vs upstream. To revert to upstream,
-    # set `repo` to ASCOMInitiative/ASCOM.Alpaca.Simulators and `version`
-    # back to v0.5.0, then refresh every SHA below. Bumping either input
-    # requires refreshing the SHAs — the verify step fails closed on any
-    # mismatch. Same shape and supply-chain reasoning as install-astap.
+    # tag v0.5.0-467.1 = v0.5.0-326.4 + the --multi-instance flag).
+    #
+    # 467.1 (rusty-photon #467) adds `--multi-instance`: skips upstream's
+    # machine-global single-instance guard (named Mutex + named-pipe command
+    # server) so bdd-infra can run one private OmniSim per test process —
+    # the enabler for parallel OmniSim BDD suites and rp:bdd sharding.
+    # bdd-infra ALWAYS passes the flag now, so this pin is a hard floor:
+    # an older binary exits at startup whenever another instance is running.
+    #
+    # The carried 326.x series fixes TelescopeHardware slew bugs behind the
+    # center_on_target hang/flake (ivonnyssen/rusty-photon #326, #319):
+    # 326.1 locked the slew-engine writers + IsSlewing/RA/Dec readers;
+    # 326.2 adds the AtPark/SlewState readers (closes the park-poll hang);
+    # 326.3 disposes the prior slew timer on Init() and resets the slew
+    # state under hardwareLock; 326.4 closes the center_on_target IsSlewing
+    # wedge proper (issue #319). ConformU-clean vs upstream.
+    #
+    # Reverting to upstream (repo=ASCOMInitiative/..., version=v0.5.0) is no
+    # longer SHA-refresh-only: upstream has no --multi-instance, so the
+    # bdd-infra spawn path would have to be reverted too. Bumping either
+    # input requires refreshing the SHAs — the verify step fails closed on
+    # any mismatch. Same shape and supply-chain reasoning as install-astap.
     - name: Determine asset name and pinned SHA-256
       id: asset
       shell: bash
@@ -41,23 +49,23 @@ runs:
         case "${{ runner.os }}-${{ runner.arch }}" in
           Linux-X64)
             ASSET="ascom.alpaca.simulators.linux-x64.tar.xz"
-            SHA256="74d96ae5b1c41f4eae27336c5dafc47e8264939ce8946f2178949eb3fcbf0153"
+            SHA256="68cca3f2b326579a71e02e70fd767987253fd7a700132cf23bd2fa5dace363e8"
             ;;
           Linux-ARM64)
             ASSET="ascom.alpaca.simulators.linux-aarch64.tar.xz"
-            SHA256="5218f57038cc520139b63454265eb53f6ecbbb7b8cee9374ad74dd759af48e30"
+            SHA256="6c6dc32479b5a10e17b9a20b831940ccfb54e80576bd4946e2c1056ba432f1aa"
             ;;
           macOS-ARM64)
             ASSET="ascom.alpaca.simulators.macos-arm64.zip"
-            SHA256="54c0d8aaf18222f572e348fc36addc884013a5ab734ace1f3c475b9603c57ee5"
+            SHA256="3ab44c0abfa82c556f73da6c85c9d727956b67e6d66a9ae30996069ba168b7d0"
             ;;
           macOS-X64)
             ASSET="ascom.alpaca.simulators.macos-x64.zip"
-            SHA256="1af188a340dfc46f0d86391af67007202a47e377b2eac0d21d0b7b26b1234336"
+            SHA256="3b01f427f875c40e6ea4b5603e568ef9615ceea57e89f12c803449031bf8eff4"
             ;;
           Windows-X64)
             ASSET="ascom.alpaca.simulators.windows-x64.zip"
-            SHA256="4aacde332d3c92ddd27924d0609d50bde020e1294d14ec6f4844a87df0a9d938"
+            SHA256="ff2d558e661ce5d465da2c345be16164ba0ddea3837ea7f68ff76073427995b6"
             ;;
           *)
             echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -30,13 +30,11 @@ jobs:
     # Bazel's action-graph change detection figures out which targets actually
     # changed and only rebuilds those; everything else is a cache hit.
     #
-    # 40-min timeout: on Linux/macOS the OmniSim-backed BDD suites run in
-    # parallel and rp:bdd is sharded (private OmniSim per test process since
-    # #467), so the BDD step is bounded by the slowest shard. Windows still
-    # serializes all OmniSim actions (omnisim pool capacity 1 in .bazelrc —
-    # OmniSim's %USERPROFILE%\.ASCOM profile store can't be isolated per
-    # instance), so rp:bdd's shards there run back-to-back (~12 min total);
-    # 40 leaves headroom for a cold-cache first run.
+    # 40-min timeout: the OmniSim-backed BDD suites run in parallel and
+    # rp:bdd is sharded on every OS (private OmniSim per test process since
+    # #467 — --multi-instance + OMNISIM_SETTINGS_DIR), so the BDD step is
+    # bounded by the slowest shard; 40 leaves generous headroom for a
+    # cold-cache first run.
     timeout-minutes: 40
     defaults:
       run:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -30,12 +30,13 @@ jobs:
     # Bazel's action-graph change detection figures out which targets actually
     # changed and only rebuilds those; everything else is a cache hit.
     #
-    # 40-min timeout: with the OmniSim race fixed (see services/rp/BUILD.bazel),
-    # rp:bdd runs to full completion (~12 min on Windows), which lengthens the
-    # BDD step on the slower Windows runner. The `omnisim` resource pool
-    # serializes rp:bdd only against calibrator-flats:bdd — both stay parallel to
-    # the other ~10 BDD targets — so the increase is modest; 40 leaves headroom
-    # for a cold-cache first run.
+    # 40-min timeout: on Linux/macOS the OmniSim-backed BDD suites run in
+    # parallel and rp:bdd is sharded (private OmniSim per test process since
+    # #467), so the BDD step is bounded by the slowest shard. Windows still
+    # serializes all OmniSim actions (omnisim pool capacity 1 in .bazelrc —
+    # OmniSim's %USERPROFILE%\.ASCOM profile store can't be isolated per
+    # instance), so rp:bdd's shards there run back-to-back (~12 min total);
+    # 40 leaves headroom for a cold-cache first run.
     timeout-minutes: 40
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ bazel test //...
 bazel test //services/filemonitor/...
 
 # The BDD suites (need OmniSim + OMNISIM_PATH; the binary must be our
-# patched fork, release v0.5.0-467.1 or newer — the harness spawns it
-# with the fork-only --multi-instance flag)
+# patched fork, release v0.5.0-467.2 or newer — the harness spawns it
+# with the fork-only --multi-instance flag + OMNISIM_SETTINGS_DIR)
 bazel test --test_tag_filters=bdd //...
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ bazel test //...
 # A single service's tests
 bazel test //services/filemonitor/...
 
-# The BDD suites (need OmniSim + OMNISIM_PATH)
+# The BDD suites (need OmniSim + OMNISIM_PATH; the binary must be our
+# patched fork, release v0.5.0-467.1 or newer — the harness spawns it
+# with the fork-only --multi-instance flag)
 bazel test --test_tag_filters=bdd //...
 ```
 

--- a/crates/bdd-infra/BUILD.bazel
+++ b/crates/bdd-infra/BUILD.bazel
@@ -37,6 +37,12 @@ rust_library(
     aliases = aliases(),
     crate_features = ["rp-harness"],
     crate_name = "bdd_infra",
+    # The OmniSim profile seed tree rides along in the runfiles of every
+    # test that links this harness, so the per-instance XDG_CONFIG_HOME
+    # seeding (rp_harness/omnisim.rs `seed_config_source`, branch 2 -- the
+    # cwd-ancestors walk) resolves it under Bazel. Without this the seed
+    # never resolved under Bazel and OmniSim ran on upstream defaults.
+    data = glob(["omnisim-config/**"]),
     edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     visibility = ["//visibility:public"],

--- a/crates/bdd-infra/BUILD.bazel
+++ b/crates/bdd-infra/BUILD.bazel
@@ -38,7 +38,7 @@ rust_library(
     crate_features = ["rp-harness"],
     crate_name = "bdd_infra",
     # The OmniSim profile seed tree rides along in the runfiles of every
-    # test that links this harness, so the per-instance XDG_CONFIG_HOME
+    # test that links this harness, so the per-instance OMNISIM_SETTINGS_DIR
     # seeding (rp_harness/omnisim.rs `seed_config_source`, branch 2 -- the
     # cwd-ancestors walk) resolves it under Bazel. Without this the seed
     # never resolved under Bazel and OmniSim ran on upstream defaults.

--- a/crates/bdd-infra/omnisim-config/ascom-alpaca-simulator/covercalibrator/v1/instance-0.xml
+++ b/crates/bdd-infra/omnisim-config/ascom-alpaca-simulator/covercalibrator/v1/instance-0.xml
@@ -2,10 +2,12 @@
 <!--
   OmniSim covercalibrator profile shipped by bdd-infra. This file is
   the source of truth for the per-test simulator defaults; bdd-infra
-  copies the entire `crates/bdd-infra/omnisim-config/ascom/alpaca/...`
-  tree to a per-build XDG_CONFIG_HOME under the cargo target directory
-  before spawning OmniSim, so the simulator's own write-back on
-  startup goes there and never touches this checked-in copy.
+  copies the entire `crates/bdd-infra/omnisim-config/` tree into a
+  per-instance OMNISIM_SETTINGS_DIR (a scratch dir under TEST_TMPDIR
+  or the cargo target tree) before spawning OmniSim, so the
+  simulator's own write-back on startup goes there and never touches
+  this checked-in copy. The tree's layout mirrors what the patched
+  fork (v0.5.0-467.2+) expects under the settings root.
 
   Tunables relevant to BDD wall-clock:
     Cover Opening Time            seconds; OmniSim uses asynchronous

--- a/crates/bdd-infra/src/lib.rs
+++ b/crates/bdd-infra/src/lib.rs
@@ -92,6 +92,13 @@
 /// they do under `cargo test`. Any `*_BINARY` env vars that hold relative
 /// paths are rewritten to absolute paths before chdir so binary discovery
 /// still resolves against the runfiles root.
+///
+/// The macro also advertises Bazel test-sharding support (touching
+/// `TEST_SHARD_STATUS_FILE` when set — required for targets with
+/// `shard_count`). Note that advertising is not partitioning: a sharded
+/// suite must additionally route its scenario filter through
+/// [`sharding::scenario_in_current_shard`], or every shard runs the whole
+/// suite.
 #[macro_export]
 macro_rules! bdd_main {
     ($($body:tt)*) => {
@@ -100,6 +107,7 @@ macro_rules! bdd_main {
 
         #[cfg(not(miri))]
         fn main() {
+            $crate::sharding::advertise_bazel_sharding_support();
             $crate::__bdd_bazel_chdir();
             // 16 MB driver + worker stacks: see the macro docs — the rp suite
             // overflows Windows' ~1 MB main-thread stack otherwise.
@@ -145,6 +153,8 @@ pub fn __bdd_bazel_chdir() {
     }
     std::env::set_current_dir(&dir).unwrap_or_else(|e| panic!("bdd_main: chdir to {}: {}", dir, e));
 }
+
+pub mod sharding;
 
 #[cfg(feature = "rp-harness")]
 pub mod rp_harness;

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -3,22 +3,28 @@
 //! A single OmniSim process is shared across all scenarios in a test binary
 //! via a [`tokio::sync::OnceCell`]. Each test process spawns its **own**
 //! instance on a **dynamically chosen port**, passing `--multi-instance` —
-//! the flag added to our OmniSim fork (release `v0.5.0-467.1`,
-//! `ivonnyssen/ASCOM.Alpaca.Simulators`) that skips upstream's machine-global
+//! the flag added to our OmniSim fork (`ivonnyssen/ASCOM.Alpaca.Simulators`,
+//! release `v0.5.0-467.1`) that skips upstream's machine-global
 //! single-instance guard (a named Mutex keyed on a fixed GUID, backed by a
 //! file under `/tmp/.dotnet/shm/` on Unix). Combined with a per-instance
-//! settings dir (see [`OmniSimProcess::prepare_xdg_config_home`]), any number
+//! settings dir (see [`OmniSimProcess::prepare_settings_dir`]), any number
 //! of BDD test processes — parallel Bazel targets, shards of one target, or a
 //! stray dev instance on the default port — can run concurrently without
 //! contending for one simulator. This is what lets Bazel run the
 //! OmniSim-backed suites in parallel and shard `rp:bdd` (issue #467).
 //!
-//! Windows is the exception: OmniSim's profile store there is
-//! `%USERPROFILE%\.ASCOM` (ASCOM.Tools `XMLProfile`), which no environment
-//! variable can redirect per-instance, so concurrent instances would race
-//! each other's profile write-backs. The Bazel `omnisim` resource pool keeps
-//! capacity 1 on Windows (see `.bazelrc`) and these suites still serialize
-//! there.
+//! The settings dir is passed via `OMNISIM_SETTINGS_DIR` (fork release
+//! `v0.5.0-467.2`, the version floor), NOT `XDG_CONFIG_HOME`: .NET honors
+//! XDG only on non-macOS Unix, so on macOS OmniSim's profile store defaults
+//! to the shared `~/Library/Application Support` (and on Windows to
+//! `%USERPROFILE%\.ASCOM`), neither redirectable by any environment
+//! variable. Concurrent instances sharing one profile store race their
+//! startup write-backs and leak persisted *settings* across suites — on
+//! macOS CI, session-runner's computed telescope site leaked into rp's
+//! shards through per-scenario `restart` (which reloads from the profile)
+//! and rp refused to start on mount-site validation. The fork's env var
+//! bypasses the platform lookup entirely, so isolation is deterministic on
+//! every OS and the Bazel `omnisim` pool runs parallel everywhere.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -86,10 +92,12 @@ impl OmniSimHandle {
     /// 2. `OMNISIM_DIR` env var — directory containing the binary
     /// 3. `ascom.alpaca.simulators` on `PATH`
     ///
-    /// The binary must support `--multi-instance` (fork release
-    /// `v0.5.0-467.1` or newer); an older binary exits immediately when
-    /// another instance is running, which surfaces here as a spawn failure
-    /// naming the flag.
+    /// The binary must support `--multi-instance` and `OMNISIM_SETTINGS_DIR`
+    /// (fork release `v0.5.0-467.2` or newer). An older binary either exits
+    /// immediately when another instance is running (pre-467.1, surfaces
+    /// here as a spawn failure naming the flag) or silently ignores the
+    /// settings-dir override and shares the platform-default profile store
+    /// with every other instance (467.1 on macOS/Windows).
     pub async fn start() -> Self {
         let process = OMNISIM
             .get_or_init(|| async { OmniSimProcess::get_or_spawn().await })
@@ -509,10 +517,11 @@ impl OmniSimProcess {
         }
         panic!(
             "failed to start OmniSim binary '{}' after {} attempts: {}. \
-             Note: bdd-infra spawns OmniSim with --multi-instance, which needs \
-             the patched fork (ivonnyssen/ASCOM.Alpaca.Simulators release \
-             v0.5.0-467.1 or newer) — an older binary exits at startup when \
-             any other OmniSim instance is running on the host.",
+             Note: bdd-infra spawns OmniSim with --multi-instance and \
+             OMNISIM_SETTINGS_DIR, which need the patched fork \
+             (ivonnyssen/ASCOM.Alpaca.Simulators release v0.5.0-467.2 or \
+             newer) — an older binary exits at startup when any other \
+             OmniSim instance is running on the host.",
             binary, SPAWN_ATTEMPTS, last_failure
         );
     }
@@ -546,12 +555,12 @@ impl OmniSimProcess {
             .env_remove("LSAN_OPTIONS");
 
         // Per-instance settings dir: concurrent OmniSims must not share a
-        // writable profile store (see `prepare_xdg_config_home`). On Windows
-        // OmniSim ignores XDG_CONFIG_HOME (profile lives in
-        // %USERPROFILE%\.ASCOM) — the env var is harmless there, and the
-        // Bazel `omnisim` pool keeps Windows serialized instead.
-        if let Some(xdg) = Self::prepare_xdg_config_home() {
-            cmd.env("XDG_CONFIG_HOME", xdg);
+        // writable profile store (see `prepare_settings_dir`). The fork's
+        // OMNISIM_SETTINGS_DIR (467.2) re-roots the profile store on every
+        // platform — XDG_CONFIG_HOME would cover Linux only (.NET ignores
+        // it on macOS, and Windows never honored it).
+        if let Some(dir) = Self::prepare_settings_dir() {
+            cmd.env("OMNISIM_SETTINGS_DIR", dir);
         }
 
         // On Linux, set PR_SET_PDEATHSIG so the kernel will SIGKILL this
@@ -595,13 +604,16 @@ impl OmniSimProcess {
             .unwrap_or_else(|e| panic!("failed to probe a free port for OmniSim: {}", e))
     }
 
-    /// Seed a per-instance `XDG_CONFIG_HOME` for OmniSim and return its
-    /// path. The seed is a recursive copy of the checked-in
-    /// `crates/bdd-infra/omnisim-config/...` tree. OmniSim writes back
-    /// to this directory on startup (e.g. emitting missing UniqueIDs,
-    /// persisting full default profiles), so we MUST copy the source
-    /// into a scratch location and never let OmniSim see the repository
-    /// copy directly.
+    /// Seed a per-instance `OMNISIM_SETTINGS_DIR` for OmniSim and return
+    /// its path. The seed is a recursive copy of the checked-in
+    /// `crates/bdd-infra/omnisim-config/` tree, whose layout mirrors what
+    /// the fork puts under the settings root
+    /// (`ascom-alpaca-simulator/<device>/v1/instance-0.xml`; the lowercase
+    /// names also satisfy Windows' case-insensitive lookups of its
+    /// platform-cased paths). OmniSim writes back to this directory on
+    /// startup (e.g. emitting missing UniqueIDs, persisting full default
+    /// profiles), so we MUST copy the source into a scratch location and
+    /// never let OmniSim see the repository copy directly.
     ///
     /// The destination is suffixed with the test process's PID
     /// (`bdd-infra-omnisim-<pid>/`) under [`Self::state_root`]: with
@@ -609,14 +621,17 @@ impl OmniSimProcess {
     /// instances must not share a writable profile dir either — a shared
     /// dir would race the startup write-backs and leak profile *settings*
     /// (e.g. the telescope site, which `restart` does not reset) between
-    /// concurrently running suites. We fully reseed on every spawn so a
-    /// write-back from a prior run can't leak into this one.
+    /// concurrently running suites. That leak is not hypothetical: it
+    /// failed 4 of 8 rp:bdd shards on macOS CI when isolation still rode
+    /// on XDG_CONFIG_HOME, which .NET ignores there. We fully reseed on
+    /// every spawn so a write-back from a prior run can't leak into this
+    /// one.
     ///
     /// Returns `None` (and the caller proceeds without the override) only
     /// when the destination dir can't be created at all. A missing seed
     /// source is non-fatal: the instance still gets a private, initially
     /// empty config dir and runs on upstream defaults.
-    fn prepare_xdg_config_home() -> Option<PathBuf> {
+    fn prepare_settings_dir() -> Option<PathBuf> {
         let dest = Self::state_root().join(format!("bdd-infra-omnisim-{}", std::process::id()));
         // Wipe whatever a prior spawn attempt (or a previous run that
         // recycled this PID) left behind so an OmniSim write-back from
@@ -685,7 +700,7 @@ impl OmniSimProcess {
     /// Resolve the log directory for OmniSim's captured stdout/stderr.
     /// Lives at `<CARGO_TARGET_DIR>/bdd-infra-omnisim-logs/` (or
     /// `<workspace>/target/bdd-infra-omnisim-logs/` if unset). Kept
-    /// outside the seeded XDG dir so `prepare_xdg_config_home`'s
+    /// outside the seeded settings dir so `prepare_settings_dir`'s
     /// `remove_dir_all` can't sweep the previous run's logs.
     ///
     /// Returns `None` (caller falls back to `Stdio::null`) only if the

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -556,13 +556,12 @@ impl OmniSimProcess {
             .env_remove("LSAN_OPTIONS");
 
         // Per-instance settings dir: concurrent OmniSims must not share a
-        // writable profile store (see `prepare_settings_dir`). The fork's
+        // writable profile store (see `prepare_settings_dir`, which panics
+        // rather than degrade to the shared platform default). The fork's
         // OMNISIM_SETTINGS_DIR (467.2) re-roots the profile store on every
         // platform — XDG_CONFIG_HOME would cover Linux only (.NET ignores
         // it on macOS, and Windows never honored it).
-        if let Some(dir) = Self::prepare_settings_dir() {
-            cmd.env("OMNISIM_SETTINGS_DIR", dir);
-        }
+        cmd.env("OMNISIM_SETTINGS_DIR", Self::prepare_settings_dir());
 
         // On Linux, set PR_SET_PDEATHSIG so the kernel will SIGKILL this
         // child when the test process exits (normal, panic, or SIGKILL).
@@ -628,22 +627,31 @@ impl OmniSimProcess {
     /// every spawn so a write-back from a prior run can't leak into this
     /// one.
     ///
-    /// Returns `None` (and the caller proceeds without the override) only
-    /// when the destination dir can't be created at all. A missing seed
-    /// source is non-fatal: the instance still gets a private, initially
-    /// empty config dir and runs on upstream defaults.
-    fn prepare_settings_dir() -> Option<PathBuf> {
+    /// Panics when the destination dir can't be created: spawning without
+    /// the override would silently fall back to the shared platform-default
+    /// profile store — reintroducing exactly the cross-suite leakage this
+    /// isolation exists to prevent — so it must fail loudly instead. A
+    /// missing seed *source* stays non-fatal: the instance still gets a
+    /// private, initially empty config dir and runs on upstream defaults.
+    fn prepare_settings_dir() -> PathBuf {
         let dest = Self::state_root().join(format!("bdd-infra-omnisim-{}", std::process::id()));
         // Wipe whatever a prior spawn attempt (or a previous run that
         // recycled this PID) left behind so an OmniSim write-back from
         // then can't survive into this run's profile.
         let _ = std::fs::remove_dir_all(&dest);
-        std::fs::create_dir_all(&dest).ok()?;
+        std::fs::create_dir_all(&dest).unwrap_or_else(|e| {
+            panic!(
+                "bdd-infra: failed to create the per-instance OmniSim settings dir {}: {e} — \
+                 proceeding without OMNISIM_SETTINGS_DIR would make concurrent OmniSim \
+                 instances share the platform-default profile store",
+                dest.display()
+            )
+        });
         if let Some(src) = Self::seed_config_source() {
             // Best-effort: a partial copy still leaves a private dir.
             let _ = Self::copy_dir_recursive(&src, &dest);
         }
-        Some(dest)
+        dest
     }
 
     /// Locate the checked-in `omnisim-config` seed tree.

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -1,8 +1,24 @@
 //! OmniSim (ASCOM Alpaca simulator) process management for BDD tests.
 //!
 //! A single OmniSim process is shared across all scenarios in a test binary
-//! via a [`tokio::sync::OnceCell`]. If an OmniSim is already listening on
-//! the default port it is reused; otherwise one is spawned.
+//! via a [`tokio::sync::OnceCell`]. Each test process spawns its **own**
+//! instance on a **dynamically chosen port**, passing `--multi-instance` —
+//! the flag added to our OmniSim fork (release `v0.5.0-467.1`,
+//! `ivonnyssen/ASCOM.Alpaca.Simulators`) that skips upstream's machine-global
+//! single-instance guard (a named Mutex keyed on a fixed GUID, backed by a
+//! file under `/tmp/.dotnet/shm/` on Unix). Combined with a per-instance
+//! settings dir (see [`OmniSimProcess::prepare_xdg_config_home`]), any number
+//! of BDD test processes — parallel Bazel targets, shards of one target, or a
+//! stray dev instance on the default port — can run concurrently without
+//! contending for one simulator. This is what lets Bazel run the
+//! OmniSim-backed suites in parallel and shard `rp:bdd` (issue #467).
+//!
+//! Windows is the exception: OmniSim's profile store there is
+//! `%USERPROFILE%\.ASCOM` (ASCOM.Tools `XMLProfile`), which no environment
+//! variable can redirect per-instance, so concurrent instances would race
+//! each other's profile write-backs. The Bazel `omnisim` resource pool keeps
+//! capacity 1 on Windows (see `.bazelrc`) and these suites still serialize
+//! there.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -10,8 +26,10 @@ use std::time::Duration;
 
 use tokio::sync::OnceCell;
 
-/// OmniSim's default HTTP port when launched without `--urls`.
-const OMNISIM_PORT: u16 = 32323;
+/// Attempts to spawn OmniSim before giving up. Each attempt picks a fresh
+/// ephemeral port, so a lost bind race (another process grabbed the port
+/// between our probe and OmniSim's bind) just costs one retry.
+const SPAWN_ATTEMPTS: u32 = 3;
 
 /// Shared OmniSim info returned to each scenario.
 #[derive(Debug, Clone)]
@@ -21,10 +39,8 @@ pub struct OmniSimHandle {
 }
 
 /// Singleton that owns the OmniSim child process for the entire test run.
-/// When `_child` is `None`, a pre-existing OmniSim was reused and we don't
-/// own the process.
 struct OmniSimProcess {
-    _child: Option<std::process::Child>,
+    _child: std::process::Child,
     base_url: String,
     port: u16,
 }
@@ -45,23 +61,35 @@ static OMNISIM: OnceCell<OmniSimProcess> = OnceCell::const_new();
 /// deadlocked mid-wave (log torn then silent, no stderr, subsequent
 /// PUTs timing out) — failing the remaining hooks loud. Holding this
 /// mutex across each PUT caps in-flight restarts at one per test
-/// process, which removes the trigger. Known limitation: it cannot
-/// serialise across *processes* (e.g. two Bazel bdd actions sharing
-/// one OmniSim on port 32323).
+/// process. A process-wide mutex is also *sufficient* now: every test
+/// process owns a private OmniSim instance (`--multi-instance` +
+/// dynamic port), so no other process can send restarts to ours — the
+/// old cross-process caveat about two Bazel actions sharing one
+/// OmniSim on port 32323 no longer applies.
 static RESTART_SERIALIZER: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 impl OmniSimHandle {
-    /// Get or start the shared OmniSim process. Returns a lightweight handle.
+    /// Get or start this process's private OmniSim. Returns a lightweight
+    /// handle.
     ///
-    /// If an OmniSim instance is already listening on the default port
-    /// (32323), it is reused. Otherwise a new process is spawned with
-    /// `PR_SET_PDEATHSIG` on Linux so the kernel kills it when the test
-    /// process exits.
+    /// The first call spawns a fresh instance with `--multi-instance` on a
+    /// dynamically chosen `127.0.0.1` port (with `PR_SET_PDEATHSIG` on Linux
+    /// so the kernel kills it when the test process exits); subsequent calls
+    /// share it. A pre-existing OmniSim — a dev instance on the default port,
+    /// or another test process's instance — is never reused: private
+    /// instances are what allow OmniSim-backed suites and shards to run
+    /// concurrently, and what stopped cross-session dev instances from
+    /// contending with test runs.
     ///
-    /// Binary discovery order (when spawning):
+    /// Binary discovery order:
     /// 1. `OMNISIM_PATH` env var — full path to the binary
     /// 2. `OMNISIM_DIR` env var — directory containing the binary
     /// 3. `ascom.alpaca.simulators` on `PATH`
+    ///
+    /// The binary must support `--multi-instance` (fork release
+    /// `v0.5.0-467.1` or newer); an older binary exits immediately when
+    /// another instance is running, which surfaces here as a spawn failure
+    /// naming the flag.
     pub async fn start() -> Self {
         let process = OMNISIM
             .get_or_init(|| async { OmniSimProcess::get_or_spawn().await })
@@ -131,14 +159,12 @@ impl OmniSimHandle {
     /// The wall-time cost is small: 6 localhost round-trips serialised
     /// is ~10-30 ms per scenario depending on runner.
     ///
-    /// Errors are collected and returned. **Exception:** when the
-    /// shared `OMNISIM` singleton has not been initialised yet (i.e.
-    /// no scenario has gone through `OmniSimHandle::start()`), errors
-    /// are non-fatal — the PUTs still fire against the default
-    /// `127.0.0.1:32323` URL so a pre-existing OmniSim from a prior
-    /// dev session is reset before scenario 1 reuses it, but
-    /// connection-refused (no OmniSim there yet) is the expected case
-    /// and we don't want to panic the very first before-hook over it.
+    /// When the shared `OMNISIM` singleton has not been initialised yet
+    /// (no scenario has gone through `OmniSimHandle::start()`), this is
+    /// a no-op: there is no instance to reset, and the one `start()`
+    /// will eventually spawn is fresh by construction. (The pre-#467
+    /// behaviour of firing best-effort PUTs at the default port to
+    /// scrub a reusable dev instance is gone along with reuse itself.)
     /// Once the suite has called `OmniSimHandle::start()`, every reset
     /// failure is fatal — that's the loud-reset behaviour from #172
     /// that catches state leakage between scenarios.
@@ -147,7 +173,9 @@ impl OmniSimHandle {
     /// also expose `/restart`, but our scenarios don't touch them yet;
     /// add a call here when that changes.
     pub async fn reset_all_devices() -> Result<(), Vec<String>> {
-        let omnisim_was_started = OMNISIM.get().is_some();
+        if OMNISIM.get().is_none() {
+            return Ok(());
+        }
         let mut errors: Vec<String> = Vec::new();
         let results = [
             Self::reset_telescope().await,
@@ -162,7 +190,7 @@ impl OmniSimHandle {
                 errors.push(e);
             }
         }
-        if errors.is_empty() || !omnisim_was_started {
+        if errors.is_empty() {
             Ok(())
         } else {
             Err(errors)
@@ -192,10 +220,7 @@ impl OmniSimHandle {
     /// `focuser`, `observingconditions`, `rotator`, `safetymonitor`,
     /// `switch`.
     pub async fn restart_device(class: &str, n: u32) -> Result<(), String> {
-        let base_url = OMNISIM
-            .get()
-            .map(|p| p.base_url.clone())
-            .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT));
+        let base_url = Self::singleton_base_url().await;
         Self::restart_device_at(&base_url, class, n).await
     }
 
@@ -210,10 +235,7 @@ impl OmniSimHandle {
     /// scenarios still set `true` explicitly during setup so they never
     /// depend on reset ordering.
     pub async fn set_safety_monitor_is_safe(is_safe: bool) -> Result<(), String> {
-        let base_url = OMNISIM
-            .get()
-            .map(|p| p.base_url.clone())
-            .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT));
+        let base_url = Self::singleton_base_url().await;
         Self::set_safety_monitor_is_safe_at(&base_url, 0, is_safe).await
     }
 
@@ -269,7 +291,7 @@ impl OmniSimHandle {
         latitude_degrees: f64,
         longitude_degrees: f64,
     ) -> Result<(), String> {
-        let base_url = Self::singleton_base_url();
+        let base_url = Self::singleton_base_url().await;
         Self::put_telescope_form_at(
             &base_url,
             0,
@@ -289,7 +311,7 @@ impl OmniSimHandle {
     /// Read the telescope simulator's observer site — the capture half
     /// of the capture/restore contract on [`Self::set_telescope_site`].
     pub async fn get_telescope_site() -> Result<(f64, f64), String> {
-        let base_url = Self::singleton_base_url();
+        let base_url = Self::singleton_base_url().await;
         let lat = Self::get_telescope_number_at(&base_url, 0, "sitelatitude").await?;
         let lon = Self::get_telescope_number_at(&base_url, 0, "sitelongitude").await?;
         Ok((lat, lon))
@@ -348,7 +370,7 @@ impl OmniSimHandle {
     /// on before `SyncToCoordinates` — call this before
     /// [`Self::sync_telescope_to`].
     pub async fn set_telescope_tracking(enabled: bool) -> Result<(), String> {
-        let base_url = Self::singleton_base_url();
+        let base_url = Self::singleton_base_url().await;
         Self::put_telescope_form_at(
             &base_url,
             0,
@@ -370,7 +392,7 @@ impl OmniSimHandle {
     /// Requires tracking on (OmniSim-imposed; see
     /// [`Self::set_telescope_tracking`]).
     pub async fn sync_telescope_to(ra_hours: f64, dec_degrees: f64) -> Result<(), String> {
-        let base_url = Self::singleton_base_url();
+        let base_url = Self::singleton_base_url().await;
         Self::put_telescope_form_at(
             &base_url,
             0,
@@ -383,14 +405,14 @@ impl OmniSimHandle {
         .await
     }
 
-    /// The shared singleton's base URL, falling back to the default
-    /// port when no scenario has started OmniSim through this process
-    /// yet (mirrors [`Self::restart_device`]).
-    fn singleton_base_url() -> String {
-        OMNISIM
-            .get()
-            .map(|p| p.base_url.clone())
-            .unwrap_or_else(|| format!("http://127.0.0.1:{}", OMNISIM_PORT))
+    /// The shared singleton's base URL, starting this process's OmniSim
+    /// first if no scenario has done so yet. There is no fixed fallback
+    /// port anymore — with per-process instances on dynamic ports, "the"
+    /// OmniSim is always the one this process owns, so the state-arranging
+    /// helpers (`restart_device`, the telescope-site/tracking/sync setters,
+    /// the safety-monitor override) simply ensure it exists.
+    async fn singleton_base_url() -> String {
+        OmniSimHandle::start().await.base_url
     }
 
     /// One form-encoded PUT against the standard Alpaca telescope API
@@ -476,17 +498,31 @@ impl OmniSimHandle {
 
 impl OmniSimProcess {
     async fn get_or_spawn() -> Self {
-        let base_url = format!("http://127.0.0.1:{}", OMNISIM_PORT);
-
-        if Self::is_healthy(&base_url).await {
-            return Self {
-                _child: None,
-                base_url,
-                port: OMNISIM_PORT,
-            };
-        }
-
         let binary = Self::find_binary();
+        let mut last_failure = String::new();
+        for _ in 0..SPAWN_ATTEMPTS {
+            let port = Self::pick_free_port();
+            match Self::spawn_on_port(&binary, port).await {
+                Ok(process) => return process,
+                Err(failure) => last_failure = failure,
+            }
+        }
+        panic!(
+            "failed to start OmniSim binary '{}' after {} attempts: {}. \
+             Note: bdd-infra spawns OmniSim with --multi-instance, which needs \
+             the patched fork (ivonnyssen/ASCOM.Alpaca.Simulators release \
+             v0.5.0-467.1 or newer) — an older binary exits at startup when \
+             any other OmniSim instance is running on the host.",
+            binary, SPAWN_ATTEMPTS, last_failure
+        );
+    }
+
+    /// One spawn attempt: launch OmniSim on `port` and wait for it to become
+    /// healthy. Returns `Err` with a diagnostic when the child exits early
+    /// (lost the port-bind race, or the binary predates `--multi-instance`)
+    /// or never turns healthy; the caller retries on a fresh port.
+    async fn spawn_on_port(binary: &str, port: u16) -> Result<Self, String> {
+        let base_url = format!("http://127.0.0.1:{}", port);
 
         // Capture OmniSim's stdout/stderr to per-run log files under the
         // cargo target tree. The previous `Stdio::null()` dropped every
@@ -494,27 +530,26 @@ impl OmniSimProcess {
         // into what the simulator was doing — see #171 for the
         // diagnostic gap. Failures here fall back to `Stdio::null` so a
         // log-write problem can't stop the test suite from running.
-        let (stdout_target, stderr_target) = Self::open_log_files();
+        let (stdout_target, stderr_target) = Self::open_log_files(port);
 
-        // Clear sanitizer-related env vars so the .NET runtime isn't broken
-        // by LD_PRELOAD injection from ASAN/LSAN.
-        let mut cmd = std::process::Command::new(&binary);
-        cmd.stdout(stdout_target)
+        // `--multi-instance` (our fork's flag) skips OmniSim's machine-global
+        // single-instance guard; `--urls` pins the Kestrel listener to the
+        // port we probed as free. Clear sanitizer-related env vars so the
+        // .NET runtime isn't broken by LD_PRELOAD injection from ASAN/LSAN.
+        let mut cmd = std::process::Command::new(binary);
+        cmd.arg("--multi-instance")
+            .arg(format!("--urls={}", base_url))
+            .stdout(stdout_target)
             .stderr(stderr_target)
             .env_remove("LD_PRELOAD")
             .env_remove("ASAN_OPTIONS")
             .env_remove("LSAN_OPTIONS");
 
-        // Point OmniSim at a per-build XDG_CONFIG_HOME under cargo's
-        // target dir, seeded from the checked-in profile templates in
-        // `crates/bdd-infra/omnisim-config/...`. The seed copy is the
-        // ONLY runtime write involved — subsequent OmniSim startup
-        // writes (UniqueID emission, full-profile persistence) all
-        // land in the per-build dir and never touch the checked-in
-        // source. Failures here are non-fatal: if the seed dir can't
-        // be prepared we just skip the override, OmniSim falls back
-        // to the user's `$HOME/.config/...`, and tests run with
-        // upstream defaults instead of our tuned ones.
+        // Per-instance settings dir: concurrent OmniSims must not share a
+        // writable profile store (see `prepare_xdg_config_home`). On Windows
+        // OmniSim ignores XDG_CONFIG_HOME (profile lives in
+        // %USERPROFILE%\.ASCOM) — the env var is harmless there, and the
+        // Bazel `omnisim` pool keeps Windows serialized instead.
         if let Some(xdg) = Self::prepare_xdg_config_home() {
             cmd.env("XDG_CONFIG_HOME", xdg);
         }
@@ -532,39 +567,111 @@ impl OmniSimProcess {
             }
         }
 
-        let child = cmd
-            .spawn()
-            .unwrap_or_else(|e| panic!("failed to start OmniSim binary '{}': {}", binary, e));
+        let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
 
-        let process = Self {
-            _child: Some(child),
-            base_url,
-            port: OMNISIM_PORT,
-        };
-        process.wait_healthy().await;
-        process
+        match Self::wait_healthy(&mut child, &base_url).await {
+            Ok(()) => Ok(Self {
+                _child: child,
+                base_url,
+                port,
+            }),
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                Err(e)
+            }
+        }
     }
 
-    /// Seed a per-build `XDG_CONFIG_HOME` for OmniSim and return its
+    /// Probe the OS for a free `127.0.0.1` port by binding an ephemeral
+    /// listener and immediately dropping it. Another process can grab the
+    /// port in the window before OmniSim binds it — that lost race surfaces
+    /// as an early child exit in [`Self::wait_healthy`] and costs one retry
+    /// in [`Self::get_or_spawn`].
+    fn pick_free_port() -> u16 {
+        std::net::TcpListener::bind(("127.0.0.1", 0))
+            .and_then(|listener| listener.local_addr())
+            .map(|addr| addr.port())
+            .unwrap_or_else(|e| panic!("failed to probe a free port for OmniSim: {}", e))
+    }
+
+    /// Seed a per-instance `XDG_CONFIG_HOME` for OmniSim and return its
     /// path. The seed is a recursive copy of the checked-in
     /// `crates/bdd-infra/omnisim-config/...` tree. OmniSim writes back
     /// to this directory on startup (e.g. emitting missing UniqueIDs,
     /// persisting full default profiles), so we MUST copy the source
-    /// into a target-tree location and never let OmniSim see the
-    /// repository copy directly.
+    /// into a scratch location and never let OmniSim see the repository
+    /// copy directly.
     ///
-    /// The destination lives under `$CARGO_TARGET_DIR/bdd-infra-omnisim/`
-    /// (or `target/bdd-infra-omnisim/` if `CARGO_TARGET_DIR` is unset),
-    /// so it ends up in the same place `cargo clean` already reaches.
-    /// We fully reseed on every spawn so an OmniSim write-back from a
-    /// prior run can't leak into the next one.
+    /// The destination is suffixed with the test process's PID
+    /// (`bdd-infra-omnisim-<pid>/`) under [`Self::state_root`]: with
+    /// parallel suites and shards each spawning a private OmniSim,
+    /// instances must not share a writable profile dir either — a shared
+    /// dir would race the startup write-backs and leak profile *settings*
+    /// (e.g. the telescope site, which `restart` does not reset) between
+    /// concurrently running suites. We fully reseed on every spawn so a
+    /// write-back from a prior run can't leak into this one.
     ///
-    /// Returns `None` (and the caller proceeds without the override) on
-    /// any I/O failure — the simulator still works, just with upstream
-    /// defaults.
+    /// Returns `None` (and the caller proceeds without the override) only
+    /// when the destination dir can't be created at all. A missing seed
+    /// source is non-fatal: the instance still gets a private, initially
+    /// empty config dir and runs on upstream defaults.
     fn prepare_xdg_config_home() -> Option<PathBuf> {
-        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("omnisim-config");
-        let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        let dest = Self::state_root().join(format!("bdd-infra-omnisim-{}", std::process::id()));
+        // Wipe whatever a prior spawn attempt (or a previous run that
+        // recycled this PID) left behind so an OmniSim write-back from
+        // then can't survive into this run's profile.
+        let _ = std::fs::remove_dir_all(&dest);
+        std::fs::create_dir_all(&dest).ok()?;
+        if let Some(src) = Self::seed_config_source() {
+            // Best-effort: a partial copy still leaves a private dir.
+            let _ = Self::copy_dir_recursive(&src, &dest);
+        }
+        Some(dest)
+    }
+
+    /// Locate the checked-in `omnisim-config` seed tree.
+    ///
+    /// 1. `env!("CARGO_MANIFEST_DIR")/omnisim-config` — resolves under
+    ///    cargo. Under Bazel `CARGO_MANIFEST_DIR` is a compile-time
+    ///    sandbox path that doesn't exist at test runtime.
+    /// 2. Walking up from the cwd looking for
+    ///    `crates/bdd-infra/omnisim-config` — resolves in the Bazel
+    ///    runfiles tree (after the `bdd_main!` chdir the cwd is
+    ///    `<runfiles>/_main/<package>`; the seed tree rides along as
+    ///    `data` on the `bdd-infra_rp_harness` target).
+    ///
+    /// Returns `None` when neither resolves. Note that before #467 the
+    /// Bazel path never resolved (branch 1 was dead and the tree wasn't in
+    /// the runfiles), so Bazel-run suites always used upstream defaults;
+    /// branch 2 closes that gap and brings the tuned timings (shorter
+    /// cover-calibrator open/close) to Bazel runs too.
+    fn seed_config_source() -> Option<PathBuf> {
+        let compile_time = Path::new(env!("CARGO_MANIFEST_DIR")).join("omnisim-config");
+        if compile_time.is_dir() {
+            return Some(compile_time);
+        }
+        let cwd = std::env::current_dir().ok()?;
+        for ancestor in cwd.ancestors() {
+            let candidate = ancestor
+                .join("crates")
+                .join("bdd-infra")
+                .join("omnisim-config");
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Root for per-instance scratch state: Bazel's per-action
+    /// `TEST_TMPDIR` when present (cleaned up by Bazel), else the cargo
+    /// target tree (reached by `cargo clean`).
+    fn state_root() -> PathBuf {
+        if let Some(tmp) = std::env::var_os("TEST_TMPDIR") {
+            return PathBuf::from(tmp);
+        }
+        std::env::var_os("CARGO_TARGET_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| {
                 Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -572,13 +679,7 @@ impl OmniSimProcess {
                     .and_then(|p| p.parent())
                     .map(|workspace| workspace.join("target"))
                     .unwrap_or_else(|| PathBuf::from("target"))
-            });
-        let dest = target_dir.join("bdd-infra-omnisim");
-        // Wipe whatever a prior run left behind so an OmniSim write-back
-        // from then can't survive into this run's profile.
-        let _ = std::fs::remove_dir_all(&dest);
-        Self::copy_dir_recursive(&src, &dest).ok()?;
-        Some(dest)
+            })
     }
 
     /// Resolve the log directory for OmniSim's captured stdout/stderr.
@@ -627,13 +728,17 @@ impl OmniSimProcess {
     /// BDD binary is a separate process sharing one `CARGO_TARGET_DIR`)
     /// don't truncate each other's logs. On Windows, file-locking on a
     /// shared name would also fail one of the spawns outright; the PID
-    /// suffix avoids that.
-    fn open_log_files() -> (Stdio, Stdio) {
+    /// suffix avoids that. The port distinguishes retried spawn attempts
+    /// within one process, so a failed attempt's log (the bind-race /
+    /// old-binary evidence) survives the retry.
+    fn open_log_files(port: u16) -> (Stdio, Stdio) {
         let dir = Self::log_dir();
         let pid = std::process::id();
         let stdout = dir
             .as_ref()
-            .and_then(|d| std::fs::File::create(d.join(format!("omnisim.{pid}.stdout.log"))).ok())
+            .and_then(|d| {
+                std::fs::File::create(d.join(format!("omnisim.{pid}.{port}.stdout.log"))).ok()
+            })
             .map(Stdio::from)
             .unwrap_or_else(Stdio::null);
         // Under Bazel, inherit OmniSim's stderr into the test process so a
@@ -647,7 +752,7 @@ impl OmniSimProcess {
         } else {
             dir.as_ref()
                 .and_then(|d| {
-                    std::fs::File::create(d.join(format!("omnisim.{pid}.stderr.log"))).ok()
+                    std::fs::File::create(d.join(format!("omnisim.{pid}.{port}.stderr.log"))).ok()
                 })
                 .map(Stdio::from)
                 .unwrap_or_else(Stdio::null)
@@ -698,14 +803,28 @@ impl OmniSimProcess {
         matches!(client.get(&url).send().await, Ok(resp) if resp.status().is_success())
     }
 
-    async fn wait_healthy(&self) {
+    /// Poll `base_url` until OmniSim answers, watching the child so an
+    /// early exit (lost port-bind race; a pre-`--multi-instance` binary
+    /// deferring to another running instance) fails fast with its exit
+    /// status instead of burning the full 30-second health window.
+    async fn wait_healthy(child: &mut std::process::Child, base_url: &str) -> Result<(), String> {
         for _ in 0..60 {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            if Self::is_healthy(&self.base_url).await {
-                return;
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(format!(
+                    "OmniSim exited during startup ({}) — lost the port-bind \
+                     race, or the binary does not support --multi-instance",
+                    status
+                ));
+            }
+            if Self::is_healthy(base_url).await {
+                return Ok(());
             }
         }
-        panic!("OmniSim did not become healthy within 30 seconds");
+        Err(format!(
+            "OmniSim did not become healthy at {} within 30 seconds",
+            base_url
+        ))
     }
 }
 

--- a/crates/bdd-infra/src/rp_harness/omnisim.rs
+++ b/crates/bdd-infra/src/rp_harness/omnisim.rs
@@ -45,6 +45,7 @@ pub struct OmniSimHandle {
 }
 
 /// Singleton that owns the OmniSim child process for the entire test run.
+#[derive(Debug)]
 struct OmniSimProcess {
     _child: std::process::Child,
     base_url: String,
@@ -662,11 +663,22 @@ impl OmniSimProcess {
     /// branch 2 closes that gap and brings the tuned timings (shorter
     /// cover-calibrator open/close) to Bazel runs too.
     fn seed_config_source() -> Option<PathBuf> {
-        let compile_time = Path::new(env!("CARGO_MANIFEST_DIR")).join("omnisim-config");
+        Self::seed_config_source_from(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("omnisim-config"),
+            std::env::current_dir().ok(),
+        )
+    }
+
+    /// `seed_config_source` extracted over explicit candidates so the
+    /// cwd-ancestors walk — the branch that resolves the seed inside the
+    /// Bazel runfiles tree, where the compile-time path is dead — is
+    /// unit-testable without depending on the build environment. See the
+    /// `tests` module at the bottom of this file.
+    fn seed_config_source_from(compile_time: PathBuf, cwd: Option<PathBuf>) -> Option<PathBuf> {
         if compile_time.is_dir() {
             return Some(compile_time);
         }
-        let cwd = std::env::current_dir().ok()?;
+        let cwd = cwd?;
         for ancestor in cwd.ancestors() {
             let candidate = ancestor
                 .join("crates")
@@ -1252,6 +1264,233 @@ mod tests {
         .await
         .expect_err("a body without ErrorNumber must not read as success");
         assert!(err.contains("without a numeric ErrorNumber"), "{err}");
+        let _ = tx.send(());
+    }
+
+    /// Serializes tests that mutate the process-wide OMNISIM_PATH /
+    /// OMNISIM_DIR env vars (`find_binary` reads them). tokio's Mutex so
+    /// async tests can hold the guard across `.await` without tripping
+    /// `clippy::await_holding_lock`; sync tests use `blocking_lock`.
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    fn restore_env(key: &str, saved: Option<std::ffi::OsString>) {
+        match saved {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    /// A PATH-resolvable binary that exits quickly (with an error) when
+    /// handed OmniSim's `--multi-instance --urls=...` args — a stand-in
+    /// for a pre-fork OmniSim losing the port-bind race or bailing out.
+    fn quick_fail_binary() -> &'static str {
+        if cfg!(windows) {
+            // whoami rejects unknown arguments and exits fast.
+            "whoami"
+        } else {
+            // false ignores arguments and exits 1 immediately.
+            "false"
+        }
+    }
+
+    #[test]
+    fn find_binary_prefers_path_then_dir_then_bare_name() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let saved_path = std::env::var_os("OMNISIM_PATH");
+        let saved_dir = std::env::var_os("OMNISIM_DIR");
+
+        let expected_name = if cfg!(target_os = "windows") {
+            "ascom.alpaca.simulators.exe"
+        } else {
+            "ascom.alpaca.simulators"
+        };
+
+        // OMNISIM_PATH wins over OMNISIM_DIR.
+        std::env::set_var("OMNISIM_PATH", "/explicit/omnisim-binary");
+        std::env::set_var("OMNISIM_DIR", "/some/install/dir");
+        let from_path = OmniSimProcess::find_binary();
+
+        // OMNISIM_DIR gets the platform binary name appended — this is the
+        // branch local dev setups rely on.
+        std::env::remove_var("OMNISIM_PATH");
+        let from_dir = OmniSimProcess::find_binary();
+
+        // Neither set: bare name, resolved via PATH at spawn time.
+        std::env::remove_var("OMNISIM_DIR");
+        let bare = OmniSimProcess::find_binary();
+
+        restore_env("OMNISIM_PATH", saved_path);
+        restore_env("OMNISIM_DIR", saved_dir);
+
+        assert_eq!(from_path, "/explicit/omnisim-binary");
+        assert_eq!(
+            std::path::PathBuf::from(&from_dir),
+            std::path::Path::new("/some/install/dir").join(expected_name)
+        );
+        assert_eq!(bare, expected_name);
+    }
+
+    #[tokio::test]
+    async fn wait_healthy_fails_fast_when_the_child_exits() {
+        // Portable quick-exit child: the health wait must report the exit
+        // (with the --multi-instance hint) instead of burning the full
+        // 30-second window against a port nothing listens on.
+        let mut child = if cfg!(windows) {
+            std::process::Command::new("cmd")
+                .args(["/C", "exit 0"])
+                .spawn()
+                .unwrap()
+        } else {
+            std::process::Command::new("sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+                .unwrap()
+        };
+        let err = OmniSimProcess::wait_healthy(&mut child, "http://127.0.0.1:9")
+            .await
+            .expect_err("an exited child must fail the health wait");
+        assert!(err.contains("exited during startup"), "{err}");
+        assert!(err.contains("--multi-instance"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn spawn_on_port_reports_early_exit_and_reaps_the_child() {
+        let port = OmniSimProcess::pick_free_port();
+        let err = OmniSimProcess::spawn_on_port(quick_fail_binary(), port)
+            .await
+            .expect_err("a binary that exits at startup must not yield an instance");
+        assert!(err.contains("exited during startup"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn get_or_spawn_panics_with_the_fork_floor_hint_after_all_attempts() {
+        let _lock = ENV_LOCK.lock().await;
+        let saved_path = std::env::var_os("OMNISIM_PATH");
+        let saved_dir = std::env::var_os("OMNISIM_DIR");
+        std::env::set_var("OMNISIM_PATH", quick_fail_binary());
+        std::env::remove_var("OMNISIM_DIR");
+
+        // get_or_spawn only touches the global OMNISIM singleton via its
+        // caller (OmniSimHandle::start), so calling it directly is safe;
+        // run it on a task so the expected panic is observable.
+        let joined = tokio::spawn(async { OmniSimProcess::get_or_spawn().await }).await;
+
+        restore_env("OMNISIM_PATH", saved_path);
+        restore_env("OMNISIM_DIR", saved_dir);
+
+        let join_err = joined.expect_err("get_or_spawn must panic when every attempt fails");
+        assert!(join_err.is_panic());
+        let message = *join_err
+            .into_panic()
+            .downcast::<String>()
+            .expect("panic payload is the formatted message");
+        assert!(
+            message.contains(&format!("after {} attempts", SPAWN_ATTEMPTS)),
+            "{message}"
+        );
+        assert!(message.contains("v0.5.0-467.2"), "{message}");
+    }
+
+    #[test]
+    fn seed_config_source_prefers_the_compile_time_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let compile_time = tmp.path().join("omnisim-config");
+        std::fs::create_dir_all(&compile_time).unwrap();
+        let found = OmniSimProcess::seed_config_source_from(compile_time.clone(), None);
+        assert_eq!(found, Some(compile_time));
+    }
+
+    #[test]
+    fn seed_config_source_walks_cwd_ancestors_when_compile_time_path_is_dead() {
+        // The Bazel case: the compile-time path points into a build sandbox
+        // that no longer exists, and the seed sits in the runfiles tree a
+        // few directories above the (chdir'd) cwd.
+        let tmp = tempfile::tempdir().unwrap();
+        let seed = tmp
+            .path()
+            .join("crates")
+            .join("bdd-infra")
+            .join("omnisim-config");
+        std::fs::create_dir_all(&seed).unwrap();
+        let cwd = tmp.path().join("services").join("rp");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let found = OmniSimProcess::seed_config_source_from(
+            tmp.path().join("no-such-sandbox").join("omnisim-config"),
+            Some(cwd),
+        );
+        assert_eq!(
+            found.map(|p| p.canonicalize().unwrap()),
+            Some(seed.canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn seed_config_source_returns_none_when_no_candidate_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let found = OmniSimProcess::seed_config_source_from(
+            tmp.path().join("missing"),
+            Some(tmp.path().to_path_buf()),
+        );
+        assert_eq!(found, None);
+    }
+
+    #[tokio::test]
+    async fn telescope_number_get_surfaces_http_error_status() {
+        use axum::routing::get;
+
+        let app = Router::new().route(
+            "/api/v1/telescope/0/sitelatitude",
+            get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        let err = OmniSimHandle::get_telescope_number_at(&base_url, 0, "sitelatitude")
+            .await
+            .expect_err("a non-success HTTP status must not read as success");
+        assert!(err.contains("500"), "{err}");
+        let _ = tx.send(());
+    }
+
+    #[tokio::test]
+    async fn telescope_form_put_surfaces_http_error_status() {
+        let app = Router::new().route(
+            "/api/v1/telescope/0/tracking",
+            put(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        let err = OmniSimHandle::put_telescope_form_at(
+            &base_url,
+            0,
+            "tracking",
+            &[("Tracking", "true".to_string())],
+        )
+        .await
+        .expect_err("a non-success HTTP status must not read as success");
+        assert!(err.contains("500"), "{err}");
         let _ = tx.send(());
     }
 

--- a/crates/bdd-infra/src/sharding.rs
+++ b/crates/bdd-infra/src/sharding.rs
@@ -1,0 +1,244 @@
+//! Bazel test-sharding support for cucumber BDD suites.
+//!
+//! Bazel splits a test target into `shard_count` separate test actions, each
+//! running the same binary with `TEST_SHARD_INDEX` / `TEST_TOTAL_SHARDS` set
+//! (and each getting its own OmniSim via the per-process singleton in
+//! `rp_harness::omnisim`). cucumber has no native support for those env vars,
+//! so suites opt in by calling [`scenario_in_current_shard`] from the filter
+//! closure they pass to `filter_run_and_exit`:
+//!
+//! ```rust,ignore
+//! .filter_run_and_exit("tests/features", |feat, _rule, sc| {
+//!     bdd_infra::sharding::scenario_in_current_shard(
+//!         feat.path.as_deref(),
+//!         &feat.name,
+//!         sc.position.line,
+//!     )
+//! })
+//! ```
+//!
+//! Scenarios are partitioned by a stable hash of the feature file name and
+//! the scenario's line number, so every shard — running the same binary over
+//! the same feature tree — computes the same partition, each scenario lands
+//! in exactly one shard, and the assignment does not depend on discovery
+//! order, environment, or platform. `@serial` semantics are unaffected:
+//! cucumber still serializes `@serial` scenarios *within* a shard, and
+//! cross-shard isolation comes from each shard process owning its own
+//! OmniSim instance.
+//!
+//! A target that sets `shard_count` without wiring its filter through
+//! [`scenario_in_current_shard`] still passes — every shard just runs the
+//! full suite, multiplying the work `shard_count` times. Don't do that.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+/// Shard assignment parsed from Bazel's test env, cached for the process
+/// lifetime. `None` means "not sharded — run everything".
+static SHARD: OnceLock<Option<(u64, u64)>> = OnceLock::new();
+
+/// Touch `TEST_SHARD_STATUS_FILE` if Bazel provided one.
+///
+/// Bazel requires a test runner to create this file to advertise that it
+/// understands `TEST_SHARD_INDEX` / `TEST_TOTAL_SHARDS`; with
+/// `shard_count > 1` and no status file, Bazel fails the test outright
+/// ("test runner did not advertise sharding support"). `bdd_main!` calls
+/// this unconditionally — it is a no-op outside Bazel and for unsharded
+/// targets.
+pub fn advertise_bazel_sharding_support() {
+    if let Some(path) = std::env::var_os("TEST_SHARD_STATUS_FILE") {
+        if let Err(e) = std::fs::write(&path, b"") {
+            eprintln!("bdd_main: failed to touch TEST_SHARD_STATUS_FILE {path:?}: {e}");
+        }
+    }
+}
+
+/// Whether the given scenario belongs to this process's shard.
+///
+/// Outside Bazel sharding (no/invalid `TEST_SHARD_INDEX` /
+/// `TEST_TOTAL_SHARDS`, or a total of 1) every scenario belongs — the suite
+/// behaves exactly as before. Pass the feature's `path`, its `name` (used
+/// only when the parser supplied no path), and the scenario's `position.line`.
+///
+/// Takes primitives instead of `gherkin` types so the base `bdd-infra`
+/// crate doesn't grow a cucumber dependency.
+pub fn scenario_in_current_shard(
+    feature_path: Option<&Path>,
+    feature_name: &str,
+    scenario_line: usize,
+) -> bool {
+    match current_shard() {
+        None => true,
+        Some((index, total)) => {
+            shard_for_scenario(feature_path, feature_name, scenario_line, total) == index
+        }
+    }
+}
+
+/// Read and cache the shard assignment from the Bazel test env.
+fn current_shard() -> Option<(u64, u64)> {
+    *SHARD.get_or_init(|| {
+        parse_shard_env(
+            std::env::var("TEST_SHARD_INDEX").ok().as_deref(),
+            std::env::var("TEST_TOTAL_SHARDS").ok().as_deref(),
+        )
+    })
+}
+
+/// Parse `(TEST_SHARD_INDEX, TEST_TOTAL_SHARDS)` into a shard assignment.
+///
+/// Anything malformed — missing vars, non-numeric values, a total of 0 or 1,
+/// an index out of range — degrades to `None` (run all scenarios). Degrading
+/// to "run everything" can only duplicate work across shards, never lose
+/// scenarios.
+fn parse_shard_env(index: Option<&str>, total: Option<&str>) -> Option<(u64, u64)> {
+    let index = index?.parse::<u64>().ok()?;
+    let total = total?.parse::<u64>().ok()?;
+    (total > 1 && index < total).then_some((index, total))
+}
+
+/// Deterministically assign a scenario to a shard in `0..total`.
+///
+/// Keys on the feature's file *name* (not its full path — absolute prefixes
+/// differ between the cargo and Bazel runfiles trees) plus the scenario's
+/// line number, hashed with FNV-1a. FNV-1a is fully specified, so the
+/// partition is stable across processes, platforms, and toolchain versions —
+/// `std`'s `DefaultHasher` promises none of that.
+fn shard_for_scenario(
+    feature_path: Option<&Path>,
+    feature_name: &str,
+    scenario_line: usize,
+    total: u64,
+) -> u64 {
+    let file_name = feature_path
+        .and_then(Path::file_name)
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| feature_name.to_string());
+    let key = format!("{file_name}:{scenario_line}");
+    fnv1a(key.as_bytes()) % total
+}
+
+/// 64-bit FNV-1a. Tiny, dependency-free, and stable by specification.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a_matches_reference_vectors() {
+        // Published FNV-1a 64-bit test vectors.
+        assert_eq!(fnv1a(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a(b"foobar"), 0x85944171f73967e8);
+    }
+
+    #[test]
+    fn parse_shard_env_accepts_valid_assignment() {
+        assert_eq!(parse_shard_env(Some("2"), Some("8")), Some((2, 8)));
+        assert_eq!(parse_shard_env(Some("0"), Some("2")), Some((0, 2)));
+    }
+
+    #[test]
+    fn parse_shard_env_degrades_to_unsharded_on_junk() {
+        assert_eq!(parse_shard_env(None, None), None);
+        assert_eq!(parse_shard_env(Some("0"), None), None);
+        assert_eq!(parse_shard_env(None, Some("4")), None);
+        assert_eq!(parse_shard_env(Some("x"), Some("4")), None);
+        assert_eq!(parse_shard_env(Some("0"), Some("x")), None);
+        // A total of 1 is "not sharded".
+        assert_eq!(parse_shard_env(Some("0"), Some("1")), None);
+        // Index out of range: run everything rather than lose scenarios.
+        assert_eq!(parse_shard_env(Some("8"), Some("8")), None);
+    }
+
+    #[test]
+    fn shard_assignment_is_in_range_and_deterministic() {
+        let total = 8;
+        let path = Path::new("tests/features/some.feature");
+        for line in 1..500usize {
+            let owner = shard_for_scenario(Some(path), "Some feature", line, total);
+            assert!(owner < total);
+            // Same inputs => same shard, every time. Combined with `owner`
+            // being a single value in 0..total, each scenario is claimed by
+            // exactly one shard across the shard processes.
+            assert_eq!(
+                owner,
+                shard_for_scenario(Some(path), "Some feature", line, total)
+            );
+        }
+    }
+
+    #[test]
+    fn partition_is_deterministic_and_path_prefix_independent() {
+        // The same file name under different directory prefixes (cargo cwd
+        // vs Bazel runfiles) must land in the same shard.
+        let a = shard_for_scenario(
+            Some(Path::new("tests/features/mount.feature")),
+            "Mount",
+            42,
+            8,
+        );
+        let b = shard_for_scenario(
+            Some(Path::new(
+                "/runfiles/_main/services/rp/tests/features/mount.feature",
+            )),
+            "Mount",
+            42,
+            8,
+        );
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn partition_spreads_across_shards() {
+        // Not a distribution-quality test — just a regression guard that the
+        // hash doesn't collapse the rp-sized suite onto one shard.
+        let total = 8;
+        let mut seen = std::collections::HashSet::new();
+        for line in (5..250usize).step_by(7) {
+            seen.insert(shard_for_scenario(
+                Some(Path::new("mount.feature")),
+                "Mount",
+                line,
+                total,
+            ));
+        }
+        assert!(
+            seen.len() >= 4,
+            "expected the partition to use several shards, got {seen:?}"
+        );
+    }
+
+    #[test]
+    fn missing_path_falls_back_to_feature_name() {
+        let with_name_a = shard_for_scenario(None, "Feature A", 10, 8);
+        let with_name_b = shard_for_scenario(None, "Feature B", 10, 8);
+        // Both are valid shard indices; determinism is per name.
+        assert_eq!(with_name_a, shard_for_scenario(None, "Feature A", 10, 8));
+        assert!(with_name_a < 8 && with_name_b < 8);
+    }
+
+    #[test]
+    fn advertise_touches_status_file_when_env_set() {
+        // Env mutation: TEST_SHARD_STATUS_FILE is only read inside this call,
+        // and no other test in this crate touches it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shard_status");
+        std::env::set_var("TEST_SHARD_STATUS_FILE", &path);
+        advertise_bazel_sharding_support();
+        std::env::remove_var("TEST_SHARD_STATUS_FILE");
+        assert!(path.exists(), "status file must be created");
+    }
+}

--- a/crates/bdd-infra/src/sharding.rs
+++ b/crates/bdd-infra/src/sharding.rs
@@ -45,11 +45,20 @@ static SHARD: OnceLock<Option<(u64, u64)>> = OnceLock::new();
 /// ("test runner did not advertise sharding support"). `bdd_main!` calls
 /// this unconditionally — it is a no-op outside Bazel and for unsharded
 /// targets.
+///
+/// Panics if the touch fails: Bazel would fail the shard anyway, but only
+/// *after* the process has run its full scenario slice, and with an error
+/// pointing at sharding support rather than at the actual I/O problem.
+/// Failing here surfaces the root cause before any scenario runs.
 pub fn advertise_bazel_sharding_support() {
     if let Some(path) = std::env::var_os("TEST_SHARD_STATUS_FILE") {
-        if let Err(e) = std::fs::write(&path, b"") {
-            eprintln!("bdd_main: failed to touch TEST_SHARD_STATUS_FILE {path:?}: {e}");
-        }
+        std::fs::write(&path, b"").unwrap_or_else(|e| {
+            panic!(
+                "bdd_main: failed to touch TEST_SHARD_STATUS_FILE {path:?}: {e} — \
+                 Bazel would treat the runner as non-sharding-aware and fail the \
+                 test after running the whole suite"
+            )
+        });
     }
 }
 
@@ -230,15 +239,43 @@ mod tests {
         assert!(with_name_a < 8 && with_name_b < 8);
     }
 
+    /// Serializes the tests that mutate the process-wide
+    /// `TEST_SHARD_STATUS_FILE` env var. Recovers from poisoning so a
+    /// panicking sibling (the should-fail test below uses catch_unwind,
+    /// but belt-and-braces) can't cascade.
+    static STATUS_FILE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_status_env() -> std::sync::MutexGuard<'static, ()> {
+        STATUS_FILE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn advertise_touches_status_file_when_env_set() {
-        // Env mutation: TEST_SHARD_STATUS_FILE is only read inside this call,
-        // and no other test in this crate touches it.
+        let _lock = lock_status_env();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shard_status");
         std::env::set_var("TEST_SHARD_STATUS_FILE", &path);
         advertise_bazel_sharding_support();
         std::env::remove_var("TEST_SHARD_STATUS_FILE");
         assert!(path.exists(), "status file must be created");
+    }
+
+    #[test]
+    fn advertise_panics_when_the_status_file_cannot_be_written() {
+        let _lock = lock_status_env();
+        let dir = tempfile::tempdir().unwrap();
+        // A path inside a directory that doesn't exist: the write must fail,
+        // and the failure must surface as a panic naming the file — not as a
+        // log line followed by Bazel failing the shard after the fact.
+        let path = dir.path().join("no-such-dir").join("shard_status");
+        std::env::set_var("TEST_SHARD_STATUS_FILE", &path);
+        let result = std::panic::catch_unwind(advertise_bazel_sharding_support);
+        std::env::remove_var("TEST_SHARD_STATUS_FILE");
+        assert!(
+            result.is_err(),
+            "an unwritable status file must fail loudly"
+        );
     }
 }

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -37,20 +37,23 @@ using (var mutex = new Mutex(false, mutexId, out bool createdNew))
 If you see `Timeout waiting for exclusive access` in OmniSim's stderr,
 another instance is already running.
 
-**Our fork lifts this** (issue #467): release `v0.5.0-467.1` of
-`ivonnyssen/ASCOM.Alpaca.Simulators` adds a `--multi-instance` flag that
-skips the mutex and the named-pipe server for that process, so any number
-of instances can run concurrently — each on its own `--urls` port and,
-because the settings write-back is unsynchronised, each with its own
-settings store (a distinct `XDG_CONFIG_HOME` on Linux/macOS; **not
-possible on Windows**, where the profile lives at `%USERPROFILE%\.ASCOM`
-with no env override — which is why the Bazel `omnisim` resource pool
-still serializes OmniSim suites on Windows). Without the flag, behavior
-is exactly upstream's. `bdd_infra::rp_harness::OmniSimHandle` always
-spawns with the flag and a dynamically chosen port, giving every BDD test
-process (including every Bazel shard of `rp:bdd`) a private simulator.
-The `@serial` feature tag still serializes scenarios *within* one test
-process, which share that process's instance.
+**Our fork lifts this** (issue #467): `ivonnyssen/ASCOM.Alpaca.Simulators`
+release `v0.5.0-467.1` adds a `--multi-instance` flag that skips the mutex
+and the named-pipe server for that process, and `v0.5.0-467.2` adds the
+`OMNISIM_SETTINGS_DIR` environment variable, which re-roots the profile
+store per instance on **every** platform. Both are needed for concurrent
+instances: the settings write-back is unsynchronised, and the default
+store location is not redirectable per-process on Windows
+(`%USERPROFILE%\.ASCOM` via SHGetKnownFolderPath) or macOS
+(`~/Library/Application Support` via NSSearchPath — .NET honors
+`XDG_CONFIG_HOME` on other Unixes only; a shared store on macOS CI leaked
+one suite's persisted telescope site into another's scenarios). Without
+the flag and variable, behavior is exactly upstream's.
+`bdd_infra::rp_harness::OmniSimHandle` always spawns with both, plus a
+dynamically chosen `--urls` port, giving every BDD test process (including
+every Bazel shard of `rp:bdd`) a private simulator. The `@serial` feature
+tag still serializes scenarios *within* one test process, which share that
+process's instance.
 
 ## Binding port
 
@@ -82,7 +85,7 @@ OmniSim writes per-device settings to XDG config:
 └── telescope/v1/instance-0.xml
 ```
 
-The path is **not configurable** via OmniSim's own config. On Linux and macOS, .NET respects `XDG_CONFIG_HOME`, so re-rooting that env var does redirect the state dir — but be aware nothing inside OmniSim documents this. On Windows the base is `%USERPROFILE%\.ASCOM` (ASCOM.Tools `XMLProfile`), which no env var redirects. `bdd_infra::rp_harness` re-roots every spawned instance to a private `bdd-infra-omnisim-<pid>/` dir seeded from `crates/bdd-infra/omnisim-config/`, so concurrent instances never share a writable profile store (and test runs never touch your real `~/.config`).
+Upstream, the path is **not configurable**: on non-macOS Unix, .NET respects `XDG_CONFIG_HOME`, so re-rooting that env var redirects the state dir (nothing inside OmniSim documents this); on Windows the base is `%USERPROFILE%\.ASCOM` and on macOS `~/Library/Application Support/ascom` (ASCOM.Tools `XMLProfile` via `GetFolderPath`), neither redirectable by any env var. Our fork's `OMNISIM_SETTINGS_DIR` (`v0.5.0-467.2+`) re-roots the store on every platform, keeping XMLProfile's own layout under the given root. `bdd_infra::rp_harness` sets it to a private `bdd-infra-omnisim-<pid>/` dir seeded from `crates/bdd-infra/omnisim-config/`, so concurrent instances never share a writable profile store (and test runs never touch your real profile dirs).
 
 State is loaded on startup and persisted on shutdown. State persists across OmniSim restarts unless explicitly reset (see CLI flags / `/simulator/v1/.../reset` below).
 
@@ -98,6 +101,7 @@ From `readme.md`:
 | `--show-browser` | Open the web UI in a browser (when invoked as a second instance) |
 | `--urls <url>` | ASP.NET Core convention; override the bind URL |
 | `--multi-instance` | **Fork-only** (`v0.5.0-467.1+`): skip the single-instance mutex + named-pipe server so several OmniSims can run concurrently (pair with distinct `--urls` and settings stores) |
+| `OMNISIM_SETTINGS_DIR` (env var) | **Fork-only** (`v0.5.0-467.2+`): re-root the profile store to the given directory (XMLProfile layout underneath), on every platform |
 
 `--reset` only takes effect at startup. To reset state in a *running* instance, use the OmniSim-only HTTP API.
 

--- a/docs/references/omnisim.md
+++ b/docs/references/omnisim.md
@@ -4,9 +4,9 @@ OmniSim is the [ASCOM Alpaca Simulators](https://github.com/ASCOMInitiative/ASCO
 
 The simulator is *faithful* to real hardware behavior in many ways that aren't immediately obvious from the ASCOM spec, and those behaviors have caused us several days of debugging. This doc captures what we've learned.
 
-## Single-instance enforcement (no parallelism)
+## Single-instance enforcement — and our `--multi-instance` escape hatch
 
-OmniSim acquires a hardcoded global named mutex on startup:
+Upstream OmniSim acquires a hardcoded global named mutex on startup:
 
 ```csharp
 // ASCOM.Alpaca.Simulators/Program.cs
@@ -23,14 +23,34 @@ using (var mutex = new Mutex(false, mutexId, out bool createdNew))
 }
 ```
 
-**Implications:**
+**Upstream implications:**
 
-- Only one OmniSim per machine. Period.
-- The GUID is hardcoded — no CLI flag, env var, or config to override it.
-- A second instance does *not* run independently. It connects to the first instance's named pipe (`{2249563F-E844-4264-8956-73AC7A44BEA0}`, also hardcoded), forwards its CLI args, and exits.
-- BDD scenarios cannot be parallelized at the OmniSim level. Cucumber's `@serial` tag (which the rusty-photon BDD features use) is what keeps things working.
+- Only one OmniSim per machine. The GUID is hardcoded — no upstream CLI
+  flag, env var, or config to override it. On Linux/macOS the mutex is
+  backed by a file under `/tmp/.dotnet/shm/global/` (that's why an isolated
+  `/tmp` — a container, or a mount namespace — defeats it); on Windows it's
+  a kernel object.
+- A second instance does *not* run independently. It connects to the first
+  instance's named pipe (`{2249563F-E844-4264-8956-73AC7A44BEA0}`, also
+  hardcoded), forwards its CLI args, and exits.
 
-If you see `Timeout waiting for exclusive access` in OmniSim's stderr, another instance is already running.
+If you see `Timeout waiting for exclusive access` in OmniSim's stderr,
+another instance is already running.
+
+**Our fork lifts this** (issue #467): release `v0.5.0-467.1` of
+`ivonnyssen/ASCOM.Alpaca.Simulators` adds a `--multi-instance` flag that
+skips the mutex and the named-pipe server for that process, so any number
+of instances can run concurrently — each on its own `--urls` port and,
+because the settings write-back is unsynchronised, each with its own
+settings store (a distinct `XDG_CONFIG_HOME` on Linux/macOS; **not
+possible on Windows**, where the profile lives at `%USERPROFILE%\.ASCOM`
+with no env override — which is why the Bazel `omnisim` resource pool
+still serializes OmniSim suites on Windows). Without the flag, behavior
+is exactly upstream's. `bdd_infra::rp_harness::OmniSimHandle` always
+spawns with the flag and a dynamically chosen port, giving every BDD test
+process (including every Bazel shard of `rp:bdd`) a private simulator.
+The `@serial` feature tag still serializes scenarios *within* one test
+process, which share that process's instance.
 
 ## Binding port
 
@@ -39,7 +59,9 @@ OmniSim is an ASP.NET Core app. Default port is **32323**. Override via either:
 - CLI: `ascom.alpaca.simulators --urls "http://127.0.0.1:33333"`
 - Env: `ASPNETCORE_URLS=http://127.0.0.1:33333`
 
-But — see above. Port override is moot if another OmniSim is already running, because the mutex blocks before the bind.
+Under upstream's single-instance guard a port override is moot if another
+OmniSim is already running (the mutex blocks before the bind); with our
+fork's `--multi-instance` it's how concurrent instances coexist.
 
 ## State persistence
 
@@ -60,7 +82,7 @@ OmniSim writes per-device settings to XDG config:
 └── telescope/v1/instance-0.xml
 ```
 
-The path is **not configurable** via OmniSim's own config. On Linux, .NET respects `XDG_CONFIG_HOME`, so re-rooting that env var does redirect the state dir — but be aware nothing inside OmniSim documents this.
+The path is **not configurable** via OmniSim's own config. On Linux and macOS, .NET respects `XDG_CONFIG_HOME`, so re-rooting that env var does redirect the state dir — but be aware nothing inside OmniSim documents this. On Windows the base is `%USERPROFILE%\.ASCOM` (ASCOM.Tools `XMLProfile`), which no env var redirects. `bdd_infra::rp_harness` re-roots every spawned instance to a private `bdd-infra-omnisim-<pid>/` dir seeded from `crates/bdd-infra/omnisim-config/`, so concurrent instances never share a writable profile store (and test runs never touch your real `~/.config`).
 
 State is loaded on startup and persisted on shutdown. State persists across OmniSim restarts unless explicitly reset (see CLI flags / `/simulator/v1/.../reset` below).
 
@@ -75,6 +97,7 @@ From `readme.md`:
 | `--local-address` | Print the URL of the running instance (when invoked as a second instance) |
 | `--show-browser` | Open the web UI in a browser (when invoked as a second instance) |
 | `--urls <url>` | ASP.NET Core convention; override the bind URL |
+| `--multi-instance` | **Fork-only** (`v0.5.0-467.1+`): skip the single-instance mutex + named-pipe server so several OmniSims can run concurrently (pair with distinct `--urls` and settings stores) |
 
 `--reset` only takes effect at startup. To reset state in a *running* instance, use the OmniSim-only HTTP API.
 

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -3587,12 +3587,15 @@ of the environment variables above. In CI, the
 automatically.
 
 **CI pins a patched fork**, not upstream: the action defaults to
-[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-467.1`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-467.1).
-That release adds the `--multi-instance` flag (issue #467) — the harness
-always spawns OmniSim with it, so **the fork is a hard requirement for
-BDD runs now**, local ones included: it skips upstream's machine-global
-single-instance mutex so every test process (parallel suites, `rp:bdd`
-shards) gets a private simulator on its own port. It also carries the
+[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-467.2`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-467.2).
+The `467.x` releases (issue #467) add the `--multi-instance` flag (467.1,
+skips upstream's machine-global single-instance mutex) and the
+`OMNISIM_SETTINGS_DIR` env var (467.2, re-roots the profile store per
+instance on every platform — the default store is not redirectable on
+Windows or macOS). The harness always spawns OmniSim with both, so **the
+fork is a hard requirement for BDD runs now**, local ones included: every
+test process (parallel suites, `rp:bdd` shards) gets a private simulator
+on its own port with a private profile store. It also carries the
 `326.x` series of `TelescopeHardware` fixes
 for the `center_on_target` slew-state hang/flake (issues #326, #319):
 326.1/.2 put the slew-engine writers and the

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -3587,8 +3587,13 @@ of the environment variables above. In CI, the
 automatically.
 
 **CI pins a patched fork**, not upstream: the action defaults to
-[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-326.4`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-326.4),
-a build of upstream `v0.5.0` plus a series of `TelescopeHardware` fixes
+[`ivonnyssen/ASCOM.Alpaca.Simulators` `v0.5.0-467.1`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-467.1).
+That release adds the `--multi-instance` flag (issue #467) — the harness
+always spawns OmniSim with it, so **the fork is a hard requirement for
+BDD runs now**, local ones included: it skips upstream's machine-global
+single-instance mutex so every test process (parallel suites, `rp:bdd`
+shards) gets a private simulator on its own port. It also carries the
+`326.x` series of `TelescopeHardware` fixes
 for the `center_on_target` slew-state hang/flake (issues #326, #319):
 326.1/.2 put the slew-engine writers and the
 `IsSlewing`/RA/Dec/`AtPark`/`SlewState` readers under `hardwareLock`;
@@ -3605,13 +3610,15 @@ the slew never finishes and `IsSlewing` stays `true` forever.
 for the `RA < 180` off-target row at certain sidereal times (hence the
 intermittent CI flake). 326.4 makes `DoSlew` take the limit-avoiding
 rotation to the *same* target (pier side unchanged, so ConformU stays
-clean) and adds a no-progress guard. The action's `repo`
-and `version` inputs revert to upstream
+clean) and adds a no-progress guard. Reverting the action's `repo` and
+`version` inputs to upstream
 [`v0.5.0`](https://github.com/ASCOMInitiative/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0)
-in one line once the fix lands upstream. For local runs, use the pinned
-fork as well — upstream `v0.5.0` still carries both the #326 races and
-the sidereal-time-gated #319 wedge, so it can hang `center_on_target`
-intermittently and is not recommended for local BDD runs.
+is no longer a one-line change: upstream has no `--multi-instance`, so
+the `bdd-infra` spawn path (and the parallel/sharded BDD scheduling
+built on it) would have to be reverted too. For local runs, use the
+pinned fork — upstream `v0.5.0` lacks `--multi-instance` (every BDD
+suite fails at OmniSim spawn) and still carries the #326 races and the
+sidereal-time-gated #319 wedge.
 
 #### Graceful Shutdown and Coverage
 

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -415,9 +415,12 @@ test spawns `rp` alongside OmniSim and/or an orchestrator plugin:
 
 - `OmniSimHandle` — per-test-process Alpaca simulator shared across that
   process's scenarios. Spawned with the fork's `--multi-instance` flag on a
-  dynamically chosen port with a private settings dir, so concurrent test
+  dynamically chosen port with a private settings dir (the fork's
+  `OMNISIM_SETTINGS_DIR` env var — works on every OS, unlike
+  `XDG_CONFIG_HOME`, which .NET ignores on macOS), so concurrent test
   processes (parallel Bazel suites, `rp:bdd` shards, a dev OmniSim on the
-  default port) never contend for one simulator.
+  default port) never contend for one simulator or leak persisted profile
+  settings into each other.
 - `RpConfigBuilder` + `CameraConfig` / `FilterWheelConfig` /
   `CoverCalibratorConfig` — fluent builder that emits rp's JSON config.
 - `start_rp`, `wait_for_rp_healthy`, `write_temp_config_file`,
@@ -710,10 +713,12 @@ sharding support to Bazel. Skipping step 2 silently makes every shard
 run the whole suite. Scenarios are partitioned by a stable hash of
 (feature file name, scenario line), and `@serial` still applies within
 each shard, which is exactly the scope it protects — one process's
-shared instance. Windows is the exception: OmniSim's profile store
-there can't be isolated per instance, so the Bazel `omnisim` resource
-pool (capacity 1 on Windows, see `.bazelrc`) serializes all
-OmniSim-spawning actions, shards included.
+shared instance. This holds on every OS: profile-store isolation uses
+the fork's `OMNISIM_SETTINGS_DIR` (release `v0.5.0-467.2`), which
+re-roots OmniSim's profile store per instance on all platforms — the
+default store is not redirectable on Windows or macOS, and a shared
+store leaks persisted settings (e.g. the telescope site) between
+concurrently running suites.
 
 ---
 

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -413,7 +413,11 @@ binary discovery, spawning, port parsing, and graceful shutdown logic.
 **Optional `rp-harness` feature** — adds the higher-level helpers needed when a
 test spawns `rp` alongside OmniSim and/or an orchestrator plugin:
 
-- `OmniSimHandle` — singleton Alpaca simulator shared across scenarios.
+- `OmniSimHandle` — per-test-process Alpaca simulator shared across that
+  process's scenarios. Spawned with the fork's `--multi-instance` flag on a
+  dynamically chosen port with a private settings dir, so concurrent test
+  processes (parallel Bazel suites, `rp:bdd` shards, a dev OmniSim on the
+  default port) never contend for one simulator.
 - `RpConfigBuilder` + `CameraConfig` / `FilterWheelConfig` /
   `CoverCalibratorConfig` — fluent builder that emits rp's JSON config.
 - `start_rp`, `wait_for_rp_healthy`, `write_temp_config_file`,
@@ -648,12 +652,11 @@ have more than one restart in flight — OmniSim's restart handler
 mutates unsynchronised static state, and concurrent restarts have
 corrupted its device list (#171) and deadlocked it outright (#431).
 Total per-scenario overhead is five localhost round-trips
-(~10-25 ms). Before the singleton has been
-initialised the helper falls back to the default OmniSim base URL
-(`http://127.0.0.1:32323`), so a pre-existing OmniSim from a prior
-dev session is reset before scenario 1 reuses it; if no OmniSim is
-listening, the request fails silently and the hook is effectively a
-no-op. Either way the hook is safe to wire up unconditionally.
+(~10-25 ms). Before the singleton has been initialised the helper is
+a no-op: the test process hasn't spawned its OmniSim yet, and the
+private instance `OmniSimHandle::start()` eventually spawns is fresh
+by construction (pre-existing instances are never reused). The hook
+is safe to wire up unconditionally.
 
 ```rust
 MyWorld::cucumber()
@@ -692,6 +695,25 @@ drain Concurrent scenarios while `@serial` ones are queued, so all
 untagged scenarios launch simultaneously once the serial queue
 empties — their before-hooks fire as one burst, which is why the
 restart PUTs are serialized process-wide; see #431.)
+
+**Parallelism comes from processes, not from dropping `@serial`.**
+Since #467 every BDD test process owns a private OmniSim
+(`--multi-instance` + dynamic port + per-instance settings dir), so
+the wall-clock lever is more processes, each with its own simulator:
+the four OmniSim suites run concurrently under Bazel on Linux/macOS,
+and `rp:bdd` is additionally split into parallel shard processes via
+Bazel `shard_count`. To shard a suite: (1) set `shard_count` on its
+`rust_test` target, and (2) route its cucumber filter through
+`bdd_infra::sharding::scenario_in_current_shard(feat.path.as_deref(),
+&feat.name, sc.position.line)` — `bdd_main!` already advertises
+sharding support to Bazel. Skipping step 2 silently makes every shard
+run the whole suite. Scenarios are partitioned by a stable hash of
+(feature file name, scenario line), and `@serial` still applies within
+each shard, which is exactly the scope it protects — one process's
+shared instance. Windows is the exception: OmniSim's profile store
+there can't be isolated per instance, so the Bazel `omnisim` resource
+pool (capacity 1 on Windows, see `.bazelrc`) serializes all
+OmniSim-spawning actions, shards included.
 
 ---
 

--- a/services/calibrator-flats/BUILD.bazel
+++ b/services/calibrator-flats/BUILD.bazel
@@ -89,12 +89,12 @@ rust_test(
     # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
     # be the service name (rules_rust would otherwise use the crate name "bdd").
     rustc_env = {"CARGO_PKG_NAME": "calibrator-flats"},
-    # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel. OmniSim
-    # allows only one instance per host (machine-global mutex keyed on a fixed GUID),
-    # so the two OmniSim-spawning BDD targets (rp:bdd, calibrator-flats:bdd) must
-    # never run concurrently or they race for that single instance and one loses
-    # OmniSim mid-run. The `omnisim` resource pool (sized 1 in .bazelrc) serializes
-    # them against each other while leaving them parallel to non-OmniSim tests.
+    # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
+    # Each OmniSim-spawning BDD action takes one token from the `omnisim`
+    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
+    # every test process a private OmniSim, so the suites run in parallel —
+    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
+    # can't be isolated per instance.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/services/calibrator-flats/BUILD.bazel
+++ b/services/calibrator-flats/BUILD.bazel
@@ -91,10 +91,10 @@ rust_test(
     rustc_env = {"CARGO_PKG_NAME": "calibrator-flats"},
     # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
     # Each OmniSim-spawning BDD action takes one token from the `omnisim`
-    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
-    # every test process a private OmniSim, so the suites run in parallel —
-    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
-    # can't be isolated per instance.
+    # pool (.bazelrc, sized generously on every OS): the harness gives every
+    # test process a private OmniSim — --multi-instance + dynamic port +
+    # per-instance OMNISIM_SETTINGS_DIR — so the suites run in parallel; the
+    # pool is only a throttle to grab if that ever turns flaky.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/services/rp/BUILD.bazel
+++ b/services/rp/BUILD.bazel
@@ -157,20 +157,19 @@ rust_test(
     # sharding support (TEST_SHARD_STATUS_FILE) and tests/bdd.rs routes the
     # scenario filter through bdd_infra::sharding, so each shard runs a
     # deterministic slice of the scenarios against its own private OmniSim
-    # (--multi-instance + dynamic port; see crates/bdd-infra/src/rp_harness/
-    # omnisim.rs). @serial semantics are preserved *within* each shard. On
-    # Windows the `omnisim` pool (capacity 1, .bazelrc) serializes the shards
-    # — wall clock there stays roughly the unsharded total.
+    # (--multi-instance + dynamic port + per-instance OMNISIM_SETTINGS_DIR;
+    # see crates/bdd-infra/src/rp_harness/omnisim.rs). @serial semantics are
+    # preserved *within* each shard.
     shard_count = 8,
     # `resources:omnisim:1`: every OmniSim-spawning BDD action (each shard of
     # this target, and the other three OmniSim suites) takes one token from
     # the `omnisim` pool defined in .bazelrc. Since #467 the harness spawns a
     # private OmniSim per test process (--multi-instance + dynamic port +
-    # per-instance XDG_CONFIG_HOME), so on Linux/macOS the pool is sized
-    # generously and these actions genuinely run in parallel. On Windows the
-    # pool stays at 1: OmniSim's profile store there is %USERPROFILE%\.ASCOM
-    # (ASCOM.Tools XMLProfile), which no env var can redirect per-instance,
-    # so concurrent instances would race each other's profile write-backs.
+    # per-instance OMNISIM_SETTINGS_DIR — the fork env var that re-roots the
+    # profile store on every platform; XDG_CONFIG_HOME only worked on Linux),
+    # so the pool is sized generously on every OS and these actions genuinely
+    # run in parallel; it remains only as a throttle to grab if OmniSim
+    # concurrency ever turns flaky.
     # Any new OmniSim-spawning BDD target MUST also carry this tag.
     tags = [
         "bdd",

--- a/services/rp/BUILD.bazel
+++ b/services/rp/BUILD.bazel
@@ -120,9 +120,10 @@ rust_test(
 
 rust_test(
     name = "bdd",
-    # 84 cucumber scenarios, including the flat_calibration suite that
-    # spawns calibrator-flats; total wall ~150 s. "large" gives a 15 min
-    # budget so occasional CI slowness doesn't time out.
+    # ~250 cucumber scenarios, most of them feature-tagged @serial (shared
+    # OmniSim device state), so a single process runs them nearly serially:
+    # ~344 s locally, up to ~12 min on the Windows CI runner. "large" gives
+    # each shard a 15 min budget so occasional CI slowness doesn't time out.
     size = "large",
     srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
     aliases = aliases(
@@ -152,21 +153,25 @@ rust_test(
     # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from it — it must be the
     # service name.
     rustc_env = {"CARGO_PKG_NAME": "rp"},
-    # OmniSim allows only one instance per host: ASCOM.Alpaca.Simulators'
-    # Program.cs guards startup with a machine-global named Mutex
-    # (`new Mutex(false, "Global\\{ApplicationGUID}")`) keyed on a fixed GUID, not
-    # the port — so a second instance can't start even on a different port; it
-    # hands its args to the first over a named pipe and exits. Under Bazel every
-    # test runs as a parallel action on one machine (Cargo CI instead isolates each
-    # BDD service into its own job), so rp:bdd and calibrator-flats:bdd — the only
-    # two OmniSim-spawning targets — would otherwise race for that single instance:
-    # whichever spawns OmniSim first owns it (the process-wrapper sandbox +
-    # PR_SET_PDEATHSIG reap it when that action ends) while the other reuses it over
-    # HTTP, then loses it mid-run when the owner finishes — the "connection refused"
-    # cascade that fails the loud-reset before-hook for every remaining scenario.
-    # `resources:omnisim:1` makes the two mutually exclusive (the `omnisim` pool is
-    # sized 1 in .bazelrc) while keeping them parallel to non-OmniSim tests. Any new
-    # OmniSim-spawning BDD target MUST also carry this tag.
+    # Split the suite into parallel shard processes. bdd_main! advertises
+    # sharding support (TEST_SHARD_STATUS_FILE) and tests/bdd.rs routes the
+    # scenario filter through bdd_infra::sharding, so each shard runs a
+    # deterministic slice of the scenarios against its own private OmniSim
+    # (--multi-instance + dynamic port; see crates/bdd-infra/src/rp_harness/
+    # omnisim.rs). @serial semantics are preserved *within* each shard. On
+    # Windows the `omnisim` pool (capacity 1, .bazelrc) serializes the shards
+    # — wall clock there stays roughly the unsharded total.
+    shard_count = 8,
+    # `resources:omnisim:1`: every OmniSim-spawning BDD action (each shard of
+    # this target, and the other three OmniSim suites) takes one token from
+    # the `omnisim` pool defined in .bazelrc. Since #467 the harness spawns a
+    # private OmniSim per test process (--multi-instance + dynamic port +
+    # per-instance XDG_CONFIG_HOME), so on Linux/macOS the pool is sized
+    # generously and these actions genuinely run in parallel. On Windows the
+    # pool stays at 1: OmniSim's profile store there is %USERPROFILE%\.ASCOM
+    # (ASCOM.Tools XMLProfile), which no env var can redirect per-instance,
+    # so concurrent instances would race each other's profile write-backs.
+    # Any new OmniSim-spawning BDD target MUST also carry this tag.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/services/rp/tests/bdd.rs
+++ b/services/rp/tests/bdd.rs
@@ -100,7 +100,15 @@ bdd_infra::bdd_main! {
         .filter_run_and_exit("tests/features", |feat, _rule, sc| {
             let is_wip = feat.tags.iter().any(|t| t == "wip" || t == "@wip")
                 || sc.tags.iter().any(|t| t == "wip" || t == "@wip");
-            !is_wip
+            // Bazel sharding (BUILD `shard_count`): each shard process runs
+            // only its deterministic slice of the scenarios, against its own
+            // private OmniSim. Outside Bazel sharding this always passes.
+            let in_shard = bdd_infra::sharding::scenario_in_current_shard(
+                feat.path.as_deref(),
+                &feat.name,
+                sc.position.line,
+            );
+            !is_wip && in_shard
         })
         .await;
 

--- a/services/session-runner/BUILD.bazel
+++ b/services/session-runner/BUILD.bazel
@@ -104,13 +104,12 @@ rust_test(
     # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
     # be the service name (rules_rust would otherwise use the crate name "bdd").
     rustc_env = {"CARGO_PKG_NAME": "session-runner"},
-    # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel. OmniSim
-    # allows only one instance per host (machine-global mutex keyed on a fixed GUID),
-    # so the OmniSim-spawning BDD targets (rp:bdd, calibrator-flats:bdd, this one)
-    # must never run concurrently or they race for that single instance and one
-    # loses OmniSim mid-run. The `omnisim` resource pool (sized 1 in .bazelrc)
-    # serializes them against each other while leaving them parallel to
-    # non-OmniSim tests.
+    # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
+    # Each OmniSim-spawning BDD action takes one token from the `omnisim`
+    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
+    # every test process a private OmniSim, so the suites run in parallel —
+    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
+    # can't be isolated per instance.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/services/session-runner/BUILD.bazel
+++ b/services/session-runner/BUILD.bazel
@@ -73,7 +73,9 @@ rust_test(
 # OMNISIM_PATH set, like any rp_harness BDD target.
 rust_test(
     name = "bdd",
-    # Spawns three processes per scenario; generous timeout.
+    # Spawns three processes per scenario; generous timeout. The deep-sky
+    # scenarios drive real-speed OmniSim slews, so the suite is ~6 min of
+    # mostly-@serial wall clock in one process.
     size = "large",
     srcs = ["tests/bdd.rs"] + glob(["tests/bdd/**/*.rs"]),
     aliases = aliases(
@@ -104,12 +106,17 @@ rust_test(
     # bdd-infra derives {PKG_UPPER_SNAKE}_BINARY from CARGO_PKG_NAME, so it must
     # be the service name (rules_rust would otherwise use the crate name "bdd").
     rustc_env = {"CARGO_PKG_NAME": "session-runner"},
+    # Split into parallel shard processes, same mechanism as rp:bdd:
+    # bdd_main! advertises sharding support and tests/bdd.rs routes the
+    # scenario filter through bdd_infra::sharding; each shard runs its
+    # deterministic slice against its own private OmniSim.
+    shard_count = 8,
     # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
     # Each OmniSim-spawning BDD action takes one token from the `omnisim`
-    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
-    # every test process a private OmniSim, so the suites run in parallel —
-    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
-    # can't be isolated per instance.
+    # pool (.bazelrc, sized generously on every OS): the harness gives every
+    # test process a private OmniSim — --multi-instance + dynamic port +
+    # per-instance OMNISIM_SETTINGS_DIR — so the suites run in parallel; the
+    # pool is only a throttle to grab if that ever turns flaky.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/services/session-runner/tests/bdd.rs
+++ b/services/session-runner/tests/bdd.rs
@@ -66,7 +66,15 @@ bdd_infra::bdd_main! {
         .filter_run_and_exit("tests/features", |feat, _rule, sc| {
             let is_wip = feat.tags.iter().any(|t| t == "wip" || t == "@wip")
                 || sc.tags.iter().any(|t| t == "wip" || t == "@wip");
-            !is_wip
+            // Bazel sharding (BUILD `shard_count`): each shard process runs
+            // only its deterministic slice of the scenarios, against its own
+            // private OmniSim. Outside Bazel sharding this always passes.
+            let in_shard = bdd_infra::sharding::scenario_in_current_shard(
+                feat.path.as_deref(),
+                &feat.name,
+                sc.position.line,
+            );
+            !is_wip && in_shard
         })
         .await;
 }

--- a/tests/operation-watchdog-e2e/BUILD.bazel
+++ b/tests/operation-watchdog-e2e/BUILD.bazel
@@ -52,10 +52,12 @@ rust_test(
         proc_macro = True,
         proc_macro_dev = True,
     ),
-    # `resources:omnisim:1`: OmniSim allows only one instance per host, so the
-    # OmniSim-spawning BDD targets must never run concurrently. The `omnisim`
-    # resource pool (sized 1 in .bazelrc) serializes them. See the note in
-    # services/rp/BUILD.bazel.
+    # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
+    # Each OmniSim-spawning BDD action takes one token from the `omnisim`
+    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
+    # every test process a private OmniSim, so the suites run in parallel —
+    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
+    # can't be isolated per instance.
     tags = [
         "bdd",
         "resources:omnisim:1",

--- a/tests/operation-watchdog-e2e/BUILD.bazel
+++ b/tests/operation-watchdog-e2e/BUILD.bazel
@@ -54,10 +54,10 @@ rust_test(
     ),
     # `resources:omnisim:1`: see the longer note in services/rp/BUILD.bazel.
     # Each OmniSim-spawning BDD action takes one token from the `omnisim`
-    # pool (.bazelrc): sized generously on Linux/macOS — the harness gives
-    # every test process a private OmniSim, so the suites run in parallel —
-    # and 1 on Windows, where OmniSim's %USERPROFILE%\.ASCOM profile store
-    # can't be isolated per instance.
+    # pool (.bazelrc, sized generously on every OS): the harness gives every
+    # test process a private OmniSim — --multi-instance + dynamic port +
+    # per-instance OMNISIM_SETTINGS_DIR — so the suites run in parallel; the
+    # pool is only a throttle to grab if that ever turns flaky.
     tags = [
         "bdd",
         "resources:omnisim:1",


### PR DESCRIPTION
Closes #467.

## What

Removes the one-OmniSim-per-host serialization from the BDD suites and shards the two slow ones, using two additions to our OmniSim fork ([`v0.5.0-467.2`](https://github.com/ivonnyssen/ASCOM.Alpaca.Simulators/releases/tag/v0.5.0-467.2), published and SHA-pinned):

- `--multi-instance` (467.1) — skips upstream's machine-global single-instance guard (named Mutex + named-pipe command server).
- `OMNISIM_SETTINGS_DIR` (467.2) — re-roots the profile store per instance on **every** platform (XMLProfile's own layout, platform casing included, just re-rooted).

**bdd-infra spawns a private OmniSim per test process**: always both fork features, dynamically probed port, per-instance settings dir (`bdd-infra-omnisim-<pid>` under `TEST_TMPDIR`/cargo target tree, seeded from the checked-in `omnisim-config/` tree), retry on lost port-bind races, fast failure naming the fork floor when the binary is too old. Pre-existing instances are never reused — cross-session dev OmniSims can no longer contend with test runs.

**Sharding**: new `bdd_infra::sharding` module (`bdd_main!` advertises Bazel sharding support; suites route their cucumber filter through `scenario_in_current_shard()`, a stable FNV-1a partition over feature file name + scenario line). `rp:bdd` runs 8 shards (verified: 279 expanded scenarios partition losslessly), `session-runner:bdd` runs 8 (its Phase E/#468 deep-sky scenarios drive real-speed OmniSim slews and had become the BDD critical path). `@serial` still applies within each shard — exactly the scope it protects.

**omnisim pool**: capacity 24 on every OS — above the worst-case concurrent demand (8 rp shards + 8 session-runner shards + 2 suites = 18) — kept only as a throttle to re-serialize if concurrency ever turns flaky.

**Bazel now gets the tuned OmniSim seed config** (it silently never resolved under Bazel — dead compile-time path): `open_cover` 10.7 s → 1.9 s.

## The macOS lesson (why 467.2 exists)

The first CI round (with 467.1 + XDG-based isolation) failed 4 of 8 rp:bdd shards **on macOS only**: .NET honors `XDG_CONFIG_HOME` on non-macOS Unix exclusively, so all macOS instances shared `~/Library/Application Support` — session-runner's persisted computed telescope site leaked into rp's shards via the per-scenario `restart` (which reloads devices from the profile), and rp refused to start on mount-site validation. Windows (`%USERPROFILE%\.ASCOM`) has the same non-redirectable default and only passed because a pool cap kept it serialized. `OMNISIM_SETTINGS_DIR` bypasses the platform lookup entirely; the pool caps are gone.

## Measured (local, 64-core)

| | before | after |
|---|---|---|
| `rp:bdd` | 344 s (single process, ~serial) | **71 s** (slowest of 8 shards) |
| `session-runner:bdd` | 360 s (post-#468 baseline) | **158 s** (slowest of 8 shards; floored by one slew scenario) |
| OmniSim suite chain | 441 s+ serialized | bounded by slowest shard |
| `open_cover` scenario (Bazel) | 10.7 s | 1.9 s |

First CI round (467.1, still Windows-capped): ubuntu job 17m42s → **10m30s**, windows 21m38s → **12m50s**, coverage green. This round should improve further with parallel Windows + sharded session-runner.

Full local gate: 73/73 green, fmt/clippy/buildifier clean.

## Notes

- **Local devs must upgrade** OmniSim to fork release `v0.5.0-467.2` (`OMNISIM_DIR`/`OMNISIM_PATH` installs, incl. `/opt` on the dev box and the Pi rigs) — the harness hard-requires both fork features and panics with a message naming the floor otherwise.
- `services/plate-solver:bdd` flaked once under the higher parallelism ("spawn timestamp parses as u128 ns: Empty", single-flight-semaphore step), 3/3 green in isolation — pre-existing race in that suite's mock-astap timestamp bookkeeping; worth its own issue if it recurs.
- Possible follow-up: the 158 s session-runner floor is one deep-sky scenario's real-speed slew; syncing the simulated mount closer to target would shrink it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
