### PR TITLE
feat(dev): field-rig dev loop — scripts/rig.sh, rig-development skill, ZWO validation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ rusty-photon/
 | [docs/skills/testing.md](docs/skills/testing.md) | Skill: writing and organizing tests |
 | [docs/skills/pre-push.md](docs/skills/pre-push.md) | Skill: running CI quality gates before pushing |
 | [docs/skills/raspberry-pi-runner.md](docs/skills/raspberry-pi-runner.md) | Skill: setting up the Pi 5 ARM64 nightly self-hosted runner |
+| [docs/skills/rig-development.md](docs/skills/rig-development.md) | Skill: fast dev loop against the telescope field rig |
 | [docs/references/ascom-alpaca.md](docs/references/ascom-alpaca.md) | ASCOM Alpaca protocol reference |
 | [docs/decisions/](docs/decisions/) | Architecture Decision Records |
 

--- a/docs/plans/zwo-real-hardware-validation.md
+++ b/docs/plans/zwo-real-hardware-validation.md
@@ -1,0 +1,90 @@
+# Plan: ZWO real-hardware validation on the field rig
+
+**Date:** 2026-07-11
+**Branch:** `feature/rig-dev-loop`
+**Status:** waiting on hardware (ZWO color main camera + ZWO EAF focuser,
+expected within days). No filter wheel is in the order — zwo Phase F
+(EFW/FilterWheel, `docs/plans/zwo-driver.md`) stays out of scope here.
+**Context:** both ZWO services have only ever been validated against the
+simulated SDK: zwo-camera passed ConformU 2026-06-16 with the *sim* backend;
+zwo-focuser (merged as PR #479) has **never touched a real EAF**. The field
+rig already runs both services (ADR-014 per-device debs, empty device lists)
+plus the full stack, so validation is configuration + observation, not
+deployment work. Remote dev loop: see
+[docs/skills/rig-development.md](../skills/rig-development.md).
+
+---
+
+## 1. Arrival-day checklist
+
+### 1.1 Physical / enumeration
+
+- [ ] Camera **directly on a Pi USB3 port**, not the PPBA Gen2's built-in
+      hub — on 2026-07-11 the QHY5III715C's firmware reproducibly failed to
+      boot on the PPBA's external USB3 ports (raw device flashed, then
+      vanished before enumerating) while working elsewhere; treat those
+      ports as serial/low-speed-only until proven otherwise. Verify
+      SuperSpeed enumeration: `lsusb -t` must show the camera at 5000M on
+      bus 2/4, not 480M on bus 1/3.
+- [ ] EAF connected (USB2 is fine — it's a low-rate HID-class device).
+- [ ] `lsusb` shows ZWO vendor ID `03c3` for both devices.
+- [ ] Camera 12 V (cooler) fed from a PPBA switched output; note which
+      output in the PPBA switch names.
+
+### 1.2 Permissions / udev
+
+- [ ] The zwo debs' udev rules fire: device nodes accessible to group
+      `plugdev` after replug (`udevadm info` on the device; the service user
+      is already in `plugdev` via the unit's `SupplementaryGroups`).
+- [ ] `systemctl restart rusty-photon-zwo-camera rusty-photon-zwo-focuser`;
+      both list their device (`/management/v1/configureddevices`).
+
+### 1.3 zwo-camera against real hardware
+
+- [ ] First real-SDK ConformU run: `scripts/test-conformance.sh` pointed at
+      the rig's zwo-camera (ports/flags per that script). The sim round
+      surfaced sensor-geometry and async-op bugs (CameraXSize R4 alignment,
+      async PulseGuide); expect the real sensor to disagree with the sim on
+      geometry, exposure limits, and gain/offset ranges — capture every
+      mismatch as a driver issue rather than hand-tuning config around it.
+- [ ] Full-frame capture at 16-bit; verify FITS lands via filemonitor and
+      dimensions/bit depth match the sensor spec.
+- [ ] Cooler: set-point reached and reported power plausible.
+
+### 1.4 zwo-focuser against real EAF (first contact ever)
+
+- [ ] ConformU Focuser suite against the rig instance.
+- [ ] Movement sanity: small relative moves in both directions, position
+      readback consistent, no missed steps at travel extremes; confirm
+      configured `max_step` against the EAF's actual range.
+- [ ] Temperature sensor reads plausibly.
+- [ ] Note backlash behavior (needed later for autofocus work).
+
+### 1.5 Stack integration
+
+- [ ] Add both devices to `ui-htmx` drivers, sentinel monitors, and rp
+      equipment on the rig; confirm the `/equipment` roster tiers them
+      correctly.
+- [ ] `scripts/rig.sh fetch-configs` afterwards so local dev configs include
+      the new endpoints.
+
+## 2. Known risks
+
+- **SDK pin vs new camera model.** The bundled `libASICamera2` comes from
+  the pinned indi-3rdparty ref in `scripts/build-packages.sh`; a
+  just-released camera model may need a newer blob. Symptom: camera
+  enumerates on USB but the SDK lists no device. Fix: bump the pin (and
+  SHAs) per ADR-013/ADR-014, rebuild the zwo debs on the rig.
+- **USB3 on the Pi 5 behind hubs** has real-world flakiness; if SuperSpeed
+  enumeration is unstable, try the Pi's own USB3 ports before the hub.
+- **Power browning out the hub** during cooler + exposure load — the reason
+  the rig uses a powered hub; watch `dmesg` for USB resets during first
+  long-exposure tests.
+
+## 3. Exit criteria
+
+Both ConformU suites green against real hardware, one full-frame capture on
+disk, EAF moving reliably, devices integrated into ui-htmx/sentinel/rp, and
+each service's design doc updated with a "validated on real hardware" note
+(zwo-camera.md, zwo-focuser.md). Then archive this plan per
+docs/skills/archiving-plans.md.

--- a/docs/skills/rig-development.md
+++ b/docs/skills/rig-development.md
@@ -1,0 +1,88 @@
+# Skill: developing against the telescope field rig
+
+How to get a near-real-time dev loop between a dev machine and the field-rig
+Raspberry Pi that runs the packaged rusty-photon stack on the telescope.
+
+The model: **drivers stay on the rig, the service you are editing runs
+locally.** Every non-driver service (rp, sentinel, ui-htmx, session-runner,
+plate-solver, calibrator-flats, phd2-guider, new tools such as autofocus) is
+an HTTP client of the ASCOM Alpaca drivers, so it can run on the dev machine
+and talk to the rig's live drivers over the LAN. That gives an edit → `cargo
+run` → real-hardware loop of a few seconds with no deploy step. Driver work
+itself still happens on the rig (build there, or install a deb per
+[docs/packaging.md](../packaging.md)).
+
+## One-time setup
+
+1. **ssh alias.** The rig's address must never appear in this repository
+   (public repo — keep infrastructure addresses out). All tooling resolves
+   the host `rig` from your `~/.ssh/config`:
+
+   ```
+   Host rig
+       HostName <rig-address>
+       User <rig-user>
+   ```
+
+   The user needs passwordless sudo on the rig (Raspberry Pi OS grants the
+   first user this by default). Override the alias name with `RIG_HOST=...`
+   if yours differs.
+
+2. **WiFi power-save must be off on the rig.** With it on (the Raspberry Pi
+   OS default), the radio naps between access-point beacons and every inbound
+   packet risks a 100–260 ms stall — it poisons ssh, rsync, and every Alpaca
+   call with random latency. Symptom: `ping` times that swing from ~4 ms to
+   hundreds of ms. Fix, on the rig:
+
+   ```sh
+   sudo iw dev wlan0 set power_save off                     # immediate
+   sudo nmcli connection modify <wifi-con> 802-11-wireless.powersave 2   # persist
+   ```
+
+   Verify with `iw dev wlan0 get power_save` (expect `off`) and a flat ~5 ms
+   ping. Cost: well under half a watt of extra idle draw.
+
+## The loop
+
+```sh
+scripts/rig.sh fetch-configs      # rig configs -> ~/.config/rusty-photon-rig,
+                                  # driver endpoints rewritten to the rig's address
+cargo run -p ui-htmx -- --config ~/.config/rusty-photon-rig/ui-htmx.json
+scripts/rig.sh logs dsd-fp2 -f    # tail the driver you're talking to
+```
+
+`scripts/rig.sh` also has `status`, `restart|start|stop <svc>`, and `ssh`.
+Edit the fetched configs freely — they are your local dev copies, never
+written back to the rig.
+
+### Rules of engagement
+
+- **One orchestrator at a time.** When running a local rp against the rig's
+  drivers, stop the rig's own instance first (`scripts/rig.sh stop rp`) so
+  two orchestrators don't command the same hardware; restart it when done.
+  The same applies to any tool that moves equipment.
+- **This is live hardware on a telescope.** A local service you're debugging
+  can slew the mount, move the focuser, or rotate the imaging train. Know
+  what your code will command before pointing it at the rig.
+- **Serial device paths on the rig must be `/dev/serial/by-id/...`**, never
+  `/dev/ttyUSB<n>` — enumeration order is not stable across boots or
+  re-plugs, and with several FTDI adapters on one hub the `ttyUSBn` numbers
+  are effectively random.
+
+## Bandwidth expectations (WiFi rig)
+
+The rig link is WiFi (~10 MB/s in practice). What that means for a locally
+run service fetching camera data over Alpaca:
+
+| Payload | Transfer time | Verdict |
+|---|---|---|
+| Autofocus/guiding subframes (≤ a few hundred KB) | ~instant | non-issue |
+| Full guide-camera frame (~13 MB) | ~1.3 s | fine |
+| Full large-CMOS frame (~50 MB) | ~5 s | tolerable dead time |
+| Planetary / video streaming (350+ MB/s) | — | impossible; run on-rig |
+
+In production the whole stack runs on the rig, so none of this applies there
+— it is purely a property of the remote dev loop. USB-over-IP forwarding of
+cameras was evaluated and rejected for the same reason (usbip and VirtualHere
+both top out at ~30–40 MB/s even on wired gigabit, with disconnect-recovery
+problems on top); revisit only if the rig ever gets a wired link.

--- a/scripts/rig.sh
+++ b/scripts/rig.sh
@@ -83,12 +83,16 @@ case "$cmd" in
             echo "add a 'Host $RIG_HOST' entry to ~/.ssh/config or set RIG_HOST" >&2
             exit 1
         fi
+        # An IPv6 literal must be bracketed in URLs; also escape sed
+        # replacement metacharacters (defensive — valid hosts have none).
+        case "$addr" in *:*) addr="[$addr]" ;; esac
+        addr_esc=$(printf '%s' "$addr" | sed 's/[\\&|]/\\&/g')
         mkdir -p "$dest"
         ssh -T "$RIG_HOST" "sudo tar -C '$CONFIG_DIR' -cf - ." | tar -C "$dest" -xf -
         for f in "$dest"/*.json; do
             [ -e "$f" ] || continue
-            sed -e "s|http://127\.0\.0\.1:|http://$addr:|g" \
-                -e "s|http://localhost:|http://$addr:|g" \
+            sed -e "s|http://127\.0\.0\.1:|http://$addr_esc:|g" \
+                -e "s|http://localhost:|http://$addr_esc:|g" \
                 "$f" > "$f.tmp" && mv "$f.tmp" "$f"
         done
         echo "rig configs written to $dest (driver endpoints -> $addr)"

--- a/scripts/rig.sh
+++ b/scripts/rig.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# rig.sh — ops helper for developing against the telescope field rig (a
+# Raspberry Pi running the packaged rusty-photon stack; see
+# docs/skills/rig-development.md).
+#
+# The rig's address is deliberately NOT in this script (public repo): it is
+# resolved from the `rig` host alias in your ~/.ssh/config, overridable with
+# the RIG_HOST environment variable. The alias must log in as a user with
+# passwordless sudo on the rig.
+#
+# Usage: scripts/rig.sh <command> [args]
+#   status                     unit overview of every rusty-photon service
+#   logs <svc> [args...]       journalctl for a service; extra args are passed
+#                              through (e.g. `logs zwo-focuser -f`, `-n 200`)
+#   restart|start|stop <svc>   control a service's systemd unit
+#   fetch-configs [dest]       copy the rig's service configs to dest (default
+#                              ~/.config/rusty-photon-rig), rewriting loopback
+#                              driver endpoints (http://127.0.0.1:PORT) to the
+#                              rig's address so a locally-run service (rp,
+#                              ui-htmx, sentinel, ...) talks to the rig's
+#                              drivers. Serial device paths are left untouched.
+#   ssh [cmd...]               interactive shell / one-off command on the rig
+#
+# <svc> accepts either the short name (zwo-focuser) or the full unit name
+# (rusty-photon-zwo-focuser).
+
+set -eu
+
+RIG_HOST="${RIG_HOST:-rig}"
+CONFIG_DIR=/var/lib/rusty-photon/.config/rusty-photon
+
+usage() {
+    sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+unit_name() {
+    case "$1" in
+        rusty-photon-*) printf '%s' "$1" ;;
+        *) printf 'rusty-photon-%s' "$1" ;;
+    esac
+}
+
+[ $# -ge 1 ] || usage 1
+cmd=$1
+shift
+
+case "$cmd" in
+    status)
+        ssh "$RIG_HOST" "systemctl list-units --type=service --all --no-pager --plain 'rusty-photon-*'"
+        ;;
+    logs)
+        [ $# -ge 1 ] || { echo "logs: service name required" >&2; exit 1; }
+        svc=$(unit_name "$1")
+        shift
+        # -t: keep colors; journalctl needs the adm group or sudo — use sudo
+        # since the rig user has it passwordless anyway.
+        ssh -t "$RIG_HOST" "sudo journalctl -u '$svc' $*"
+        ;;
+    restart | start | stop)
+        [ $# -eq 1 ] || { echo "$cmd: exactly one service name required" >&2; exit 1; }
+        svc=$(unit_name "$1")
+        ssh "$RIG_HOST" "sudo systemctl $cmd '$svc' && systemctl --no-pager --plain list-units --type=service --all '$svc'"
+        ;;
+    fetch-configs)
+        dest="${1:-$HOME/.config/rusty-photon-rig}"
+        # The address as reachable from this machine, taken from ssh's own
+        # resolution of the alias — keeps it out of the repo.
+        addr=$(ssh -G "$RIG_HOST" | awk '/^hostname /{print $2}')
+        mkdir -p "$dest"
+        ssh -T "$RIG_HOST" "sudo tar -C '$CONFIG_DIR' -cf - ." | tar -C "$dest" -xf -
+        for f in "$dest"/*.json; do
+            [ -e "$f" ] || continue
+            sed -e "s|http://127\.0\.0\.1:|http://$addr:|g" \
+                -e "s|http://localhost:|http://$addr:|g" \
+                "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+        done
+        echo "rig configs written to $dest (driver endpoints -> $addr)"
+        ;;
+    ssh)
+        if [ $# -eq 0 ]; then
+            ssh "$RIG_HOST"
+        else
+            ssh -t "$RIG_HOST" "$@"
+        fi
+        ;;
+    -h | --help | help)
+        usage 0
+        ;;
+    *)
+        echo "unknown command: $cmd" >&2
+        usage 1
+        ;;
+esac

--- a/scripts/rig.sh
+++ b/scripts/rig.sh
@@ -30,7 +30,9 @@ RIG_HOST="${RIG_HOST:-rig}"
 CONFIG_DIR=/var/lib/rusty-photon/.config/rusty-photon
 
 usage() {
-    sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+    # Print the header comment block (everything from line 2 to the first
+    # non-comment line), so the help text can never desync from the header.
+    awk 'NR < 2 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
     exit "${1:-0}"
 }
 
@@ -75,7 +77,12 @@ case "$cmd" in
         dest="${1:-$HOME/.config/rusty-photon-rig}"
         # The address as reachable from this machine, taken from ssh's own
         # resolution of the alias — keeps it out of the repo.
-        addr=$(ssh -G "$RIG_HOST" | awk '/^hostname /{print $2}')
+        addr=$(ssh -G "$RIG_HOST" 2>/dev/null | awk '/^hostname /{print $2}')
+        if [ -z "$addr" ]; then
+            echo "fetch-configs: ssh could not resolve an address for '$RIG_HOST'" >&2
+            echo "add a 'Host $RIG_HOST' entry to ~/.ssh/config or set RIG_HOST" >&2
+            exit 1
+        fi
         mkdir -p "$dest"
         ssh -T "$RIG_HOST" "sudo tar -C '$CONFIG_DIR' -cf - ." | tar -C "$dest" -xf -
         for f in "$dest"/*.json; do

--- a/scripts/rig.sh
+++ b/scripts/rig.sh
@@ -41,6 +41,15 @@ unit_name() {
     esac
 }
 
+# Single-quote each argument for the remote shell (ssh concatenates its
+# command arguments and the remote shell re-parses them, so boundaries and
+# metacharacters survive only if we quote here): abc -> 'abc', don't -> 'don'\''t'.
+quote_args() {
+    for a in "$@"; do
+        printf " '%s'" "$(printf '%s' "$a" | sed "s/'/'\\\\''/g")"
+    done
+}
+
 [ $# -ge 1 ] || usage 1
 cmd=$1
 shift
@@ -55,7 +64,7 @@ case "$cmd" in
         shift
         # -t: keep colors; journalctl needs the adm group or sudo — use sudo
         # since the rig user has it passwordless anyway.
-        ssh -t "$RIG_HOST" "sudo journalctl -u '$svc' $*"
+        ssh -t "$RIG_HOST" "sudo journalctl -u '$svc'$(quote_args "$@")"
         ;;
     restart | start | stop)
         [ $# -eq 1 ] || { echo "$cmd: exactly one service name required" >&2; exit 1; }

--- a/scripts/rig.sh
+++ b/scripts/rig.sh
@@ -66,12 +66,12 @@ case "$cmd" in
         shift
         # -t: keep colors; journalctl needs the adm group or sudo — use sudo
         # since the rig user has it passwordless anyway.
-        ssh -t "$RIG_HOST" "sudo journalctl -u '$svc'$(quote_args "$@")"
+        ssh -t "$RIG_HOST" "sudo journalctl -u$(quote_args "$svc")$(quote_args "$@")"
         ;;
     restart | start | stop)
         [ $# -eq 1 ] || { echo "$cmd: exactly one service name required" >&2; exit 1; }
         svc=$(unit_name "$1")
-        ssh "$RIG_HOST" "sudo systemctl $cmd '$svc' && systemctl --no-pager --plain list-units --type=service --all '$svc'"
+        ssh "$RIG_HOST" "sudo systemctl $cmd$(quote_args "$svc") && systemctl --no-pager --plain list-units --type=service --all$(quote_args "$svc")"
         ;;
     fetch-configs)
         dest="${1:-$HOME/.config/rusty-photon-rig}"


### PR DESCRIPTION
## Summary

Tooling and docs for fast round-trip development against the telescope field rig: **drivers stay on the rig, the service under edit runs locally** and talks to the rig's live drivers over Alpaca HTTP.

- **`scripts/rig.sh`** — ops helper: `status`, `logs <svc> [-f]`, `restart|start|stop <svc>`, `ssh`, and `fetch-configs`, which pulls the rig's service configs locally and rewrites loopback driver endpoints (`http://127.0.0.1:PORT`) to the rig's address so a locally-run rp/ui-htmx/sentinel/tool targets real hardware. The rig's address is resolved from the user's `rig` ssh alias / `RIG_HOST` env — never stored in the repo.
- **`docs/skills/rig-development.md`** — the dev-loop skill: one-time setup (ssh alias, why WiFi power-save must be off and how to disable it persistently), the loop itself, rules of engagement (one orchestrator at a time, live-hardware caution, `/dev/serial/by-id` only), and WiFi bandwidth expectations — including why USB-over-IP camera forwarding was evaluated and rejected (~30–40 MB/s protocol ceiling on usbip/VirtualHere plus disconnect-recovery gaps).
- **`docs/plans/zwo-real-hardware-validation.md`** — arrival checklist for the incoming ZWO color camera + EAF: first-ever real-SDK ConformU runs for zwo-camera/zwo-focuser, udev/plugdev verification, EAF movement sanity, stack integration, risks (SDK pin vs brand-new camera model), exit criteria. Incorporates a lesson learned on the rig: USB3 camera firmware reproducibly failed to boot on the PPBA Gen2 hub's external USB3 ports, so cameras go directly on Pi USB3 ports.
- **README.md** — index the new skill doc.

No production code changes; shell script + docs only.

## Test plan

- Full local gate green: `bazel build //... && bazel test //...` (77/77), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`.
- `scripts/rig.sh` smoke-tested against the live rig: `status`, `logs`, and `fetch-configs` (all 10 configs pulled, endpoints rewritten, serial device paths untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)