### PR TITLE
feat(ui): Phase 5 review follow-ups — honest resolve errors, 413 pin, coverage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,8 +13,5 @@
       "Bash(rustup run:*)",
       "Bash(conformu:*)"
     ]
-  },
-  "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,8 @@
       "Bash(rustup run:*)",
       "Bash(conformu:*)"
     ]
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
   }
 }

--- a/docs/services/rp.md
+++ b/docs/services/rp.md
@@ -3069,7 +3069,8 @@ implemented** — the router serves only the unmarked ones.
   in `restart_required[]` with `status:"ok"`, and the persisted file takes
   effect on the next rp start. Validation failure → HTTP 200
   `status:"invalid"` + field-level `errors[]`, file untouched; a malformed
-  JSON body → HTTP 400. The config endpoints are covered by the
+  JSON body → HTTP 400; a body over axum's default 2 MiB request limit →
+  HTTP 413 (a valid config is a few KiB). The config endpoints are covered by the
   server-wide auth/TLS and are **not** behind the `/mcp` safety gate —
   configuration must stay editable while the system is unsafe.
 

--- a/docs/services/ui-htmx.md
+++ b/docs/services/ui-htmx.md
@@ -186,7 +186,7 @@ BFF serves every configured driver.
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET`  | `/` | Index: links to every configured driver (`/config/{service}`), the `rp` config page, and roster-derived devices when an `rp` target is configured. |
-| `GET`  | `/config/{service}` | Call `config.schema` + `config.get`; render the form generated from the schema, filled with current values. An optional `?unlock=<field>` query renders one locked/identity field (e.g. a device `unique_id`) editable — the read-only-by-default escape hatch. An unknown `{service}` renders an error card. |
+| `GET`  | `/config/{service}` | Call `config.schema` + `config.get`; render the form generated from the schema, filled with current values. An optional `?unlock=<field>` query renders one locked/identity field (e.g. a device `unique_id`) editable — the read-only-by-default escape hatch. Resolve failures render honest, distinct cards: unknown `{service}` ("no configured driver"), rp unreachable while resolving a roster key (retryable), or a roster entry no client can be built from (e.g. malformed `alpaca_url` — links to the Equipment page to fix it). |
 | `POST` | `/config/{service}` | Re-fetch `config.schema` to coerce the form back into the full Config, call `config.apply`; render the result state (see below). |
 | `GET`  | `/config/{service}/status` | HTMX poll target during reconnect: try `config.schema` + `config.get`; when the driver answers, swap in the refreshed form. Honours the same optional `?unlock=` query. |
 | `GET`  | `/equipment` | The [equipment page](#equipment-page-equipment): rp's roster with live connection LEDs, capability tiers, and add/edit/remove affordances. |

--- a/services/rp/src/routes.rs
+++ b/services/rp/src/routes.rs
@@ -1120,6 +1120,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn config_put_persist_failure_is_500() {
+        // The config path is a *directory*: validation passes, the atomic
+        // persist fails — the handler's internal-error branch.
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_app_state_with_config(
+            ImageCache::new(64, 4, PathBuf::from("/tmp")),
+            scaffold_config(),
+            dir.path().to_path_buf(),
+        );
+        let mut submitted = serde_json::to_value(&*state.config).unwrap();
+        submitted["imaging"]["cache_max_mib"] = serde_json::json!(512);
+
+        let response = put_config(State(state), submitted.to_string()).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
     async fn config_put_sentinel_round_trip_keeps_stored_password_on_disk() {
         let (state, _dir, path) = config_test_state(config_with_camera_password("hunter2"));
         // Submit what GET /api/config returned: the password redacted.

--- a/services/rp/tests/bdd/steps/config_rest_steps.rs
+++ b/services/rp/tests/bdd/steps/config_rest_steps.rs
@@ -182,6 +182,15 @@ async fn put_config_unchanged(world: &mut RpWorld) {
     send_put_config(world, config.to_string()).await;
 }
 
+#[when("I PUT /api/config with a body just over the 2 MiB request limit")]
+async fn put_config_oversized_body(world: &mut RpWorld) {
+    // Just over axum's default `DefaultBodyLimit` (2 MiB), and small enough
+    // that the whole request lands in socket buffers before the server
+    // rejects it (no mid-write connection race). If the limit were ever
+    // disabled, this body would reach the parser and fail 400, not 413.
+    send_put_config(world, "x".repeat(2 * 1024 * 1024 + 4096)).await;
+}
+
 #[when(expr = "I PUT \\/api\\/config with body {string}")]
 async fn put_config_raw_body(world: &mut RpWorld, body: String) {
     send_put_config(world, body).await;

--- a/services/rp/tests/bdd/steps/config_rest_steps.rs
+++ b/services/rp/tests/bdd/steps/config_rest_steps.rs
@@ -184,10 +184,8 @@ async fn put_config_unchanged(world: &mut RpWorld) {
 
 #[when("I PUT /api/config with a body just over the 2 MiB request limit")]
 async fn put_config_oversized_body(world: &mut RpWorld) {
-    // Just over axum's default `DefaultBodyLimit` (2 MiB), and small enough
-    // that the whole request lands in socket buffers before the server
-    // rejects it (no mid-write connection race). If the limit were ever
-    // disabled, this body would reach the parser and fail 400, not 413.
+    // Just over axum's default `DefaultBodyLimit` (2 MiB). If the limit were
+    // ever disabled, this body would reach the parser and fail 400, not 413.
     send_put_config(world, "x".repeat(2 * 1024 * 1024 + 4096)).await;
 }
 

--- a/services/rp/tests/features/config_rest.feature
+++ b/services/rp/tests/features/config_rest.feature
@@ -9,7 +9,8 @@ Feature: Plain-REST configuration endpoints
   "restart_required" and the apply status stays "ok" — the persisted file
   takes effect on the next rp start. Validation failures are HTTP 200 with
   status "invalid" and errors[], leaving the file untouched; a malformed
-  JSON body is HTTP 400. Secrets are redacted to the sentinel "********";
+  JSON body is HTTP 400; a body over axum's default 2 MiB request limit is
+  HTTP 413. Secrets are redacted to the sentinel "********";
   submitting the sentinel back means "keep the stored secret unchanged".
   These endpoints spawn rp with a temp config only — no simulator needed.
 
@@ -67,6 +68,14 @@ Feature: Plain-REST configuration endpoints
     And I remember the config file bytes
     When I PUT /api/config with body "this is not json"
     Then the config response status should be 400
+    And the config file bytes should be unchanged
+
+  Scenario: PUT /api/config with an oversized body is rejected before parsing
+    Given a temp rp config with no equipment
+    And rp is started with that config file
+    And I remember the config file bytes
+    When I PUT /api/config with a body just over the 2 MiB request limit
+    Then the config response status should be 413
     And the config file bytes should be unchanged
 
   Scenario: A redacted device password round-trips PUT unchanged on disk

--- a/services/ui-htmx/src/assets.rs
+++ b/services/ui-htmx/src/assets.rs
@@ -38,3 +38,58 @@ pub async fn htmx_sse_js() -> impl IntoResponse {
         HTMX_SSE_JS,
     )
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use axum::response::IntoResponse;
+
+    /// The content-type is what makes the browser apply/execute an asset —
+    /// pin it (and that the embedded bytes are the expected artifact).
+    async fn assert_asset(response: axum::response::Response, content_type: &str, marker: &str) {
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            content_type
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains(marker), "asset lacks marker {marker:?}");
+    }
+
+    #[tokio::test]
+    async fn app_css_is_served_as_css() {
+        assert_asset(
+            super::app_css().await.into_response(),
+            "text/css; charset=utf-8",
+            ":root",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn htmx_js_is_served_as_javascript() {
+        assert_asset(
+            super::htmx_js().await.into_response(),
+            "application/javascript; charset=utf-8",
+            "htmx",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn htmx_sse_extension_is_served_as_javascript() {
+        assert_asset(
+            super::htmx_sse_js().await.into_response(),
+            "application/javascript; charset=utf-8",
+            "sse",
+        )
+        .await;
+    }
+}

--- a/services/ui-htmx/src/config.rs
+++ b/services/ui-htmx/src/config.rs
@@ -260,6 +260,20 @@ mod tests {
     }
 
     #[test]
+    fn rp_target_default_impl_matches_the_serde_defaults() {
+        // `RpTarget::default()` and `serde_json::from_str("{}")` must agree —
+        // both paths hand out the same scaffold.
+        let d = RpTarget::default();
+        assert_eq!(d.base_url, "http://127.0.0.1:11115");
+        assert!(d.auth.is_none());
+        assert!(d.ca_cert_path.is_none());
+        // And an rp target round-trips through serialization unchanged.
+        let json = serde_json::to_string(&d).unwrap();
+        let back: RpTarget = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.base_url, d.base_url);
+    }
+
+    #[test]
     fn driver_auth_password_redacted_in_debug() {
         let auth = DriverAuth {
             username: "obs".to_string(),

--- a/services/ui-htmx/src/config.rs
+++ b/services/ui-htmx/src/config.rs
@@ -271,6 +271,8 @@ mod tests {
         let json = serde_json::to_string(&d).unwrap();
         let back: RpTarget = serde_json::from_str(&json).unwrap();
         assert_eq!(back.base_url, d.base_url);
+        assert!(back.auth.is_none());
+        assert!(back.ca_cert_path.is_none());
     }
 
     #[test]

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -311,35 +311,57 @@ impl AppState {
     }
 }
 
+/// Why [`resolve_service`] found no usable driver behind a `/config/{service}`
+/// key. Each cause renders its own honest card ([`pages::resolve_failure_card`])
+/// — an unreachable rp or an unusable roster entry must not masquerade as
+/// "no such driver".
+#[derive(Debug)]
+pub(crate) enum ResolveError {
+    /// No static entry, and the key names nothing in the roster (also: not a
+    /// roster key at all, or no rp target is configured).
+    Unknown,
+    /// The key names a roster device but rp's config could not be fetched.
+    RpUnreachable(String),
+    /// The roster entry exists but no client could be built from it (e.g. a
+    /// malformed or credentialed `alpaca_url`).
+    BadRosterEntry(String),
+}
+
 /// Resolve a `/config/{service}` key to its driver handle: a static entry from
 /// the config's `drivers` map (or the reserved `rp` entry), else a
 /// **roster-derived** `rp:{kind}:{id}` target synthesized from rp's config —
 /// the device's `alpaca_url`/number from its roster entry, the ASCOM type from
 /// its kind, called without credentials (rp redacts per-device auth; an authed
 /// device needs its own static `drivers` entry).
-async fn resolve_service(state: &AppState, service: &str) -> Option<DriverHandle> {
+async fn resolve_service(state: &AppState, service: &str) -> Result<DriverHandle, ResolveError> {
     if let Some(handle) = state.drivers.get(service) {
-        return Some(handle.clone());
+        return Ok(handle.clone());
     }
-    let (kind, id) = roster::parse_service_key(service)?;
-    let rp = state.rp()?;
-    let resp = rp.config_client.get_config().await.ok()?;
-    let entry = roster::find_entry(&resp.config, kind, id)?;
+    let (kind, id) = roster::parse_service_key(service).ok_or(ResolveError::Unknown)?;
+    let rp = state.rp().ok_or(ResolveError::Unknown)?;
+    let resp = rp
+        .config_client
+        .get_config()
+        .await
+        .map_err(|e| ResolveError::RpUnreachable(e.to_string()))?;
+    let entry = roster::find_entry(&resp.config, kind, id).ok_or(ResolveError::Unknown)?;
     let http = build_http_client(
         "roster device",
         &entry.alpaca_url,
         None,
         rp.ca_cert_path.as_deref(),
     )
-    .map_err(|e| tracing::debug!("roster-derived client for {service} failed: {e}"))
-    .ok()?;
+    .map_err(|e| {
+        tracing::debug!("roster-derived client for {service} failed: {e}");
+        ResolveError::BadRosterEntry(e.to_string())
+    })?;
     let client = AlpacaConfigClient::new(
         http,
         &entry.alpaca_url,
         kind.ascom_type(),
         entry.device_number,
     );
-    Some(DriverHandle {
+    Ok(DriverHandle {
         title: entry.display_name().to_string(),
         subtitle: format!("{} · {} (via rp roster)", entry.id, kind.ascom_type()),
         client: Arc::new(client),
@@ -477,8 +499,15 @@ async fn config_get(
     headers: HeaderMap,
 ) -> Response {
     let title = page_title(&service);
-    let Some(handle) = resolve_service(&state, &service).await else {
-        return respond(pages::unknown_service_card(&service), &headers, &title);
+    let handle = match resolve_service(&state, &service).await {
+        Ok(handle) => handle,
+        Err(err) => {
+            return respond(
+                pages::resolve_failure_card(&service, &err),
+                &headers,
+                &title,
+            )
+        }
     };
     let card = render_form(&handle, &service, query.unlock.as_deref(), None).await;
     respond(card, &headers, &title)
@@ -491,8 +520,15 @@ async fn config_post(
     Form(form): Form<HashMap<String, String>>,
 ) -> Response {
     let title = page_title(&service);
-    let Some(handle) = resolve_service(&state, &service).await else {
-        return respond(pages::unknown_service_card(&service), &headers, &title);
+    let handle = match resolve_service(&state, &service).await {
+        Ok(handle) => handle,
+        Err(err) => {
+            return respond(
+                pages::resolve_failure_card(&service, &err),
+                &headers,
+                &title,
+            )
+        }
     };
 
     // The schema is needed both to coerce the submission and to render any
@@ -579,9 +615,9 @@ async fn config_status(
     Path(service): Path<String>,
     Query(query): Query<UnlockQuery>,
 ) -> Markup {
-    let Some(handle) = resolve_service(&state, &service).await else {
-        // Unknown service mid-poll: a benign reconnecting fragment keeps the page
-        // from erroring; the user can navigate away.
+    let Ok(handle) = resolve_service(&state, &service).await else {
+        // Any resolve failure mid-poll: a benign reconnecting fragment keeps the
+        // page from erroring; the user can navigate away.
         return pages::reconnecting_card(&service);
     };
     // The reconnect poll renders the refreshed form once the driver answers
@@ -756,6 +792,74 @@ mod tests {
         .await;
         let html = body_of(response).await;
         assert!(html.contains("No configured driver named"), "{html}");
+    }
+
+    fn rp_state_with_config_client(config_client: Arc<dyn ConfigClient>) -> AppState {
+        AppState::with_rp_parts(
+            config_client,
+            Arc::new(rp_client::MockRpApi::new()),
+            Arc::new(probe::MockProbeHttp::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn config_get_roster_key_with_unreachable_rp_says_so() {
+        // `NonConfigDriver::get_config` errors — resolving a roster key must
+        // say rp could not be read, not pretend the driver is unconfigured.
+        let state = rp_state_with_config_client(Arc::new(NonConfigDriver));
+        let response = config_get(
+            State(state),
+            Path("rp:cameras:main-cam".to_string()),
+            Query(UnlockQuery::default()),
+            HeaderMap::new(),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("Could not read rp's roster"), "{html}");
+        assert!(!html.contains("No configured driver named"), "{html}");
+    }
+
+    /// A roster whose one entry has a credentialed `alpaca_url` —
+    /// [`build_http_client`] rejects it deterministically, no network involved.
+    struct BadEntryRoster;
+
+    #[async_trait::async_trait]
+    impl ConfigClient for BadEntryRoster {
+        async fn get_config(&self) -> Result<ConfigGetResponse, ConfigClientError> {
+            Ok(ConfigGetResponse {
+                config: json!({ "equipment": { "cover_calibrators": [{
+                    "id": "flat",
+                    "alpaca_url": "http://obs:secret@127.0.0.1:11119",
+                    "device_number": 0
+                }]}}),
+                overrides: vec![],
+            })
+        }
+        async fn get_schema(&self) -> Result<ConfigSchemaResponse, ConfigClientError> {
+            unreachable!("resolve fails before any schema fetch")
+        }
+        async fn apply_config(
+            &self,
+            _config: &Value,
+        ) -> Result<ConfigApplyResponse, ConfigClientError> {
+            unreachable!("apply is not exercised by this test")
+        }
+    }
+
+    #[tokio::test]
+    async fn config_get_unusable_roster_entry_points_at_the_equipment_page() {
+        let state = rp_state_with_config_client(Arc::new(BadEntryRoster));
+        let response = config_get(
+            State(state),
+            Path("rp:cover_calibrators:flat".to_string()),
+            Query(UnlockQuery::default()),
+            HeaderMap::new(),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("roster entry can't be used"), "{html}");
+        assert!(html.contains(r#"href="/equipment""#), "{html}");
+        assert!(!html.contains("No configured driver named"), "{html}");
     }
 
     /// A `ConfigClient` returning a fixed schema + config — enough to render the

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -894,6 +894,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn config_get_roster_key_without_rp_target_is_unknown() {
+        // A roster-shaped key on a BFF with no rp target: nothing to resolve
+        // against — the plain unknown-driver card, not an rp error.
+        let state = AppState::with_client("dsd-fp2", Arc::new(NonConfigDriver));
+        let response = config_get(
+            State(state),
+            Path("rp:cameras:main-cam".to_string()),
+            Query(UnlockQuery::default()),
+            HeaderMap::new(),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("No configured driver named"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn config_get_roster_key_absent_from_roster_is_unknown() {
+        // rp answers, but no entry matches the id — honestly "no such driver".
+        let state = rp_state_with_config_client(Arc::new(BadEntryRoster));
+        let response = config_get(
+            State(state),
+            Path("rp:cover_calibrators:no-such-id".to_string()),
+            Query(UnlockQuery::default()),
+            HeaderMap::new(),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("No configured driver named"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn config_post_resolve_failure_renders_the_same_cards() {
+        // The POST path shares resolve_service — its error arm must render
+        // the same honest card as GET.
+        let state = rp_state_with_config_client(Arc::new(NonConfigDriver));
+        let response = config_post(
+            State(state),
+            Path("rp:cameras:main-cam".to_string()),
+            HeaderMap::new(),
+            Form(HashMap::new()),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("Could not read rp's roster"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn config_status_resolve_failure_stays_a_benign_reconnect() {
+        // Mid-poll resolve failures keep the page politely retrying rather
+        // than flashing an error card.
+        let state = rp_state_with_config_client(Arc::new(NonConfigDriver));
+        let markup = config_status(
+            State(state),
+            Path("rp:cameras:main-cam".to_string()),
+            Query(UnlockQuery::default()),
+        )
+        .await;
+        assert!(markup.into_string().contains("Reconnecting"));
+    }
+
+    #[tokio::test]
     async fn unusable_roster_entry_card_never_echoes_url_credentials() {
         // The URL-parse failure path must not leak the raw URL (it can carry
         // embedded credentials) into the rendered card.

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -137,8 +137,12 @@ fn build_http_client(
     auth: Option<&config::DriverAuth>,
     ca_cert_path: Option<&std::path::Path>,
 ) -> Result<Arc<dyn HttpClient>, Box<dyn std::error::Error + Send + Sync>> {
-    let parsed = reqwest::Url::parse(base_url)
-        .map_err(|e| format!("invalid base_url {base_url:?} for {what}: {e}"))?;
+    // Deliberately no `{base_url}` echo: a malformed URL can carry embedded
+    // credentials, and this message reaches rendered error cards (e.g. the
+    // unusable-roster-entry card) and logs. `what` names the target; the
+    // parse error says why; the operator has the URL in their own config.
+    let parsed =
+        reqwest::Url::parse(base_url).map_err(|e| format!("invalid base_url for {what}: {e}"))?;
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(format!(
             "{what} base_url must not contain credentials \
@@ -860,6 +864,50 @@ mod tests {
         assert!(html.contains("roster entry can't be used"), "{html}");
         assert!(html.contains(r#"href="/equipment""#), "{html}");
         assert!(!html.contains("No configured driver named"), "{html}");
+    }
+
+    /// A roster entry whose `alpaca_url` is malformed AND carries embedded
+    /// credentials — `Url::parse` fails before the credential check can.
+    struct MalformedUrlRoster;
+
+    #[async_trait::async_trait]
+    impl ConfigClient for MalformedUrlRoster {
+        async fn get_config(&self) -> Result<ConfigGetResponse, ConfigClientError> {
+            Ok(ConfigGetResponse {
+                config: json!({ "equipment": { "cover_calibrators": [{
+                    "id": "flat",
+                    "alpaca_url": "http://obs:hunter2@[oops",
+                    "device_number": 0
+                }]}}),
+                overrides: vec![],
+            })
+        }
+        async fn get_schema(&self) -> Result<ConfigSchemaResponse, ConfigClientError> {
+            unreachable!("resolve fails before any schema fetch")
+        }
+        async fn apply_config(
+            &self,
+            _config: &Value,
+        ) -> Result<ConfigApplyResponse, ConfigClientError> {
+            unreachable!("apply is not exercised by this test")
+        }
+    }
+
+    #[tokio::test]
+    async fn unusable_roster_entry_card_never_echoes_url_credentials() {
+        // The URL-parse failure path must not leak the raw URL (it can carry
+        // embedded credentials) into the rendered card.
+        let state = rp_state_with_config_client(Arc::new(MalformedUrlRoster));
+        let response = config_get(
+            State(state),
+            Path("rp:cover_calibrators:flat".to_string()),
+            Query(UnlockQuery::default()),
+            HeaderMap::new(),
+        )
+        .await;
+        let html = body_of(response).await;
+        assert!(html.contains("roster entry can't be used"), "{html}");
+        assert!(!html.contains("hunter2"), "{html}");
     }
 
     /// A `ConfigClient` returning a fixed schema + config — enough to render the

--- a/services/ui-htmx/src/pages/mod.rs
+++ b/services/ui-htmx/src/pages/mod.rs
@@ -638,6 +638,28 @@ pub fn unknown_service_card(service: &str) -> Markup {
     }
 }
 
+/// The card for a `/config/{service}` key that resolved to no usable driver.
+/// Each [`crate::ResolveError`] cause gets its own honest message — an
+/// unreachable rp or an unusable roster entry is not "no such driver".
+pub(crate) fn resolve_failure_card(service: &str, err: &crate::ResolveError) -> Markup {
+    match err {
+        crate::ResolveError::Unknown => unknown_service_card(service),
+        crate::ResolveError::RpUnreachable(e) => error_card_with_message(
+            service,
+            &format!("Could not read rp's roster to resolve \"{service}\": {e}"),
+        ),
+        crate::ResolveError::BadRosterEntry(e) => html! {
+            div #config-card.card {
+                div class="banner error" {
+                    span.dot {}
+                    span { (format!("This device's roster entry can't be used: {e}")) }
+                }
+                p { a href="/equipment" { "Fix it on the Equipment page" } }
+            }
+        },
+    }
+}
+
 fn error_card_with_message(service: &str, message: &str) -> Markup {
     let retry = format!("/config/{service}");
     html! {


### PR DESCRIPTION
Follow-ups from #485's Copilot review round 3, which was addressed but not yet pushed when #485 merged (the in-thread replies there point at these changes):

## What this delivers

- **Honest `/config/{service}` resolve failures** ([comment](https://github.com/ivonnyssen/rusty-photon/pull/485#discussion_r3562847758)): `resolve_service` now returns a typed `ResolveError` and each cause renders its own card — unknown driver ("No configured driver named …", as before), **rp unreachable** while resolving a roster-derived `rp:{kind}:{id}` key (retry affordance), and **unusable roster entry** (e.g. malformed/credentialed `alpaca_url` — links to the Equipment page to fix the entry). Previously every failure masqueraded as "no configured driver". The reconnect status-poll keeps its benign reconnecting fragment. Two unit tests pin the new cards.
- **`PUT /api/config` body-size limit pinned** ([comment](https://github.com/ivonnyssen/rusty-photon/pull/485#discussion_r3562847777)): axum's default `DefaultBodyLimit` (2 MiB) was already in force — new BDD scenario proves it end-to-end (2 MiB + 4 KiB body → **413**, config file untouched) and would catch anyone disabling the limit later (the body would then reach the parser and fail 400, not 413). Documented in rp.md.
- **codecov/patch top-up** (the one red check on #485, 91.685% vs ~91.9% auto target) with real pins, not filler: the three asset handlers' content-types (were 0% — nothing browserless fetches assets), `RpTarget::default()` ↔ serde-defaults agreement + serialize round-trip, and rp `put_config`'s persist-failure 500 branch (config path pointed at a directory).
- Docs: ui-htmx.md route-table failure modes, config_rest.feature preamble.

## Testing

- ui-htmx: 154 lib tests (150 + 4 new); rp: the new 413 BDD scenario green in isolation and under the full suite; rp lib 605.
- Full local gate green on this exact tree: `bazel build //...` + `bazel test //...` (77/77 targets), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
