### PR TITLE
feat(sentinel,ui-htmx): service restart API + Restart-via-Sentinel UI (config-actions Phase 4)

### DIFF
--- a/docs/plans/ui-design/config-actions.md
+++ b/docs/plans/ui-design/config-actions.md
@@ -7,7 +7,11 @@ reload). Phase 2 **landed** — the BFF skeleton + dsd-fp2 config page ship as t
 across **all six** drivers via the shared `rusty-photon-config::actions` module (see
 [`docs/services/config-actions.md`](../../services/config-actions.md)), and the
 `ui-htmx` BFF now renders **any** driver's form generically from `config.schema`,
-routing every configured driver under `/config/{service}`. Key protocol decisions
+routing every configured driver under `/config/{service}`. Phase 4 **landed** —
+Sentinel's `POST /api/services/{name}/restart` (driven by the new top-level
+`services` registry) plus the BFF's "Restart via Sentinel" button and
+`restart_required` escalation; decisions resolved 2026-07-10 — see
+[Decisions (2026-07-10)](#decisions-2026-07-10). Key protocol decisions
 resolved 2026-05-24 — see [Resolved](#resolved-2026-05-24).
 **Companion to:** [`mocks/README.md`](mocks/README.md) (the chosen UI direction and stack).
 
@@ -452,11 +456,27 @@ along the natural driver ⇆ BFF fault line.
 - Future: promote the shared helper to a standalone vendor-neutral crate once it
   has settled (see [Decisions](#decisions-2026-05-27)).
 
-**Phase 4 — Sentinel `service.restart`.**
-- Implement the `Restarter` + per-service `restart_command` config; expose
-  `POST /api/services/{name}/restart`. Wire the BFF "Restart (via Sentinel)"
-  affordance and the `restart_required` escalation. (Coordinate with the watchdog
-  plan.)
+**Phase 4 — Sentinel `service.restart`. ✅ Landed.**
+- ✅ Sentinel exposes `POST /api/services/{name}/restart` on the dashboard
+  router (behind the same `dashboard.auth`/TLS layers), reusing the watchdog
+  ladder's already-implemented `Restarter`/`ShellRestarter`. The per-service
+  registry is the **new top-level `services` map** (moved out of
+  `operation_watchdog.services`, which is gone — the watchdog references the
+  shared map), with `base_url` now optional so non-Alpaca services can be
+  restart-only entries, a new optional shell `health_command` (exit 0 =
+  healthy; polled after the restart to confirm recovery), and a per-service
+  `max_restart_duration` (default 60s) replacing the watchdog-global knob.
+  See [`docs/services/sentinel.md`](../../services/sentinel.md)
+  §Service Restart API for the endpoint contract (200 ok/failed + recovery,
+  404 unknown, 409 not-restartable / in-flight).
+- ✅ The BFF renders a "Restart via Sentinel" button on every driver card when
+  its config has a `sentinel` block (`{base_url, auth, ca_cert_path}`; each
+  driver's Sentinel-side name comes from `sentinel_service`, defaulting to the
+  service id), and escalates a non-empty `restart_required[]` from
+  `config.apply` with an inline banner + the same button. A restart that
+  Sentinel accepts flows into the existing reconnecting/poll fragment.
+  See [`docs/services/ui-htmx.md`](../../services/ui-htmx.md)
+  §Restart via Sentinel.
 
 **Phase 5 — `rp` config + equipment roster + the activity stream. ⏳ In progress
 (single PR).** Scope as built (details in
@@ -559,10 +579,39 @@ Calls made while scoping the [federated roster](#federated-roster-managed-own-vs
   auto-detect as *managed*. Timing: only after the pattern has settled across a few
   of our own drivers — don't publish a moving target.
 
+### Decisions (2026-07-10)
+
+Calls made while implementing Phase 4:
+
+- **One supervised-services registry, top-level.** The restart endpoint must
+  not require configuring the watchdog (whose block demands `rp_url`), and two
+  maps carrying `restart_command` would drift — so `operation_watchdog.services`
+  moved to a **top-level `services` map** consumed by both. Breaking config
+  change, sanctioned pre-1.0.
+- **Recovery confirmation is a shell command, symmetric with the restart.**
+  Since `restart_command` is a shell command, the recovery probe is the
+  optional per-service `health_command` (exit 0 = healthy) rather than an HTTP
+  Alpaca probe — it works for non-Alpaca services and needs no device-type
+  config. Follow platform best practice: `systemctl --user is-active <svc>` on
+  unix, `sc query <svc> | findstr RUNNING` on Windows. The watchdog ladder's
+  HTTP probe (device `connected`) is unchanged.
+- **The restart budget is per-service.** `max_restart_duration` (default 60s)
+  lives on each `services` entry and bounds command + recovery together, for
+  both consumers; the watchdog-global `max_restart_duration` is removed — one
+  knob per service.
+- **Domain outcomes are HTTP 200.** A failed restart command is
+  `{"status":"failed"}` on a 200 (mirroring `config.apply`'s
+  `status:"invalid"` convention); 4xx is reserved for addressing errors
+  (404 unknown name, 409 not-restartable / already in flight).
+- **Manual restarts notify no one.** The endpoint logs, but does not dispatch
+  notifiers or write notification history — the operator pressing the button
+  already knows.
+
 ## Doc impact (CLAUDE.md rule 2)
 
 When implementing: add a "Config actions" section to `docs/services/dsd-fp2.md`
 (done); create `docs/services/ui-htmx.md` for the BFF (done); extend
 `docs/services/sentinel.md` with
-`service.restart` (Phase 4); note any `ReloadSignal` trigger addition in
+`service.restart` (Phase 4 — done: §Service Restart API + the top-level
+`services` registry); note any `ReloadSignal` trigger addition in
 `docs/skills/service-lifecycle.md`; and link this plan from `mocks/README.md`.

--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -400,7 +400,9 @@ POST /api/services/{name}/restart
 or own the processes — it shells out to the service's configured
 `restart_command` (the OS supervisor owns relaunch), then, when a
 `health_command` is configured, polls it until it exits 0 or the service's
-`max_restart_duration` budget elapses. The endpoint is the manual "recovery
+`max_restart_duration` budget elapses (each probe is bounded to its
+per-attempt slice of the budget, so one hanging probe is killed and retried
+rather than consuming the whole phase). The endpoint is the manual "recovery
 hammer" the web UI's *Restart via Sentinel* affordance calls (see
 [`ui-htmx.md`](ui-htmx.md)), and the escalation target for `config.apply`
 fields classified `restart_required`.

--- a/docs/services/sentinel.md
+++ b/docs/services/sentinel.md
@@ -36,7 +36,7 @@ Dashboard (axum + hand-rolled HTML) --- web UI w/ JS polling
 - **`Monitor`** — `poll() -> MonitorState`, `connect()`, `disconnect()`, `polling_interval() -> Duration`. A **pull-based** monitor the engine polls on a fixed interval. First implementation: `AlpacaSafetyMonitor`.
 - **`EventMonitor`** — `name()`, `run(cancel)`. A **push-based** monitor that owns a long-lived connection and reacts to a stream of events rather than being polled. It runs until the cancellation token fires. First implementation: `OperationDeadlineMonitor` (see [Operation Watchdog](#operation-watchdog)). Added because the watchdog's natural interface is "react to each event as it arrives", which a `poll() -> State` shape cannot express; the engine spawns a parallel task per `EventMonitor` alongside the per-`Monitor` poll loops.
 - **`Notifier`** — `notify(notification)`. First implementation: `PushoverNotifier`. The watchdog reuses this dispatch path — an expiry or liveness escalation is just another notification.
-- **`Corrective`** / **`HealthChecker`** / **`Aborter`** / **`Restarter`** — the watchdog's corrective-action ladder for `abort_then_restart` operations. `CorrectiveLadder` composes the three rung traits (health → abort → restart) behind the single `Corrective::run` seam the watchdog calls; HTTP and shell default impls live in `corrective.rs`. See [Operation Watchdog](#operation-watchdog).
+- **`Corrective`** / **`HealthChecker`** / **`Aborter`** / **`Restarter`** — the watchdog's corrective-action ladder for `abort_then_restart` operations. `CorrectiveLadder` composes the three rung traits (health → abort → restart) behind the single `Corrective::run` seam the watchdog calls; HTTP and shell default impls live in `corrective.rs`. See [Operation Watchdog](#operation-watchdog). `Restarter` (run a shell command bounded by a budget, `Ok` iff it exits 0 in time) is also the seam behind the [Service Restart API](#service-restart-api): the REST endpoint runs both `restart_command` and the `health_command` recovery poll through it, so tests inject a recording stub.
 - **`HttpClient`** — wraps `reqwest` for testability (mockall in tests). Used by monitors, notifiers, and the corrective health-check / abort rungs.
 
 ### Dependency Injection
@@ -58,6 +58,48 @@ For custom monitors/notifiers (e.g. in an astrophotography app), use `with_monit
 Configuration is loaded from a JSON file. All sections are optional with sensible defaults.
 
 See `examples/config.json` for a complete example.
+
+### Supervised services (`services`)
+
+The optional top-level `services` map is sentinel's registry of the services it
+can supervise, keyed by a name of the operator's choosing (conventionally the
+systemd unit / package name). It has **two consumers**: the
+[REST restart endpoint](#service-restart-api) and the operation watchdog's
+[corrective ladder](#escalation-corrective-action-ladder)
+(`operations.<family>.service` references keys in this map). Configuring the
+watchdog is *not* required to use the restart endpoint, and vice versa.
+
+```json
+{
+  "services": {
+    "dsd-fp2": {
+      "base_url": "http://localhost:11119/api/v1",
+      "device_number": 0,
+      "restart_command": "systemctl --user restart dsd-fp2",
+      "health_command": "systemctl --user is-active dsd-fp2",
+      "max_restart_duration": "60s"
+    },
+    "rp": { "restart_command": "systemctl --user restart rp" }
+  }
+}
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `base_url` | *(none)* | Alpaca API base of the service, e.g. `http://host:port/api/v1`. Used only by the watchdog ladder's HTTP health-check and abort rungs; optional so non-Alpaca services (e.g. `rp`) can still be restart-only entries. |
+| `device_number` | `0` | Alpaca device number for the ladder's health-check / abort URLs. |
+| `restart_command` | `null` | Shell command that restarts the service; `null` = not restartable (the ladder stops at abort; the REST endpoint answers 409). |
+| `health_command` | `null` | Shell command whose **exit 0 means healthy**. When set, the REST restart endpoint polls it after the restart command to confirm recovery; when absent, recovery confirmation is skipped. |
+| `max_restart_duration` | `60s` | Per-service time budget (humantime) for the restart command *and* the recovery wait together. Used by both the REST endpoint and the watchdog ladder. |
+
+Commands run through the platform shell (`sh -c` on Unix, `cmd /C` on
+Windows), so follow each platform's best practice:
+
+| Platform | `restart_command` | `health_command` |
+|---|---|---|
+| Linux (systemd user unit) | `systemctl --user restart dsd-fp2` | `systemctl --user is-active dsd-fp2` (exit 0 iff active) |
+| Linux (system unit) | `systemctl restart dsd-fp2` | `systemctl is-active dsd-fp2` |
+| Windows (SCM service) | `powershell -Command "Restart-Service dsd-fp2"` | `sc query dsd-fp2 \| findstr RUNNING` |
 
 ### Monitor Types
 
@@ -230,7 +272,7 @@ operation family's `on_expiry` policy:
      on the stream, which clears its tracking entry.
   3. **Restart** — if the service is unresponsive, the abort failed, or the
      family has no abort verb (e.g. the compound `centering`), and a
-     `restart_command` is configured, run it (bounded by
+     `restart_command` is configured, run it (bounded by the service's
      `max_restart_duration`) and then poll the health check until the
      service is responsive again or the budget elapses.
      `restart_command: null` marks a service as **not restartable** (a
@@ -241,9 +283,13 @@ operation family's `on_expiry` policy:
      `{action}` placeholder).
 
 A family configured `abort_then_restart` whose `service` cannot be
-resolved (no `service` set, or a name absent from `services`) **degrades
-safely to `notify_only`** with a logged warning — a config mistake never
+resolved (no `service` set, or a name absent from the top-level
+[`services`](#supervised-services-services) map) **degrades safely to
+`notify_only`** with a logged warning — a config mistake never
 aborts the wrong device or wedges the watchdog (tenet #2, robustness).
+A resolvable service with no `base_url` cannot be health-checked or
+aborted (health reports *unknown*, abort is skipped), so the ladder falls
+through to the restart rung.
 
 > **End-to-end coverage.** The ladder's rungs are unit-tested
 > (`services/sentinel/src/corrective.rs`) and the watchdog's policy branching +
@@ -272,16 +318,22 @@ aborts the wrong device or wedges the watchdog (tenet #2, robustness).
 ### Configuration
 
 The watchdog is configured by an optional top-level `operation_watchdog`
-block:
+block. Services it can health-check, abort, and restart are declared in the
+**top-level [`services`](#supervised-services-services) map** (shared with the
+REST restart endpoint), referenced by `operations.<family>.service`:
 
 ```json
 {
+  "services": {
+    "star-adventurer": { "base_url": "http://localhost:11117/api/v1", "restart_command": null },
+    "qhyccd-alpaca":   { "base_url": "http://localhost:11111/api/v1", "device_number": 0, "restart_command": "systemctl --user restart qhyccd-alpaca" },
+    "qhy-focuser":     { "base_url": "http://localhost:11113/api/v1", "restart_command": "systemctl --user restart qhy-focuser", "max_restart_duration": "45s" }
+  },
   "operation_watchdog": {
     "rp_url": "http://localhost:8080",
     "reconnect_max_attempts": 5,
     "reconnect_backoff": "5s",
     "default_buffer": "10s",
-    "max_restart_duration": "60s",
     "notifiers": ["pushover"],
     "message_template": "Operation {operation} ({operation_id}) {reason} after {elapsed}{action}",
     "operations": {
@@ -290,11 +342,6 @@ block:
       "exposure":     { "buffer": "30s", "on_expiry": "abort_then_restart", "service": "qhyccd-alpaca"   },
       "centering":    { "buffer": "0s",  "on_expiry": "notify_only"        },
       "move_focuser": { "buffer": "5s",  "on_expiry": "abort_then_restart", "service": "qhy-focuser"     }
-    },
-    "services": {
-      "star-adventurer": { "base_url": "http://localhost:11117/api/v1", "restart_command": null },
-      "qhyccd-alpaca":   { "base_url": "http://localhost:11111/api/v1", "device_number": 0, "restart_command": "systemctl --user restart qhyccd-alpaca" },
-      "qhy-focuser":     { "base_url": "http://localhost:11113/api/v1", "restart_command": "systemctl --user restart qhy-focuser" }
     }
   }
 }
@@ -306,15 +353,15 @@ block:
 | `reconnect_max_attempts` | `5` | How many consecutive reconnect attempts before escalating "rp unresponsive". |
 | `reconnect_backoff` | `5s` | Delay between reconnect attempts (humantime). |
 | `default_buffer` | `10s` | Buffer added to `max_duration_ms` for families with no `operations` entry. |
-| `max_restart_duration` | `60s` | Time budget for a `restart_command` to exit *and* the service to become responsive again. |
 | `notifiers` | *(all)* | Which notifier `type`s receive escalations; omitted means every configured notifier. |
 | `message_template` | built-in | Escalation message; placeholders `{operation}`, `{operation_id}`, `{elapsed}`, `{reason}`, `{action}` (the corrective-action summary, empty for `notify_only`). |
 | `operations.<family>.buffer` | `default_buffer` | Buffer for this operation family. |
 | `operations.<family>.on_expiry` | `notify_only` | Corrective-action policy: `notify_only`, or `abort_then_restart` (runs the ladder against `service`). |
-| `operations.<family>.service` | *(none)* | Service (key into `services`) that owns this family. Required for `abort_then_restart`; ignored otherwise. |
-| `services.<name>.base_url` | *(required)* | Alpaca API base of the service, e.g. `http://host:port/api/v1`; used for the health-check and abort calls. |
-| `services.<name>.device_number` | `0` | Alpaca device number for the health-check / abort URLs. |
-| `services.<name>.restart_command` | `null` | Shell command (`sh -c`) to restart the service; `null` = not restartable (ladder stops at abort). |
+| `operations.<family>.service` | *(none)* | Service (key into the top-level `services` map) that owns this family. Required for `abort_then_restart`; ignored otherwise. |
+
+The restart rung's time budget is the referenced service's
+`max_restart_duration` (default `60s`) — there is no watchdog-global budget;
+each service declares how long its restart may take.
 
 `reconnect_max_attempts` of `0` means "never give up reconnecting" (the
 watchdog keeps retrying without ever escalating an unresponsive rp), and a
@@ -329,6 +376,7 @@ watchdog keeps retrying without ever escalating an unresponsive rp), and a
 | Expiry, `abort_then_restart`, service responsive | Health check passes → abort verb `PUT`; ladder stops; notification reports `abort=ok`. |
 | Expiry, `abort_then_restart`, service unresponsive | Abort skipped → `restart_command` run (if set) → recovery awaited up to `max_restart_duration`; notification reports the restart outcome. |
 | Expiry, `abort_then_restart`, family has no abort verb (`centering`, `plate_solve`) | Abort skipped; restart attempted if configured, else notify-only. |
+| Expiry, `abort_then_restart`, service has no `base_url` | Health reports unknown, abort skipped; restart attempted if configured. |
 | Expiry, `abort_then_restart`, `service` unset or unknown | Degrades to `notify_only` with a logged warning. |
 | `*_started` without `max_duration_ms` | Tracked open, no timer; clears on completion or on a liveness escalation. |
 | Stream drops, reconnect succeeds within `reconnect_max_attempts` | Replays buffered events, resumes tracking. No escalation unless a `stream_gap` is reported. |
@@ -336,12 +384,61 @@ watchdog keeps retrying without ever escalating an unresponsive rp), and a
 | rp unreachable for `reconnect_max_attempts` reconnects | "rp unresponsive" escalation. |
 | `operation_watchdog` block absent | Watchdog disabled; sentinel runs safety polling only. |
 
-## Dashboard
+## Service Restart API
 
-The web dashboard runs on port 11114 (configurable) and provides:
+Sentinel owns **process restart** for the rest of the stack (`rp.md`
+§Sentinel Watchdog Integration; the config-actions plan's service-lifecycle
+split: drivers reload *themselves* via `config.apply`, sentinel restarts
+*processes*). The dashboard router exposes one endpoint:
+
+```
+POST /api/services/{name}/restart
+```
+
+`{name}` is a key in the top-level
+[`services`](#supervised-services-services) map. Sentinel does **not** spawn
+or own the processes — it shells out to the service's configured
+`restart_command` (the OS supervisor owns relaunch), then, when a
+`health_command` is configured, polls it until it exits 0 or the service's
+`max_restart_duration` budget elapses. The endpoint is the manual "recovery
+hammer" the web UI's *Restart via Sentinel* affordance calls (see
+[`ui-htmx.md`](ui-htmx.md)), and the escalation target for `config.apply`
+fields classified `restart_required`.
+
+### Behavioral contract
+
+| Condition | Response |
+|---|---|
+| Restart command exits 0; `health_command` set and exits 0 within the remaining budget | `200` `{"service":"<name>","status":"ok","recovery":"healthy"}` |
+| Restart command exits 0; `health_command` set but never exits 0 in budget | `200` `{"service":"<name>","status":"ok","recovery":"timeout"}` |
+| Restart command exits 0; no `health_command` | `200` `{"service":"<name>","status":"ok","recovery":"skipped"}` |
+| Restart command exits non-zero, fails to spawn, or exceeds the budget | `200` `{"service":"<name>","status":"failed","detail":"…"}` (no recovery poll) |
+| `{name}` not in the `services` map | `404` `{"error":"no configured service named '<name>'"}` |
+| Service configured with `restart_command: null` | `409` `{"error":"service '<name>' is not restartable"}` |
+| A restart for `{name}` is already in flight | `409` `{"error":"a restart of '<name>' is already in flight"}` |
+
+- **`status` reports the action's outcome, not the transport's** — a failed
+  restart command is a domain result (HTTP 200 with `status:"failed"`),
+  mirroring the config-actions protocol's `status:"invalid"` convention.
+  4xx is reserved for addressing errors (unknown / not restartable / busy).
+- **One restart per service at a time.** Concurrent POSTs for the same
+  service are rejected with `409` while the first is running; different
+  services restart independently.
+- **The request blocks** until the command (and recovery poll, if any)
+  completes — bounded by the service's `max_restart_duration`, so the
+  response always arrives within that budget plus scheduling noise.
+- **Same protection as the rest of the dashboard.** The endpoint sits on the
+  dashboard router, behind the same optional `dashboard.auth` Basic-auth and
+  TLS layers — there is no separate gate. Deploying without dashboard auth
+  leaves it (like the JSON API) open; the restart commands themselves come
+  only from sentinel's own config file, never from the request.
+- A user-initiated restart is logged (`info!`) but does **not** dispatch
+  notifications and is not recorded in the notification history — the
+  operator who pressed the button already knows.
 
 - **Web UI**: Server-rendered HTML with JavaScript polling (auto-refreshes every 5 seconds)
 - **JSON API**: `/api/status` (monitor statuses), `/api/history` (notification history)
+- **Service restart**: `POST /api/services/{name}/restart` (see [Service Restart API](#service-restart-api))
 - **Health check**: `/health` returns 200 OK
 
 The dashboard is server-rendered HTML with vanilla JavaScript, built with `format!()` in `services/sentinel/src/dashboard.rs`. (An experimental `sentinel-app` Leptos/WASM frontend was scaffolded and later abandoned; it was removed in 2026-06 — see [docs/plans/archive/sentinel-app-leptos-dashboard.md](../plans/archive/sentinel-app-leptos-dashboard.md).)
@@ -359,6 +456,7 @@ services/sentinel/src/
   alpaca_client.rs     AlpacaSafetyMonitor (Monitor impl)
   watchdog.rs          EventMonitor trait + OperationDeadlineMonitor + SSE event source + deadline tracking
   corrective.rs        Corrective-action ladder: HealthChecker/Aborter/Restarter traits + HTTP/shell impls + CorrectiveLadder
+  restart.rs           RestartManager: services registry + in-flight guard + restart/recovery orchestration for the REST endpoint
   notifier.rs          Notifier trait + Notification types
   pushover.rs          PushoverNotifier (Notifier impl)
   engine.rs            Engine: polling loops + transition matching + dispatch

--- a/docs/services/ui-htmx.md
+++ b/docs/services/ui-htmx.md
@@ -189,6 +189,7 @@ BFF serves every configured driver.
 | `GET`  | `/config/{service}` | Call `config.schema` + `config.get`; render the form generated from the schema, filled with current values. An optional `?unlock=<field>` query renders one locked/identity field (e.g. a device `unique_id`) editable — the read-only-by-default escape hatch. Resolve failures render honest, distinct cards: unknown `{service}` ("no configured driver"), rp unreachable while resolving a roster key (retryable), or a roster entry no client can be built from (e.g. malformed `alpaca_url` — links to the Equipment page to fix it). |
 | `POST` | `/config/{service}` | Re-fetch `config.schema` to coerce the form back into the full Config, call `config.apply`; render the result state (see below). |
 | `GET`  | `/config/{service}/status` | HTMX poll target during reconnect: try `config.schema` + `config.get`; when the driver answers, swap in the refreshed form. Honours the same optional `?unlock=` query. |
+| `POST` | `/config/{service}/restart` | Ask Sentinel to restart the driver's process (`POST {sentinel}/api/services/{sentinel_service}/restart`); render the outcome (see [Restart via Sentinel](#restart-via-sentinel-post-configservicerestart)). |
 | `GET`  | `/equipment` | The [equipment page](#equipment-page-equipment): rp's roster with live connection LEDs, capability tiers, and add/edit/remove affordances. |
 | `GET`  | `/equipment/{kind}/new` | Schema-generated "add device" form for one equipment kind (`cameras`, `filter_wheels`, `cover_calibrators`, `focusers`, `safety_monitors`, `mount`). |
 | `POST` | `/equipment/{kind}/new` | Insert the new entry into rp's config (`GET /api/config` → splice → `PUT /api/config`); render the roster with the apply outcome. |
@@ -399,6 +400,42 @@ locked/identity field that the user unlocked.
   reconnecting fragment so HTMX keeps polling. The blip is normally well under a
   second; the poll is bounded only by the user leaving the page.
 
+### Restart via Sentinel (`POST /config/{service}/restart`)
+
+Sentinel owns *process* restart (the config-actions plan's service-lifecycle
+split); the BFF is just an authorised client of Sentinel's
+[Service Restart API](sentinel.md#service-restart-api). Two affordances lead
+here, both rendered only when the BFF has a `sentinel` block configured:
+
+- **The recovery hammer**: every driver config card carries a
+  "Restart via Sentinel" button (`hx-post="/config/{service}/restart"`,
+  swapping `#config-card`) in its footer — for a wedged or misbehaving driver,
+  independent of any config edit. The `rp` config page gets it too (rp's
+  Sentinel-side name is the `rp` convention).
+- **The `restart_required` escalation**: when `config.apply` returns a
+  non-empty `restart_required[]`, the restart callout listing those paths
+  offers the same restart button inline. rp reaches this on every apply
+  (`ApplyDisposition::Restart` — no in-process reload); no driver classifies
+  fields this way *today*, so the driver-side path is covered by handler unit
+  tests with a stub `ConfigClient`.
+
+Outcome rendering (the Sentinel wire contract is
+[sentinel.md §Behavioral contract](sentinel.md#behavioral-contract)):
+
+- **`status:"ok"`** (any `recovery` value) → the driver's process was
+  restarted; render the same reconnecting fragment the reload flow uses, which
+  polls `GET /config/{service}/status` until the driver serves its config
+  again. `recovery:"timeout"` additionally warns that Sentinel could not
+  confirm recovery within the budget (the poll may still succeed — the budget
+  is Sentinel's, not the driver's).
+- **`status:"failed"`** → render an error banner with Sentinel's `detail`
+  and a retry button; the form is re-rendered untouched underneath.
+- **HTTP 404 / 409 / transport error** → error banner naming Sentinel and the
+  reason (unknown service name, not restartable, restart already in flight,
+  Sentinel unreachable).
+- **No `sentinel` block configured** → the route answers with an error card
+  ("no Sentinel configured"); the buttons that would reach it are not rendered.
+
 ## Equipment page (`/equipment`)
 
 The roster view of the observatory, per the
@@ -436,7 +473,9 @@ renders the restart callout, since roster changes take effect on the next rp
 start). **The list always shows the roster rp is *running***: `GET /api/config`
 returns the effective config, so a just-persisted entry appears (or a removed
 one disappears) only after rp's next start — the callout names the pending
-paths, which is the honest state until Phase 4's restart affordance lands. An
+paths; restart rp from its own config page's
+[Restart via Sentinel](#restart-via-sentinel-post-configservicerestart) button
+(when a `sentinel` block is configured). An
 empty form input means "unset — rp's default applies"; it is never sent as an
 empty string (which would fail rp's typed parses, e.g. a humantime
 `poll_interval`). The add/edit forms are **schema-generated per
@@ -551,7 +590,8 @@ without it those routes render a "no rp configured" card.
       "device_type": "covercalibrator",
       "device_number": 0,
       "auth": null,            // optional { "username": "...", "password": "..." }
-      "ca_cert_path": null     // optional PEM CA for a TLS-enabled driver
+      "ca_cert_path": null,    // optional PEM CA for a TLS-enabled driver
+      "sentinel_service": null // optional name in Sentinel's `services` map (defaults to the driver's id)
     },
     "qhy-focuser": {
       "base_url": "http://127.0.0.1:11113",
@@ -562,9 +602,22 @@ without it those routes render a "no rp configured" card.
     "base_url": "http://127.0.0.1:11115",    // rp's REST base URL
     "auth": null,                            // optional Basic credentials for rp
     "ca_cert_path": null                     // optional PEM CA for a TLS-enabled rp
+  },
+  // Optional: where Sentinel's dashboard/REST API lives. Absent (the default)
+  // means no restart affordances are rendered anywhere.
+  "sentinel": {
+    "base_url": "http://127.0.0.1:11114",
+    "auth": null,            // optional Basic credentials for an auth-enabled dashboard
+    "ca_cert_path": null     // optional PEM CA for a TLS-enabled dashboard
   }
 }
 ```
+
+The restart button targets Sentinel's `services` map entry named by the
+driver's `sentinel_service`, defaulting to the driver's own service id — so
+when the BFF id and the Sentinel-side name match (the convention), no extra
+wiring is needed. A name Sentinel does not know simply surfaces Sentinel's
+404 in the error banner.
 
 ### CLI Arguments
 
@@ -620,6 +673,10 @@ without it those routes render a "no rp configured" card.
   chosen mock, live over the SSE proxy with cursor passthrough, `stream_gap`
   rendering, rp-unreachable self-healing, and the shared-nav night-vision
   toggle.
+- The **Restart via Sentinel** affordance (button per driver card when a
+  `sentinel` block is configured) and the restart callout's inline restart
+  button, both posting to `/config/{service}/restart` (Phase 4 of the
+  config-actions plan).
 - Dark theme reusing the mock CSS tokens; assets embedded via `include_str!`
   (CSS + the HTMX bundle + the SSE extension); no npm, no WASM.
 - Plain-axum lifecycle under `rusty-photon-service-lifecycle::ServiceRunner` with
@@ -647,8 +704,6 @@ without it those routes render a "no rp configured" card.
   discriminated form. A generic `oneOf`/enum renderer (and a dedicated password
   input for redacted-secret leaves) is a follow-up; until then such fields are
   edited in the config file.
-- **Sentinel `service.restart` affordance** and the `restart_required` escalation
-  button (Phase 4 — the restart callout is where it will attach).
 - **BFF-side TLS/auth**, the **LCARS theme**, and **i18n**.
 
 ## Testing Strategy
@@ -834,6 +889,24 @@ call end to end. Scenarios:
 - One BFF exposes the driver under two service ids: the index links to both and
   each `/config/{service}` route renders independently (multi-driver routing).
 
+**Restart scenarios spawn a real Sentinel too** (`restart.feature`): the same
+`bdd_infra::ServiceHandle` pattern starts the workspace's real `sentinel`
+binary (dashboard on port 0, `bound_addr=` discovery) with a `services` map
+whose `restart_command` writes a marker file — commands are chosen to work
+under both `sh -c` and `cmd /C` so the suite stays green on Windows. Scenarios:
+
+- The config card offers "Restart via Sentinel" when a sentinel block is
+  configured, and clicking it runs the configured restart command (the marker
+  file exists) and swaps in the reconnecting fragment, which then serves the
+  form again (the dsd-fp2 driver never actually died — the command is a
+  stand-in — so the poll reconnects immediately).
+- A failing restart command surfaces Sentinel's `status:"failed"` detail in an
+  error banner.
+- A driver whose `sentinel_service` Sentinel does not know surfaces the 404
+  reason.
+- With no `sentinel` block configured, the config card renders no restart
+  affordance.
+
 ### Phase 5 BDD (`equipment_page.feature`, `rp_config_page.feature`, `stream_page.feature`)
 
 The rp-backed surfaces follow the same real-binaries rule: scenarios spawn the
@@ -876,7 +949,12 @@ suites run everywhere the existing one does. Coverage:
   configuration" banner on `ACTION_NOT_IMPLEMENTED` and the "no configured driver"
   card for an unknown `{service}` — error states the end-to-end suite can't
   produce — driven in-process through `AppState::with_client` with a stub
-  `ConfigClient`.
+  `ConfigClient`. The `restart_required` escalation banner (no driver emits the
+  classification today) and the `recovery:"timeout"` warning are likewise driven
+  through stub `ConfigClient` / `SentinelClient` implementations.
+- `sentinel_client.rs`: `HttpSentinelClient` shapes the restart POST and parses
+  each outcome (`ok`+recovery variants, `failed`+detail, 404, 409, transport
+  error). Mocks `HttpClient`.
 - `pages`: the schema walker (`$ref` resolution, plain-object recursion,
   `anyOf`/`oneOf` skipping, `FieldKind` inference); schema-driven form ⇆ Config
   reconstruction (hidden blob + editable overlay by JSON pointer; override-pinned
@@ -908,9 +986,10 @@ suites run everywhere the existing one does. Coverage:
 
 | Module | Description |
 |--------|-------------|
-| `config.rs` | `Config`, `ServerConfig`, the `Drivers` map + `DriverTarget`, the optional `RpTarget`, defaults + JSON load. |
+| `config.rs` | `Config`, `ServerConfig`, the `Drivers` map + `DriverTarget` (+ `sentinel_service`), the optional `RpTarget` + `SentinelTarget`, defaults + JSON load. |
 | `io.rs` | `HttpClient` trait (`#[cfg_attr(test, mockall::automock)]`) + `ReqwestHttpClient` (rp-tls CA trust + optional Basic auth). |
 | `driver_client.rs` | `ConfigClient` trait + `AlpacaConfigClient` (ASCOM action transport) + `RestConfigClient` (rp's plain-REST transport): request shaping, envelope parsing, error mapping. Re-exports the shared wire types from `rusty_photon_config::actions`. |
+| `sentinel_client.rs` | `SentinelClient` trait + `HttpSentinelClient`: `POST /api/services/{name}/restart` request shaping + outcome/404/409 parsing against Sentinel's REST API. |
 | `rp_client.rs` | The non-config rp surface: `RpApi` trait (`equipment_status`, `session_status`) + its reqwest impl — the seam the equipment page and stream shell render from. |
 | `roster.rs` | The roster domain: `EquipKind` (kind ⇄ ASCOM-type mapping), `parse_roster` over rp's config value, the `rp:{kind}:{id}` key codec, and the insert/replace/remove config surgery with duplicate-id/singular-mount guards. |
 | `pages/mod.rs` | The schema-driven renderer: `FieldModel` (schema walker + `FieldKind`, incl. the array-item subschema entry point), `config_card`/`index`/fragment templates, the schema-driven `merge_form` coercion, and the shared `layout` shell (nav tabs + night-vision toggle). |
@@ -919,7 +998,7 @@ suites run everywhere the existing one does. Coverage:
 | `probe.rs` | The capability probe: bounded concurrent `supportedactions`/setup-page checks → tier. |
 | `sse_proxy.rs` | `/stream/events`: rp SSE client (incremental frame parser), envelope→fragment translation, cursor passthrough, shutdown token. |
 | `assets.rs` | `include_str!` of `assets/app.css` + `assets/htmx.min.js` + `assets/htmx-ext-sse.js`; asset routes. |
-| `lib.rs` | `build_router`, multi-driver `AppState` (+ rp target), the `/config/{service}`, `/equipment*`, `/stream*` handlers, public exports. |
+| `lib.rs` | `build_router`, multi-driver `AppState` (+ rp target + Sentinel client), the `/config/{service}` (+ `/restart`), `/equipment*`, `/stream*` handlers, public exports. |
 | `main.rs` | CLI (clap) + tracing init; lifecycle owned by `ServiceRunner` (plain axum + graceful shutdown; SSE shutdown token). |
 
 ## References

--- a/services/sentinel/examples/config.json
+++ b/services/sentinel/examples/config.json
@@ -40,5 +40,13 @@
     "enabled": true,
     "port": 11114,
     "history_size": 100
+  },
+  "services": {
+    "dsd-fp2": {
+      "base_url": "http://localhost:11119/api/v1",
+      "restart_command": "systemctl --user restart dsd-fp2",
+      "health_command": "systemctl --user is-active dsd-fp2",
+      "max_restart_duration": "60s"
+    }
   }
 }

--- a/services/sentinel/src/config.rs
+++ b/services/sentinel/src/config.rs
@@ -24,6 +24,13 @@ pub struct Config {
     /// Path to CA certificate for trusting TLS-enabled services
     #[serde(default)]
     pub ca_cert: Option<String>,
+    /// Supervised services, keyed by an operator-chosen name. The registry has
+    /// two consumers: the dashboard's `POST /api/services/{name}/restart`
+    /// endpoint and the operation watchdog's corrective ladder
+    /// (`operations.<family>.service` references keys here). See
+    /// [`ServiceConfig`].
+    #[serde(default)]
+    pub services: std::collections::HashMap<String, ServiceConfig>,
     /// Optional push-based operation watchdog. Absent means safety polling
     /// only (today's behavior). See [`OperationWatchdogConfig`].
     #[serde(default)]
@@ -204,11 +211,6 @@ pub struct OperationWatchdogConfig {
     /// explicit `operations` entry.
     #[serde(default = "default_watchdog_buffer", with = "humantime_serde")]
     pub default_buffer: Duration,
-    /// Time budget for a `restart_command` to exit *and* the restarted
-    /// service to become responsive again (the corrective ladder's restart
-    /// rung). See [`ServiceConfig::restart_command`].
-    #[serde(default = "default_max_restart_duration", with = "humantime_serde")]
-    pub max_restart_duration: Duration,
     /// Which notifier `type`s receive escalations. Empty means every
     /// configured notifier.
     #[serde(default)]
@@ -220,12 +222,10 @@ pub struct OperationWatchdogConfig {
     pub message_template: String,
     /// Per-operation-family policy overrides, keyed by family (the event
     /// name with its `_started` / `_complete` / `_failed` suffix stripped).
+    /// `operations.<family>.service` references the **top-level**
+    /// [`Config::services`] map.
     #[serde(default)]
     pub operations: std::collections::HashMap<String, OperationPolicy>,
-    /// Services the corrective ladder can health-check, abort, and restart,
-    /// keyed by a name that `operations.<family>.service` references.
-    #[serde(default)]
-    pub services: std::collections::HashMap<String, ServiceConfig>,
 }
 
 /// Per-operation-family watchdog policy.
@@ -260,22 +260,40 @@ pub enum OnExpiry {
     AbortThenRestart,
 }
 
-/// A service the corrective ladder can health-check, abort, and restart.
+/// One supervised service: how the watchdog ladder probes/aborts it and how
+/// both the ladder and the restart endpoint restart it. Commands run through
+/// the platform shell (`sh -c` on unix, `cmd /C` on windows).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
     /// Alpaca API base of the service, e.g. `http://host:port/api/v1`. The
-    /// ladder appends `{device-type}/{device_number}/connected` (health) or
-    /// the family's abort verb to it.
-    pub base_url: String,
+    /// watchdog ladder appends `{device-type}/{device_number}/connected`
+    /// (health) or the family's abort verb to it. Optional so non-Alpaca
+    /// services (e.g. `rp`) can be restart-only entries; without it the
+    /// ladder cannot probe or abort and falls through to restart.
+    #[serde(default)]
+    pub base_url: Option<String>,
     /// Alpaca device number for the health-check / abort URLs.
     #[serde(default)]
     pub device_number: u32,
-    /// Shell command (`sh -c`) that restarts the service. `null` marks the
-    /// service as not restartable (the ladder stops at abort) — the canonical
-    /// example is a remote MCU we cannot `systemctl`.
+    /// Shell command that restarts the service. `null` marks the service as
+    /// not restartable (the ladder stops at abort; the restart endpoint
+    /// answers 409) — the canonical example is a remote MCU we cannot
+    /// `systemctl`.
     #[serde(default)]
     pub restart_command: Option<String>,
+    /// Shell command whose exit 0 means the service is healthy (e.g.
+    /// `systemctl --user is-active dsd-fp2`). When set, the restart endpoint
+    /// polls it after `restart_command` to confirm recovery; when absent,
+    /// recovery confirmation is skipped. Not used by the watchdog ladder
+    /// (which probes over HTTP via `base_url`).
+    #[serde(default)]
+    pub health_command: Option<String>,
+    /// Time budget for `restart_command` to exit *and* the service to become
+    /// healthy/responsive again — one budget for both phases, used by the
+    /// restart endpoint and the watchdog ladder's restart rung.
+    #[serde(default = "default_max_restart_duration", with = "humantime_serde")]
+    pub max_restart_duration: Duration,
 }
 
 /// Dashboard configuration
@@ -700,25 +718,26 @@ mod tests {
     #[test]
     fn parse_operation_watchdog_full() {
         let json = r#"{
+            "services": {
+                "mount": {
+                    "base_url": "http://localhost:11112/api/v1",
+                    "device_number": 2,
+                    "restart_command": "systemctl restart mount",
+                    "health_command": "systemctl is-active mount",
+                    "max_restart_duration": "45s"
+                },
+                "camera": { "base_url": "http://localhost:11111/api/v1" }
+            },
             "operation_watchdog": {
                 "rp_url": "http://localhost:8080",
                 "reconnect_max_attempts": 3,
                 "reconnect_backoff": "2s",
                 "default_buffer": "15s",
-                "max_restart_duration": "45s",
                 "notifiers": ["pushover"],
                 "message_template": "{operation} stuck",
                 "operations": {
                     "slew": { "buffer": "5s", "on_expiry": "abort_then_restart", "service": "mount" },
                     "park": { "on_expiry": "notify_only" }
-                },
-                "services": {
-                    "mount": {
-                        "base_url": "http://localhost:11112/api/v1",
-                        "device_number": 2,
-                        "restart_command": "systemctl restart mount"
-                    },
-                    "camera": { "base_url": "http://localhost:11111/api/v1" }
                 }
             }
         }"#;
@@ -728,7 +747,6 @@ mod tests {
         assert_eq!(wd.reconnect_max_attempts, 3);
         assert_eq!(wd.reconnect_backoff, Duration::from_secs(2));
         assert_eq!(wd.default_buffer, Duration::from_secs(15));
-        assert_eq!(wd.max_restart_duration, Duration::from_secs(45));
         assert_eq!(wd.notifiers, vec!["pushover".to_string()]);
         assert_eq!(wd.message_template, "{operation} stuck");
 
@@ -742,19 +760,36 @@ mod tests {
         assert_eq!(park.on_expiry, OnExpiry::NotifyOnly);
         assert_eq!(park.service, None);
 
-        let mount = wd.services.get("mount").unwrap();
-        assert_eq!(mount.base_url, "http://localhost:11112/api/v1");
+        let mount = config.services.get("mount").unwrap();
+        assert_eq!(
+            mount.base_url.as_deref(),
+            Some("http://localhost:11112/api/v1")
+        );
         assert_eq!(mount.device_number, 2);
         assert_eq!(
             mount.restart_command.as_deref(),
             Some("systemctl restart mount")
         );
+        assert_eq!(
+            mount.health_command.as_deref(),
+            Some("systemctl is-active mount")
+        );
+        assert_eq!(mount.max_restart_duration, Duration::from_secs(45));
 
-        let camera = wd.services.get("camera").unwrap();
+        let camera = config.services.get("camera").unwrap();
         assert_eq!(camera.device_number, 0, "device_number defaults to 0");
         assert_eq!(
             camera.restart_command, None,
             "restart_command defaults to null"
+        );
+        assert_eq!(
+            camera.health_command, None,
+            "health_command defaults to null"
+        );
+        assert_eq!(
+            camera.max_restart_duration,
+            Duration::from_secs(60),
+            "max_restart_duration defaults to 60s"
         );
     }
 
@@ -764,39 +799,54 @@ mod tests {
             "operation_watchdog": { "rp_url": "http://rp:9000" }
         }"#;
         let config: Config = serde_json::from_str(json).unwrap();
+        assert!(config.services.is_empty());
         let wd = config.operation_watchdog.unwrap();
         assert_eq!(wd.reconnect_max_attempts, 5);
         assert_eq!(wd.reconnect_backoff, Duration::from_secs(5));
         assert_eq!(wd.default_buffer, Duration::from_secs(10));
-        assert_eq!(wd.max_restart_duration, Duration::from_secs(60));
         assert!(wd.notifiers.is_empty());
         assert!(wd.operations.is_empty());
-        assert!(wd.services.is_empty());
         assert!(wd.message_template.contains("{operation}"));
     }
 
     #[test]
     fn service_config_rejects_unknown_field() {
         let json = r#"{
-            "operation_watchdog": {
-                "rp_url": "http://rp",
-                "services": { "mount": { "base_url": "http://x", "bogus": 1 } }
-            }
+            "services": { "mount": { "base_url": "http://x", "bogus": 1 } }
         }"#;
         let err = serde_json::from_str::<Config>(json).unwrap_err();
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]
-    fn service_config_requires_base_url() {
+    fn service_config_base_url_is_optional() {
+        // A restart-only entry (e.g. a non-Alpaca service like rp) needs no
+        // Alpaca base URL; the ladder degrades and the restart endpoint never
+        // uses it.
+        let json = r#"{
+            "services": { "rp": { "restart_command": "systemctl --user restart rp" } }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let rp = config.services.get("rp").unwrap();
+        assert_eq!(rp.base_url, None);
+        assert_eq!(
+            rp.restart_command.as_deref(),
+            Some("systemctl --user restart rp")
+        );
+    }
+
+    #[test]
+    fn operation_watchdog_rejects_nested_services() {
+        // The registry moved to the top level; a config still nesting it inside
+        // the watchdog block must fail loudly, not be silently ignored.
         let json = r#"{
             "operation_watchdog": {
                 "rp_url": "http://rp",
-                "services": { "mount": { "device_number": 0 } }
+                "services": { "mount": { "base_url": "http://x" } }
             }
         }"#;
         let err = serde_json::from_str::<Config>(json).unwrap_err();
-        assert!(err.to_string().contains("base_url"), "{err}");
+        assert!(err.to_string().contains("services"), "{err}");
     }
 
     #[test]

--- a/services/sentinel/src/corrective.rs
+++ b/services/sentinel/src/corrective.rs
@@ -64,10 +64,15 @@ pub fn alpaca_binding(family: &str) -> Option<AlpacaBinding> {
 #[derive(Debug, Clone)]
 pub struct CorrectiveTarget {
     pub service_name: String,
-    pub base_url: String,
+    /// Alpaca API base. `None` for a service with no Alpaca surface (a
+    /// restart-only entry): no probe, no abort — the ladder falls through to
+    /// restart.
+    pub base_url: Option<String>,
     pub device_number: u32,
     pub binding: Option<AlpacaBinding>,
     pub restart_command: Option<String>,
+    /// The service's own budget for the restart command + recovery wait.
+    pub max_restart_duration: Duration,
 }
 
 impl CorrectiveTarget {
@@ -75,30 +80,36 @@ impl CorrectiveTarget {
     pub fn new(service_name: &str, family: &str, service: &ServiceConfig) -> Self {
         Self {
             service_name: service_name.to_string(),
-            base_url: service.base_url.trim_end_matches('/').to_string(),
+            base_url: service
+                .base_url
+                .as_deref()
+                .map(|u| u.trim_end_matches('/').to_string()),
             device_number: service.device_number,
             binding: alpaca_binding(family),
             restart_command: service.restart_command.clone(),
+            max_restart_duration: service.max_restart_duration,
         }
     }
 
     /// `{base}/{device-type}/{n}/connected`, or `None` when the family has no
-    /// Alpaca device to probe.
+    /// Alpaca device to probe or the service no Alpaca base URL.
     fn connected_url(&self) -> Option<String> {
+        let base = self.base_url.as_deref()?;
         let b = self.binding?;
         Some(format!(
             "{}/{}/{}/connected",
-            self.base_url, b.device_type, self.device_number
+            base, b.device_type, self.device_number
         ))
     }
 
     /// `{base}/{device-type}/{n}/{verb}`, or `None` when the family has no
-    /// abort verb.
+    /// abort verb or the service no Alpaca base URL.
     fn abort_url(&self) -> Option<String> {
+        let base = self.base_url.as_deref()?;
         let b = self.binding?;
         Some(format!(
             "{}/{}/{}/{}",
-            self.base_url, b.device_type, self.device_number, b.abort_verb
+            base, b.device_type, self.device_number, b.abort_verb
         ))
     }
 }
@@ -323,7 +334,6 @@ pub struct CorrectiveLadder {
     health: Arc<dyn HealthChecker>,
     aborter: Arc<dyn Aborter>,
     restarter: Arc<dyn Restarter>,
-    max_restart_duration: Duration,
 }
 
 impl CorrectiveLadder {
@@ -331,24 +341,21 @@ impl CorrectiveLadder {
         health: Arc<dyn HealthChecker>,
         aborter: Arc<dyn Aborter>,
         restarter: Arc<dyn Restarter>,
-        max_restart_duration: Duration,
     ) -> Self {
         Self {
             health,
             aborter,
             restarter,
-            max_restart_duration,
         }
     }
 
     /// Production ladder: HTTP health-check + abort over a shared client, shell
     /// restarter.
-    pub fn http(http: Arc<dyn HttpClient>, max_restart_duration: Duration) -> Self {
+    pub fn http(http: Arc<dyn HttpClient>) -> Self {
         Self::new(
             Arc::new(HttpHealthChecker::new(Arc::clone(&http))),
             Arc::new(HttpAborter::new(http)),
             Arc::new(ShellRestarter),
-            max_restart_duration,
         )
     }
 
@@ -362,18 +369,15 @@ impl CorrectiveLadder {
             outcome.push("restart=skipped(not restartable)");
             return;
         };
-        // `max_restart_duration` is one budget for the command *and* the
-        // recovery wait — measure what the command spends so recovery gets only
-        // the remainder (rather than a second full budget).
+        // The service's `max_restart_duration` is one budget for the command
+        // *and* the recovery wait — measure what the command spends so recovery
+        // gets only the remainder (rather than a second full budget).
+        let budget = target.max_restart_duration;
         let started = Instant::now();
-        match self
-            .restarter
-            .restart(command, self.max_restart_duration)
-            .await
-        {
+        match self.restarter.restart(command, budget).await {
             Ok(()) => {
                 outcome.push("restart=ran");
-                let remaining = self.max_restart_duration.saturating_sub(started.elapsed());
+                let remaining = budget.saturating_sub(started.elapsed());
                 if self.await_recovery(target, remaining).await {
                     outcome.push("recovery=responsive");
                 } else {
@@ -462,29 +466,27 @@ mod tests {
 
     use crate::io::{HttpResponse, MockHttpClient};
 
+    /// The tight per-service budget every mock-ladder test target carries, so
+    /// recovery polling resolves in milliseconds.
+    const TEST_BUDGET: Duration = Duration::from_millis(20);
+
+    fn service(restart_command: Option<&str>) -> ServiceConfig {
+        ServiceConfig {
+            base_url: Some("http://svc/api/v1".to_string()),
+            device_number: 0,
+            restart_command: restart_command.map(String::from),
+            health_command: None,
+            max_restart_duration: TEST_BUDGET,
+        }
+    }
+
     fn target(restart_command: Option<&str>) -> CorrectiveTarget {
-        CorrectiveTarget::new(
-            "mount",
-            "slew",
-            &ServiceConfig {
-                base_url: "http://svc/api/v1".to_string(),
-                device_number: 0,
-                restart_command: restart_command.map(String::from),
-            },
-        )
+        CorrectiveTarget::new("mount", "slew", &service(restart_command))
     }
 
     fn compound_target(restart_command: Option<&str>) -> CorrectiveTarget {
         // `centering` has no Alpaca binding.
-        CorrectiveTarget::new(
-            "rp",
-            "centering",
-            &ServiceConfig {
-                base_url: "http://svc/api/v1".to_string(),
-                device_number: 0,
-                restart_command: restart_command.map(String::from),
-            },
-        )
+        CorrectiveTarget::new("rp", "centering", &service(restart_command))
     }
 
     // ---- mock rungs ----------------------------------------------------
@@ -574,7 +576,7 @@ mod tests {
         aborter: Arc<MockAbort>,
         restarter: Arc<MockRestart>,
     ) -> CorrectiveLadder {
-        CorrectiveLadder::new(health, aborter, restarter, Duration::from_millis(20))
+        CorrectiveLadder::new(health, aborter, restarter)
     }
 
     // ---- ladder orchestration -----------------------------------------
@@ -721,9 +723,11 @@ mod tests {
             "mount",
             "exposure",
             &ServiceConfig {
-                base_url: "http://svc:11111/api/v1/".to_string(),
+                base_url: Some("http://svc:11111/api/v1/".to_string()),
                 device_number: 3,
                 restart_command: None,
+                health_command: None,
+                max_restart_duration: TEST_BUDGET,
             },
         );
         assert_eq!(
@@ -739,6 +743,25 @@ mod tests {
     #[test]
     fn target_with_no_binding_has_no_urls() {
         let t = compound_target(None);
+        assert!(t.connected_url().is_none());
+        assert!(t.abort_url().is_none());
+    }
+
+    #[test]
+    fn target_without_base_url_has_no_urls() {
+        // A restart-only service (no Alpaca surface): even a family with an
+        // abort verb cannot be probed or aborted.
+        let t = CorrectiveTarget::new(
+            "rp",
+            "slew",
+            &ServiceConfig {
+                base_url: None,
+                device_number: 0,
+                restart_command: Some("restart".to_string()),
+                health_command: None,
+                max_restart_duration: TEST_BUDGET,
+            },
+        );
         assert!(t.connected_url().is_none());
         assert!(t.abort_url().is_none());
     }

--- a/services/sentinel/src/corrective.rs
+++ b/services/sentinel/src/corrective.rs
@@ -265,9 +265,15 @@ fn shell_command(command: &str) -> tokio::process::Command {
 
 #[cfg(windows)]
 fn shell_command(command: &str) -> tokio::process::Command {
-    let mut c = tokio::process::Command::new("cmd");
-    c.arg("/C").arg(command);
-    c
+    use std::os::windows::process::CommandExt;
+    // `cmd` does not understand backslash-escaped quotes, so std's default
+    // argv encoding (quote the whole argument, escape its inner quotes as
+    // `\"`) mangles any command containing quotes — e.g. a redirect target
+    // like `echo ok > "C:\path\marker.txt"` exits 1. Hand `cmd` the line
+    // verbatim instead.
+    let mut c = std::process::Command::new("cmd");
+    c.raw_arg(format!("/C {command}"));
+    tokio::process::Command::from(c)
 }
 
 #[async_trait]
@@ -917,7 +923,8 @@ mod tests {
         aborter.abort(&target(None)).await.unwrap();
     }
 
-    // ---- shell restarter (unix only; CI Windows lacks `sh`) -----------
+    // ---- shell restarter (exit-code tests unix only — they use `sh`
+    //      built-ins; the quoted-path test runs on both platforms) ------
 
     #[cfg(unix)]
     #[tokio::test]
@@ -946,5 +953,21 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("exceeded"), "{err}");
+    }
+
+    // Cross-platform (the command shape the BDD marker commands use). On
+    // Windows this regression-tests the `raw_arg` invocation: std's default
+    // argv encoding escapes the inner quotes as `\"`, which `cmd` does not
+    // parse — the space in the file name makes the quotes load-bearing.
+    #[tokio::test]
+    async fn shell_restart_preserves_quoted_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("restart marker.txt");
+        let command = format!("echo ok > \"{}\"", marker.display());
+        ShellRestarter
+            .restart(&command, Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert!(marker.exists(), "`{command}` did not write the marker");
     }
 }

--- a/services/sentinel/src/dashboard.rs
+++ b/services/sentinel/src/dashboard.rs
@@ -1,12 +1,16 @@
 //! Web dashboard with JSON API endpoints (hand-rolled HTML + JS polling)
+//! plus the Service Restart API (`POST /api/services/{name}/restart`).
 
+use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
-use axum::response::{Html, IntoResponse};
-use axum::routing::get;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
 use axum::Router;
 
+use crate::restart::{RestartError, RestartManager};
 use crate::state::StateHandle;
 
 /// Flatten a `Duration` to integer milliseconds for the dashboard JS, which
@@ -25,16 +29,20 @@ fn duration_to_ms_for_js(d: Duration) -> u64 {
 #[derive(Clone)]
 pub struct DashboardState {
     pub state: StateHandle,
+    /// The Service Restart API's engine (the supervised-services registry +
+    /// shell seam). See `docs/services/sentinel.md` §Service Restart API.
+    pub restarts: Arc<RestartManager>,
 }
 
 /// Build the dashboard axum router
-pub fn build_router(state: StateHandle) -> Router {
-    let dashboard_state = DashboardState { state };
+pub fn build_router(state: StateHandle, restarts: Arc<RestartManager>) -> Router {
+    let dashboard_state = DashboardState { state, restarts };
 
     Router::new()
         .route("/", get(index_handler))
         .route("/api/status", get(status_handler))
         .route("/api/history", get(history_handler))
+        .route("/api/services/{name}/restart", post(restart_handler))
         .route("/health", get(health_handler))
         .with_state(dashboard_state)
 }
@@ -235,6 +243,32 @@ async fn history_handler(State(dashboard): State<DashboardState>) -> impl IntoRe
     axum::Json(history)
 }
 
+/// `POST /api/services/{name}/restart`: run the service's configured restart
+/// command (and health-confirmation poll). The command's outcome is a domain
+/// result on HTTP 200; addressing errors map to 404 (unknown name) or 409
+/// (not restartable / already in flight).
+async fn restart_handler(
+    State(dashboard): State<DashboardState>,
+    Path(name): Path<String>,
+) -> Response {
+    match dashboard.restarts.restart(&name).await {
+        Ok(report) => (StatusCode::OK, axum::Json(report)).into_response(),
+        Err(e) => {
+            let code = match e {
+                RestartError::UnknownService(_) => StatusCode::NOT_FOUND,
+                RestartError::NotRestartable(_) | RestartError::AlreadyInFlight(_) => {
+                    StatusCode::CONFLICT
+                }
+            };
+            (
+                code,
+                axum::Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
 async fn health_handler() -> impl IntoResponse {
     "OK"
 }
@@ -251,6 +285,11 @@ mod tests {
     use crate::monitor::MonitorState;
     use crate::notifier::NotificationRecord;
     use crate::state::new_state_handle;
+
+    /// Router with an empty supervised-services registry (non-restart tests).
+    fn router(state: StateHandle) -> Router {
+        build_router(state, Arc::new(RestartManager::shell(Default::default())))
+    }
 
     #[test]
     fn duration_to_ms_zero_stays_zero() {
@@ -288,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn health_returns_ok() {
         let state = setup_state();
-        let app = build_router(state);
+        let app = router(state);
         let response = app
             .oneshot(
                 Request::builder()
@@ -308,7 +347,7 @@ mod tests {
             let mut s = state.write().await;
             s.update_monitor("Test Monitor", MonitorState::Safe, 1000);
         }
-        let app = build_router(state);
+        let app = router(state);
         let response = app
             .oneshot(
                 Request::builder()
@@ -344,7 +383,7 @@ mod tests {
                 timestamp_epoch_ms: 1000,
             });
         }
-        let app = build_router(state);
+        let app = router(state);
         let response = app
             .oneshot(
                 Request::builder()
@@ -368,7 +407,7 @@ mod tests {
     #[tokio::test]
     async fn index_returns_html() {
         let state = setup_state();
-        let app = build_router(state);
+        let app = router(state);
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
             .await
@@ -384,10 +423,83 @@ mod tests {
         assert!(html.contains("Next Check"));
     }
 
+    /// A [`crate::corrective::Restarter`] that accepts every command — the
+    /// restart-handler tests only assert the HTTP mapping, not the shell.
+    #[derive(Debug)]
+    struct AlwaysOkRunner;
+
+    #[async_trait::async_trait]
+    impl crate::corrective::Restarter for AlwaysOkRunner {
+        async fn restart(&self, _command: &str, _budget: Duration) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn restart_router(services_json: &str) -> Router {
+        let services = serde_json::from_str(services_json).unwrap();
+        build_router(
+            setup_state(),
+            Arc::new(RestartManager::new(services, Arc::new(AlwaysOkRunner))),
+        )
+    }
+
+    async fn post_restart(app: Router, name: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/services/{name}/restart"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    #[tokio::test]
+    async fn restart_unknown_service_is_404() {
+        let app = restart_router("{}");
+        let (status, body) = post_restart(app, "nope").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("no configured service named 'nope'"),
+            "{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_not_restartable_service_is_409() {
+        let app = restart_router(r#"{ "mount": { "restart_command": null } }"#);
+        let (status, body) = post_restart(app, "mount").await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            body["error"].as_str().unwrap().contains("not restartable"),
+            "{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_ok_reports_domain_outcome_on_200() {
+        let app = restart_router(r#"{ "svc": { "restart_command": "restart-cmd" } }"#);
+        let (status, body) = post_restart(app, "svc").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["service"], "svc");
+        assert_eq!(body["status"], "ok");
+        assert_eq!(body["recovery"], "skipped");
+    }
+
     #[tokio::test]
     async fn status_empty_monitors() {
         let state = new_state_handle(vec![], 10);
-        let app = build_router(state);
+        let app = router(state);
         let response = app
             .oneshot(
                 Request::builder()

--- a/services/sentinel/src/lib.rs
+++ b/services/sentinel/src/lib.rs
@@ -13,6 +13,7 @@ pub mod io;
 pub mod monitor;
 pub mod notifier;
 pub mod pushover;
+pub mod restart;
 pub mod state;
 pub mod watchdog;
 
@@ -105,16 +106,15 @@ impl Config {
             Some(watchdog) => {
                 let source: Arc<dyn WatchdogEventSource> =
                     Arc::new(HttpWatchdogEventSource::new(&watchdog.rp_url));
-                let corrective: Arc<dyn Corrective> = Arc::new(CorrectiveLadder::http(
-                    Arc::clone(http),
-                    watchdog.max_restart_duration,
-                ));
+                let corrective: Arc<dyn Corrective> =
+                    Arc::new(CorrectiveLadder::http(Arc::clone(http)));
                 let monitor = OperationDeadlineMonitor::new(
                     "Operation Watchdog",
                     source,
                     notifiers.to_vec(),
                     Arc::clone(state),
                     watchdog.clone(),
+                    self.services.clone(),
                     corrective,
                 );
                 vec![Arc::new(monitor)]
@@ -255,6 +255,10 @@ impl SentinelBuilder {
         let dashboard_tls = config.dashboard.tls.clone();
         let dashboard_auth = config.dashboard.auth.clone();
 
+        // The Service Restart API's engine, over the top-level supervised-
+        // services registry. Commands run through the platform shell.
+        let restarts = Arc::new(restart::RestartManager::shell(config.services.clone()));
+
         Ok(Sentinel {
             engine,
             state,
@@ -262,6 +266,7 @@ impl SentinelBuilder {
             dashboard_listener,
             dashboard_tls,
             dashboard_auth,
+            restarts,
         })
     }
 }
@@ -274,6 +279,7 @@ pub struct Sentinel {
     dashboard_listener: Option<tokio::net::TcpListener>,
     dashboard_tls: Option<rp_tls::config::TlsConfig>,
     dashboard_auth: Option<rp_auth::config::AuthConfig>,
+    restarts: Arc<restart::RestartManager>,
 }
 
 impl Sentinel {
@@ -298,6 +304,7 @@ impl Sentinel {
             let cancel_for_dashboard = cancel.clone();
             let dashboard_tls = self.dashboard_tls;
             let dashboard_auth = self.dashboard_auth;
+            let restarts = Arc::clone(&self.restarts);
 
             let addr = listener.local_addr()?;
             let scheme = if dashboard_tls.is_some() {
@@ -309,7 +316,7 @@ impl Sentinel {
             println!("Sentinel dashboard bound_addr={}", addr);
 
             tokio::spawn(async move {
-                let router = dashboard::build_router(dashboard_state);
+                let router = dashboard::build_router(dashboard_state, restarts);
 
                 // Layer authentication if configured
                 let router = match &dashboard_auth {

--- a/services/sentinel/src/restart.rs
+++ b/services/sentinel/src/restart.rs
@@ -147,6 +147,9 @@ impl RestartManager {
     /// Poll `health_command` until it exits 0 or the remaining `budget` runs
     /// out. Mirrors the corrective ladder's `await_recovery`: the whole phase —
     /// probe runs *and* the sleeps between them — sits under one outer timeout.
+    /// Each probe gets only its per-attempt slice of the budget, so one probe
+    /// that hangs (e.g. a check blocking while the service is half-up) is
+    /// killed and retried instead of monopolizing the whole phase.
     async fn await_healthy(&self, name: &str, command: &str, budget: Duration) -> bool {
         if budget.is_zero() {
             return false;
@@ -154,7 +157,7 @@ impl RestartManager {
         let interval = budget.checked_div(RECOVERY_ATTEMPTS).unwrap_or(budget);
         let poll = async {
             for attempt in 0..RECOVERY_ATTEMPTS {
-                match self.runner.restart(command, budget).await {
+                match self.runner.restart(command, interval).await {
                     Ok(()) => return true,
                     Err(e) => debug!("service '{name}' health probe not yet passing: {e}"),
                 }
@@ -210,6 +213,8 @@ mod tests {
         /// Commands that succeed; everything else errors.
         succeeds: Vec<String>,
         calls: Mutex<Vec<String>>,
+        /// The per-call budget each command was given.
+        budgets: Mutex<Vec<Duration>>,
         /// When set, the runner blocks on this notification before returning
         /// (used to hold a restart in flight).
         hold: Option<Arc<tokio::sync::Notify>>,
@@ -226,8 +231,9 @@ mod tests {
 
     #[async_trait]
     impl Restarter for ScriptedRunner {
-        async fn restart(&self, command: &str, _budget: Duration) -> crate::Result<()> {
+        async fn restart(&self, command: &str, budget: Duration) -> crate::Result<()> {
             self.calls.lock().unwrap().push(command.to_string());
+            self.budgets.lock().unwrap().push(budget);
             if let Some(hold) = &self.hold {
                 hold.notified().await;
             }
@@ -342,6 +348,30 @@ mod tests {
         assert_eq!(report.recovery, Some(Recovery::Timeout));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn health_probes_get_a_per_attempt_slice_of_the_budget() {
+        let svc = service(
+            Some("restart-cmd"),
+            Some("health-cmd"),
+            Duration::from_millis(50),
+        );
+        let runner = ScriptedRunner::succeeding(&["restart-cmd"]);
+        let (m, runner) = manager(&[("svc", svc)], runner);
+        m.restart("svc").await.unwrap();
+        let budgets = runner.budgets.lock().unwrap();
+        assert_eq!(
+            budgets[0],
+            Duration::from_millis(50),
+            "the restart command gets the full budget"
+        );
+        assert!(budgets.len() > 1, "health probes must have run");
+        for probe_budget in &budgets[1..] {
+            // budget / RECOVERY_ATTEMPTS: one hanging probe is killed after its
+            // slice instead of monopolizing the phase and foreclosing retries.
+            assert_eq!(*probe_budget, Duration::from_millis(10), "{budgets:?}");
+        }
+    }
+
     #[tokio::test]
     async fn failing_restart_command_reports_failed_with_detail() {
         let svc = service(
@@ -371,8 +401,8 @@ mod tests {
         let notify = Arc::new(tokio::sync::Notify::new());
         let runner = ScriptedRunner {
             succeeds: vec!["restart-cmd".to_string()],
-            calls: Mutex::new(Vec::new()),
             hold: Some(Arc::clone(&notify)),
+            ..ScriptedRunner::default()
         };
         let svc = service(Some("restart-cmd"), None, Duration::from_secs(5));
         let (m, _) = manager(&[("svc", svc)], runner);

--- a/services/sentinel/src/restart.rs
+++ b/services/sentinel/src/restart.rs
@@ -1,0 +1,398 @@
+//! The Service Restart API's engine: `POST /api/services/{name}/restart`.
+//!
+//! Sentinel owns *process* restart for the rest of the stack (drivers reload
+//! themselves via `config.apply`; sentinel restarts processes). For each entry
+//! in the top-level `services` map the [`RestartManager`] runs the configured
+//! `restart_command` through the platform shell and — when a `health_command`
+//! is configured — polls it (exit 0 = healthy) until it succeeds or the
+//! service's `max_restart_duration` budget elapses. The command's outcome is a
+//! *domain* result ([`RestartReport`], HTTP 200 either way); addressing errors
+//! ([`RestartError`]) map to 4xx. See `docs/services/sentinel.md`
+//! §Service Restart API.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio::time::Instant;
+use tracing::{debug, info, warn};
+
+use crate::config::ServiceConfig;
+use crate::corrective::{Restarter, ShellRestarter};
+
+/// How many times recovery re-runs `health_command` before giving up. The
+/// total wait is bounded by the service's `max_restart_duration` regardless.
+const RECOVERY_ATTEMPTS: u32 = 5;
+
+/// Addressing errors — the dashboard handler maps these to 4xx.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RestartError {
+    /// `{name}` is not in the `services` map (404).
+    #[error("no configured service named '{0}'")]
+    UnknownService(String),
+    /// The service is configured `restart_command: null` (409).
+    #[error("service '{0}' is not restartable")]
+    NotRestartable(String),
+    /// Another restart of this service is still running (409).
+    #[error("a restart of '{0}' is already in flight")]
+    AlreadyInFlight(String),
+}
+
+/// Recovery-confirmation outcome, reported in the response body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Recovery {
+    /// `health_command` exited 0 within the remaining budget.
+    Healthy,
+    /// `health_command` never exited 0 before the budget elapsed.
+    Timeout,
+    /// No `health_command` is configured — confirmation skipped.
+    Skipped,
+}
+
+/// Domain outcome of a restart request. `status:"failed"` is still HTTP 200 —
+/// the *action* ran and this is its result (mirroring `config.apply`'s
+/// `status:"invalid"` convention).
+#[derive(Debug, Clone, Serialize)]
+pub struct RestartReport {
+    pub service: String,
+    /// `"ok"` (command exited 0) or `"failed"`.
+    pub status: &'static str,
+    /// Present on `"ok"`: whether recovery was confirmed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<Recovery>,
+    /// Present on `"failed"`: what went wrong with the command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// The supervised-services registry plus the shell seam and the one-restart-
+/// per-service in-flight guard.
+#[derive(derive_more::Debug)]
+pub struct RestartManager {
+    services: HashMap<String, ServiceConfig>,
+    /// Runs both `restart_command` and each `health_command` probe: the
+    /// [`Restarter`] contract — run a shell command bounded by a budget,
+    /// `Ok` iff it exits 0 in time — is exactly what both need.
+    #[debug(skip)]
+    runner: Arc<dyn Restarter>,
+    in_flight: Mutex<HashSet<String>>,
+}
+
+impl RestartManager {
+    pub fn new(services: HashMap<String, ServiceConfig>, runner: Arc<dyn Restarter>) -> Self {
+        Self {
+            services,
+            runner,
+            in_flight: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Production manager: commands run through the platform shell.
+    pub fn shell(services: HashMap<String, ServiceConfig>) -> Self {
+        Self::new(services, Arc::new(ShellRestarter))
+    }
+
+    /// Restart `name`: run its `restart_command`, then confirm recovery via
+    /// `health_command` when configured. Blocks until done — bounded by the
+    /// service's `max_restart_duration`.
+    pub async fn restart(&self, name: &str) -> Result<RestartReport, RestartError> {
+        let service = self
+            .services
+            .get(name)
+            .ok_or_else(|| RestartError::UnknownService(name.to_string()))?;
+        let command = service
+            .restart_command
+            .as_deref()
+            .ok_or_else(|| RestartError::NotRestartable(name.to_string()))?;
+        let _guard = InFlightGuard::acquire(&self.in_flight, name)?;
+
+        let budget = service.max_restart_duration;
+        info!("restarting service '{name}' (budget {budget:?})");
+        let started = Instant::now();
+        match self.runner.restart(command, budget).await {
+            Ok(()) => {
+                let recovery = match service.health_command.as_deref() {
+                    Some(health) => {
+                        let remaining = budget.saturating_sub(started.elapsed());
+                        if self.await_healthy(name, health, remaining).await {
+                            Recovery::Healthy
+                        } else {
+                            Recovery::Timeout
+                        }
+                    }
+                    None => Recovery::Skipped,
+                };
+                info!("service '{name}' restarted (recovery: {recovery:?})");
+                Ok(RestartReport {
+                    service: name.to_string(),
+                    status: "ok",
+                    recovery: Some(recovery),
+                    detail: None,
+                })
+            }
+            Err(e) => {
+                warn!("service '{name}' restart command failed: {e}");
+                Ok(RestartReport {
+                    service: name.to_string(),
+                    status: "failed",
+                    recovery: None,
+                    detail: Some(e.to_string()),
+                })
+            }
+        }
+    }
+
+    /// Poll `health_command` until it exits 0 or the remaining `budget` runs
+    /// out. Mirrors the corrective ladder's `await_recovery`: the whole phase —
+    /// probe runs *and* the sleeps between them — sits under one outer timeout.
+    async fn await_healthy(&self, name: &str, command: &str, budget: Duration) -> bool {
+        if budget.is_zero() {
+            return false;
+        }
+        let interval = budget.checked_div(RECOVERY_ATTEMPTS).unwrap_or(budget);
+        let poll = async {
+            for attempt in 0..RECOVERY_ATTEMPTS {
+                match self.runner.restart(command, budget).await {
+                    Ok(()) => return true,
+                    Err(e) => debug!("service '{name}' health probe not yet passing: {e}"),
+                }
+                if attempt + 1 < RECOVERY_ATTEMPTS {
+                    tokio::time::sleep(interval).await;
+                }
+            }
+            false
+        };
+        tokio::time::timeout(budget, poll).await.unwrap_or(false)
+    }
+}
+
+/// RAII entry in the in-flight set: acquiring an already-present name fails,
+/// dropping removes it — so a restart that panics or is cancelled never wedges
+/// its service's slot.
+struct InFlightGuard<'a> {
+    set: &'a Mutex<HashSet<String>>,
+    name: String,
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn acquire(set: &'a Mutex<HashSet<String>>, name: &str) -> Result<Self, RestartError> {
+        let mut in_flight = set.lock().unwrap_or_else(|p| p.into_inner());
+        if !in_flight.insert(name.to_string()) {
+            return Err(RestartError::AlreadyInFlight(name.to_string()));
+        }
+        Ok(Self {
+            set,
+            name: name.to_string(),
+        })
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        let mut in_flight = self.set.lock().unwrap_or_else(|p| p.into_inner());
+        in_flight.remove(&self.name);
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+
+    /// Records every command it runs; scripts one result per named command.
+    #[derive(Debug, Default)]
+    struct ScriptedRunner {
+        /// Commands that succeed; everything else errors.
+        succeeds: Vec<String>,
+        calls: Mutex<Vec<String>>,
+        /// When set, the runner blocks on this notification before returning
+        /// (used to hold a restart in flight).
+        hold: Option<Arc<tokio::sync::Notify>>,
+    }
+
+    impl ScriptedRunner {
+        fn succeeding(commands: &[&str]) -> Self {
+            Self {
+                succeeds: commands.iter().map(|s| s.to_string()).collect(),
+                ..Self::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Restarter for ScriptedRunner {
+        async fn restart(&self, command: &str, _budget: Duration) -> crate::Result<()> {
+            self.calls.lock().unwrap().push(command.to_string());
+            if let Some(hold) = &self.hold {
+                hold.notified().await;
+            }
+            if self.succeeds.iter().any(|c| c == command) {
+                Ok(())
+            } else {
+                Err(crate::SentinelError::Monitor(format!(
+                    "`{command}` exited with 1"
+                )))
+            }
+        }
+    }
+
+    fn service(
+        restart_command: Option<&str>,
+        health_command: Option<&str>,
+        budget: Duration,
+    ) -> ServiceConfig {
+        ServiceConfig {
+            base_url: None,
+            device_number: 0,
+            restart_command: restart_command.map(String::from),
+            health_command: health_command.map(String::from),
+            max_restart_duration: budget,
+        }
+    }
+
+    fn manager(
+        services: &[(&str, ServiceConfig)],
+        runner: ScriptedRunner,
+    ) -> (RestartManager, Arc<ScriptedRunner>) {
+        let map = services
+            .iter()
+            .map(|(n, s)| (n.to_string(), s.clone()))
+            .collect();
+        let runner = Arc::new(runner);
+        (
+            RestartManager::new(map, Arc::clone(&runner) as Arc<dyn Restarter>),
+            runner,
+        )
+    }
+
+    #[tokio::test]
+    async fn unknown_service_is_rejected() {
+        let (m, _) = manager(&[], ScriptedRunner::default());
+        let err = m.restart("nope").await.unwrap_err();
+        assert_eq!(err, RestartError::UnknownService("nope".to_string()));
+        assert!(err.to_string().contains("no configured service"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn not_restartable_service_is_rejected() {
+        let svc = service(None, None, Duration::from_secs(1));
+        let (m, runner) = manager(&[("mount", svc)], ScriptedRunner::default());
+        let err = m.restart("mount").await.unwrap_err();
+        assert!(
+            runner.calls.lock().unwrap().is_empty(),
+            "no command may run for a non-restartable service"
+        );
+        assert_eq!(err, RestartError::NotRestartable("mount".to_string()));
+        assert!(err.to_string().contains("not restartable"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn restart_without_health_command_skips_recovery() {
+        let svc = service(Some("restart-cmd"), None, Duration::from_secs(1));
+        let (m, runner) = manager(
+            &[("svc", svc)],
+            ScriptedRunner::succeeding(&["restart-cmd"]),
+        );
+        let report = m.restart("svc").await.unwrap();
+        assert_eq!(report.status, "ok");
+        assert_eq!(report.recovery, Some(Recovery::Skipped));
+        assert_eq!(report.detail, None);
+        assert_eq!(
+            *runner.calls.lock().unwrap(),
+            vec!["restart-cmd".to_string()],
+            "exactly the restart command runs; no health probe is configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_with_passing_health_reports_healthy() {
+        let svc = service(
+            Some("restart-cmd"),
+            Some("health-cmd"),
+            Duration::from_secs(1),
+        );
+        let runner = ScriptedRunner::succeeding(&["restart-cmd", "health-cmd"]);
+        let (m, runner) = manager(&[("svc", svc)], runner);
+        let report = m.restart("svc").await.unwrap();
+        assert_eq!(report.status, "ok");
+        assert_eq!(report.recovery, Some(Recovery::Healthy));
+        assert_eq!(
+            *runner.calls.lock().unwrap(),
+            vec!["restart-cmd".to_string(), "health-cmd".to_string()]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn restart_with_failing_health_reports_timeout() {
+        let svc = service(
+            Some("restart-cmd"),
+            Some("health-cmd"),
+            Duration::from_millis(50),
+        );
+        // Only the restart command succeeds; every health probe errors.
+        let runner = ScriptedRunner::succeeding(&["restart-cmd"]);
+        let (m, _) = manager(&[("svc", svc)], runner);
+        let report = m.restart("svc").await.unwrap();
+        assert_eq!(report.status, "ok");
+        assert_eq!(report.recovery, Some(Recovery::Timeout));
+    }
+
+    #[tokio::test]
+    async fn failing_restart_command_reports_failed_with_detail() {
+        let svc = service(
+            Some("restart-cmd"),
+            Some("health-cmd"),
+            Duration::from_secs(1),
+        );
+        // Nothing succeeds — the restart command itself errors.
+        let runner = ScriptedRunner::default();
+        let (m, runner) = manager(&[("svc", svc)], runner);
+        let report = m.restart("svc").await.unwrap();
+        assert_eq!(report.status, "failed");
+        assert_eq!(report.recovery, None);
+        assert!(
+            report.detail.as_deref().unwrap_or("").contains("exited"),
+            "{report:?}"
+        );
+        assert_eq!(
+            *runner.calls.lock().unwrap(),
+            vec!["restart-cmd".to_string()],
+            "a failed restart must not probe health"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_restart_of_same_service_is_rejected() {
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let runner = ScriptedRunner {
+            succeeds: vec!["restart-cmd".to_string()],
+            calls: Mutex::new(Vec::new()),
+            hold: Some(Arc::clone(&notify)),
+        };
+        let svc = service(Some("restart-cmd"), None, Duration::from_secs(5));
+        let (m, _) = manager(&[("svc", svc)], runner);
+        let m = Arc::new(m);
+
+        // Hold the first restart mid-command, then race a second one.
+        let first = tokio::spawn({
+            let m = Arc::clone(&m);
+            async move { m.restart("svc").await }
+        });
+        tokio::task::yield_now().await;
+        let err = m.restart("svc").await.unwrap_err();
+        assert_eq!(err, RestartError::AlreadyInFlight("svc".to_string()));
+
+        // Release the held command; the first restart completes and frees the
+        // slot, so a follow-up restart is accepted again.
+        notify.notify_one();
+        first.await.unwrap().unwrap();
+        notify.notify_one();
+        let report = m.restart("svc").await.unwrap();
+        assert_eq!(report.status, "ok");
+    }
+}

--- a/services/sentinel/src/watchdog.rs
+++ b/services/sentinel/src/watchdog.rs
@@ -20,7 +20,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use crate::config::{OnExpiry, OperationWatchdogConfig};
+use crate::config::{OnExpiry, OperationWatchdogConfig, ServiceConfig};
 use crate::corrective::{Corrective, CorrectiveTarget};
 use crate::notifier::{Notification, NotificationRecord, Notifier};
 use crate::state::StateHandle;
@@ -226,6 +226,9 @@ pub struct OperationDeadlineMonitor {
     notifiers: Vec<Arc<dyn Notifier>>,
     state: StateHandle,
     config: OperationWatchdogConfig,
+    /// The top-level supervised-services registry (`Config::services`), which
+    /// `operations.<family>.service` references.
+    services: std::collections::HashMap<String, ServiceConfig>,
     /// Corrective-action ladder, run on expiry for `abort_then_restart`
     /// families. Never invoked for `notify_only` or liveness triggers.
     corrective: Arc<dyn Corrective>,
@@ -238,6 +241,7 @@ impl OperationDeadlineMonitor {
         notifiers: Vec<Arc<dyn Notifier>>,
         state: StateHandle,
         config: OperationWatchdogConfig,
+        services: std::collections::HashMap<String, ServiceConfig>,
         corrective: Arc<dyn Corrective>,
     ) -> Self {
         Self {
@@ -246,16 +250,18 @@ impl OperationDeadlineMonitor {
             notifiers,
             state,
             config,
+            services,
             corrective,
         }
     }
 
     /// Resolve the corrective target for a family: its configured `service`
-    /// must exist in the `services` map. `None` for unconfigured / mismatched
-    /// families (the caller degrades to notify-only).
+    /// must exist in the top-level `services` registry. `None` for
+    /// unconfigured / mismatched families (the caller degrades to
+    /// notify-only).
     fn resolve_target(&self, family: &str) -> Option<CorrectiveTarget> {
         let service_name = self.config.operations.get(family)?.service.as_deref()?;
-        let service = self.config.services.get(service_name)?;
+        let service = self.services.get(service_name)?;
         Some(CorrectiveTarget::new(service_name, family, service))
     }
 
@@ -857,6 +863,19 @@ mod tests {
         Arc<Mutex<Vec<String>>>,
         Arc<RecordingCorrective>,
     ) {
+        build_monitor_with_services(source, config, std::collections::HashMap::new())
+    }
+
+    /// [`build_monitor`] plus a top-level `services` registry (ladder tests).
+    fn build_monitor_with_services(
+        source: Arc<MockSource>,
+        config: OperationWatchdogConfig,
+        services: std::collections::HashMap<String, ServiceConfig>,
+    ) -> (
+        OperationDeadlineMonitor,
+        Arc<Mutex<Vec<String>>>,
+        Arc<RecordingCorrective>,
+    ) {
         let messages = Arc::new(Mutex::new(Vec::new()));
         let notifier = Arc::new(RecordingNotifier {
             messages: Arc::clone(&messages),
@@ -869,6 +888,7 @@ mod tests {
             vec![notifier],
             state,
             config,
+            services,
             Arc::clone(&corrective) as Arc<dyn Corrective>,
         );
         (monitor, messages, corrective)
@@ -1058,12 +1078,17 @@ mod tests {
             "message_template": "{operation}/{operation_id} {reason} after {elapsed}{action}",
             "operations": {
                 "slew": { "buffer": "0s", "on_expiry": "abort_then_restart", "service": "mount" }
-            },
-            "services": {
-                "mount": { "base_url": "http://mount/api/v1", "restart_command": null }
             }
         }"#;
         serde_json::from_str(json).unwrap()
+    }
+
+    /// The top-level `services` registry [`ladder_config`]'s `slew` references.
+    fn ladder_services() -> std::collections::HashMap<String, ServiceConfig> {
+        serde_json::from_str(
+            r#"{ "mount": { "base_url": "http://mount/api/v1", "restart_command": null } }"#,
+        )
+        .unwrap()
     }
 
     #[tokio::test(start_paused = true)]
@@ -1074,7 +1099,8 @@ mod tests {
             Some("op-1"),
             Some(5000),
         )])]);
-        let (monitor, messages, corrective) = build_monitor(source, ladder_config());
+        let (monitor, messages, corrective) =
+            build_monitor_with_services(source, ladder_config(), ladder_services());
         let cancel = CancellationToken::new();
         let cancel2 = cancel.clone();
         let handle = tokio::spawn(async move { monitor.run(cancel2).await });
@@ -1114,7 +1140,8 @@ mod tests {
             Some("op-1"),
             Some(5000),
         )])]);
-        let (monitor, messages, corrective) = build_monitor(source, config);
+        let (monitor, messages, corrective) =
+            build_monitor_with_services(source, config, ladder_services());
         let cancel = CancellationToken::new();
         let cancel2 = cancel.clone();
         let handle = tokio::spawn(async move { monitor.run(cancel2).await });

--- a/services/sentinel/tests/bdd/steps/mod.rs
+++ b/services/sentinel/tests/bdd/steps/mod.rs
@@ -4,5 +4,6 @@ pub mod auth_steps;
 pub mod dashboard_steps;
 pub mod lifecycle_steps;
 pub mod monitoring_steps;
+pub mod restart_steps;
 pub mod tls_steps;
 pub mod watchdog_steps;

--- a/services/sentinel/tests/bdd/steps/restart_steps.rs
+++ b/services/sentinel/tests/bdd/steps/restart_steps.rs
@@ -1,0 +1,121 @@
+//! BDD step definitions for the service restart API feature
+
+use cucumber::{given, then, when};
+
+use crate::world::SentinelWorld;
+
+/// A shell command that writes the marker file. The same line works under both
+/// platform shells (`sh -c` on unix, `cmd /C` on windows), quoted path included.
+fn write_marker_command(path: &std::path::Path) -> String {
+    format!("echo ok > \"{}\"", path.display())
+}
+
+/// Exit-0 / exit-1 one-liners understood by both platform shells.
+const SUCCEED: &str = "exit 0";
+const FAIL: &str = "exit 1";
+
+#[given(
+    expr = "sentinel is running with a supervised service {string} whose restart command writes a marker file and whose health command succeeds"
+)]
+async fn service_with_marker_and_health(world: &mut SentinelWorld, name: String) {
+    let marker = world.restart_marker_path();
+    world.add_supervised_service(
+        &name,
+        Some(write_marker_command(&marker)),
+        Some(SUCCEED.to_string()),
+        None,
+    );
+    world.start_sentinel().await;
+}
+
+#[given(
+    expr = "sentinel is running with a supervised service {string} whose restart command writes a marker file"
+)]
+async fn service_with_marker(world: &mut SentinelWorld, name: String) {
+    let marker = world.restart_marker_path();
+    world.add_supervised_service(&name, Some(write_marker_command(&marker)), None, None);
+    world.start_sentinel().await;
+}
+
+#[given(
+    expr = "sentinel is running with a supervised service {string} whose restart command succeeds, whose health command fails, and whose restart budget is {string}"
+)]
+async fn service_with_failing_health(world: &mut SentinelWorld, name: String, budget: String) {
+    world.add_supervised_service(
+        &name,
+        Some(SUCCEED.to_string()),
+        Some(FAIL.to_string()),
+        Some(&budget),
+    );
+    world.start_sentinel().await;
+}
+
+#[given(
+    expr = "sentinel is running with a supervised service {string} whose restart command fails"
+)]
+async fn service_with_failing_restart(world: &mut SentinelWorld, name: String) {
+    world.add_supervised_service(&name, Some(FAIL.to_string()), None, None);
+    world.start_sentinel().await;
+}
+
+#[given(
+    expr = "sentinel is running with a supervised service {string} that has no restart command"
+)]
+async fn service_not_restartable(world: &mut SentinelWorld, name: String) {
+    world.add_supervised_service(&name, None, None, None);
+    world.start_sentinel().await;
+}
+
+#[when(expr = "the restart endpoint is requested for {string}")]
+async fn request_restart(world: &mut SentinelWorld, name: String) {
+    world
+        .http_post(&format!("/api/services/{name}/restart"))
+        .await;
+}
+
+#[then(expr = "the restart response reports status {string} and recovery {string}")]
+fn restart_status_and_recovery(world: &mut SentinelWorld, status: String, recovery: String) {
+    let json = restart_body(world);
+    assert_eq!(
+        json["status"].as_str(),
+        Some(status.as_str()),
+        "body: {json}"
+    );
+    assert_eq!(
+        json["recovery"].as_str(),
+        Some(recovery.as_str()),
+        "body: {json}"
+    );
+}
+
+#[then(expr = "the restart response reports status {string}")]
+fn restart_status(world: &mut SentinelWorld, status: String) {
+    let json = restart_body(world);
+    assert_eq!(
+        json["status"].as_str(),
+        Some(status.as_str()),
+        "body: {json}"
+    );
+}
+
+#[then("the restart marker file exists")]
+fn restart_marker_exists(world: &mut SentinelWorld) {
+    let marker = world
+        .restart_marker
+        .as_ref()
+        .expect("no marker path recorded");
+    assert!(
+        marker.exists(),
+        "restart command did not write {}",
+        marker.display()
+    );
+}
+
+fn restart_body(world: &SentinelWorld) -> serde_json::Value {
+    let body = world
+        .last_response_body
+        .as_ref()
+        .expect("no response body captured");
+    serde_json::from_str(body)
+        .unwrap_or_else(|e| panic!("restart response is not JSON ({e}): {body}"))
+}

--- a/services/sentinel/tests/bdd/world.rs
+++ b/services/sentinel/tests/bdd/world.rs
@@ -54,6 +54,11 @@ pub struct SentinelWorld {
     // config. Present only for the abort scenario.
     pub mount_stub: Option<MountServiceStub>,
     pub mount_service_url: Option<String>,
+
+    // Service restart API: entries for the top-level `services` map, plus the
+    // marker file the scripted restart command writes (proof it ran).
+    pub supervised_services: serde_json::Map<String, serde_json::Value>,
+    pub restart_marker: Option<PathBuf>,
 }
 
 impl SentinelWorld {
@@ -143,6 +148,12 @@ impl SentinelWorld {
             }
         }
 
+        // The top-level supervised-services map (the restart endpoint's and the
+        // corrective ladder's shared registry).
+        if !self.supervised_services.is_empty() {
+            config["services"] = serde_json::Value::Object(self.supervised_services.clone());
+        }
+
         // Wire the operation watchdog when a watched rp URL is set. Buffers are
         // zeroed so the tracked deadline equals the operation's
         // `max_duration_ms` exactly, keeping the BDD fast and deterministic;
@@ -153,20 +164,26 @@ impl SentinelWorld {
                 "reconnect_max_attempts": 2,
                 "reconnect_backoff": "1s",
                 "default_buffer": "0s",
-                "max_restart_duration": "2s",
                 "notifiers": ["pushover"],
                 "operations": { "slew": { "buffer": "0s" } }
             });
             // When a corrective service stub is configured, make `slew` run the
             // abort ladder against it (responsive service + abort verb => the
             // ladder stops at a clean abort, so `restart_command` stays null and
-            // the BDD never shells out).
+            // the BDD never shells out). The service lives in the top-level
+            // `services` map (shared with the restart endpoint); its restart
+            // budget is per-service, kept tight so a regression that reaches the
+            // restart rung fails fast.
             if let Some(svc_url) = &self.mount_service_url {
                 watchdog["operations"]["slew"]["on_expiry"] =
                     serde_json::json!("abort_then_restart");
                 watchdog["operations"]["slew"]["service"] = serde_json::json!("mount");
-                watchdog["services"] = serde_json::json!({
-                    "mount": { "base_url": svc_url, "restart_command": null }
+                config["services"] = serde_json::json!({
+                    "mount": {
+                        "base_url": svc_url,
+                        "restart_command": null,
+                        "max_restart_duration": "2s"
+                    }
                 });
             }
             config["operation_watchdog"] = watchdog;
@@ -202,6 +219,51 @@ impl SentinelWorld {
             "device_number": 0,
             "polling_interval": "1s"
         }));
+    }
+
+    /// Absolute path of the marker file the scripted restart command writes —
+    /// recorded so the Then-step can assert the command actually ran.
+    pub fn restart_marker_path(&mut self) -> PathBuf {
+        let dir = self
+            .temp_dir
+            .get_or_insert_with(|| TempDir::new().expect("failed to create temp dir"));
+        let path = dir.path().join("restart-marker.txt");
+        self.restart_marker = Some(path.clone());
+        path
+    }
+
+    /// Add an entry to the top-level `services` map (the restart endpoint's
+    /// registry). `restart_command: None` serializes as `null` (not restartable).
+    pub fn add_supervised_service(
+        &mut self,
+        name: &str,
+        restart_command: Option<String>,
+        health_command: Option<String>,
+        max_restart_duration: Option<&str>,
+    ) {
+        let mut entry = serde_json::json!({ "restart_command": restart_command });
+        if let Some(health) = health_command {
+            entry["health_command"] = serde_json::json!(health);
+        }
+        if let Some(budget) = max_restart_duration {
+            entry["max_restart_duration"] = serde_json::json!(budget);
+        }
+        self.supervised_services.insert(name.to_string(), entry);
+    }
+
+    /// POST a dashboard endpoint (empty body) and capture status + body.
+    pub async fn http_post(&mut self, path: &str) {
+        let client = reqwest::Client::new();
+        let url = self.dashboard_url(path);
+        match client.post(&url).send().await {
+            Ok(resp) => {
+                self.last_status_code = Some(resp.status().as_u16());
+                self.last_response_body = Some(resp.text().await.unwrap_or_default());
+            }
+            Err(e) => {
+                self.last_error = Some(e.to_string());
+            }
+        }
     }
 
     /// Start a local stub that mimics the Pushover API, replying 200 to any

--- a/services/sentinel/tests/bdd/world.rs
+++ b/services/sentinel/tests/bdd/world.rs
@@ -171,19 +171,18 @@ impl SentinelWorld {
             // abort ladder against it (responsive service + abort verb => the
             // ladder stops at a clean abort, so `restart_command` stays null and
             // the BDD never shells out). The service lives in the top-level
-            // `services` map (shared with the restart endpoint); its restart
-            // budget is per-service, kept tight so a regression that reaches the
-            // restart rung fails fast.
+            // `services` map (shared with the restart endpoint) — inserted, not
+            // assigned, so `supervised_services` entries added by restart-API
+            // steps survive; its restart budget is per-service, kept tight so a
+            // regression that reaches the restart rung fails fast.
             if let Some(svc_url) = &self.mount_service_url {
                 watchdog["operations"]["slew"]["on_expiry"] =
                     serde_json::json!("abort_then_restart");
                 watchdog["operations"]["slew"]["service"] = serde_json::json!("mount");
-                config["services"] = serde_json::json!({
-                    "mount": {
-                        "base_url": svc_url,
-                        "restart_command": null,
-                        "max_restart_duration": "2s"
-                    }
+                config["services"]["mount"] = serde_json::json!({
+                    "base_url": svc_url,
+                    "restart_command": null,
+                    "max_restart_duration": "2s"
                 });
             }
             config["operation_watchdog"] = watchdog;

--- a/services/sentinel/tests/features/service_restart.feature
+++ b/services/sentinel/tests/features/service_restart.feature
@@ -1,0 +1,47 @@
+Feature: Service restart API
+  Sentinel owns process restart for the observatory stack. For each entry in
+  the top-level services map the dashboard exposes
+  POST /api/services/{name}/restart: it runs the service's configured
+  restart_command through the platform shell and, when a health_command is
+  configured, polls it (exit 0 means healthy) until it succeeds or the
+  service's max_restart_duration budget elapses. The command's outcome is a
+  domain result reported on HTTP 200 with a JSON body carrying "status"
+  ("ok" or "failed") and "recovery" ("healthy", "timeout", or "skipped");
+  4xx is reserved for addressing errors: 404 for an unknown service name,
+  409 for a service that is not restartable or is already restarting.
+
+  Scenario: A restart runs the configured command and confirms recovery
+    Given sentinel is running with a supervised service "dsd-fp2" whose restart command writes a marker file and whose health command succeeds
+    When the restart endpoint is requested for "dsd-fp2"
+    Then the response status should be 200
+    And the restart response reports status "ok" and recovery "healthy"
+    And the restart marker file exists
+
+  Scenario: A restart without a health command skips recovery confirmation
+    Given sentinel is running with a supervised service "dsd-fp2" whose restart command writes a marker file
+    When the restart endpoint is requested for "dsd-fp2"
+    Then the response status should be 200
+    And the restart response reports status "ok" and recovery "skipped"
+    And the restart marker file exists
+
+  Scenario: Recovery that never confirms is reported as a timeout
+    Given sentinel is running with a supervised service "dsd-fp2" whose restart command succeeds, whose health command fails, and whose restart budget is "1s"
+    When the restart endpoint is requested for "dsd-fp2"
+    Then the response status should be 200
+    And the restart response reports status "ok" and recovery "timeout"
+
+  Scenario: A failing restart command is a domain failure, not a transport error
+    Given sentinel is running with a supervised service "dsd-fp2" whose restart command fails
+    When the restart endpoint is requested for "dsd-fp2"
+    Then the response status should be 200
+    And the restart response reports status "failed"
+
+  Scenario: Restarting an unknown service is not found
+    Given sentinel is running with no monitors
+    When the restart endpoint is requested for "unknown-service"
+    Then the response status should be 404
+
+  Scenario: A service with no restart command is not restartable
+    Given sentinel is running with a supervised service "star-adventurer" that has no restart command
+    When the restart endpoint is requested for "star-adventurer"
+    Then the response status should be 409

--- a/services/ui-htmx/BUILD.bazel
+++ b/services/ui-htmx/BUILD.bazel
@@ -138,6 +138,9 @@ rust_test(
         ":ui-htmx_fixtures",
         "//services/dsd-fp2:dsd-fp2_mock",
         "//services/rp",
+        # The restart.feature scenarios spawn a real sentinel (its Service
+        # Restart API is what the BFF's "Restart via Sentinel" button calls).
+        "//services/sentinel",
     ] + glob(["tests/features/**"]) +
     # insta goldens (UI-testing plan Layer B): the committed .snap files must
     # reach the runfiles tree so the snapshot-path resolver can read them under
@@ -150,8 +153,9 @@ rust_test(
         "BDD_PACKAGE_DIR": "services/ui-htmx",
         "DSD_FP2_BINARY": "$(rootpath //services/dsd-fp2:dsd-fp2_mock)",
         "RP_BINARY": "$(rootpath //services/rp:rp)",
+        "SENTINEL_BINARY": "$(rootpath //services/sentinel)",
         "UI_HTMX_BINARY": "$(rootpath :ui-htmx_fixtures)",
-        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath //services/dsd-fp2:dsd-fp2_mock):$(rootpath :ui-htmx_fixtures):$(rootpath //services/rp:rp)",
+        "RUST_COVERAGE_EXTRA_OBJECTS": "$(rootpath //services/dsd-fp2:dsd-fp2_mock):$(rootpath :ui-htmx_fixtures):$(rootpath //services/rp:rp):$(rootpath //services/sentinel)",
         # Bazel does not propagate CI, so force insta to compare-only / fail on
         # mismatch (the sandbox is read-only; goldens are updated Cargo-locally).
         "INSTA_UPDATE": "no",

--- a/services/ui-htmx/assets/app.css
+++ b/services/ui-htmx/assets/app.css
@@ -189,6 +189,27 @@ button.link:hover { text-decoration: underline; }
 .banner code { font-family: var(--mono); color: var(--dim); }
 .banner .mono { font-family: var(--mono); color: var(--dim); }
 
+/* Restart-via-Sentinel affordance (config-actions plan Phase 4): a footer on
+ * the config card, separated from Apply so a process restart is never a
+ * one-pixel slip away from a config save. */
+.card-footer {
+  margin-top: 26px; padding-top: 16px; border-top: 1px solid var(--edge);
+  display: flex; align-items: center; gap: 14px;
+}
+.card-footer .hint { color: var(--dim); font-size: 12px; flex: 1; }
+button.restart-sentinel {
+  font: inherit; font-weight: 600; cursor: pointer; white-space: nowrap;
+  padding: 8px 14px; border-radius: 7px;
+  color: var(--bad); background: none; border: 1px solid rgba(248, 113, 113, .4);
+}
+button.restart-sentinel:hover { background: rgba(248, 113, 113, .08); }
+/* The escalation banner's inline restart button reads as a link (like the
+ * unlock/retry affordances), not the bordered footer button. */
+.banner button.restart-sentinel {
+  font-weight: inherit; padding: 0; border: 0; color: var(--accent-a);
+}
+.banner button.restart-sentinel:hover { background: none; text-decoration: underline; }
+
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .3; } }
 
 .service-list { list-style: none; margin: 0; padding: 0; }

--- a/services/ui-htmx/src/config.rs
+++ b/services/ui-htmx/src/config.rs
@@ -26,6 +26,11 @@ pub struct Config {
     /// driver-config UI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rp: Option<RpTarget>,
+    /// Where Sentinel's dashboard/REST API lives. Absent (the default) means
+    /// no restart affordances are rendered anywhere — Sentinel is optional
+    /// infrastructure. See `docs/services/ui-htmx.md` §Restart via Sentinel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sentinel: Option<SentinelTarget>,
 }
 
 /// Where the BFF itself listens.
@@ -68,6 +73,25 @@ pub struct DriverTarget {
     #[serde(default)]
     pub auth: Option<DriverAuth>,
     /// Optional PEM CA path for a TLS-enabled driver (trusted via `rp-tls`).
+    #[serde(default)]
+    pub ca_cert_path: Option<PathBuf>,
+    /// This driver's name in Sentinel's `services` map (the `{name}` in
+    /// `POST /api/services/{name}/restart`). Defaults to the driver's own
+    /// service id — the convention — so it only needs setting when the two
+    /// differ. Meaningful only when the top-level `sentinel` block is present.
+    #[serde(default)]
+    pub sentinel_service: Option<String>,
+}
+
+/// How to reach Sentinel's dashboard/REST API (the restart endpoint).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentinelTarget {
+    #[serde(default = "default_sentinel_base_url")]
+    pub base_url: String,
+    /// Optional HTTP Basic credentials for an auth-enabled dashboard.
+    #[serde(default)]
+    pub auth: Option<DriverAuth>,
+    /// Optional PEM CA path for a TLS-enabled dashboard (trusted via `rp-tls`).
     #[serde(default)]
     pub ca_cert_path: Option<PathBuf>,
 }
@@ -123,6 +147,10 @@ fn default_base_url() -> String {
     "http://127.0.0.1:11119".to_string()
 }
 
+fn default_sentinel_base_url() -> String {
+    "http://127.0.0.1:11114".to_string()
+}
+
 fn default_device_type() -> String {
     "covercalibrator".to_string()
 }
@@ -145,6 +173,7 @@ impl Default for DriverTarget {
             device_number: 0,
             auth: None,
             ca_cert_path: None,
+            sentinel_service: None,
         }
     }
 }
@@ -220,6 +249,52 @@ mod tests {
         let c = load_config(&path).unwrap();
         assert_eq!(c.server.port, 11120);
         assert!(c.drivers.0.contains_key("dsd-fp2"));
+    }
+
+    #[test]
+    fn sentinel_block_absent_by_default() {
+        let c = Config::default();
+        assert!(c.sentinel.is_none());
+        assert!(c
+            .drivers
+            .0
+            .get("dsd-fp2")
+            .unwrap()
+            .sentinel_service
+            .is_none());
+    }
+
+    #[test]
+    fn deserialises_sentinel_block_and_service_override() {
+        let json = r#"{
+            "drivers": {
+                "dsd-fp2": { "sentinel_service": "dsd-fp2-unit" }
+            },
+            "sentinel": {
+                "base_url": "http://127.0.0.1:19114",
+                "auth": { "username": "obs", "password": "secret" }
+            }
+        }"#;
+        let c: Config = serde_json::from_str(json).unwrap();
+        let sentinel = c.sentinel.unwrap();
+        assert_eq!(sentinel.base_url, "http://127.0.0.1:19114");
+        assert_eq!(sentinel.auth.unwrap().username, "obs");
+        assert_eq!(
+            c.drivers
+                .0
+                .get("dsd-fp2")
+                .unwrap()
+                .sentinel_service
+                .as_deref(),
+            Some("dsd-fp2-unit")
+        );
+    }
+
+    #[test]
+    fn sentinel_base_url_defaults_to_dashboard_port() {
+        let json = r#"{ "sentinel": {} }"#;
+        let c: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(c.sentinel.unwrap().base_url, "http://127.0.0.1:11114");
     }
 
     #[test]

--- a/services/ui-htmx/src/io.rs
+++ b/services/ui-htmx/src/io.rs
@@ -37,6 +37,10 @@ pub trait HttpClient: Send + Sync {
     /// Send a PUT request with a JSON body. rp's REST config endpoint
     /// (`PUT /api/config`) takes the full Config JSON directly.
     async fn put_json(&self, url: &str, body: &str) -> Result<HttpResponse, HttpError>;
+
+    /// Send a POST request with an empty body. Sentinel's REST restart
+    /// endpoint (`POST /api/services/{name}/restart`) takes no body.
+    async fn post(&self, url: &str) -> Result<HttpResponse, HttpError>;
 }
 
 /// Production HTTP client using `reqwest`, with optional CA trust and Basic auth.
@@ -150,6 +154,30 @@ impl HttpClient for ReqwestHttpClient {
         tracing::debug!("PUT {url} -> {status} ({} bytes)", body.len());
         Ok(HttpResponse { status, body })
     }
+
+    async fn post(&self, url: &str) -> Result<HttpResponse, HttpError> {
+        tracing::debug!("POST {url}");
+        // `Connection: close` for the same reason as `get` — a restart tears
+        // processes down, so a pooled connection would go stale.
+        let mut request = self
+            .client
+            .post(url)
+            .header(reqwest::header::CONNECTION, "close");
+        if let Some((user, pass)) = &self.auth {
+            request = request.basic_auth(user, Some(pass));
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|e| HttpError(format!("POST {url} failed: {e}")))?;
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| HttpError(format!("reading response body: {e}")))?;
+        tracing::debug!("POST {url} -> {status} ({} bytes)", body.len());
+        Ok(HttpResponse { status, body })
+    }
 }
 
 #[cfg(test)]
@@ -183,5 +211,12 @@ mod tests {
         let client = ReqwestHttpClient::new(None).unwrap();
         let err = client.put_json(UNREACHABLE_URL, "{}").await.unwrap_err();
         assert!(err.0.starts_with("PUT "), "{}", err.0);
+    }
+
+    #[tokio::test]
+    async fn post_connection_refused_is_an_error() {
+        let client = ReqwestHttpClient::new(None).unwrap();
+        let err = client.post(UNREACHABLE_URL).await.unwrap_err();
+        assert!(err.0.starts_with("POST "), "{}", err.0);
     }
 }

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -184,18 +184,13 @@ impl AppState {
     pub fn from_config(config: &Config) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let sentinel: Option<Arc<dyn SentinelClient>> = match &config.sentinel {
             Some(target) => {
-                let reqwest_client = match &target.auth {
-                    Some(auth) => ReqwestHttpClient::with_auth(
-                        target.ca_cert_path.as_deref(),
-                        auth.username.clone(),
-                        auth.password.clone(),
-                    )?,
-                    None => ReqwestHttpClient::new(target.ca_cert_path.as_deref())?,
-                };
-                Some(Arc::new(HttpSentinelClient::new(
-                    Arc::new(reqwest_client),
+                let http = build_http_client(
+                    "sentinel",
                     &target.base_url,
-                )))
+                    target.auth.as_ref(),
+                    target.ca_cert_path.as_deref(),
+                )?;
+                Some(Arc::new(HttpSentinelClient::new(http, &target.base_url)))
             }
             None => None,
         };
@@ -815,6 +810,22 @@ mod tests {
             state.drivers.get("qhy-focuser").unwrap().subtitle,
             "qhy-focuser · focuser"
         );
+    }
+
+    #[test]
+    fn from_config_rejects_sentinel_url_credentials() {
+        // The sentinel target goes through the same `build_http_client`
+        // validation as drivers/rp: embedded credentials would leak into
+        // error strings and request-URL debug logs.
+        let json = r#"{ "sentinel": { "base_url": "http://obs:secret@127.0.0.1:11114" } }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        match AppState::from_config(&config) {
+            Ok(_) => panic!("expected from_config to reject credentials in sentinel base_url"),
+            Err(e) => assert!(
+                e.to_string().contains("must not contain credentials"),
+                "{e}"
+            ),
+        }
     }
 
     #[test]

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -24,6 +24,7 @@ pub mod pages;
 pub mod probe;
 pub mod roster;
 pub mod rp_client;
+pub mod sentinel_client;
 /// Test-only Server-Sent-Events fixture routes (UI-testing plan §9 Tier 2) —
 /// compiled ONLY under the `test-sse` cargo feature, so they ship nothing in the
 /// real binary. `#[coverage(off)]` keeps this test-only code (and the streaming
@@ -51,6 +52,9 @@ pub use driver_client::{
     ConfigGetResponse, ConfigSchemaResponse, FieldError, RestConfigClient,
 };
 pub use io::{HttpClient, ReqwestHttpClient};
+pub use sentinel_client::{
+    HttpSentinelClient, RestartOutcome, SentinelClient, SentinelClientError,
+};
 
 use pages::{Banner, DriverLink, FieldModel, Page};
 
@@ -61,6 +65,10 @@ struct DriverHandle {
     title: String,
     subtitle: String,
     client: Arc<dyn ConfigClient>,
+    /// This driver's name in Sentinel's `services` map. `Some` only when the
+    /// BFF has a `sentinel` block configured (then it defaults to the driver's
+    /// own service id) — it gates every restart affordance.
+    sentinel_service: Option<String>,
 }
 
 impl DriverHandle {
@@ -69,6 +77,7 @@ impl DriverHandle {
             service,
             title: &self.title,
             subtitle: &self.subtitle,
+            can_restart: self.sentinel_service.is_some(),
         }
     }
 }
@@ -95,11 +104,13 @@ pub struct RpState {
 }
 
 /// Shared handler state: every configured driver, keyed by service id, plus
-/// the optional rp-backed surface state.
+/// the optional rp-backed surface state and the optional Sentinel restart
+/// client the restart affordances call.
 #[derive(Clone)]
 pub struct AppState {
     drivers: Arc<BTreeMap<String, DriverHandle>>,
     rp: Option<Arc<RpState>>,
+    sentinel: Option<Arc<dyn SentinelClient>>,
     /// Ends open SSE proxy streams on service shutdown — axum's graceful
     /// shutdown does not close them on its own (axum #2673); `main` links this
     /// to the `ServiceRunner` shutdown (the same pattern as rp's `sse_shutdown`).
@@ -168,8 +179,27 @@ impl AppState {
     /// Build the production state: an `AlpacaConfigClient` over a `reqwest`-backed
     /// `HttpClient` (CA trust + optional Basic auth) for every configured driver,
     /// plus — when an `rp` target is configured — a `RestConfigClient` under the
-    /// reserved `rp` key for rp's own config page.
+    /// reserved `rp` key for rp's own config page, plus an `HttpSentinelClient`
+    /// when a `sentinel` block is configured.
     pub fn from_config(config: &Config) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let sentinel: Option<Arc<dyn SentinelClient>> = match &config.sentinel {
+            Some(target) => {
+                let reqwest_client = match &target.auth {
+                    Some(auth) => ReqwestHttpClient::with_auth(
+                        target.ca_cert_path.as_deref(),
+                        auth.username.clone(),
+                        auth.password.clone(),
+                    )?,
+                    None => ReqwestHttpClient::new(target.ca_cert_path.as_deref())?,
+                };
+                Some(Arc::new(HttpSentinelClient::new(
+                    Arc::new(reqwest_client),
+                    &target.base_url,
+                )))
+            }
+            None => None,
+        };
+
         let mut drivers = BTreeMap::new();
         for (service, target) in &config.drivers.0 {
             // `rp` is reserved for the rp target so `/config/rp` is unambiguous.
@@ -192,12 +222,21 @@ impl AppState {
                 &target.device_type,
                 target.device_number,
             );
+            // The restart affordances render only with a Sentinel to call;
+            // the Sentinel-side name defaults to the driver's own service id.
+            let sentinel_service = sentinel.as_ref().map(|_| {
+                target
+                    .sentinel_service
+                    .clone()
+                    .unwrap_or_else(|| service.clone())
+            });
             drivers.insert(
                 service.clone(),
                 DriverHandle {
                     title: target.name.clone().unwrap_or_else(|| service.clone()),
                     subtitle: format!("{service} · {}", target.device_type),
                     client: Arc::new(client),
+                    sentinel_service,
                 },
             );
         }
@@ -217,6 +256,10 @@ impl AppState {
                     title: "rp".to_string(),
                     subtitle: "rp · orchestrator (REST)".to_string(),
                     client: Arc::clone(&config_client),
+                    // rp has no in-process reload — every apply is
+                    // restart-required — so the Sentinel affordance matters
+                    // most here. Sentinel-side name: the `rp` convention.
+                    sentinel_service: sentinel.as_ref().map(|_| RP_SERVICE.to_string()),
                 },
             );
             rp_state = Some(Arc::new(RpState {
@@ -239,6 +282,7 @@ impl AppState {
         Ok(Self {
             drivers: Arc::new(drivers),
             rp: rp_state,
+            sentinel,
             sse_shutdown: tokio_util::sync::CancellationToken::new(),
         })
     }
@@ -252,11 +296,38 @@ impl AppState {
                 title: service.to_string(),
                 subtitle: service.to_string(),
                 client,
+                sentinel_service: None,
             },
         );
         Self {
             drivers: Arc::new(drivers),
             rp: None,
+            sentinel: None,
+            sse_shutdown: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
+    /// [`AppState::with_client`] plus a Sentinel client (tests inject stubs for
+    /// both), with the Sentinel-side name defaulting to the service id.
+    pub fn with_client_and_sentinel(
+        service: &str,
+        client: Arc<dyn ConfigClient>,
+        sentinel: Arc<dyn SentinelClient>,
+    ) -> Self {
+        let mut drivers = BTreeMap::new();
+        drivers.insert(
+            service.to_string(),
+            DriverHandle {
+                title: service.to_string(),
+                subtitle: service.to_string(),
+                client,
+                sentinel_service: Some(service.to_string()),
+            },
+        );
+        Self {
+            drivers: Arc::new(drivers),
+            rp: None,
+            sentinel: Some(sentinel),
             sse_shutdown: tokio_util::sync::CancellationToken::new(),
         }
     }
@@ -276,10 +347,12 @@ impl AppState {
                 title: "rp".to_string(),
                 subtitle: "rp · orchestrator (REST)".to_string(),
                 client: Arc::clone(&config_client),
+                sentinel_service: None,
             },
         );
         Self {
             drivers: Arc::new(drivers),
+            sentinel: None,
             rp: Some(Arc::new(RpState {
                 config_client,
                 api,
@@ -369,6 +442,9 @@ async fn resolve_service(state: &AppState, service: &str) -> Result<DriverHandle
         title: entry.display_name().to_string(),
         subtitle: format!("{} · {} (via rp roster)", entry.id, kind.ascom_type()),
         client: Arc::new(client),
+        // Roster devices are hardware rp manages, not OS services Sentinel
+        // supervises — no restart affordance.
+        sentinel_service: None,
     })
 }
 
@@ -378,6 +454,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/", get(index))
         .route("/config/{service}", get(config_get).post(config_post))
         .route("/config/{service}/status", get(config_status))
+        .route(
+            "/config/{service}/restart",
+            axum::routing::post(config_restart),
+        )
         .route("/equipment", get(pages::equipment::page))
         .route(
             "/equipment/{kind}/new",
@@ -643,6 +723,50 @@ async fn config_status(
         &[],
         Some(Banner::Reconnected),
     )
+}
+
+/// Ask Sentinel to restart the driver's process (the "Restart via Sentinel"
+/// affordances post here), then render the outcome: an accepted restart swaps
+/// in the reconnect-polling fragment; everything else is an error card naming
+/// the reason. See `docs/services/ui-htmx.md` §Restart via Sentinel.
+async fn config_restart(
+    State(state): State<AppState>,
+    Path(service): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    let title = page_title(&service);
+    let Some(handle) = state.drivers.get(&service) else {
+        return respond(pages::unknown_service_card(&service), &headers, &title);
+    };
+    let (Some(sentinel), Some(name)) = (&state.sentinel, &handle.sentinel_service) else {
+        // The affordances that post here only render with a Sentinel
+        // configured, so this answers only hand-crafted requests.
+        return respond(
+            pages::message_error_card(
+                &service,
+                "No Sentinel is configured, so the BFF cannot restart this driver.",
+            ),
+            &headers,
+            &title,
+        );
+    };
+    let card = match sentinel.restart(name).await {
+        Ok(outcome) if outcome.is_ok() => {
+            pages::restarting_card(&service, outcome.recovery_timed_out())
+        }
+        Ok(outcome) => pages::message_error_card(
+            &service,
+            &format!(
+                "Sentinel could not restart the driver: {}",
+                outcome
+                    .detail
+                    .as_deref()
+                    .unwrap_or("the restart command failed")
+            ),
+        ),
+        Err(err) => pages::message_error_card(&service, &err.to_string()),
+    };
+    respond(card, &headers, &title)
 }
 
 #[cfg(test)]
@@ -1149,5 +1273,247 @@ mod tests {
         );
         assert!(html.contains("site.latitude_degrees"), "{html}");
         assert!(html.contains("banner warn"), "{html}");
+    }
+
+    // --- Restart via Sentinel (config-actions plan Phase 4) -----------------
+
+    /// A `SentinelClient` returning a canned outcome, recording the Sentinel-
+    /// side service name it was asked to restart.
+    struct StubSentinel {
+        result: Result<RestartOutcome, SentinelClientError>,
+        last_service: std::sync::Mutex<Option<String>>,
+    }
+
+    impl StubSentinel {
+        fn new(result: Result<RestartOutcome, SentinelClientError>) -> Arc<Self> {
+            Arc::new(Self {
+                result,
+                last_service: std::sync::Mutex::new(None),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SentinelClient for StubSentinel {
+        async fn restart(&self, service: &str) -> Result<RestartOutcome, SentinelClientError> {
+            *self.last_service.lock().unwrap() = Some(service.to_string());
+            self.result.clone()
+        }
+    }
+
+    fn outcome(status: &str, recovery: Option<&str>, detail: Option<&str>) -> RestartOutcome {
+        RestartOutcome {
+            status: status.to_string(),
+            recovery: recovery.map(String::from),
+            detail: detail.map(String::from),
+        }
+    }
+
+    async fn post_restart(state: AppState) -> String {
+        let response =
+            config_restart(State(state), Path("dsd-fp2".to_string()), HeaderMap::new()).await;
+        body_of(response).await
+    }
+
+    #[tokio::test]
+    async fn config_get_offers_restart_only_with_sentinel_configured() {
+        let without = AppState::with_client("dsd-fp2", Arc::new(StaticConfigDriver));
+        let html = body_of(
+            config_get(
+                State(without),
+                Path("dsd-fp2".to_string()),
+                Query(UnlockQuery::default()),
+                HeaderMap::new(),
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            !html.contains("restart-sentinel"),
+            "restart affordance rendered with no sentinel configured:\n{html}"
+        );
+
+        let sentinel = StubSentinel::new(Ok(outcome("ok", Some("healthy"), None)));
+        let with =
+            AppState::with_client_and_sentinel("dsd-fp2", Arc::new(StaticConfigDriver), sentinel);
+        let html = body_of(
+            config_get(
+                State(with),
+                Path("dsd-fp2".to_string()),
+                Query(UnlockQuery::default()),
+                HeaderMap::new(),
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            html.contains(r#"hx-post="/config/dsd-fp2/restart""#),
+            "missing restart affordance:\n{html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_restart_without_sentinel_is_an_error_card() {
+        let state = AppState::with_client("dsd-fp2", Arc::new(StaticConfigDriver));
+        let html = post_restart(state).await;
+        assert!(html.contains("No Sentinel is configured"), "{html}");
+    }
+
+    #[tokio::test]
+    async fn config_restart_accepted_renders_reconnect_poll() {
+        let sentinel = StubSentinel::new(Ok(outcome("ok", Some("healthy"), None)));
+        let state = AppState::with_client_and_sentinel(
+            "dsd-fp2",
+            Arc::new(StaticConfigDriver),
+            Arc::clone(&sentinel) as Arc<StubSentinel>,
+        );
+        let html = post_restart(state).await;
+        assert!(html.contains("Restart requested via Sentinel"), "{html}");
+        assert!(
+            html.contains(r#"hx-get="/config/dsd-fp2/status""#),
+            "restarting card must poll the status route:\n{html}"
+        );
+        assert_eq!(
+            sentinel.last_service.lock().unwrap().as_deref(),
+            Some("dsd-fp2"),
+            "the Sentinel-side name defaults to the service id"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_restart_recovery_timeout_warns() {
+        let sentinel = StubSentinel::new(Ok(outcome("ok", Some("timeout"), None)));
+        let state =
+            AppState::with_client_and_sentinel("dsd-fp2", Arc::new(StaticConfigDriver), sentinel);
+        let html = post_restart(state).await;
+        assert!(
+            html.contains("did not confirm recovery"),
+            "missing recovery-timeout warning:\n{html}"
+        );
+        assert!(
+            html.contains(r#"hx-get="/config/dsd-fp2/status""#),
+            "the poll still runs — the budget is Sentinel's, not the driver's:\n{html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_restart_failed_command_shows_detail() {
+        let sentinel = StubSentinel::new(Ok(outcome(
+            "failed",
+            None,
+            Some("restart `x` exited with 1"),
+        )));
+        let state =
+            AppState::with_client_and_sentinel("dsd-fp2", Arc::new(StaticConfigDriver), sentinel);
+        let html = post_restart(state).await;
+        assert!(
+            html.contains("could not restart the driver: restart `x` exited with 1"),
+            "{html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_restart_unsupervised_names_the_reason() {
+        let sentinel = StubSentinel::new(Err(SentinelClientError::UnknownService(
+            "no configured service named 'dsd-fp2'".to_string(),
+        )));
+        let state =
+            AppState::with_client_and_sentinel("dsd-fp2", Arc::new(StaticConfigDriver), sentinel);
+        let html = post_restart(state).await;
+        assert!(html.contains("does not supervise"), "{html}");
+        assert!(html.contains("no configured service named"), "{html}");
+    }
+
+    /// Renders like [`StaticConfigDriver`]; `config.apply` reports the change
+    /// persisted but needing a process restart — the classification no real
+    /// driver emits today, so this arm is unit-driven.
+    struct RestartRequiredDriver;
+
+    #[async_trait::async_trait]
+    impl ConfigClient for RestartRequiredDriver {
+        async fn get_config(&self) -> Result<ConfigGetResponse, ConfigClientError> {
+            StaticConfigDriver.get_config().await
+        }
+        async fn get_schema(&self) -> Result<ConfigSchemaResponse, ConfigClientError> {
+            StaticConfigDriver.get_schema().await
+        }
+        async fn apply_config(
+            &self,
+            _config: &Value,
+        ) -> Result<ConfigApplyResponse, ConfigClientError> {
+            Ok(ConfigApplyResponse {
+                status: ApplyStatus::Ok,
+                applied: Vec::new(),
+                reload: Vec::new(),
+                restart_required: vec!["server.port".to_string()],
+                skipped_override: Vec::new(),
+                persisted_to: None,
+                errors: Vec::new(),
+            })
+        }
+    }
+
+    /// Submit the static driver's own config back through `config_post` (the
+    /// hidden blobs plus every enabled field, as a browser would send them).
+    async fn submit_static_form(state: AppState) -> String {
+        let config = StaticConfigDriver.get_config().await.unwrap().config;
+        let mut form = HashMap::new();
+        form.insert(
+            "__config".to_string(),
+            serde_json::to_string(&config).unwrap(),
+        );
+        form.insert("__overrides".to_string(), "[]".to_string());
+        form.insert("__unlocked".to_string(), "[]".to_string());
+        for (name, value) in [
+            ("serial.port", "/dev/ttyACM0"),
+            ("serial.baud_rate", "115200"),
+            ("server.discovery_port", "32227"),
+            ("cover_calibrator.name", "FP2"),
+            ("cover_calibrator.max_brightness", "4096"),
+        ] {
+            form.insert(name.to_string(), value.to_string());
+        }
+        let response = config_post(
+            State(state),
+            Path("dsd-fp2".to_string()),
+            HeaderMap::new(),
+            Form(form),
+        )
+        .await;
+        body_of(response).await
+    }
+
+    #[tokio::test]
+    async fn apply_with_restart_required_escalates_to_sentinel() {
+        let sentinel = StubSentinel::new(Ok(outcome("ok", Some("skipped"), None)));
+        let state = AppState::with_client_and_sentinel(
+            "dsd-fp2",
+            Arc::new(RestartRequiredDriver),
+            sentinel,
+        );
+        let html = submit_static_form(state).await;
+        assert!(
+            html.contains("take effect when dsd-fp2 is restarted"),
+            "missing restart callout:\n{html}"
+        );
+        assert!(html.contains("server.port"), "{html}");
+        assert!(
+            html.contains(r#"hx-post="/config/dsd-fp2/restart""#),
+            "the callout must offer the Sentinel restart:\n{html}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_with_restart_required_without_sentinel_has_no_button() {
+        let state = AppState::with_client("dsd-fp2", Arc::new(RestartRequiredDriver));
+        let html = submit_static_form(state).await;
+        assert!(
+            html.contains("take effect when dsd-fp2 is restarted"),
+            "missing restart callout:\n{html}"
+        );
+        assert!(
+            !html.contains("restart-sentinel"),
+            "no restart button without a sentinel:\n{html}"
+        );
     }
 }

--- a/services/ui-htmx/src/lib.rs
+++ b/services/ui-htmx/src/lib.rs
@@ -1365,7 +1365,10 @@ mod tests {
         let state = AppState::with_client_and_sentinel(
             "dsd-fp2",
             Arc::new(StaticConfigDriver),
-            Arc::clone(&sentinel) as Arc<StubSentinel>,
+            // Method-call clone: `Arc::clone(&sentinel)` would infer
+            // `T = dyn SentinelClient` from the parameter and fail on the
+            // concrete `&Arc<StubSentinel>`.
+            sentinel.clone(),
         );
         let html = post_restart(state).await;
         assert!(html.contains("Restart requested via Sentinel"), "{html}");

--- a/services/ui-htmx/src/pages/equipment.rs
+++ b/services/ui-htmx/src/pages/equipment.rs
@@ -288,6 +288,9 @@ fn entry_form(
         service: "equipment",
         title: &heading,
         subtitle: kind_key,
+        // Equipment forms edit roster entries in rp's config — there is no
+        // process here for Sentinel to restart.
+        can_restart: false,
     };
     let ctx = super::FieldCtx {
         model,

--- a/services/ui-htmx/src/pages/mod.rs
+++ b/services/ui-htmx/src/pages/mod.rs
@@ -526,9 +526,12 @@ pub fn config_card(
             @if page.can_restart {
                 div.card-footer {
                     div.hint {
-                        "Configuration changes apply via an in-process reload — no "
-                        "restart needed. Sentinel can restart the driver's process: "
-                        "the recovery hammer for a wedged driver."
+                        (format!(
+                            "Sentinel can restart {}'s process — the recovery hammer \
+                             for a wedged service, and how saved changes that need a \
+                             process restart take effect.",
+                            page.service
+                        ))
                     }
                     (restart_button(page))
                 }

--- a/services/ui-htmx/src/pages/mod.rs
+++ b/services/ui-htmx/src/pages/mod.rs
@@ -31,6 +31,17 @@ pub struct Page<'a> {
     pub service: &'a str,
     pub title: &'a str,
     pub subtitle: &'a str,
+    /// Whether the "Restart via Sentinel" affordances render: true only when
+    /// the BFF has a `sentinel` block configured (the driver then has a
+    /// Sentinel-side service name to target).
+    pub can_restart: bool,
+}
+
+impl Page<'_> {
+    /// The BFF route the restart affordances post to.
+    fn restart_url(&self) -> String {
+        format!("/config/{}/restart", self.service)
+    }
 }
 
 /// A status banner rendered above the form.
@@ -41,8 +52,9 @@ pub enum Banner {
     /// `config.apply` returned `status:"ok"` with `restart_required[]` paths:
     /// persisted, but the listed changes only take effect on the target's next
     /// process start (`ApplyDisposition::Restart` — rp, which has no in-process
-    /// reload). The restart callout; Phase 4's "Restart via Sentinel" affordance
-    /// attaches here.
+    /// reload — or a driver field classified restart-required). The restart
+    /// callout; when a Sentinel is configured, the "Restart via Sentinel"
+    /// affordance attaches inline.
     SavedRestartRequired(Vec<String>),
     /// `config.apply` returned `status:"invalid"`.
     Invalid,
@@ -488,7 +500,7 @@ pub fn config_card(
     let action = format!("/config/{}", page.service);
     html! {
         div #config-card.card {
-            @if let Some(b) = banner { (banner_markup(page.service, &b)) }
+            @if let Some(b) = banner { (banner_markup(page, &b)) }
             h1 { (page.title) }
             p.subtitle { (page.subtitle) }
             // htmx-driven, JavaScript-required: the form submits via `hx-post`.
@@ -507,6 +519,35 @@ pub fn config_card(
                 }
                 div.actions { button.primary type="submit" { "Apply" } }
             }
+            // The recovery hammer (config-actions plan Phase 4): Sentinel owns
+            // process restart; this posts to the BFF's restart route, which
+            // calls Sentinel's REST API. Outside the form so the POST carries
+            // no form data, and rendered only when a Sentinel is configured.
+            @if page.can_restart {
+                div.card-footer {
+                    div.hint {
+                        "Configuration changes apply via an in-process reload — no "
+                        "restart needed. Sentinel can restart the driver's process: "
+                        "the recovery hammer for a wedged driver."
+                    }
+                    (restart_button(page))
+                }
+            }
+        }
+    }
+}
+
+/// The "Restart via Sentinel" htmx button (JS-required, plan §7). The native
+/// `hx-confirm` prompt guards against a stray click bouncing a healthy driver.
+fn restart_button(page: &Page<'_>) -> Markup {
+    let confirm = format!(
+        "Restart {}'s process via Sentinel? In-flight operations are lost.",
+        page.service
+    );
+    html! {
+        button.restart-sentinel type="button" hx-post=(page.restart_url())
+            hx-target="#config-card" hx-swap="outerHTML" hx-confirm=(confirm) {
+            "Restart via Sentinel"
         }
     }
 }
@@ -598,13 +639,34 @@ fn field_hints(
 /// The "applying — reconnecting" fragment: polls `…/status` once a second until
 /// the driver answers and the poll swaps in a fresh card.
 pub fn reconnecting_card(service: &str) -> Markup {
+    polling_card(service, "Saved — the driver is reloading. Reconnecting…")
+}
+
+/// The restart-accepted fragment: Sentinel ran the restart command, so the
+/// driver's process is coming back — same poll wiring as the reload flow.
+/// `recovery_timed_out` adds that Sentinel's own health check never confirmed
+/// recovery within its budget (the poll may still succeed — the budget is
+/// Sentinel's, not the driver's).
+pub fn restarting_card(service: &str, recovery_timed_out: bool) -> Markup {
+    let message = if recovery_timed_out {
+        "Restart requested via Sentinel, but its health check did not confirm \
+         recovery within the budget. Reconnecting anyway…"
+    } else {
+        "Restart requested via Sentinel — the driver is restarting. Reconnecting…"
+    };
+    polling_card(service, message)
+}
+
+/// Shared skeleton of the reconnect-polling fragments: polls `…/status` once a
+/// second until the driver answers and the poll swaps in a fresh card.
+fn polling_card(service: &str, message: &str) -> Markup {
     let status_url = format!("/config/{service}/status");
     html! {
         div #config-card.card hx-get=(status_url) hx-trigger="every 1s"
             hx-swap="outerHTML" hx-target="this" {
             div class="banner applying" {
                 span.dot {}
-                span { "Saved — the driver is reloading. Reconnecting…" }
+                span { (message) }
             }
         }
     }
@@ -680,16 +742,19 @@ fn simple_banner(kind: &str, text: &str) -> Markup {
     }
 }
 
-fn banner_markup(service: &str, banner: &Banner) -> Markup {
+fn banner_markup(page: &Page<'_>, banner: &Banner) -> Markup {
     match banner {
         // The restart callout lists the pending paths — persisted, but only in
-        // effect after the target's next process start.
+        // effect after the target's next process start. When a Sentinel is
+        // configured, the restart affordance attaches inline so the operator
+        // can act on the callout directly.
         Banner::SavedRestartRequired(paths) => html! {
             div class="banner warn" {
                 span.dot {}
                 span {
-                    (format!("Saved. These changes take effect when {service} is restarted: "))
+                    (format!("Saved. These changes take effect when {} is restarted: ", page.service))
                     span.mono { (paths.join(", ")) }
+                    @if page.can_restart { " " (restart_button(page)) }
                 }
             }
         },
@@ -1105,6 +1170,7 @@ mod tests {
             service: "dsd-fp2",
             title: "Deep Sky Dad FP2",
             subtitle: "dsd-fp2 · covercalibrator",
+            can_restart: false,
         }
     }
 

--- a/services/ui-htmx/src/sentinel_client.rs
+++ b/services/ui-htmx/src/sentinel_client.rs
@@ -1,0 +1,217 @@
+//! Sentinel restart client.
+//!
+//! Speaks Sentinel's Service Restart API (`POST /api/services/{name}/restart`,
+//! see `docs/services/sentinel.md` §Service Restart API) over an
+//! [`HttpClient`]. Sentinel reports the restart command's outcome as a domain
+//! result on HTTP 200 ([`RestartOutcome`]); 404/409 are addressing errors
+//! (unknown service name / not restartable / already in flight), surfaced as
+//! typed [`SentinelClientError`] variants so the page can name the reason.
+//! Handlers depend on the [`SentinelClient`] trait so tests can inject stubs.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::io::HttpClient;
+
+/// Sentinel's domain outcome for an accepted restart request (HTTP 200).
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RestartOutcome {
+    /// `"ok"` (the restart command exited 0) or `"failed"`.
+    pub status: String,
+    /// Present on `"ok"`: `"healthy"`, `"timeout"`, or `"skipped"`.
+    #[serde(default)]
+    pub recovery: Option<String>,
+    /// Present on `"failed"`: what went wrong with the command.
+    #[serde(default)]
+    pub detail: Option<String>,
+}
+
+impl RestartOutcome {
+    /// The restart command ran and exited 0.
+    pub fn is_ok(&self) -> bool {
+        self.status == "ok"
+    }
+
+    /// Sentinel's `health_command` never confirmed recovery within its budget.
+    /// (The driver may still come back — the budget is Sentinel's, not the
+    /// driver's — so the page keeps its own reconnect poll either way.)
+    pub fn recovery_timed_out(&self) -> bool {
+        self.recovery.as_deref() == Some("timeout")
+    }
+}
+
+/// A failure asking Sentinel to restart a service.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SentinelClientError {
+    /// Sentinel answered 404: the name is not in its `services` map.
+    #[error("Sentinel does not supervise this driver: {0}")]
+    UnknownService(String),
+    /// Sentinel answered 409: not restartable, or a restart is already running.
+    #[error("Sentinel rejected the restart: {0}")]
+    Rejected(String),
+    /// Network failure or an unexpected HTTP status (Sentinel is down, or its
+    /// auth/TLS layer refused us).
+    #[error("could not reach Sentinel: {0}")]
+    Transport(String),
+    /// The response body could not be decoded.
+    #[error("could not decode the Sentinel response: {0}")]
+    Decode(String),
+}
+
+/// Asks Sentinel to restart a supervised service. Handlers depend on this
+/// trait so tests can inject canned outcomes.
+#[async_trait]
+pub trait SentinelClient: Send + Sync {
+    /// `POST /api/services/{service}/restart` — `service` is the name in
+    /// Sentinel's `services` map, not the BFF's own service id.
+    async fn restart(&self, service: &str) -> Result<RestartOutcome, SentinelClientError>;
+}
+
+/// `SentinelClient` backed by Sentinel's REST API.
+pub struct HttpSentinelClient {
+    http: Arc<dyn HttpClient>,
+    base_url: String,
+}
+
+impl HttpSentinelClient {
+    pub fn new(http: Arc<dyn HttpClient>, base_url: &str) -> Self {
+        Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+/// Extract the `error` string a 4xx body carries (`{"error":"…"}`), falling
+/// back to the raw body so an unexpected shape is still surfaced verbatim.
+fn error_reason(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+        .unwrap_or_else(|| body.to_string())
+}
+
+#[async_trait]
+impl SentinelClient for HttpSentinelClient {
+    async fn restart(&self, service: &str) -> Result<RestartOutcome, SentinelClientError> {
+        let url = format!("{}/api/services/{service}/restart", self.base_url);
+        let response = self
+            .http
+            .post(&url)
+            .await
+            .map_err(|e| SentinelClientError::Transport(e.to_string()))?;
+        match response.status {
+            200..=299 => serde_json::from_str(&response.body)
+                .map_err(|e| SentinelClientError::Decode(e.to_string())),
+            404 => Err(SentinelClientError::UnknownService(error_reason(
+                &response.body,
+            ))),
+            409 => Err(SentinelClientError::Rejected(error_reason(&response.body))),
+            status => Err(SentinelClientError::Transport(format!(
+                "HTTP {status} from {url}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::unreachable)]
+mod tests {
+    use super::*;
+    use crate::io::{HttpResponse, MockHttpClient};
+
+    fn client_returning(status: u16, body: &str) -> HttpSentinelClient {
+        let body = body.to_string();
+        let mut mock = MockHttpClient::new();
+        mock.expect_post()
+            .withf(|url| url == "http://sentinel:11114/api/services/dsd-fp2/restart")
+            .returning(move |_| {
+                let body = body.clone();
+                Box::pin(async move { Ok(HttpResponse { status, body }) })
+            });
+        HttpSentinelClient::new(Arc::new(mock), "http://sentinel:11114/")
+    }
+
+    #[tokio::test]
+    async fn ok_outcome_is_parsed() {
+        let client = client_returning(
+            200,
+            r#"{"service":"dsd-fp2","status":"ok","recovery":"healthy"}"#,
+        );
+        let outcome = client.restart("dsd-fp2").await.unwrap();
+        assert!(outcome.is_ok());
+        assert!(!outcome.recovery_timed_out());
+        assert_eq!(outcome.recovery.as_deref(), Some("healthy"));
+    }
+
+    #[tokio::test]
+    async fn recovery_timeout_is_flagged() {
+        let client = client_returning(
+            200,
+            r#"{"service":"dsd-fp2","status":"ok","recovery":"timeout"}"#,
+        );
+        let outcome = client.restart("dsd-fp2").await.unwrap();
+        assert!(outcome.is_ok());
+        assert!(outcome.recovery_timed_out());
+    }
+
+    #[tokio::test]
+    async fn failed_outcome_carries_detail() {
+        let client = client_returning(
+            200,
+            r#"{"service":"dsd-fp2","status":"failed","detail":"restart `x` exited with 1"}"#,
+        );
+        let outcome = client.restart("dsd-fp2").await.unwrap();
+        assert!(!outcome.is_ok());
+        assert_eq!(outcome.detail.as_deref(), Some("restart `x` exited with 1"));
+    }
+
+    #[tokio::test]
+    async fn not_found_maps_to_unknown_service_with_reason() {
+        let client = client_returning(404, r#"{"error":"no configured service named 'dsd-fp2'"}"#);
+        let err = client.restart("dsd-fp2").await.unwrap_err();
+        assert!(
+            matches!(&err, SentinelClientError::UnknownService(reason)
+                if reason == "no configured service named 'dsd-fp2'"),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("does not supervise"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn conflict_maps_to_rejected_with_reason() {
+        let client = client_returning(409, r#"{"error":"service 'dsd-fp2' is not restartable"}"#);
+        let err = client.restart("dsd-fp2").await.unwrap_err();
+        assert!(
+            matches!(&err, SentinelClientError::Rejected(reason)
+                if reason == "service 'dsd-fp2' is not restartable"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_status_is_a_transport_error() {
+        let client = client_returning(500, "boom");
+        let err = client.restart("dsd-fp2").await.unwrap_err();
+        assert!(matches!(err, SentinelClientError::Transport(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn malformed_ok_body_is_a_decode_error() {
+        let client = client_returning(200, "not json");
+        let err = client.restart("dsd-fp2").await.unwrap_err();
+        assert!(matches!(err, SentinelClientError::Decode(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn non_envelope_error_body_is_surfaced_verbatim() {
+        let client = client_returning(404, "plain text");
+        let err = client.restart("dsd-fp2").await.unwrap_err();
+        assert!(
+            matches!(&err, SentinelClientError::UnknownService(reason) if reason == "plain text"),
+            "{err:?}"
+        );
+    }
+}

--- a/services/ui-htmx/tests/bdd.rs
+++ b/services/ui-htmx/tests/bdd.rs
@@ -46,6 +46,9 @@ bdd_infra::bdd_main! {
                     if let Some(ui) = world.ui.as_mut() {
                         ui.stop().await;
                     }
+                    if let Some(sentinel) = world.sentinel.as_mut() {
+                        sentinel.stop().await;
+                    }
                     if let Some(driver) = world.driver.as_mut() {
                         driver.stop().await;
                     }

--- a/services/ui-htmx/tests/bdd/steps/mod.rs
+++ b/services/ui-htmx/tests/bdd/steps/mod.rs
@@ -2,6 +2,7 @@ pub mod browser_steps;
 pub mod config_page_steps;
 pub mod equipment_steps;
 pub mod fixtures_steps;
+pub mod restart_steps;
 pub mod rp_config_steps;
 pub mod sse_steps;
 pub mod stream_steps;

--- a/services/ui-htmx/tests/bdd/steps/restart_steps.rs
+++ b/services/ui-htmx/tests/bdd/steps/restart_steps.rs
@@ -1,0 +1,102 @@
+//! Step definitions for the Restart-via-Sentinel feature: a real sentinel is
+//! spawned alongside the driver + BFF, its scripted `restart_command` proving
+//! the whole BFF → sentinel → shell chain end to end.
+
+use cucumber::{given, then, when};
+use serde_json::json;
+
+use crate::dom;
+use crate::world::UiWorld;
+
+/// A shell command that writes the marker file. The same line works under both
+/// platform shells (`sh -c` on unix, `cmd /C` on windows), quoted path included.
+fn write_marker_command(path: &std::path::Path) -> String {
+    format!("echo ok > \"{}\"", path.display())
+}
+
+#[given(expr = "a sentinel supervising {string} with a restart command that writes a marker file")]
+async fn sentinel_with_marker_command(world: &mut UiWorld, service: String) {
+    let marker = world.restart_marker_path();
+    let services = json!({ service: { "restart_command": write_marker_command(&marker) } });
+    world.start_sentinel_and_rewire_bff(services).await;
+}
+
+#[given(expr = "a sentinel supervising {string} with a restart command that fails")]
+async fn sentinel_with_failing_command(world: &mut UiWorld, service: String) {
+    // `exit 1` is understood by both platform shells.
+    let services = json!({ service: { "restart_command": "exit 1" } });
+    world.start_sentinel_and_rewire_bff(services).await;
+}
+
+#[given("a sentinel supervising no services")]
+async fn sentinel_with_no_services(world: &mut UiWorld) {
+    world.start_sentinel_and_rewire_bff(json!({})).await;
+}
+
+#[when("I request a restart of the dsd-fp2 driver")]
+async fn request_restart(world: &mut UiWorld) {
+    world.request_restart().await;
+}
+
+#[then("the page offers to restart the driver via Sentinel")]
+fn offers_restart(world: &mut UiWorld) {
+    assert_eq!(
+        dom::attr(&world.last_body, "button.restart-sentinel", "hx-post").as_deref(),
+        Some("/config/dsd-fp2/restart"),
+        "missing restart affordance:\n{}",
+        world.last_body
+    );
+}
+
+#[then("the page offers no restart affordance")]
+fn no_restart_affordance(world: &mut UiWorld) {
+    assert!(
+        !dom::matches(&world.last_body, "button.restart-sentinel"),
+        "unexpected restart affordance with no sentinel configured:\n{}",
+        world.last_body
+    );
+}
+
+#[then("the restart marker file exists")]
+fn restart_marker_exists(world: &mut UiWorld) {
+    let marker = world
+        .restart_marker
+        .as_ref()
+        .expect("no marker path recorded");
+    assert!(
+        marker.exists(),
+        "sentinel's restart command did not write {}",
+        marker.display()
+    );
+}
+
+#[then("the page reports the driver is restarting")]
+fn reports_restarting(world: &mut UiWorld) {
+    assert!(
+        dom::text_contains(&world.last_body, "div.banner.applying", "restart"),
+        "missing restarting banner:\n{}",
+        world.last_body
+    );
+}
+
+#[then("the page reports the restart failed")]
+fn reports_restart_failed(world: &mut UiWorld) {
+    assert!(
+        dom::text_contains(
+            &world.last_body,
+            "div.banner.error",
+            "could not restart the driver"
+        ),
+        "missing restart-failed banner:\n{}",
+        world.last_body
+    );
+}
+
+#[then("the page reports Sentinel does not supervise the driver")]
+fn reports_not_supervised(world: &mut UiWorld) {
+    assert!(
+        dom::text_contains(&world.last_body, "div.banner.error", "does not supervise"),
+        "missing not-supervised banner:\n{}",
+        world.last_body
+    );
+}

--- a/services/ui-htmx/tests/bdd/world.rs
+++ b/services/ui-htmx/tests/bdd/world.rs
@@ -36,6 +36,10 @@ pub struct UiWorld {
     pub driver: Option<ServiceHandle>,
     /// The BFF under test.
     pub ui: Option<ServiceHandle>,
+    /// A real sentinel the BFF's restart affordance calls (restart scenarios only).
+    pub sentinel: Option<ServiceHandle>,
+    /// Marker file sentinel's scripted restart command writes — proof it ran.
+    pub restart_marker: Option<PathBuf>,
     temp_dir: Option<TempDir>,
     /// The port the driver bound — OS-assigned (the driver binds `:0`),
     /// discovered from its stdout. The reload-reconnect scenario pins this into
@@ -167,7 +171,9 @@ impl UiWorld {
     }
 
     /// Spawn a BFF configured with the given `(service id, driver port)` entries,
-    /// all on loopback. The same real driver can appear under several ids.
+    /// all on loopback. The same real driver can appear under several ids. When a
+    /// sentinel is running (restart scenarios), its URL is carried in the BFF's
+    /// `sentinel` block so the restart affordances render.
     async fn start_bff_with_drivers(&mut self, drivers: &[(&str, u16)]) {
         let mut map = serde_json::Map::new();
         for (service, port) in drivers {
@@ -180,14 +186,65 @@ impl UiWorld {
                 }),
             );
         }
-        let config = json!({
+        let mut config = json!({
             "server": { "bind": "127.0.0.1", "port": 0 },
             "drivers": Value::Object(map),
         });
+        if let Some(sentinel) = &self.sentinel {
+            config["sentinel"] = json!({
+                "base_url": format!("http://127.0.0.1:{}", sentinel.port)
+            });
+        }
         let path = self.temp_path("ui-htmx.json");
         std::fs::write(&path, config.to_string()).expect("failed to write BFF config");
         let handle = ServiceHandle::start("ui-htmx", path.to_str().unwrap()).await;
         self.ui = Some(handle);
+    }
+
+    // --- the sentinel the restart affordance calls --------------------------
+
+    /// Path of the marker file sentinel's scripted restart command writes —
+    /// recorded so the Then-step can assert the command actually ran.
+    pub fn restart_marker_path(&mut self) -> PathBuf {
+        let path = self.temp_path("restart-marker.txt");
+        self.restart_marker = Some(path.clone());
+        path
+    }
+
+    /// Spawn a real sentinel supervising the given `services` map (its top-level
+    /// registry), then **replace** the already-running BFF with one whose config
+    /// carries a `sentinel` block — the sentinel URL is only known once it has
+    /// bound, and the driver Given has already started the first BFF.
+    pub async fn start_sentinel_and_rewire_bff(&mut self, services: Value) {
+        let config = json!({
+            "dashboard": { "enabled": true, "port": 0, "history_size": 100 },
+            "services": services,
+        });
+        let path = self.temp_path("sentinel.json");
+        std::fs::write(&path, config.to_string()).expect("failed to write sentinel config");
+        let handle = ServiceHandle::start("sentinel", path.to_str().unwrap()).await;
+        self.sentinel = Some(handle);
+        if let Some(mut ui) = self.ui.take() {
+            ui.stop().await;
+        }
+        let port = self.driver_port;
+        self.start_bff_with_drivers(&[("dsd-fp2", port)]).await;
+    }
+
+    /// Follow the page's own "Restart via Sentinel" affordance the way htmx
+    /// would: render the page, read the button's rendered `hx-post` URL, and
+    /// POST it with htmx's headers (the affordance carries no form fields).
+    pub async fn request_restart(&mut self) {
+        self.get("/config/dsd-fp2").await;
+        let url = dom::attr(&self.last_body, "button.restart-sentinel", "hx-post")
+            .unwrap_or_else(|| panic!("no restart affordance in:\n{}", self.last_body));
+        let resp = reqwest::Client::new()
+            .post(self.ui_url(&url))
+            .headers(self.hx_headers())
+            .send()
+            .await
+            .expect("BFF restart POST failed");
+        self.last_body = resp.text().await.unwrap_or_default();
     }
 
     fn write_driver_config(&mut self, serial_port: &str, max_brightness: u32) -> String {

--- a/services/ui-htmx/tests/features/restart.feature
+++ b/services/ui-htmx/tests/features/restart.feature
@@ -1,0 +1,44 @@
+Feature: Restart via Sentinel
+  Sentinel owns process restart; the BFF is its authorised client. When the
+  BFF config carries a sentinel block, every driver's config card renders a
+  "Restart via Sentinel" button posting to /config/{service}/restart; the BFF
+  forwards to Sentinel's POST /api/services/{name}/restart (the name is the
+  driver's sentinel_service, defaulting to its service id) and renders the
+  outcome. An accepted restart swaps in the reconnecting fragment, which
+  polls /config/{service}/status until the driver serves its configuration
+  again; a failed restart command surfaces Sentinel's failure detail; a
+  service Sentinel does not supervise surfaces Sentinel's not-found reason.
+  Without a sentinel block, no restart affordance is rendered.
+
+  Scenario: The config card offers a restart via Sentinel
+    Given a dsd-fp2 driver running with serial.port "/dev/ttyACM0" and max_brightness 4096
+    And a sentinel supervising "dsd-fp2" with a restart command that writes a marker file
+    When I open the dsd-fp2 config page
+    Then the page offers to restart the driver via Sentinel
+
+  Scenario: An accepted restart runs Sentinel's command and the page reconnects
+    Given a dsd-fp2 driver running with serial.port "/dev/ttyACM0" and max_brightness 4096
+    And a sentinel supervising "dsd-fp2" with a restart command that writes a marker file
+    When I request a restart of the dsd-fp2 driver
+    Then the restart marker file exists
+    And the page reports the driver is restarting
+    And the page polls /config/dsd-fp2/status every 1s for reconnection
+    When I poll the reconnect status until max_brightness 4096 is served
+    Then the page shows the value "4096"
+
+  Scenario: A failing restart command surfaces Sentinel's failure detail
+    Given a dsd-fp2 driver running with serial.port "/dev/ttyACM0" and max_brightness 4096
+    And a sentinel supervising "dsd-fp2" with a restart command that fails
+    When I request a restart of the dsd-fp2 driver
+    Then the page reports the restart failed
+
+  Scenario: A driver Sentinel does not supervise surfaces the not-found reason
+    Given a dsd-fp2 driver running with serial.port "/dev/ttyACM0" and max_brightness 4096
+    And a sentinel supervising no services
+    When I request a restart of the dsd-fp2 driver
+    Then the page reports Sentinel does not supervise the driver
+
+  Scenario: No sentinel configured renders no restart affordance
+    Given a dsd-fp2 driver running with serial.port "/dev/ttyACM0" and max_brightness 4096
+    When I open the dsd-fp2 config page
+    Then the page offers no restart affordance

--- a/tests/operation-watchdog-e2e/tests/bdd/world.rs
+++ b/tests/operation-watchdog-e2e/tests/bdd/world.rs
@@ -158,33 +158,36 @@ impl WatchdogE2eWorld {
             }],
             "transitions": [],
             "dashboard": { "enabled": true, "port": 0, "history_size": 100 },
+            // The top-level supervised-services registry (shared by the
+            // watchdog ladder and the restart endpoint). `centering` has no
+            // Alpaca binding, so the ladder skips health/abort and goes
+            // straight to this restart command. base_url is unused for a
+            // binding-less family. The command is a trivial cross-shell
+            // `exit 0` (works under both `sh -c` and `cmd /C`, no
+            // path/quoting/redirection to mis-parse); the `restart=ran` token
+            // the test asserts on is emitted only after the real
+            // ShellRestarter spawns it and it exits 0, which is the
+            // end-to-end proof the restart rung executed. The restart budget
+            // is per-service.
+            "services": {
+                "rp": {
+                    "base_url": "http://127.0.0.1:1/api/v1",
+                    "device_number": 0,
+                    "restart_command": "exit 0",
+                    "max_restart_duration": "2s",
+                }
+            },
             "operation_watchdog": {
                 "rp_url": rp_url,
                 "reconnect_max_attempts": 2,
                 "reconnect_backoff": "1s",
                 "default_buffer": "0s",
-                "max_restart_duration": "2s",
                 "notifiers": ["pushover"],
                 "operations": {
                     "centering": {
                         "buffer": "0s",
                         "on_expiry": "abort_then_restart",
                         "service": "rp",
-                    }
-                },
-                "services": {
-                    // `centering` has no Alpaca binding, so the ladder skips
-                    // health/abort and goes straight to this restart command.
-                    // base_url is unused for a binding-less family. The command
-                    // is a trivial cross-shell `exit 0` (works under both `sh -c`
-                    // and `cmd /C`, no path/quoting/redirection to mis-parse);
-                    // the `restart=ran` token the test asserts on is emitted only
-                    // after the real ShellRestarter spawns it and it exits 0,
-                    // which is the end-to-end proof the restart rung executed.
-                    "rp": {
-                        "base_url": "http://127.0.0.1:1/api/v1",
-                        "device_number": 0,
-                        "restart_command": "exit 0",
                     }
                 }
             }


### PR DESCRIPTION
Phase 4 of `docs/plans/ui-design/config-actions.md`: Sentinel gets a Service Restart API, and the ui-htmx BFF gets the "Restart via Sentinel" affordance plus the `restart_required` escalation.

## Sentinel — Service Restart API

- **Top-level `services` map** (breaking config change, pre-1.0): the supervised-services registry moves out of `operation_watchdog.services` and is shared by the watchdog's corrective ladder and the new REST endpoint. `base_url` is now optional, so a non-Alpaca service (e.g. `rp`) can be a restart-only entry.
- **`POST /api/services/{name}/restart`** on the dashboard router (inherits the dashboard's Basic-auth/TLS): runs the service's `restart_command` through the platform shell (`sh -c` / `cmd /C`), then polls the optional **`health_command`** (exit 0 = healthy; e.g. `systemctl --user is-active <svc>`, `sc query <svc> | findstr RUNNING`) until healthy or the per-service **`max_restart_duration`** budget (default 60 s, replaces the watchdog-global knob) elapses.
- **Domain outcomes on HTTP 200** — `{service, status: "ok"|"failed", recovery: "healthy"|"timeout"|"skipped", detail}` (mirrors the config.apply convention); 404 unknown service, 409 not-restartable / already-in-flight (RAII per-service guard). Manual restarts log but notify no one.

## ui-htmx — Restart via Sentinel

- Optional **`sentinel {base_url, auth, ca_cert_path}`** config block + per-driver `sentinel_service` (defaults to the driver's own service id). Without the block, no restart affordance renders anywhere.
- **Recovery hammer**: every config card gets a footer "Restart via Sentinel" button (`hx-confirm`-guarded, outside the form). An accepted restart swaps in the existing reconnect-poll fragment; failures/404/409 surface Sentinel's reason in the error banner.
- **`restart_required` escalation**: the restart callout (`Banner::SavedRestartRequired`) now carries the restart button inline when a Sentinel is configured — rp reaches this on every apply (no in-process reload); no driver classifies fields this way yet, so the driver-side path is unit-driven.
- rp's own config page gets the button too (Sentinel-side name: the `rp` convention). Roster-derived device pages and equipment forms deliberately get none — they are hardware entries, not OS services.

## Phase 5 integration (rebased onto #485/#487)

Phase 5 landed mid-flight with its own restart callout that anticipated this branch ("Phase 4's affordance attaches here") — the two banner variants were unified on `SavedRestartRequired` with main's wording, and this branch's redundant `config_post` arm was dropped in favor of Phase 5's re-fetching version. `HttpClient` carries both sides' additions (`put_json` + `post`); the BDD target stages rp *and* sentinel binaries.

## Testing

- 6 new sentinel BDD scenarios (`service_restart.feature`): recovery healthy/skipped/timeout, failed command, 404, 409 — cross-shell commands keep Windows green.
- 5 new ui-htmx BDD scenarios (`restart.feature`) spawning a **real sentinel**: button → BFF → Sentinel → shell → marker file → reconnect poll, end to end.
- Unit: `restart.rs` manager (scripted runner, in-flight guard), `sentinel_client.rs` (8 tests), handler escalation paths via stubs.
- Full local gate green: `bazel build //... && bazel test //...` (77/77 incl. the merged ui-htmx suite running Phase 5's rp/equipment/stream features together with restart.feature), `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, buildifier.

Docs: `sentinel.md` (§Supervised services, §Service Restart API), `ui-htmx.md` (§Restart via Sentinel, config/module/testing sections), plan Phase 4 marked landed with the 2026-07-10 decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
